### PR TITLE
[AXON-19] fix: remove accidentally added build command

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Replace package name
-        run: sed -i 's/atlascode/atlascode-nightly/g' package.json
-
       # TODO if we want to publish this, just a different version is not enough
       # We'd probably want to use a different id for the extension, too - e.g. atlascode-nightly
       - name: Evaluate version


### PR DESCRIPTION
### What is this?

Removing the accidentally added command from the nightly build. It was supposed to just test the scheduling right now, not actually change anything in the `package.json` ;D

### How was this tested?

Briefly changed triggers to `push`, ran the build separately [here](https://github.com/atlassian/atlascode/actions/runs/12145250422) 