### PR TITLE
[AXON-19] feat: nightly versioning & release scripts

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -3,30 +3,38 @@ name: Release Nightly
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_call: {}
+  # Can be triggered manually if needed
+  workflow_dispatch: {}
 
 jobs:
-  release:
+  release-nightly:
+
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
 
-      # TODO if we want to publish this, just a different version is not enough
-      # We'd probably want to use a different id for the extension, too - e.g. atlascode-nightly
       - name: Evaluate version
         run: |
-          RELEASE_VERSION=$(./nightlyver.sh ${GITHUB_SHA}) && \
-          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV && \
-          echo "Using version '${RELEASE_VERSION}'"
-
-      - name: Set version
-        run: npm -no-git-tag-version --allow-same-version -f version $RELEASE_VERSION
+          PACKAGE_VERSION=$(./scripts/version/get-next-nightly.sh)
+          ./scripts/version/assert-nightly.sh $PACKAGE_VERSION
+          echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=v${PACKAGE_VERSION}" >> $GITHUB_ENV
+          echo "Using version '${PACKAGE_VERSION}'"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      - name: Set version
+        run: |
+          npm -no-git-tag-version --allow-same-version -f version $PACKAGE_VERSION
 
       - name: Install dependencies
         run: npm install
@@ -40,4 +48,33 @@ jobs:
       - name: Build the extension
         run: npm run extension:package
 
-      # No publish actions here for the time being - let's get the builds going first
+      # No VSCE/OVSX publish actions here for the time being - let's get the builds going first
+
+      - name: Create Tag
+        run: |
+          git config --global user.email "atlascode-nightly@atlassian.com"
+          git config --global user.name "Nightly Release Bot"
+          git tag -a $RELEASE_TAG -m "Nightly build for $(date +'%Y-%m-%d %H:%M')"
+          git push origin $RELEASE_TAG
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          release_name: Release ${{ env.RELEASE_TAG }}
+          draft: false
+          prerelease: true
+
+      - name: Upload Release Assets
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./atlascode-${{ env.PACKAGE_VERSION }}.vsix
+          asset_name: atlascode-${{ env.PACKAGE_VERSION }}.vsix
+          asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,14 +3,34 @@ name: Release
 on:
   push:
     tags:
-      - '**'
+      - 'v*'
+      - '!*nightly*'
 
 jobs:
+  release-nightly:
+    uses: ./.github/workflows/release-nightly.yaml
+
   release:
     runs-on: ubuntu-latest
+
+    # Release the next `nightly` before a stable version
+    # to prvent folks on pre-releases from being downgraded
+    needs: release-nightly
+
+    permissions:
+      contents: write
+
     steps:
 
       - uses: actions/checkout@v4
+
+      - name: Evaluate version
+        run: |
+          PACKAGE_VERSION=${GITHUB_REF##*/v}
+          ./scripts/version/assert-stable.sh $PACKAGE_VERSION
+          echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=v${PACKAGE_VERSION}" >> $GITHUB_ENV
+          echo "Using version '${PACKAGE_VERSION}'"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -18,14 +38,8 @@ jobs:
           node-version: 20
           cache: 'npm'
 
-      - name: Evaluate version
-        run: |
-          RELEASE_VERSION=${GITHUB_REF##*/v} && \
-          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV && \
-          echo "Using version '${RELEASE_VERSION}'"
-
       - name: Set version
-        run: npm -no-git-tag-version --allow-same-version -f version $RELEASE_VERSION
+        run: npm -no-git-tag-version --allow-same-version -f version $PACKAGE_VERSION
 
       - name: Install dependencies
         run: npm install
@@ -52,12 +66,33 @@ jobs:
           # echo npx vsce publish \
           #   -p ${{ secrets.VSCE_MARKETPLACE_TOKEN }} \
           #   --baseContentUrl https://bitbucket.org/atlassianlabs/atlascode/src/main/ \
-          #   --packagePath atlascode-${GITHUB_REF##*/v}.vsix
+          #   --packagePath atlascode-${PACKAGE_VERSION}.vsix
 
       - name: Publish to OpenVSX
         run: |
           npx ovsx verify-pat -p ${{ secrets.OPENVSX_KEY }}
           # echo npx ovsx publish \
           #    -p ${{ secrets.OPENVSX_KEY }} \
-          #   "atlascode-${GITHUB_REF##*/v}.vsix"
+          #   "atlascode-${PACKAGE_VERSION}.vsix"
 
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          release_name: Release ${{ env.RELEASE_TAG }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Assets
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./atlascode-${{ env.PACKAGE_VERSION }}.vsix
+          asset_name: atlascode-${{ env.PACKAGE_VERSION }}.vsix
+          asset_content_type: application/zip

--- a/scripts/version/assert-nightly.sh
+++ b/scripts/version/assert-nightly.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Make sure that the minor version is odd
+version=$1
+
+if [[ $version =~ ^[0-9]+\.[0-9]*[13579]\.[0-9]+.*$ ]]; then
+    echo "Version $version is a valid pre-release (odd minor version)"
+    exit 0
+else
+    echo "Version $version is not a valid pre-release (even minor version or invalid format)"
+    exit 1
+fi

--- a/scripts/version/assert-stable.sh
+++ b/scripts/version/assert-stable.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Make sure that the minor version is even
+version=$1
+
+if [[ $version =~ ^[0-9]+\.[0-9]*[02468]\.[0-9]+$ ]]; then
+    echo "Version $version is a valid stable release (even minor version)"
+    exit 0
+else
+    echo "Version $version is not a valid stable release (odd minor version or invalid format)"
+    exit 1
+fi

--- a/scripts/version/get-latest-nightly.sh
+++ b/scripts/version/get-latest-nightly.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+n_release=${1:-1}
+
+# Get latest nightly tag from the repository
+# Pre-releases are defined by the version number having an ODD minor number
+# https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+git tag --list | \
+    sort --version-sort -r | \
+    grep -E '^v[0-9]+\.[0-9]*[13579]\.[0-9]+.*' | \
+    head -n $n_release | \
+    tail -n 1 | \
+    cut -c 2-

--- a/scripts/version/get-latest-stable.sh
+++ b/scripts/version/get-latest-stable.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+n_release=${1:-1}
+
+# Get latest release tag from the repository
+# Stable releases are defined by the version number having an EVEN minor number
+# https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+git tag --list | \
+    sort --version-sort -r | \
+    grep -E '^v[0-9]+\.[0-9]*[02468]\.[0-9]+$' | \
+    head -n $n_release | \
+    tail -n 1 | \
+    cut -c 2-

--- a/scripts/version/get-next-nightly.sh
+++ b/scripts/version/get-next-nightly.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Nightly version is defined by the latest stable release tag,
+# except the minor version is incremented by one
+# https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+
+git fetch --tags -q
+latest_stable_version=$(./scripts/version/get-latest-stable.sh)
+latest_nightly_version=$(./scripts/version/get-latest-nightly.sh)
+
+# Major version is the same as the latest stable version
+stable_major=$(echo $latest_stable_version | cut -d '.' -f 1)
+nightly_major=$(echo $latest_nightly_version | cut -d '.' -f 1)
+
+# Minor version is always "latest stable + 1"
+stable_minor=$(echo $latest_stable_version | cut -d '.' -f 2)
+nightly_minor=$(echo $latest_nightly_version | cut -d '.' -f 2)
+next_minor=$((stable_minor + 1))
+
+# Patch is incrementing, unless we're on a new minor
+if [[ $nightly_major -eq $stable_major && $next_minor -eq $nightly_minor ]]; then
+    nightly_patch=$(echo $latest_nightly_version | cut -d '.' -f 3 | cut -d '-' -f 1)
+    nightly_patch=${nightly_patch:--1} # In case of new nightly minor
+    next_patch=$((nightly_patch + 1))
+else
+    next_patch=0
+fi
+
+echo "$stable_major.$next_minor.$next_patch-nightly"


### PR DESCRIPTION
### What is this?

A set of scripts to define the versioning behavior for nightly releases, in line with [the vscode docs](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions)

In this implementation:
* Versions with `EVEN` minor number (e.g. `v3.0.14`, `v3.2.1`) - are treated as **stable**
* Versions with `ODD` minor number (e.g. `v1.1.1`, `v3.1.0`) - are treated as **pre-release** (or nightly)
* Nightly versions increment patch independently - except when there's a next stable release, then the major/minor is bumped accordingly, and the patch is reset to `0`
* Nightly versions are suffixed with `-nightly` to indicate pre-release as per [semver](https://semver.org/)

### How was this tested

* Bunch of runs for the version scripts to simulate the different `stable` version updates
* Played around with these build scripts in a separate repo to satisfactory results
* Ran `release` pipeline once here - but more testing will follow once the CI code is merged to `main
![image](https://github.com/user-attachments/assets/4c588bb5-e9e4-4e87-a1d1-084a51eec8a9)
