### PR TITLE
[AXON-19] fix: pass FX3 client vars to build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,17 @@ on:
       - '**'
 
 jobs:
+
   build:
+
     runs-on: ubuntu-latest
+
+    env:
+      ATLASCODE_FX3_API_KEY: ${{ secrets.ATLASCODE_FX3_API_KEY }}
+      ATLASCODE_FX3_ENVIRONMENT: ${{ vars.ATLASCODE_FX3_ENVIRONMENT }}
+      ATLASCODE_FX3_TARGET_APP: ${{ vars.ATLASCODE_FX3_TARGET_APP }}
+      ATLASCODE_FX3_TIMEOUT: ${{ vars.ATLASCODE_FX3_TIMEOUT }}
+
     steps:
 
       - uses: actions/checkout@v4

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -15,6 +15,12 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      ATLASCODE_FX3_API_KEY: ${{ secrets.ATLASCODE_FX3_API_KEY }}
+      ATLASCODE_FX3_ENVIRONMENT: ${{ vars.ATLASCODE_FX3_ENVIRONMENT }}
+      ATLASCODE_FX3_TARGET_APP: ${{ vars.ATLASCODE_FX3_TARGET_APP }}
+      ATLASCODE_FX3_TIMEOUT: ${{ vars.ATLASCODE_FX3_TIMEOUT }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,12 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      ATLASCODE_FX3_API_KEY: ${{ secrets.ATLASCODE_FX3_API_KEY }}
+      ATLASCODE_FX3_ENVIRONMENT: ${{ vars.ATLASCODE_FX3_ENVIRONMENT }}
+      ATLASCODE_FX3_TARGET_APP: ${{ vars.ATLASCODE_FX3_TARGET_APP }}
+      ATLASCODE_FX3_TIMEOUT: ${{ vars.ATLASCODE_FX3_TIMEOUT }}
+
     steps:
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
### What is this?

When doing the round of bug bashing today, we caught that the `atlascode` feature flag client initialization vars are not getting passed to the build environment correctly.

Now they are 😉 

### How was this tested?

This is related to CI - so I've only run a pipeline to make sure things work, and checked that the environment variables propagate to the build env correctly. Once this is merged, I'll check the next `nightly` for any feature flag initialization issues