### PR TITLE
[AXON-23] Add pre-release logic to CI

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -54,7 +54,20 @@ jobs:
       - name: Build the extension
         run: npm run extension:package
 
-      # No VSCE/OVSX publish actions here for the time being - let's get the builds going first
+      - name: Publish the pre-release extension
+        run: |
+          echo npx vsce publish \
+            --pre-release \
+            --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/ \
+            -p ${{ secrets.VSCE_MARKETPLACE_TOKEN }} \
+            --packagePath atlascode-${PACKAGE_VERSION}.vsix
+
+      - name: Publish the pre-release to OpenVSX
+        run: |
+          echo npx ovsx publish \
+            --pre-release \
+            -p ${{ secrets.OPENVSX_KEY }} \
+            "atlascode-${PACKAGE_VERSION}.vsix"
 
       - name: Create Tag
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           npx vsce verify-pat -p ${{ secrets.VSCE_MARKETPLACE_TOKEN }}
           # echo npx vsce publish \
           #   -p ${{ secrets.VSCE_MARKETPLACE_TOKEN }} \
-          #   --baseContentUrl https://bitbucket.org/atlassianlabs/atlascode/src/main/ \
+          #   --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/ \
           #   --packagePath atlascode-${PACKAGE_VERSION}.vsix
 
       - name: Publish to OpenVSX


### PR DESCRIPTION
### What is this?

Here we add the actual logic to push the pre-release builds of the extension, marked with `--pre-release`, to the VSCode Marketplace and OpenVSX repos

### How was this tested?

This is a CI change, so technically it wasn't, except for:

* Several previous nightly build runs
* Publish code being carried over from `release` path where it worked historically