### PR TITLE
AXON-23 prerelease flag on the packaging for nightly

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -52,7 +52,7 @@ jobs:
         run: npm run test
 
       - name: Build the extension
-        run: npm run extension:package
+        run: npm run extension:package:prerelease
 
       - name: Publish the pre-release extension
         run: |

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "compile:react": "NODE_OPTIONS=--openssl-legacy-provider webpack --mode production --config webpack.react.prod.js",
         "postinstall": "patch-package",
         "extension:clean": "rm -rf ./atlascode-*.vsix",
+        "extension:package:prerelease": "npm run extension:clean && vsce package --pre-release --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/ --allow-star-activation",
         "extension:package": "npm run extension:clean && vsce package --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/ --allow-star-activation",
         "extension:install": "npm run extension:package && code --install-extension ./atlascode-*.vsix --force",
         "test": "jest",


### PR DESCRIPTION
- Adds the pre-release flag on the nightly packaging command. 
- Done because of this error: 
```
Error: Cannot use '--pre-release' flag with a package that was not packaged as pre-release. Please package it using the '--pre-release' flag and publish again.
Error: Process completed with exit code 1.
```
Source: https://github.com/atlassian/atlascode/actions/runs/12242743894/job/34150733698