### PR TITLE
AXON-23 add '-nightly' to the GH tags to get around the tag restrictions

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -29,7 +29,7 @@ jobs:
           PACKAGE_VERSION=$(./scripts/version/get-next-nightly.sh)
           ./scripts/version/assert-nightly.sh $PACKAGE_VERSION
           echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
-          echo "RELEASE_TAG=v${PACKAGE_VERSION}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=v${PACKAGE_VERSION}-nightly" >> $GITHUB_ENV
           echo "Using version '${PACKAGE_VERSION}'"
 
       - name: Set up Node.js


### PR DESCRIPTION
Due to this error: 
```
 ! [remote rejected]   v3.1.1 -> v3.1.1 (push declined due to repository rule violations)
```
Source: https://github.com/atlassian/atlascode/actions/runs/12243113285/job/34151929479 