### PR TITLE
VSCODE-1050: Add Bearer Auth using PAT for hosted BitBucket (as done for hosted Jira)

### DIFF
--- a/src/atlclients/clientManager.ts
+++ b/src/atlclients/clientManager.ts
@@ -134,10 +134,10 @@ export class ClientManager implements Disposable {
             } else {
                 result = {
                     repositories: isBasicAuthInfo(info)
-                        ? new ServerRepositoriesApi(this.createBasicHTTPClient(site, info.username, info.password))
+                        ? new ServerRepositoriesApi(this.createHTTPClient(site, info))
                         : undefined!,
                     pullrequests: isBasicAuthInfo(info)
-                        ? new ServerPullRequestApi(this.createBasicHTTPClient(site, info.username, info.password))
+                        ? new ServerPullRequestApi(this.createHTTPClient(site, info))
                         : undefined!,
                     issues: undefined,
                     pipelines: undefined,
@@ -216,10 +216,17 @@ export class ClientManager implements Disposable {
         );
     }
 
-    private createBasicHTTPClient(site: DetailedSiteInfo, username: string, password: string): HTTPClient {
+    private createHTTPClient(site: DetailedSiteInfo, info: AuthInfo): HTTPClient {
+        let auth = '';
+        if (isBasicAuthInfo(info)) {
+            auth = `Basic ${Buffer.from(info.username + ':' + info.password).toString('base64')}`;
+        } else if (isPATAuthInfo(info)) {
+            auth = `Bearer ${info.token}`;
+        }
+        Logger.info(auth);
         return new HTTPClient(
             site.baseApiUrl,
-            `Basic ${Buffer.from(username + ':' + password).toString('base64')}`,
+            auth,
             getAgent(site),
             async (response: AxiosResponse): Promise<Error> => {
                 let errString = 'Unknown error';

--- a/src/react/atlascode/config/auth/AuthDialog.tsx
+++ b/src/react/atlascode/config/auth/AuthDialog.tsx
@@ -278,7 +278,7 @@ export const AuthDialog: React.FunctionComponent<AuthDialogProps> = memo(
                                     }}
                                 >
                                     <Tab label="Username and Password" />
-                                    {product.key === ProductJira.key && <Tab label="Personal Access Token" />}
+                                    <Tab label="Personal Access Token" />
                                 </Tabs>
                                 <TabPanel value={authTypeTabIndex} index={0}>
                                     <Grid item>


### PR DESCRIPTION
Like the API of Jira and Bitbucket, the API of Bitbucket supports Bearer Auth using PAT instead of Basic Auth:
https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html

A number of other customers have expressed a need for this feature, not just us (Cloud Software Group): We disallow the use of HTTP Basic Auth for security reasons for the Confluence, Jira and Bitbucket APIs of our self-hosted services. Instead, we require the use of Bearer Auth using a PAT by the users.

A background information for this is that, that your security policy requires 2FA or alternatively tokens, password authentication without a 2nd factor as implemented in HTTP Basic Authentication is prohibited by company security policy, and therefore HTTP Basic Authentication is prohibited.

Also, by security policy, passwords have to be changed frequently, so even without that prohibition, password authentication would be very cumbersome as frequent changes result in frequent breakdown of the Atlascode login in VS Code.

Right now, the Atlascloud plugin supports authenticating to Jira using PAT because of a requirement by a customer, but the same has not been extended to Bitbucket, it only supports using username/password (Basic Authentication).

Therfore, we use [Personal Access Tokens](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) with Bearer authentication. This is an example with curl as client:

curl -v --oauth2-bearer $PAT https://<self-hosted bitbucket server>/rest/api/1.0/users/userslug?avatarSize=48

Bearer Authorization is already available in atlascode, but not yet enabled for Bitbucket, it just was requested for Jira and not for Bitbucket:
https://bitbucket.org/atlassianlabs/atlascode/issues/237/allow-saml-sso-as-authentication-method

All that remains for Atlascode is to allow Bearer Authorization for Bitbucket as well.

This is what this PR does. It adds the same option to alternatively use PAT auth for self-hosted Bitbucket like the Jira client of Atlascode already implements.

This is a transfer of my original PR from BitBucket to Github:
https://bitbucket.org/atlassianlabs/atlascode/pull-requests/1050/bitbucket-add-support-for-login-by-api
https://bitbucket.org/atlassianlabs/atlascode/issues/820/allow-authentication-method-pat-personal
Users that approved or wanted this PR as well: Jeff Byrnes, Sham Garud, Mark Turner, Vladyslav Zuiev, Remy Even