### PR TITLE
[AXON-31] (PR-5 to minimize merge conflicts) Unit testing setup + URI handler rework

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+module.exports = {
+    ...require('jest-mock-vscode').createVSCodeMock(jest),
+    env: {
+        uriScheme: 'vscode'
+    }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    roots: ['<rootDir>/src'],
+    roots: ['<rootDir>'],
     testMatch: ['**/test/**/*.+(ts|tsx|js)', '**/?(*.)+(spec|test).+(ts|tsx|js)'],
     transform: {
         '^.+\\.(min.js|ts|tsx)$': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,7 @@
                 "fork-ts-checker-webpack-plugin": "^9.0.2",
                 "html-webpack-plugin": "^5.6.0",
                 "jest": "^29.7.0",
+                "jest-mock-vscode": "^4.0.4",
                 "license-checker": "^25.0.1",
                 "mini-css-extract-plugin": "^2.9.1",
                 "npm-run-all": "^4.1.5",
@@ -18768,6 +18769,22 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/jest-mock-vscode": {
+            "version": "4.0.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jest-mock-vscode/-/jest-mock-vscode-4.0.4.tgz",
+            "integrity": "sha512-Mq9/sTcYjuYRIKJwYrPy29+oX5gkJcCbMoPl9m2lZbCAzJH7UasRJn42/oRE8XFwMSyLMJPmU4Uvx9vqjX0nRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vscode-uri": "^3.0.8"
+            },
+            "engines": {
+                "node": ">20.0.0"
+            },
+            "peerDependencies": {
+                "@types/vscode": "^1.90.0"
             }
         },
         "node_modules/jest-pnp-resolver": {
@@ -43033,6 +43050,15 @@
                         "has-flag": "^4.0.0"
                     }
                 }
+            }
+        },
+        "jest-mock-vscode": {
+            "version": "4.0.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jest-mock-vscode/-/jest-mock-vscode-4.0.4.tgz",
+            "integrity": "sha512-Mq9/sTcYjuYRIKJwYrPy29+oX5gkJcCbMoPl9m2lZbCAzJH7UasRJn42/oRE8XFwMSyLMJPmU4Uvx9vqjX0nRg==",
+            "dev": true,
+            "requires": {
+                "vscode-uri": "^3.0.8"
             }
         },
         "jest-pnp-resolver": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "vscode:uninstall": "node ./build/extension/uninstall.js",
         "vscode:prepublish": "npm run compile",
         "clean": "rm -rf ./build",
-        "format": "prettier --write . --log-level warn",
+        "format": "prettier --write --log-level warn src",
         "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
         "lint:fix": "eslint --fix ./src --ext .js,.jsx,.ts,.tsx",
         "compile:ui-test": "tsc --project tsconfig.ui-test.json",

--- a/package.json
+++ b/package.json
@@ -1521,6 +1521,7 @@
         "fork-ts-checker-webpack-plugin": "^9.0.2",
         "html-webpack-plugin": "^5.6.0",
         "jest": "^29.7.0",
+        "jest-mock-vscode": "^4.0.4",
         "license-checker": "^25.0.1",
         "mini-css-extract-plugin": "^2.9.1",
         "npm-run-all": "^4.1.5",

--- a/src/atlclients/authStore.ts
+++ b/src/atlclients/authStore.ts
@@ -26,7 +26,7 @@ import { Tokens } from './tokens';
 import crypto from 'crypto';
 import { keychain } from '../util/keychain';
 import { loggedOutEvent } from '../analytics';
-import { Container } from 'src/container';
+import { Container } from '../container';
 const keychainServiceNameV3 = version.endsWith('-insider') ? 'atlascode-insiders-authinfoV3' : 'atlascode-authinfoV3';
 
 enum Priority {

--- a/src/atlclients/oauthRefresher.ts
+++ b/src/atlclients/oauthRefresher.ts
@@ -6,7 +6,7 @@ import { AxiosUserAgent } from '../constants';
 import { ConnectionTimeout } from '../util/time';
 import { Container } from '../container';
 import { Disposable } from 'vscode';
-import { Logger } from 'src/logger';
+import { Logger } from '../logger';
 import { addCurlLogging } from './interceptors';
 import { getAgent } from '../jira/jira-client/providers';
 import { strategyForProvider } from './strategy';

--- a/src/bitbucket/checkoutHelper.ts
+++ b/src/bitbucket/checkoutHelper.ts
@@ -6,6 +6,7 @@ import { Logger } from '../logger';
 import { checkout } from '../views/pullrequest/gitActions';
 import { bitbucketSiteForRemote, clientForHostname } from './bbUtils';
 import { WorkspaceRepo } from './model';
+import { CheckoutHelper } from './interfaces';
 
 type RefInfo = {
     timestamp: number;
@@ -28,10 +29,16 @@ const RefInfoLifespanMs = 60 * 1000;
 /**
  * Methods for checking out branches and pulling repos given their urls and ref names.
  */
-export class CheckoutHelper {
+export class BitbucketCheckoutHelper implements CheckoutHelper {
     constructor(private globalState: Memento) {}
 
-    public async checkoutRef(cloneUrl: string, ref: string, refType: string, sourceCloneUrl = ''): Promise<boolean> {
+    public async checkoutRef(
+        cloneUrl: string,
+        ref: string,
+        refType: string,
+        sourceCloneUrl?: string,
+    ): Promise<boolean> {
+        sourceCloneUrl = sourceCloneUrl || '';
         let wsRepo = this.findRepoInCurrentWorkspace(cloneUrl);
         if (!wsRepo) {
             this.globalState.update(BitbucketRefInfoKey, {

--- a/src/bitbucket/interfaces.ts
+++ b/src/bitbucket/interfaces.ts
@@ -1,0 +1,19 @@
+// Bitbucket-related interfaces to reduce coupling
+
+/**
+ * Methods for checking out branches and pulling repos given their urls and ref names.
+ */
+export interface CheckoutHelper {
+    checkoutRef(cloneUrl: string, ref: string, refType: string, sourceCloneUrl?: string): Promise<boolean>;
+
+    /**
+     * If the user clicks a URL to check out a branch but that repo isn't checked out the extension will reload itself
+     * as part of the process of opening the repo. Call this method on startup to check to see if we should check out
+     * a branch.
+     */
+    completeBranchCheckOut(): Promise<void>;
+
+    cloneRepository(repoUrl: string): Promise<void>;
+
+    pullRequest(repoUrl: string, pullRequestId: number): Promise<void>;
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -9,7 +9,7 @@ import { AuthStatusBar } from './views/authStatusBar';
 import { BitbucketContext } from './bitbucket/bbContext';
 import { BitbucketIssueAction } from './lib/ipc/fromUI/bbIssue';
 import { CancellationManager } from './lib/cancellation';
-import { CheckoutHelper } from './bitbucket/checkoutHelper';
+import { BitbucketCheckoutHelper } from './bitbucket/checkoutHelper';
 import { ClientManager } from './atlclients/clientManager';
 import { CommonActionMessageHandler } from './lib/webview/controller/common/commonActionMessageHandler';
 import { ConfigAction } from './lib/ipc/fromUI/config';
@@ -67,6 +67,7 @@ import { WelcomeAction } from './lib/ipc/fromUI/welcome';
 import { WelcomeInitMessage } from './lib/ipc/toUI/welcome';
 import { FeatureFlagClient } from './util/featureFlags';
 import { EventBuilder } from './util/featureFlags/eventBuilder';
+import { CheckoutHelper } from './bitbucket/interfaces';
 
 const isDebuggingRegex = /^--(debug|inspect)\b(-brk\b|(?!-))=?/;
 const ConfigTargetKey = 'configurationTarget';
@@ -187,7 +188,7 @@ export class Container {
         this._pmfStats = new PmfStats(context);
 
         this._loginManager = new LoginManager(this._credentialManager, this._siteManager, this._analyticsClient);
-        this._bitbucketHelper = new CheckoutHelper(context.globalState);
+        this._bitbucketHelper = new BitbucketCheckoutHelper(context.globalState);
         context.subscriptions.push(
             (this._uriHandler = new AtlascodeUriHandler(this._analyticsApi, this._bitbucketHelper)),
         );

--- a/src/jira/jira-client/providers.ts
+++ b/src/jira/jira-client/providers.ts
@@ -3,7 +3,7 @@ import { AgentProvider, getProxyHostAndPort, shouldTunnelHost } from '@atlassian
 import axios, { AxiosInstance } from 'axios';
 import * as fs from 'fs';
 import * as https from 'https';
-import { Logger } from 'src/logger';
+import { Logger } from '../../logger';
 import * as sslRootCas from 'ssl-root-cas';
 import { DetailedSiteInfo, SiteInfo } from '../../atlclients/authInfo';
 import { BasicInterceptor } from '../../atlclients/basicInterceptor';

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -2,7 +2,7 @@ import { ConfigSection, ConfigSubSection } from './lib/ipc/models/config';
 import { Disposable, Uri, UriHandler, env, window } from 'vscode';
 
 import { AnalyticsApi } from './lib/analyticsApi';
-import { CheckoutHelper } from './bitbucket/checkoutHelper';
+import { CheckoutHelper } from './bitbucket/interfaces';
 import { Container } from './container';
 import { Logger } from './logger';
 import { ProductJira } from './atlclients/authInfo';

--- a/src/uriHandler/actions/checkoutBranch.test.ts
+++ b/src/uriHandler/actions/checkoutBranch.test.ts
@@ -1,0 +1,47 @@
+import { Uri, window } from 'vscode';
+import { CheckoutBranchUriHandlerAction } from './checkoutBranch';
+
+describe('CheckoutBranchUriHandlerAction', () => {
+    const mockAnalyticsApi = {
+        fireDeepLinkEvent: jest.fn(),
+    };
+    const mockCheckoutHelper = {
+        checkoutRef: jest.fn().mockResolvedValue(true),
+    };
+    let action: CheckoutBranchUriHandlerAction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        action = new CheckoutBranchUriHandlerAction(mockCheckoutHelper as any, mockAnalyticsApi as any);
+    });
+
+    describe('handle', () => {
+        it('throws if required query params are missing', async () => {
+            await expect(action.handle(Uri.parse('https://some-uri/checkoutBranch'))).rejects.toThrow();
+            await expect(
+                action.handle(Uri.parse('https://some-uri/checkoutBranch?cloneUrl=...&ref=...')),
+            ).rejects.toThrow();
+            await expect(
+                action.handle(Uri.parse('https://some-uri/checkoutBranch?cloneUrl=...&refType=...')),
+            ).rejects.toThrow();
+            await expect(
+                action.handle(Uri.parse('https://some-uri/checkoutBranch?ref=...&refType=...')),
+            ).rejects.toThrow();
+        });
+
+        it('checks out the branch and fires an event on success', async () => {
+            mockCheckoutHelper.checkoutRef.mockResolvedValue(true);
+            await action.handle(Uri.parse('https://some-uri/checkoutBranch?cloneUrl=one&ref=two&refType=three'));
+
+            expect(mockCheckoutHelper.checkoutRef).toHaveBeenCalledWith('one', 'two', 'three', '');
+            expect(mockAnalyticsApi.fireDeepLinkEvent).toHaveBeenCalled();
+        });
+
+        it('shows an error message on failure', async () => {
+            mockCheckoutHelper.checkoutRef.mockRejectedValue(new Error('oh no'));
+            await action.handle(Uri.parse('https://some-uri/checkoutBranch?cloneUrl=one&ref=two&refType=three'));
+
+            expect(window.showErrorMessage).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/uriHandler/actions/checkoutBranch.ts
+++ b/src/uriHandler/actions/checkoutBranch.ts
@@ -1,0 +1,53 @@
+import { Uri, window } from 'vscode';
+import { isAcceptedBySuffix, UriHandlerAction } from '../uriHandlerAction';
+import { CheckoutHelper } from '../../bitbucket/interfaces';
+import { AnalyticsApi } from '../../lib/analyticsApi';
+import { Logger } from '../../logger';
+
+/**
+ * Use a deep link to checkout a branch
+ *
+ * Expected link:
+ * `vscode://atlassian.atlascode/checkoutBranch?cloneUrl=...&ref=...&refType=...`
+ *
+ * Query params:
+ * - `cloneUrl`: the clone URL of the repository
+ * - `ref`: the ref to check out
+ * - `refType`: the type of ref to check out
+ * - `sourceCloneUrl`: (optional) the clone URL of the source repository (for branches originating from a forked repo)
+ */
+export class CheckoutBranchUriHandlerAction implements UriHandlerAction {
+    constructor(
+        private bitbucketHelper: CheckoutHelper,
+        private analyticsApi: AnalyticsApi,
+    ) {}
+
+    isAccepted(uri: Uri): boolean {
+        return isAcceptedBySuffix(uri, 'checkoutBranch');
+    }
+
+    async handle(uri: Uri) {
+        const query = new URLSearchParams(uri.query);
+        const cloneUrl = decodeURIComponent(query.get('cloneUrl') || '');
+        const sourceCloneUrl = decodeURIComponent(query.get('sourceCloneUrl') || ''); //For branches originating from a forked repo
+        const ref = query.get('ref');
+        const refType = query.get('refType');
+        if (!ref || !cloneUrl || !refType) {
+            throw new Error(`Query params are missing data: ${query}`);
+        }
+
+        try {
+            const success = await this.bitbucketHelper.checkoutRef(cloneUrl, ref, refType, sourceCloneUrl);
+
+            if (success) {
+                this.analyticsApi.fireDeepLinkEvent(
+                    decodeURIComponent(query.get('source') || 'unknown'),
+                    'checkoutBranch',
+                );
+            }
+        } catch (e) {
+            Logger.debug('error checkout out branch:', e);
+            window.showErrorMessage('Error checkout out branch (check log for details)');
+        }
+    }
+}

--- a/src/uriHandler/actions/cloneRepository.test.ts
+++ b/src/uriHandler/actions/cloneRepository.test.ts
@@ -1,0 +1,45 @@
+import { Uri, window } from 'vscode';
+import { CloneRepositoryUriHandlerAction } from './cloneRepository';
+
+describe('CloneRepositoryUriHandlerAction', () => {
+    const mockAnalyticsApi = {
+        fireDeepLinkEvent: jest.fn(),
+    };
+    const mockCheckoutHelper = {
+        cloneRepository: jest.fn(),
+    };
+    let action: CloneRepositoryUriHandlerAction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        action = new CloneRepositoryUriHandlerAction(mockCheckoutHelper as any, mockAnalyticsApi as any);
+    });
+
+    describe('isAccepted', () => {
+        it('only accepts URIs ending with cloneRepository', () => {
+            expect(action.isAccepted(Uri.parse('https://some-uri/cloneRepository'))).toBe(true);
+            expect(action.isAccepted(Uri.parse('https://some-uri/otherThing'))).toBe(false);
+        });
+    });
+
+    describe('handle', () => {
+        it('throws if required query params are missing', async () => {
+            await expect(action.handle(Uri.parse('https://some-uri/cloneRepository'))).rejects.toThrow();
+        });
+
+        it('clones the repo and fires an event on success', async () => {
+            mockCheckoutHelper.cloneRepository.mockResolvedValue(null);
+            await action.handle(Uri.parse('https://some-uri/cloneRepository?q=one'));
+
+            expect(mockCheckoutHelper.cloneRepository).toHaveBeenCalledWith('one');
+            expect(mockAnalyticsApi.fireDeepLinkEvent).toHaveBeenCalled();
+        });
+
+        it('shows an error message on failure', async () => {
+            mockCheckoutHelper.cloneRepository.mockRejectedValue(new Error('oh no'));
+            await action.handle(Uri.parse('https://some-uri/cloneRepository?q=one'));
+
+            expect(window.showErrorMessage).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/uriHandler/actions/cloneRepository.ts
+++ b/src/uriHandler/actions/cloneRepository.ts
@@ -1,0 +1,44 @@
+import { Uri, window } from 'vscode';
+import { isAcceptedBySuffix, UriHandlerAction } from '../uriHandlerAction';
+import { CheckoutHelper } from '../../bitbucket/interfaces';
+import { AnalyticsApi } from '../../lib/analyticsApi';
+import { Logger } from '../../logger';
+
+/**
+ * Use a deep link to clone a repository
+ *
+ * Expected link:
+ * `vscode://atlassian.atlascode/cloneRepository?q=...`
+ *
+ * Query params:
+ * - `q`: the clone URL of the repository
+ */
+export class CloneRepositoryUriHandlerAction implements UriHandlerAction {
+    constructor(
+        private bitbucketHelper: CheckoutHelper,
+        private analyticsApi: AnalyticsApi,
+    ) {}
+
+    isAccepted(uri: Uri): boolean {
+        return isAcceptedBySuffix(uri, 'cloneRepository');
+    }
+
+    async handle(uri: Uri) {
+        const query = new URLSearchParams(uri.query);
+        const repoUrl = decodeURIComponent(query.get('q') || '');
+        if (!repoUrl) {
+            throw new Error(`Cannot parse clone URL from: ${query}`);
+        }
+
+        try {
+            await this.bitbucketHelper.cloneRepository(repoUrl);
+            this.analyticsApi.fireDeepLinkEvent(
+                decodeURIComponent(query.get('source') || 'unknown'),
+                'cloneRepository',
+            );
+        } catch (e) {
+            Logger.debug('error cloning repository:', e);
+            window.showErrorMessage('Error cloning repository (check log for details)');
+        }
+    }
+}

--- a/src/uriHandler/actions/openPullRequest.test.ts
+++ b/src/uriHandler/actions/openPullRequest.test.ts
@@ -1,0 +1,70 @@
+import { Uri, window } from 'vscode';
+import { OpenPullRequestUriHandlerAction } from './openPullRequest';
+
+describe('OpenPullRequestUriHandlerAction', () => {
+    let action: OpenPullRequestUriHandlerAction;
+    const mockAnalyticsApi = {
+        fireDeepLinkEvent: jest.fn(),
+    };
+    const mockCheckoutHelper = {
+        pullRequest: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        action = new OpenPullRequestUriHandlerAction(mockAnalyticsApi as any, mockCheckoutHelper as any);
+    });
+
+    describe('isAccepted', () => {
+        it('only accepts URIs ending with openPullRequest', () => {
+            expect(action.isAccepted(Uri.parse('https://some-uri/openPullRequest'))).toBe(true);
+            expect(action.isAccepted(Uri.parse('https://some-uri/otherThing'))).toBe(false);
+        });
+    });
+
+    describe('parsePrUrl', () => {
+        it('extracts the repo url and pr number from a URL', () => {
+            expect(action.parsePrUrl('https://bitbucket.com/my-cool-repo/pull-requests/123')).toEqual({
+                repoUrl: 'https://bitbucket.com/my-cool-repo',
+                prId: 123,
+            });
+
+            // This will actually fail with the current implementation:
+            // expect(action.parsePrUrl('https://bitbucket.com/my-cool-repo/pull-requests/123/overview')).toEqual({
+            //     repoUrl: 'https://bitbucket.com/my-cool-repo',
+            //     prId: 123
+            // });
+        });
+    });
+
+    describe('handle', () => {
+        it('throws if required query params are missing', async () => {
+            await expect(action.handle(Uri.parse('https://some-uri/openPullRequest'))).rejects.toThrow();
+        });
+
+        it('throws if repo URL fails to parse', async () => {
+            action.parsePrUrl = jest.fn().mockImplementation(() => {
+                throw new Error('oh no');
+            });
+            await expect(action.handle(Uri.parse('https://some-uri/openPullRequest?q=...'))).rejects.toThrow();
+        });
+
+        it('opens a pull request and fires an event on success', async () => {
+            mockCheckoutHelper.pullRequest.mockResolvedValue(true);
+            action.parsePrUrl = jest.fn().mockReturnValue({ repoUrl: 'one', prId: 2 });
+            await action.handle(Uri.parse('https://some-uri/openPullRequest?q=one'));
+
+            expect(mockCheckoutHelper.pullRequest).toHaveBeenCalledWith('one', 2);
+            expect(mockAnalyticsApi.fireDeepLinkEvent).toHaveBeenCalled();
+        });
+
+        it('shows an error message on failure', async () => {
+            mockCheckoutHelper.pullRequest.mockRejectedValue(new Error('oh no'));
+            await action.handle(Uri.parse('https://some-uri/openPullRequest?q=...'));
+            action.parsePrUrl = jest.fn().mockReturnValue({ repoUrl: 'one', prId: 2 });
+
+            // This will actually fail with the current implementation:
+            expect(window.showErrorMessage).toHaveBeenCalledWith('Error opening pull request (check log for details)');
+        });
+    });
+});

--- a/src/uriHandler/actions/openPullRequest.ts
+++ b/src/uriHandler/actions/openPullRequest.ts
@@ -1,0 +1,52 @@
+import { Uri, window } from 'vscode';
+import { Logger } from '../../logger';
+import { UriHandlerAction } from '../uriHandlerAction';
+import { AnalyticsApi } from '../../lib/analyticsApi';
+import { CheckoutHelper } from '../../bitbucket/interfaces';
+
+/**
+ * Use a deep link to open pull request
+ *
+ * Expected link:
+ * `vscode://atlassian.atlascode/openPullRequest?q=...[&source=...]`
+ *
+ * Query params:
+ * - `q`: the pull request URL
+ * - `source`: (optional) the source of the deep link
+ */
+export class OpenPullRequestUriHandlerAction implements UriHandlerAction {
+    constructor(
+        private analyticsApi: AnalyticsApi,
+        private bitbucketHelper: CheckoutHelper,
+    ) {}
+
+    isAccepted(uri: Uri): boolean {
+        return uri.path.endsWith('openPullRequest');
+    }
+
+    async handle(uri: Uri) {
+        const query = new URLSearchParams(uri.query);
+        const source = decodeURIComponent(query.get('source') || 'unknown');
+        const prUrl = decodeURIComponent(query.get('q') || '');
+        const { repoUrl, prId } = this.parsePrUrl(prUrl);
+        if (!prUrl) {
+            throw new Error(`Cannot parse pull request URL from: ${query}`);
+        }
+
+        try {
+            await this.bitbucketHelper.pullRequest(repoUrl, prId);
+            this.analyticsApi.fireDeepLinkEvent(source, 'pullRequest');
+        } catch (e) {
+            Logger.debug('error opening pull request:', e);
+            window.showErrorMessage('Error opening pull request (check log for details)');
+        }
+    }
+
+    parsePrUrl(url: string): { repoUrl: string; prId: number } {
+        // TODO: this feels very sketchy. Redo in a follow-up using a proper URL parser and some regex?
+        const repoUrl = url.slice(0, url.indexOf('/pull-requests'));
+        const prUrlPath = Uri.parse(url).path;
+        const prId = prUrlPath.slice(prUrlPath.lastIndexOf('/') + 1);
+        return { repoUrl, prId: parseInt(prId) };
+    }
+}

--- a/src/uriHandler/actions/showJiraIssue.test.ts
+++ b/src/uriHandler/actions/showJiraIssue.test.ts
@@ -1,0 +1,54 @@
+import { Uri, window } from 'vscode';
+
+jest.mock('../../commands/jira/showIssue', () => ({
+    showIssue: jest.fn(),
+}));
+import { showIssue } from '../../commands/jira/showIssue';
+
+import { ShowJiraIssueUriHandlerAction } from './showJiraIssue';
+
+describe('ShowJiraIssueUriHandlerAction', () => {
+    const mockAnalyticsApi = {
+        fireDeepLinkEvent: jest.fn(),
+    };
+    const mockFetcher = {
+        fetchIssue: jest.fn(),
+    };
+    let action: ShowJiraIssueUriHandlerAction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        action = new ShowJiraIssueUriHandlerAction(mockAnalyticsApi as any, mockFetcher as any);
+    });
+
+    describe('isAccepted', () => {
+        it('only accepts URIs ending with showJiraIssue', () => {
+            expect(action.isAccepted(Uri.parse('https://some-uri/showJiraIssue'))).toBe(true);
+            expect(action.isAccepted(Uri.parse('https://some-uri/otherThing'))).toBe(false);
+        });
+    });
+
+    describe('handle', () => {
+        it('throws if required query params are missing', async () => {
+            await expect(action.handle(Uri.parse('https://some-uri/showJiraIssue'))).rejects.toThrow();
+            await expect(
+                action.handle(Uri.parse('https://some-uri/showJiraIssue?issueKey=AXON-123')),
+            ).rejects.toThrow();
+        });
+
+        it('shows error if the issue could not be fetched', async () => {
+            mockFetcher.fetchIssue.mockRejectedValue(new Error('oh no'));
+            await expect(
+                action.handle(Uri.parse('https://some-uri/showJiraIssue?issueKey=AXON-123&site=jira')),
+            ).resolves.toBeUndefined();
+            expect(window.showErrorMessage).toHaveBeenCalled();
+        });
+
+        it('shows the Jira issue and fires an analytics event if everything is good', async () => {
+            mockFetcher.fetchIssue.mockResolvedValue({ some: 'issue' });
+            await action.handle(Uri.parse('https://some-uri/showJiraIssue?issueKey=AXON-123&site=jira'));
+            expect(showIssue).toHaveBeenCalledWith({ some: 'issue' });
+            expect(mockAnalyticsApi.fireDeepLinkEvent).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/uriHandler/actions/showJiraIssue.ts
+++ b/src/uriHandler/actions/showJiraIssue.ts
@@ -1,0 +1,46 @@
+import { Uri, window } from 'vscode';
+import { UriHandlerAction } from '../uriHandlerAction';
+import { Logger } from '../../logger';
+import { AnalyticsApi } from '../../lib/analyticsApi';
+import { showIssue } from '../../commands/jira/showIssue';
+import { JiraIssueFetcher } from './util/jiraIssueFetcher';
+
+/**
+ * Use a deep link to show a Jira issue
+ *
+ * Expected link:
+ * vscode://atlassian.atlascode/showJiraIssue?site=...&issueKey=...
+ *
+ * Query params:
+ * - `site`: the site base URL, like `https://site.atlassian.net`
+ * - `issueKey`: the issue key, like `PROJ-123`
+ */
+export class ShowJiraIssueUriHandlerAction implements UriHandlerAction {
+    constructor(
+        private analyticsApi: AnalyticsApi,
+        private issueFetcher: JiraIssueFetcher,
+    ) {}
+
+    isAccepted(uri: Uri): boolean {
+        return uri.path.endsWith('showJiraIssue');
+    }
+
+    async handle(uri: Uri) {
+        const query = new URLSearchParams(uri.query);
+        const siteBaseURL = query.get('site');
+        const issueKey = query.get('issueKey');
+
+        if (!siteBaseURL || !issueKey) {
+            throw new Error(`Cannot parse request URL from: ${query}`);
+        }
+
+        try {
+            const issue = await this.issueFetcher.fetchIssue(issueKey, siteBaseURL);
+            showIssue(issue);
+            this.analyticsApi.fireDeepLinkEvent(decodeURIComponent(query.get('source') || 'unknown'), 'showJiraIssue');
+        } catch (e) {
+            Logger.debug('error opening issue page:', e);
+            window.showErrorMessage('Error opening issue page (check log for details)');
+        }
+    }
+}

--- a/src/uriHandler/actions/simpleCallback.test.ts
+++ b/src/uriHandler/actions/simpleCallback.test.ts
@@ -1,0 +1,26 @@
+import { Uri } from 'vscode';
+import { SimpleCallbackAction } from './simpleCallback';
+
+describe('OpenSettingsUriHandlerAction', () => {
+    const suffix = 'cool-callback';
+    const callback = jest.fn();
+    const action = new SimpleCallbackAction(suffix, callback);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('isAccepted', () => {
+        it('only accepts URIs ending with openSettings', () => {
+            expect(action.isAccepted(Uri.parse(`https://some-uri/${suffix}`))).toBe(true);
+            expect(action.isAccepted(Uri.parse('https://some-uri/otherThing'))).toBe(false);
+        });
+    });
+
+    describe('handle', () => {
+        it('calls the callback', async () => {
+            await action.handle(Uri.parse('https://some-uri/openSettings'));
+            expect(callback).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/uriHandler/actions/simpleCallback.ts
+++ b/src/uriHandler/actions/simpleCallback.ts
@@ -1,0 +1,26 @@
+import { Uri } from 'vscode';
+import { UriHandlerAction } from '../uriHandlerAction';
+
+/**
+ * Use a deep link to trigger a callback
+ *
+ * Expected link:
+ * vscode://atlassian.atlascode/[uriSuffix]
+ *
+ * Query params:
+ * - none
+ */
+export class SimpleCallbackAction implements UriHandlerAction {
+    constructor(
+        private uriSuffix: string,
+        private callback: () => Promise<void>,
+    ) {}
+
+    isAccepted(uri: Uri): boolean {
+        return uri.path.endsWith(this.uriSuffix);
+    }
+
+    async handle(uri: Uri): Promise<void> {
+        return await this.callback();
+    }
+}

--- a/src/uriHandler/actions/startWork.test.ts
+++ b/src/uriHandler/actions/startWork.test.ts
@@ -1,0 +1,52 @@
+import { Uri, window } from 'vscode';
+
+const mockStartWork = jest.fn();
+jest.mock('../../commands/jira/startWorkOnIssue', () => ({
+    startWorkOnIssue: mockStartWork,
+}));
+import { StartWorkUriHandlerAction } from './startWork';
+
+describe('StartWorkAction', () => {
+    const mockAnalyticsApi = {
+        fireDeepLinkEvent: jest.fn(),
+    };
+    const mockFetcher = {
+        fetchIssue: jest.fn(),
+    };
+    let action: StartWorkUriHandlerAction;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        action = new StartWorkUriHandlerAction(mockAnalyticsApi as any, mockFetcher as any);
+    });
+
+    describe('isAccepted', () => {
+        it('only accepts URIs ending with startWorkOnJiraIssue', () => {
+            expect(action.isAccepted(Uri.parse('https://some-uri/startWorkOnJiraIssue'))).toBe(true);
+            expect(action.isAccepted(Uri.parse('https://some-uri/otherThing'))).toBe(false);
+        });
+    });
+
+    describe('handle', () => {
+        it('throws if required query params are missing', async () => {
+            await expect(action.handle(Uri.parse('https://some-uri/startWork'))).rejects.toThrow();
+            await expect(action.handle(Uri.parse('https://some-uri/startWork?issueKey=AXON-123'))).rejects.toThrow();
+            await expect(action.handle(Uri.parse('https://some-uri/startWork?site=localhost'))).rejects.toThrow();
+        });
+
+        it('shows error if the issue could not be fetched', async () => {
+            mockFetcher.fetchIssue.mockRejectedValue(new Error('oh no'));
+            await expect(
+                action.handle(Uri.parse('https://some-uri/startWork?issueKey=AXON-123&site=localhost')),
+            ).resolves.toBeUndefined();
+            expect(window.showErrorMessage).toHaveBeenCalled();
+        });
+
+        it('shows the Start Work view, and fires an analytics event if everything is good', async () => {
+            mockFetcher.fetchIssue.mockResolvedValue({ some: 'issue' });
+            await action.handle(Uri.parse('https://some-uri/startWork?issueKey=AXON-123&site=localhost'));
+            expect(mockStartWork).toHaveBeenCalledWith({ some: 'issue' });
+            expect(mockAnalyticsApi.fireDeepLinkEvent).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/uriHandler/actions/startWork.ts
+++ b/src/uriHandler/actions/startWork.ts
@@ -1,0 +1,51 @@
+import { Uri, window } from 'vscode';
+import { UriHandlerAction } from '../uriHandlerAction';
+import { startWorkOnIssue } from '../../commands/jira/startWorkOnIssue';
+import { AnalyticsApi } from '../../lib/analyticsApi';
+import { Logger } from '../../logger';
+import { JiraIssueFetcher } from './util/jiraIssueFetcher';
+
+/**
+ * Use a deep link to start work on a Jira issue
+ *
+ * Expected link:
+ * vscode://atlassian.atlascode/startWorkOnJiraIssue?site=...&issueKey=...
+ *
+ * Query params:
+ * - `site`: the site base URL, like `https://site.atlassian.net`
+ * - `issueKey`: the issue key, like `PROJ-123`
+ */
+export class StartWorkUriHandlerAction implements UriHandlerAction {
+    constructor(
+        private analyticsApi: AnalyticsApi,
+        private issueFetcher: JiraIssueFetcher,
+    ) {}
+
+    isAccepted(uri: Uri): boolean {
+        return uri.path.endsWith('startWorkOnJiraIssue');
+    }
+
+    async handle(uri: Uri) {
+        const query = new URLSearchParams(uri.query);
+        const siteBaseURL = query.get('site');
+        const issueKey = query.get('issueKey');
+        // const aaid = query.get('aaid'); aaid is not currently used for anything is included in the url and may be useful to have in the future
+
+        if (!siteBaseURL || !issueKey) {
+            throw new Error(`Cannot parse request URL from: ${query}`);
+        }
+
+        try {
+            const issue = await this.issueFetcher.fetchIssue(issueKey, siteBaseURL);
+            startWorkOnIssue(issue);
+
+            this.analyticsApi.fireDeepLinkEvent(
+                decodeURIComponent(query.get('source') || 'unknown'),
+                'startWorkOnJiraIssue',
+            );
+        } catch (e) {
+            Logger.debug('error opening start work page:', e);
+            window.showErrorMessage('Error opening start work page (check log for details)');
+        }
+    }
+}

--- a/src/uriHandler/actions/util/jiraIssueFetcher.test.ts
+++ b/src/uriHandler/actions/util/jiraIssueFetcher.test.ts
@@ -1,0 +1,104 @@
+import { window } from 'vscode';
+
+const mockSiteInfo = {
+    id: 'one',
+    baseLinkUrl: 'https://jira.com',
+    isCloud: true,
+};
+
+const mockFindIssue = jest.fn();
+const mockFetchIssue = jest.fn();
+
+jest.mock('../../../jira/fetchIssue', () => ({
+    fetchMinimalIssue: mockFetchIssue,
+}));
+
+jest.mock('../../../container', () => ({
+    Container: {
+        siteManager: {
+            getSitesAvailable: jest.fn().mockImplementation(() => [mockSiteInfo]),
+        },
+        settingsWebviewFactory: {
+            createOrShow: jest.fn(),
+        },
+        jiraExplorer: {
+            findIssue: mockFindIssue,
+        },
+    },
+}));
+import { Container } from '../../../container';
+import { JiraIssueFetcher } from './jiraIssueFetcher';
+
+describe('JiraIssueFetcher', () => {
+    let fetcher: JiraIssueFetcher;
+    const mockShowInformationMessage: jest.Mock = window.showInformationMessage as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        fetcher = new JiraIssueFetcher();
+    });
+
+    describe('fetchIssue', () => {
+        it('fetches the issue if found', async () => {
+            fetcher.findMatchingSite = jest.fn().mockReturnValue(mockSiteInfo);
+            fetcher.findIssueOnSite = jest.fn().mockResolvedValue({ issue: 'found' });
+            await expect(fetcher.fetchIssue('AXON-123', 'https://jira.com')).resolves.toEqual({ issue: 'found' });
+        });
+
+        it('throws an error if the site is not found', async () => {
+            fetcher.findMatchingSite = jest.fn().mockReturnValue(undefined);
+            await expect(fetcher.fetchIssue('AXON-123', 'https://github.com')).rejects.toThrowError();
+        });
+
+        it('throws an error if the issue is not found', async () => {
+            fetcher.findMatchingSite = jest.fn().mockReturnValue(mockSiteInfo);
+            fetcher.findIssueOnSite = jest.fn().mockResolvedValue(undefined);
+            await expect(fetcher.fetchIssue('AXON-123', 'https://jira.com')).rejects.toThrowError();
+        });
+    });
+
+    describe('findMatchingSite', () => {
+        it('returns the matching site if found', () => {
+            expect(fetcher.findMatchingSite('jira')).toBe(mockSiteInfo);
+        });
+
+        it('returns undefined if no matching site is found', () => {
+            expect(fetcher.findMatchingSite('github')).toBeUndefined();
+        });
+    });
+
+    describe('findIssueOnSite', () => {
+        it('returns the issue if found', async () => {
+            mockFindIssue.mockResolvedValue({ issue: 'found' });
+            mockFetchIssue.mockResolvedValue({ issue: 'found' });
+            await expect(fetcher.findIssueOnSite('AXON-123', mockSiteInfo as any)).resolves.toEqual({ issue: 'found' });
+        });
+
+        it('returns undefined if the issue is not found', async () => {
+            mockFindIssue.mockResolvedValue({ issue: 'found' });
+            mockFetchIssue.mockResolvedValue(undefined);
+            await expect(fetcher.findIssueOnSite('AXON-123', mockSiteInfo as any)).resolves.toBeUndefined();
+        });
+
+        it('returns undefined if the issue failed to fetch', async () => {
+            mockFindIssue.mockResolvedValue(undefined);
+            await expect(fetcher.findIssueOnSite('AXON-123', mockSiteInfo as any)).resolves.toBeUndefined();
+        });
+    });
+
+    describe('handleSiteNotFound', () => {
+        it('shows settings if the user selects `Open oauth settings`', async () => {
+            mockShowInformationMessage.mockResolvedValue('Open auth settings');
+            await expect(fetcher.handleSiteNotFound('AXON-123', 'https://jira.com')).resolves.toBeUndefined();
+            expect(mockShowInformationMessage).toHaveBeenCalled();
+            expect(Container.settingsWebviewFactory.createOrShow).toHaveBeenCalled();
+        });
+
+        it('does nothing otherwise', async () => {
+            mockShowInformationMessage.mockResolvedValue('literally anything else');
+            await expect(fetcher.handleSiteNotFound('AXON-123', 'https://jira.com')).resolves.toBeUndefined();
+            expect(mockShowInformationMessage).toHaveBeenCalled();
+            expect(Container.settingsWebviewFactory.createOrShow).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/uriHandler/actions/util/jiraIssueFetcher.ts
+++ b/src/uriHandler/actions/util/jiraIssueFetcher.ts
@@ -1,0 +1,58 @@
+import { DetailedSiteInfo, ProductJira } from '../../../atlclients/authInfo';
+import { Container } from '../../../container';
+import { fetchMinimalIssue } from '../../../jira/fetchIssue';
+import { ConfigSection, ConfigSubSection } from '../../../lib/ipc/models/config';
+import { window } from 'vscode';
+
+// Common logic that's shared between multiple actions that deal with Jira issues
+export class JiraIssueFetcher {
+    // Resolves the site that matches the given siteBaseURL,
+    // finds the issue on that site and returns it
+    // Throws an error if anything goes wrong
+    async fetchIssue(issueKey: string, siteBaseURL: string) {
+        const site = this.findMatchingSite(siteBaseURL);
+        if (!site) {
+            this.handleSiteNotFound(issueKey, siteBaseURL);
+            throw new Error(`Could not find auth details for ${siteBaseURL}`);
+        }
+
+        const issue = await this.findIssueOnSite(issueKey, site);
+        if (!issue) {
+            throw new Error(`Could not fetch issue: ${issueKey}`);
+        }
+
+        return issue;
+    }
+
+    async findIssueOnSite(issueKey: string, site: DetailedSiteInfo) {
+        let foundIssue = await Container.jiraExplorer.findIssue(issueKey);
+        if (foundIssue) {
+            return await fetchMinimalIssue(issueKey, site);
+        }
+
+        return undefined;
+    }
+
+    async handleSiteNotFound(issueKey: string, siteBaseURL: string) {
+        await window
+            .showInformationMessage(
+                `Cannot open ${issueKey} because site '${siteBaseURL}' is not authenticated. Please authenticate and try again.`,
+                'Open auth settings',
+            )
+            .then((userChoice) => {
+                if (userChoice === 'Open auth settings') {
+                    Container.settingsWebviewFactory.createOrShow({
+                        section: ConfigSection.Jira,
+                        subSection: ConfigSubSection.Auth,
+                    });
+                }
+            });
+    }
+
+    findMatchingSite(siteBaseURL: string): DetailedSiteInfo | undefined {
+        const jiraSitesAvailable = Container.siteManager.getSitesAvailable(ProductJira);
+        return jiraSitesAvailable.find(
+            (availableSite) => availableSite.isCloud && availableSite.baseLinkUrl.includes(siteBaseURL),
+        );
+    }
+}

--- a/src/uriHandler/atlascodeUriHandler.test.ts
+++ b/src/uriHandler/atlascodeUriHandler.test.ts
@@ -1,0 +1,61 @@
+import { AtlascodeUriHandler } from './atlascodeUriHandler';
+import { Uri, window } from 'vscode';
+
+describe('AtlascodeUriHandler', () => {
+    const mockDispose = jest.fn();
+    const mockShowErrorMessage = jest.fn();
+    const mockRegisterUriHandler = jest.fn().mockImplementation(() => ({ dispose: mockDispose }));
+
+    const uri = Uri.parse('https://some-uri');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        window.showErrorMessage = mockShowErrorMessage;
+        window.registerUriHandler = mockRegisterUriHandler;
+    });
+
+    describe('create', () => {
+        it('should create a new instance', () => {
+            const uriHandler = AtlascodeUriHandler.create({} as any, {} as any);
+            expect(uriHandler).not.toBeNull();
+            expect(uriHandler).toBeInstanceOf(AtlascodeUriHandler);
+        });
+    });
+
+    describe('handleUri', () => {
+        it('shows error if the right action is not found', async () => {
+            const uriHandler = new AtlascodeUriHandler([]);
+            await uriHandler.handleUri(uri);
+            expect(mockShowErrorMessage).toHaveBeenCalled();
+        });
+
+        it('shows error if action is found, but throws', async () => {
+            const action = {
+                isAccepted: jest.fn().mockReturnValue(true),
+                handle: jest.fn().mockRejectedValue(new Error('oh no')),
+            };
+            const uriHandler = new AtlascodeUriHandler([action]);
+            await uriHandler.handleUri(uri);
+            expect(action.handle).toHaveBeenCalled();
+            expect(mockShowErrorMessage).toHaveBeenCalled();
+        });
+
+        it('executes the action if found', async () => {
+            const action = {
+                isAccepted: jest.fn().mockReturnValue(true),
+                handle: jest.fn().mockResolvedValue(undefined),
+            };
+            const uriHandler = new AtlascodeUriHandler([action]);
+            await uriHandler.handleUri(uri);
+            expect(action.handle).toHaveBeenCalled();
+        });
+    });
+
+    describe('dispose', () => {
+        it('should dispose the uri handler', () => {
+            const uriHandler = new AtlascodeUriHandler([]);
+            uriHandler.dispose();
+            expect(mockDispose).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/uriHandler/atlascodeUriHandler.ts
+++ b/src/uriHandler/atlascodeUriHandler.ts
@@ -1,0 +1,62 @@
+import { CheckoutBranchUriHandlerAction } from './actions/checkoutBranch';
+import { CloneRepositoryUriHandlerAction } from './actions/cloneRepository';
+import { OpenPullRequestUriHandlerAction } from './actions/openPullRequest';
+import { SimpleCallbackAction } from './actions/simpleCallback';
+import { ShowJiraIssueUriHandlerAction } from './actions/showJiraIssue';
+import { StartWorkUriHandlerAction } from './actions/startWork';
+import { UriHandlerAction } from './uriHandlerAction';
+import { AnalyticsApi } from '../lib/analyticsApi';
+import { CheckoutHelper } from '../bitbucket/interfaces';
+import { Uri, UriHandler, window, Disposable } from 'vscode';
+import { Logger } from '../logger';
+import { JiraIssueFetcher } from './actions/util/jiraIssueFetcher';
+import { Container } from '../container';
+
+export class AtlascodeUriHandler implements Disposable, UriHandler {
+    private disposables: Disposable;
+
+    constructor(private actions: Array<UriHandlerAction>) {
+        this.disposables = window.registerUriHandler(this);
+    }
+
+    async handleUri(uri: Uri) {
+        Logger.debug(`Handling URI (new router): ${uri.toString()}`);
+
+        // TODO: keeping the exact logic of the original code for now,
+        //       since changing this would need a lot of manual E2E testing.
+        //       We could probably simplify this to a route map?
+        const action = this.actions.find((h) => h.isAccepted(uri));
+        if (!action) {
+            Logger.debug(`Unsupported URI path: ${uri.path}`);
+            window.showErrorMessage(`Handler not found for URI: ${uri.toString()}`);
+            return;
+        }
+
+        try {
+            await action.handle(uri);
+        } catch (e) {
+            Logger.debug('Error handling URI:', e);
+            window.showErrorMessage(`Error handling URI: ${uri.toString()}. Check log for details`);
+        }
+    }
+
+    dispose(): void {
+        this.disposables.dispose();
+    }
+
+    static create(
+        analyticsApi: AnalyticsApi,
+        bitbucketHelper: CheckoutHelper,
+        jiraIssueFetcher: JiraIssueFetcher = new JiraIssueFetcher(),
+    ) {
+        return new AtlascodeUriHandler([
+            new SimpleCallbackAction('openSettings', () => Container.settingsWebviewFactory.createOrShow()),
+            new SimpleCallbackAction('openOnboarding', () => Container.onboardingWebviewFactory.createOrShow()),
+            new CheckoutBranchUriHandlerAction(bitbucketHelper, analyticsApi),
+            new OpenPullRequestUriHandlerAction(analyticsApi, bitbucketHelper),
+            new CloneRepositoryUriHandlerAction(bitbucketHelper, analyticsApi),
+            new StartWorkUriHandlerAction(analyticsApi, jiraIssueFetcher),
+            new ShowJiraIssueUriHandlerAction(analyticsApi, jiraIssueFetcher),
+        ]);
+    }
+}

--- a/src/uriHandler/index.ts
+++ b/src/uriHandler/index.ts
@@ -1,0 +1,3 @@
+import { AtlascodeUriHandler } from './atlascodeUriHandler';
+
+export { AtlascodeUriHandler };

--- a/src/uriHandler/legacyUriHandler.ts
+++ b/src/uriHandler/legacyUriHandler.ts
@@ -1,14 +1,14 @@
-import { ConfigSection, ConfigSubSection } from './lib/ipc/models/config';
+import { ConfigSection, ConfigSubSection } from '../lib/ipc/models/config';
 import { Disposable, Uri, UriHandler, env, window } from 'vscode';
 
-import { AnalyticsApi } from './lib/analyticsApi';
-import { CheckoutHelper } from './bitbucket/interfaces';
-import { Container } from './container';
-import { Logger } from './logger';
-import { ProductJira } from './atlclients/authInfo';
-import { fetchMinimalIssue } from './jira/fetchIssue';
-import { showIssue } from './commands/jira/showIssue';
-import { startWorkOnIssue } from './commands/jira/startWorkOnIssue';
+import { AnalyticsApi } from '../lib/analyticsApi';
+import { CheckoutHelper } from '../bitbucket/interfaces';
+import { Container } from '../container';
+import { Logger } from '../logger';
+import { ProductJira } from '../atlclients/authInfo';
+import { fetchMinimalIssue } from '../jira/fetchIssue';
+import { showIssue } from '../commands/jira/showIssue';
+import { startWorkOnIssue } from '../commands/jira/startWorkOnIssue';
 
 const ExtensionId = 'atlassian.atlascode';
 //const pullRequestUrl = `${env.uriScheme}://${ExtensionId}/openPullRequest`;
@@ -46,7 +46,8 @@ export const ONBOARDING_URL = `${env.uriScheme}://${ExtensionId}/openOnboarding`
  *      -- issueKey: issue key to show
  *      e.g. vscode://atlassian.atlascode/showJiraIssue?site=https%3A%2F%2Fsome-test-site.atlassian.net&issueKey=VSCODE-1320
  */
-export class AtlascodeUriHandler implements Disposable, UriHandler {
+
+export class LegacyAtlascodeUriHandler implements Disposable, UriHandler {
     private disposables: Disposable;
 
     constructor(

--- a/src/uriHandler/uriHandlerAction.test.ts
+++ b/src/uriHandler/uriHandlerAction.test.ts
@@ -1,0 +1,23 @@
+import { Uri } from 'vscode';
+import { isAcceptedBySuffix } from './uriHandlerAction';
+
+describe('isAcceptedBySuffix', () => {
+    const suffix = 'myCoolPath';
+    const check = (uriString: string) => isAcceptedBySuffix(Uri.parse(uriString), suffix);
+
+    it('returns true if the URI path ends with the suffix', () => {
+        // Regular URI
+        expect(check(`https://some-uri/${suffix}`)).toBe(true);
+        // Query is OK
+        expect(check(`https://some-uri/${suffix}?cloneUrl=...&ref=...&refType=...`)).toBe(true);
+        // No check on the host
+        expect(check(`https://some-other-uri/${suffix}`)).toBe(true);
+    });
+
+    it('returns false if the URI path does not end with the suffix', () => {
+        // No extra path
+        expect(check(`https://some-uri/${suffix}/somethingExtra`)).toBe(false);
+        // No other suffix
+        expect(check(`https://some-uri/somethingElse`)).toBe(false);
+    });
+});

--- a/src/uriHandler/uriHandlerAction.ts
+++ b/src/uriHandler/uriHandlerAction.ts
@@ -1,0 +1,16 @@
+import { Uri } from 'vscode';
+
+export function isAcceptedBySuffix(uri: Uri, suffix: string): boolean {
+    return uri.path.endsWith(suffix);
+}
+
+// Helper interface to route URIs to the correct action
+export interface UriHandlerAction {
+    // Return true if the URI is accepted by this action
+    // In that case, handle() will be called, and the URI
+    // will be considered handled by this action
+    isAccepted(uri: Uri): boolean;
+
+    // Handle the URI - put your logic here
+    handle(uri: Uri): Promise<void>;
+}

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -1,3 +1,4 @@
 export enum Features {
     EnableRemoteAuthentication = 'atlascode-enable-remote-authentication',
+    EnableNewUriHandler = 'atlascode-enable-new-uri-handler',
 }

--- a/src/webview/singleViewFactory.ts
+++ b/src/webview/singleViewFactory.ts
@@ -16,7 +16,7 @@ import { CommonMessageType } from '../lib/ipc/toUI/common';
 import { WebviewController } from '../lib/webview/controller/webviewController';
 import { UIWebsocket } from '../ws';
 import { VSCWebviewControllerFactory } from './vscWebviewControllerFactory';
-import { FeatureFlagClient } from 'src/util/featureFlags';
+import { FeatureFlagClient } from '../util/featureFlags';
 
 // ReactWebview is the interface for all basic webviews.
 // It takes FD as a generic type parameter that represents the type of "Factory Data" that will be

--- a/src/webview/startwork/vscStartWorkActionApi.ts
+++ b/src/webview/startwork/vscStartWorkActionApi.ts
@@ -1,5 +1,5 @@
 import { MinimalIssue, Transition } from '@atlassianlabs/jira-pi-common-models';
-import { Logger } from 'src/logger';
+import { Logger } from '../../logger';
 import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { clientForSite } from '../../bitbucket/bbUtils';
 import { Repo, WorkspaceRepo, emptyRepo } from '../../bitbucket/model';


### PR DESCRIPTION
### What is this?

Refactoring URI handler to prepare for the next steps in auth work.
 * Extract individual routes into handler actions
 * Cover everything with tests
 * Put the new implementation under a feature flag

This turned from a small bit of refactoring into a bit of an example of unit test setup for the `vscode` API ;D

### What's not in here?

A lot of the logic is deliberately left "as is", to track the changes a bit better in another PR:
 * Route lookup is suboptimal
 * URL handling is different across the actions (e.g. query parameters escaped or not)
 * Query handling in general could use some work
 * No new analytics events

However, I have included some small changes:
* A more consistent (but still suboptimal) error handling across actions
* Some common logic extracted into `CheckoutHelper` and `JiraIssueFetcher`

### How was this tested?

* All the standard CI stuff:
```
npm run lint # ok
npm run test # ok (and a lot more coverage now, lol)
npm run compile
```
* Tested the feature flag working as expected
* Tested some deep linking - but need to iterate a bit more exhaustively