### PR TITLE
[AXON-37] (PR-1) Fix .vscodeignore to not bloat the extension artifact

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,32 @@
+# Allowed:
+# build/
+# resources/
+# images/
+# LICENSE
+
+.env
+.env.example
+.eslintignore
+.mocharc.js
+.nvmrc
+.prettierignore
+CODEOWNERS
+HOMEPAGE.md
+changelog.md
+nightlyver.sh
+package.json
+readme.md
+setupTests.js
+tsconfig.notest.json
+tsconfig.ui-test.json
+ui-test-settings.json
+vscode-stylenames.txt
+.devcontainer/
+.github/
+.test-extensions/
+coverage/
+scripts/
+
 .vscode/**
 .vscode-test/**
 out/test/**


### PR DESCRIPTION
### What is this?

I've noticed that our extension artifact has become quite bloated - and the problem became 1000 times worse once I've tried creating a local cache for e2e tests :D

This should hopefully curtail the bloat ;)

| | Latest nightly (3.1.7) | After the fix |
|-|-|-|
| Size | 3.77 MB | 1.7 MB |
| Composition | ![image](https://github.com/user-attachments/assets/9c203fd7-34d0-4e90-b7ae-689711470145) | ![image](https://github.com/user-attachments/assets/677d1ade-1ff5-43ad-beb6-39ed556c3d2f) |

### How was this tested?

* _Not thoroughly_ - but I've installed the version and poked around a bunch to make sure that icons still work, and components don't look weird