### PR TITLE
[AXON-37] chore: add __mocks__ to vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,7 @@
 # images/
 # LICENSE
 
+__mocks__/
 .generated/
 e2e/
 .npm/


### PR DESCRIPTION
### What is this?

Small chore - prevent __mocks__ folder from being rolled into `.vsix` artifact

### How was this tested?

| Before (latest [build](https://github.com/atlassian/atlascode/actions/runs/12360487221/job/34495554628)) | After (`npm run extension:package` |
|-|-|
| ![image](https://github.com/user-attachments/assets/e50b4bba-c438-4b66-9c61-291ca05f384d) | ![image](https://github.com/user-attachments/assets/8b8d45ec-194d-4dbb-8d6e-4ff9541b65c8) |

