### PR TITLE
[AXON-38] chore: silence old linter warnings from React

### DIFF
--- a/src/react/atlascode/common/editor/MarkdownEditor.tsx
+++ b/src/react/atlascode/common/editor/MarkdownEditor.tsx
@@ -177,7 +177,7 @@ export const MarkdownEditor: React.FC<PropsType> = (props: PropsType) => {
             setContent('');
         }
         props.onCancel?.();
-    }, [enableRichTextEditor, props.onCancel]);
+    }, [enableRichTextEditor, props.onCancel]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleSave = useCallback(async () => {
         const mdContent: string = enableRichTextEditor ? mdSerializer.serialize(view.current!.state.doc) : content;

--- a/src/react/atlascode/common/form/useFormValidation.tsx
+++ b/src/react/atlascode/common/form/useFormValidation.tsx
@@ -228,7 +228,7 @@ export function useFormValidation<FieldTypes>(watch?: Partial<FieldTypes>): Form
     }
 
     return {
-        register: useCallback(register, []),
+        register: useCallback(register, []), // eslint-disable-line react-hooks/exhaustive-deps
         watches: watches.current,
         errors: errors.current,
         handleSubmit,

--- a/src/react/atlascode/config/auth/AuthDialog.tsx
+++ b/src/react/atlascode/config/auth/AuthDialog.tsx
@@ -203,8 +203,8 @@ export const AuthDialog: React.FunctionComponent<AuthDialogProps> = memo(
             [],
         );
 
-        const registerUrl = useCallback(register(validateStartsWithProtocol), []);
-        const registerRequiredString = useCallback(register(validateRequiredString), []);
+        const registerUrl = useCallback(register(validateStartsWithProtocol), []); // eslint-disable-line react-hooks/exhaustive-deps
+        const registerRequiredString = useCallback(register(validateRequiredString), []); // eslint-disable-line react-hooks/exhaustive-deps
         return (
             <Dialog fullWidth maxWidth="md" open={open} onExited={onExited}>
                 <DialogTitle>

--- a/src/react/atlascode/pipelines/PipelineSummaryPage.tsx
+++ b/src/react/atlascode/pipelines/PipelineSummaryPage.tsx
@@ -484,7 +484,7 @@ const PipelineSummaryPage: React.FunctionComponent = () => {
                 </div>
             );
         },
-        [classes.loglessStepHeader, classes.stepHeader, controller.fetchLogs, stepHeader],
+        [classes.loglessStepHeader, classes.stepHeader, controller.fetchLogs, stepHeader], // eslint-disable-line react-hooks/exhaustive-deps
     );
 
     const renderPipelineStep = useCallback(

--- a/src/react/atlascode/pullrequest/InlineRenderedTextEditor.tsx
+++ b/src/react/atlascode/pullrequest/InlineRenderedTextEditor.tsx
@@ -52,7 +52,7 @@ const InlineRenderedTextEditor: React.FC<InlineTextEditorProps> = (props: Inline
             await props.onSave?.(value);
             exitEditMode();
         },
-        [exitEditMode, props.onSave],
+        [exitEditMode, props.onSave], // eslint-disable-line react-hooks/exhaustive-deps
     );
 
     return editMode ? (

--- a/src/webviews/components/RenderedContent.tsx
+++ b/src/webviews/components/RenderedContent.tsx
@@ -34,7 +34,7 @@ export const RenderedContent: React.FC<Props> = (props: Props) => {
             },
             { capture: true },
         );
-    }, [props.fetchImage, ref]);
+    }, [props.fetchImage, ref]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return <p ref={ref} dangerouslySetInnerHTML={{ __html: props.html }} />;
 };


### PR DESCRIPTION
### What is this?

Edit: on second thought, __don't fix what's not broken__. I've tried making sure it all works - and quickly realized that I _really_ don't want to touch the old react code - at least not until we have reliable E2E tests. For now, I've just silenced the warnings instead. Hopefully eventually we rebuild the whole components where they appear

~My friend Copilot and I have just gone over the (very annoying) linter warnings :)~

~Unfortunately, I know basically nothing about the actual pages these bits of code renders - so some extra testing might be in order, especially for some of the fixes here 😢~

### How was this tested?

`npm run lint` - linter warnings no longer show up :)