### PR TITLE
[AXON-41] Implement AtlascodeErrorBoundary

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -2,6 +2,7 @@ import { ScreenEvent, TrackEvent, UIEvent } from './analytics-node-client/src/ty
 import { DetailedSiteInfo, isEmptySiteInfo, Product, ProductJira, SiteInfo } from './atlclients/authInfo';
 import { BitbucketIssuesTreeViewId, PullRequestTreeViewId } from './constants';
 import { Container } from './container';
+import { UIErrorInfo } from './analyticsTypes';
 
 // IMPORTANT
 // Make sure there is a corresponding event with the correct attributes in the Data Portal for any event created here.
@@ -254,6 +255,13 @@ export async function viewScreenEvent(
 }
 
 // UI Events
+
+export async function uiErrorEvent(errorInfo: UIErrorInfo): Promise<TrackEvent> {
+    const e = trackEvent('failedTest', 'ui', {
+        attributes: { ...errorInfo },
+    });
+    return e;
+}
 
 export async function bbIssuesPaginationEvent(): Promise<UIEvent> {
     const e = {

--- a/src/analyticsTypes.ts
+++ b/src/analyticsTypes.ts
@@ -1,0 +1,20 @@
+// TODO: move this with other analytics stuff into a separate folder
+// not doing it now to prevent too many import changes
+
+/**
+ * Names of the channels used for routing analytics events in UI
+ */
+export enum AnalyticsChannels {
+    AtlascodeUiErrors = 'atlascode.ui.errors',
+}
+
+export type UIAnalyticsContext = {
+    view: string;
+};
+
+export type UIErrorInfo = UIAnalyticsContext & {
+    stack: string;
+    errorName: string;
+    errorMessage: string;
+    errorCause: string;
+};

--- a/src/lib/analyticsApi.ts
+++ b/src/lib/analyticsApi.ts
@@ -1,3 +1,4 @@
+import { UIErrorInfo } from '../analyticsTypes';
 import { DetailedSiteInfo, Product, SiteInfo } from '../atlclients/authInfo';
 
 export interface AnalyticsApi {
@@ -48,4 +49,5 @@ export interface AnalyticsApi {
     fireOpenSettingsButtonEvent(source: string): Promise<void>;
     fireExploreFeaturesButtonEvent(source: string): Promise<void>;
     firePipelineRerunEvent(site: DetailedSiteInfo, source: string): Promise<void>;
+    fireUIErrorEvent(errorInfo: UIErrorInfo): Promise<void>;
 }

--- a/src/lib/ipc/fromUI/common.ts
+++ b/src/lib/ipc/fromUI/common.ts
@@ -2,6 +2,7 @@ import { ReducerAction } from '@atlassianlabs/guipi-core-controller';
 import { MinimalIssueOrKeyAndSite } from '@atlassianlabs/jira-pi-common-models';
 import { DetailedSiteInfo } from '../../../atlclients/authInfo';
 import { FeedbackData, PMFData } from '../models/common';
+import { UIErrorInfo } from '../../../analyticsTypes';
 
 export enum CommonActionType {
     SubmitPMF = 'pmfSubmit',
@@ -14,9 +15,11 @@ export enum CommonActionType {
     CopyLink = 'copyLink',
     OpenJiraIssue = 'openJiraIssue',
     Cancel = 'cancelInFlight',
+    SendAnalytics = 'sendAnalytics',
 }
 
 export type CommonAction =
+    | ReducerAction<CommonActionType.SendAnalytics, SendAnalyticsAction>
     | ReducerAction<CommonActionType.SubmitPMF, PMFSubmitAction>
     | ReducerAction<CommonActionType.OpenPMFSurvey>
     | ReducerAction<CommonActionType.DismissPMFLater>
@@ -28,6 +31,9 @@ export type CommonAction =
     | ReducerAction<CommonActionType.OpenJiraIssue, OpenJiraIssueAction>
     | ReducerAction<CommonActionType.Cancel, CancelAction>;
 
+export interface SendAnalyticsAction {
+    errorInfo: UIErrorInfo;
+}
 export interface PMFSubmitAction {
     pmfData: PMFData;
 }

--- a/src/lib/webview/controller/bbIssue/bitbucketIssueWebviewController.ts
+++ b/src/lib/webview/controller/bbIssue/bitbucketIssueWebviewController.ts
@@ -194,6 +194,7 @@ export class BitbucketIssueWebviewController implements WebviewController<Bitbuc
                 break;
             }
 
+            case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:
             case CommonActionType.Cancel:

--- a/src/lib/webview/controller/bbIssue/createBitbucketIssueWebviewController.ts
+++ b/src/lib/webview/controller/bbIssue/createBitbucketIssueWebviewController.ts
@@ -107,6 +107,7 @@ export class CreateBitbucketIssueWebviewController implements WebviewController<
                 break;
             }
 
+            case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:
             case CommonActionType.Cancel:

--- a/src/lib/webview/controller/config/configWebviewController.ts
+++ b/src/lib/webview/controller/config/configWebviewController.ts
@@ -275,6 +275,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                 break;
             }
 
+            case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:
             case CommonActionType.ExternalLink:

--- a/src/lib/webview/controller/onboarding/onboardingWebviewController.ts
+++ b/src/lib/webview/controller/onboarding/onboardingWebviewController.ts
@@ -159,6 +159,7 @@ export class OnboardingWebviewController implements WebviewController<SectionCha
                 break;
             }
 
+            case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:
             case CommonActionType.SubmitFeedback:

--- a/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.ts
+++ b/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.ts
@@ -173,6 +173,7 @@ export class CreatePullRequestWebviewController implements WebviewController<Wor
                 }
                 break;
 
+            case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:
             case CommonActionType.ExternalLink:

--- a/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.ts
+++ b/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.ts
@@ -567,6 +567,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                 }
                 break;
 
+            case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:
             case CommonActionType.SubmitFeedback:

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -171,6 +171,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                 break;
             }
 
+            case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:
             case CommonActionType.ExternalLink:

--- a/src/lib/webview/controller/welcome/welcomeWebviewController.ts
+++ b/src/lib/webview/controller/welcome/welcomeWebviewController.ts
@@ -76,6 +76,7 @@ export class WelcomeWebviewController implements WebviewController<WelcomeInitMe
                 break;
             }
 
+            case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:
             case CommonActionType.ExternalLink:

--- a/src/react/atlascode/common/ErrorBoundary.tsx
+++ b/src/react/atlascode/common/ErrorBoundary.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { AnalyticsErrorBoundary, AnalyticsListener, UIAnalyticsEvent } from '@atlaskit/analytics-next';
+import { CommonActionType } from 'src/lib/ipc/fromUI/common';
+import { AnalyticsChannels, UIAnalyticsContext } from 'src/analyticsTypes';
+
+const STACK_LIMIT = 150;
+const COMPONENT_GLOBAL = 'global';
+
+export type AtlascodeErrorBoundaryProps = {
+    postMessageFunc: (action: any) => void;
+    context: UIAnalyticsContext;
+    children?: React.ReactNode;
+};
+
+/**
+ * Global error boundary for Atlascode UI components
+ *
+ * Put this somewhere close to the root of your component tree.
+ * It will catch all rendering errors in the subtree and send them to the main process.
+ *
+ * Add `AnalyticsErrorBoundary` around the specific components you'd like to handle and track separately.
+ *
+ * @param {AtlascodeErrorBoundaryProps} props
+ * @returns
+ */
+export const AtlascodeErrorBoundary: React.FC<AtlascodeErrorBoundaryProps> = ({
+    children,
+    postMessageFunc,
+    context,
+}: AtlascodeErrorBoundaryProps) => {
+    const onRenderError = useCallback(
+        (event: UIAnalyticsEvent) => {
+            const { error, info, ...rest } = event.payload.attributes;
+            postMessageFunc({
+                type: CommonActionType.SendAnalytics,
+                errorInfo: {
+                    ...context,
+                    errorType: error.name,
+                    errorMessage: error.message,
+                    errorCause: error.cause,
+                    componentStack: simplifyStack(
+                        info.componentStack,
+                        (line) => line.match(/in (.*) \(created by (.*)\)/)?.[1],
+                    ),
+                    stack: simplifyStack(error.stack, (line) => line.match(/at (.*) \((.*)\)/)?.[1]),
+                    ...rest,
+                },
+            });
+        },
+        [postMessageFunc, context],
+    );
+
+    return (
+        <AnalyticsListener channel={AnalyticsChannels.AtlascodeUiErrors} onEvent={onRenderError}>
+            <AnalyticsErrorBoundary
+                channel={AnalyticsChannels.AtlascodeUiErrors}
+                data={{ component: COMPONENT_GLOBAL }}
+            >
+                {children}
+            </AnalyticsErrorBoundary>
+        </AnalyticsListener>
+    );
+};
+
+const simplifyStack = (stack: string, extractFunc: (line: string) => string | undefined) => {
+    const line = stack.split('\n').map(extractFunc).filter(Boolean).join(' < ');
+
+    return line.length > STACK_LIMIT ? line.substring(0, STACK_LIMIT) + '...' : line;
+};

--- a/src/react/atlascode/config/ConfigPage.tsx
+++ b/src/react/atlascode/config/ConfigPage.tsx
@@ -33,6 +33,7 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import WorkIcon from '@material-ui/icons/Work';
 import equal from 'fast-deep-equal/es6';
+import { AtlascodeErrorBoundary } from '../common/ErrorBoundary';
 
 const useStyles = makeStyles(
     (theme: Theme) =>
@@ -169,157 +170,159 @@ const ConfigPage: React.FunctionComponent = () => {
     return (
         <ConfigControllerContext.Provider value={controller}>
             <AuthDialogControllerContext.Provider value={authDialogController}>
-                <Container maxWidth="xl">
-                    <AppBar position="relative">
-                        <Toolbar>
-                            <Typography variant="h3" className={classes.title}>
-                                Atlassian Settings
-                            </Typography>
-                            <Tabs
-                                value={openSection}
-                                onChange={handleTabChange}
-                                aria-label="simple tabs example"
-                                indicatorColor="primary"
-                                variant="scrollable"
-                                scrollButtons="on"
-                            >
-                                <Tab
-                                    id="simple-tab-0"
-                                    aria-controls="simple-tabpanel-0"
-                                    value={ConfigSection.Jira}
-                                    label={
-                                        <ProductEnabler
-                                            label="Jira"
-                                            enabled={state.config['jira.enabled']}
-                                            onToggle={handleJiraToggle}
-                                        />
-                                    }
-                                />
-                                <Tab
-                                    id="simple-tab-1"
-                                    aria-controls="simple-tabpanel-1"
-                                    value={ConfigSection.Bitbucket}
-                                    label={
-                                        <ProductEnabler
-                                            label="Bitbucket"
-                                            enabled={state.config['bitbucket.enabled']}
-                                            onToggle={handleBitbucketToggle}
-                                        />
-                                    }
-                                />
-                                <Tab
-                                    id="simple-tab-2"
-                                    aria-controls="simple-tabpanel-2"
-                                    value={ConfigSection.General}
-                                    label="General"
-                                />
-                                <Tab
-                                    id="simple-tab-3"
-                                    aria-controls="simple-tabpanel-3"
-                                    value={ConfigSection.Explore}
-                                    label="Explore"
-                                />
-                            </Tabs>
-                            <div className={classes.grow} />
-                            <Typography variant="subtitle1" classes={{ root: classes.targetSelectLabel }}>
-                                Save settings to:{' '}
-                            </Typography>
-                            <ToggleButtonGroup
-                                color="primary"
-                                size="small"
-                                value={internalTarget}
-                                exclusive
-                                onChange={handleTargetChange}
-                            >
-                                <Tooltip title="User settings">
-                                    <ToggleButton
-                                        key={1}
-                                        value={ConfigTarget.User}
-                                        selected={internalTarget !== ConfigTarget.User}
-                                        disableRipple={internalTarget === ConfigTarget.User}
-                                    >
-                                        <Badge
-                                            color="primary"
-                                            variant="dot"
-                                            invisible={internalTarget !== ConfigTarget.User}
+                <AtlascodeErrorBoundary postMessageFunc={controller.postMessage} context={{ view: 'config' }}>
+                    <Container maxWidth="xl">
+                        <AppBar position="relative">
+                            <Toolbar>
+                                <Typography variant="h3" className={classes.title}>
+                                    Atlassian Settings
+                                </Typography>
+                                <Tabs
+                                    value={openSection}
+                                    onChange={handleTabChange}
+                                    aria-label="simple tabs example"
+                                    indicatorColor="primary"
+                                    variant="scrollable"
+                                    scrollButtons="on"
+                                >
+                                    <Tab
+                                        id="simple-tab-0"
+                                        aria-controls="simple-tabpanel-0"
+                                        value={ConfigSection.Jira}
+                                        label={
+                                            <ProductEnabler
+                                                label="Jira"
+                                                enabled={state.config['jira.enabled']}
+                                                onToggle={handleJiraToggle}
+                                            />
+                                        }
+                                    />
+                                    <Tab
+                                        id="simple-tab-1"
+                                        aria-controls="simple-tabpanel-1"
+                                        value={ConfigSection.Bitbucket}
+                                        label={
+                                            <ProductEnabler
+                                                label="Bitbucket"
+                                                enabled={state.config['bitbucket.enabled']}
+                                                onToggle={handleBitbucketToggle}
+                                            />
+                                        }
+                                    />
+                                    <Tab
+                                        id="simple-tab-2"
+                                        aria-controls="simple-tabpanel-2"
+                                        value={ConfigSection.General}
+                                        label="General"
+                                    />
+                                    <Tab
+                                        id="simple-tab-3"
+                                        aria-controls="simple-tabpanel-3"
+                                        value={ConfigSection.Explore}
+                                        label="Explore"
+                                    />
+                                </Tabs>
+                                <div className={classes.grow} />
+                                <Typography variant="subtitle1" classes={{ root: classes.targetSelectLabel }}>
+                                    Save settings to:{' '}
+                                </Typography>
+                                <ToggleButtonGroup
+                                    color="primary"
+                                    size="small"
+                                    value={internalTarget}
+                                    exclusive
+                                    onChange={handleTargetChange}
+                                >
+                                    <Tooltip title="User settings">
+                                        <ToggleButton
+                                            key={1}
+                                            value={ConfigTarget.User}
+                                            selected={internalTarget !== ConfigTarget.User}
+                                            disableRipple={internalTarget === ConfigTarget.User}
                                         >
-                                            <PersonIcon />
-                                        </Badge>
-                                    </ToggleButton>
-                                </Tooltip>
-                                <Tooltip title="Workspace settings">
-                                    <ToggleButton
-                                        key={2}
-                                        value={ConfigTarget.Workspace}
-                                        selected={internalTarget !== ConfigTarget.Workspace}
-                                        disableRipple={internalTarget === ConfigTarget.Workspace}
-                                    >
-                                        <Badge
-                                            color="primary"
-                                            variant="dot"
-                                            invisible={internalTarget !== ConfigTarget.Workspace}
+                                            <Badge
+                                                color="primary"
+                                                variant="dot"
+                                                invisible={internalTarget !== ConfigTarget.User}
+                                            >
+                                                <PersonIcon />
+                                            </Badge>
+                                        </ToggleButton>
+                                    </Tooltip>
+                                    <Tooltip title="Workspace settings">
+                                        <ToggleButton
+                                            key={2}
+                                            value={ConfigTarget.Workspace}
+                                            selected={internalTarget !== ConfigTarget.Workspace}
+                                            disableRipple={internalTarget === ConfigTarget.Workspace}
                                         >
-                                            <WorkIcon />
-                                        </Badge>
-                                    </ToggleButton>
-                                </Tooltip>
-                            </ToggleButtonGroup>
-                            <RefreshButton loading={state.isSomethingLoading} onClick={controller.refresh} />
-                        </Toolbar>
-                    </AppBar>
-                    <Grid container spacing={1}>
-                        <Grid item xs={12} md={9} lg={10} xl={10}>
-                            <Paper className={classes.paper100}>
-                                <ErrorDisplay />
-                                <PMFDisplay postMessageFunc={controller.postMessage} />
-                                <Box margin={2}>
-                                    <JiraPanel
-                                        visible={openSection === ConfigSection.Jira}
-                                        selectedSubSections={openSubsections[ConfigSection.Jira]}
-                                        onSubsectionChange={handleSubsectionChange}
-                                        config={state.config!}
-                                        sites={state.jiraSites}
-                                        isRemote={state.isRemote}
-                                    />
-                                    <BitbucketPanel
-                                        visible={openSection === ConfigSection.Bitbucket}
-                                        selectedSubSections={openSubsections[ConfigSection.Bitbucket]}
-                                        onSubsectionChange={handleSubsectionChange}
-                                        config={state.config!}
-                                        sites={state.bitbucketSites}
-                                        isRemote={state.isRemote}
-                                    />
-                                    <GeneralPanel
-                                        visible={openSection === ConfigSection.General}
-                                        selectedSubSections={openSubsections[ConfigSection.General]}
-                                        onSubsectionChange={handleSubsectionChange}
-                                        config={state.config!}
-                                    />
-                                    <ExplorePanel
-                                        visible={openSection === ConfigSection.Explore}
-                                        config={state.config!}
-                                        sectionChanger={handleCompleteSectionChange}
-                                    />
-                                </Box>
-                            </Paper>
+                                            <Badge
+                                                color="primary"
+                                                variant="dot"
+                                                invisible={internalTarget !== ConfigTarget.Workspace}
+                                            >
+                                                <WorkIcon />
+                                            </Badge>
+                                        </ToggleButton>
+                                    </Tooltip>
+                                </ToggleButtonGroup>
+                                <RefreshButton loading={state.isSomethingLoading} onClick={controller.refresh} />
+                            </Toolbar>
+                        </AppBar>
+                        <Grid container spacing={1}>
+                            <Grid item xs={12} md={9} lg={10} xl={10}>
+                                <Paper className={classes.paper100}>
+                                    <ErrorDisplay />
+                                    <PMFDisplay postMessageFunc={controller.postMessage} />
+                                    <Box margin={2}>
+                                        <JiraPanel
+                                            visible={openSection === ConfigSection.Jira}
+                                            selectedSubSections={openSubsections[ConfigSection.Jira]}
+                                            onSubsectionChange={handleSubsectionChange}
+                                            config={state.config!}
+                                            sites={state.jiraSites}
+                                            isRemote={state.isRemote}
+                                        />
+                                        <BitbucketPanel
+                                            visible={openSection === ConfigSection.Bitbucket}
+                                            selectedSubSections={openSubsections[ConfigSection.Bitbucket]}
+                                            onSubsectionChange={handleSubsectionChange}
+                                            config={state.config!}
+                                            sites={state.bitbucketSites}
+                                            isRemote={state.isRemote}
+                                        />
+                                        <GeneralPanel
+                                            visible={openSection === ConfigSection.General}
+                                            selectedSubSections={openSubsections[ConfigSection.General]}
+                                            onSubsectionChange={handleSubsectionChange}
+                                            config={state.config!}
+                                        />
+                                        <ExplorePanel
+                                            visible={openSection === ConfigSection.Explore}
+                                            config={state.config!}
+                                            sectionChanger={handleCompleteSectionChange}
+                                        />
+                                    </Box>
+                                </Paper>
+                            </Grid>
+                            <Grid item xs={12} md={3} lg={2} xl={2}>
+                                <Paper className={classes.paperOverflow}>
+                                    <Box margin={2}>
+                                        <SidebarButtons feedbackUser={state.feedbackUser} />
+                                    </Box>
+                                </Paper>
+                            </Grid>
                         </Grid>
-                        <Grid item xs={12} md={3} lg={2} xl={2}>
-                            <Paper className={classes.paperOverflow}>
-                                <Box margin={2}>
-                                    <SidebarButtons feedbackUser={state.feedbackUser} />
-                                </Box>
-                            </Paper>
-                        </Grid>
-                    </Grid>
-                </Container>
-                <AuthDialog
-                    product={authDialogProduct}
-                    doClose={authDialogController.close}
-                    authEntry={authDialogEntry}
-                    open={authDialogOpen}
-                    save={controller.login}
-                    onExited={authDialogController.onExited}
-                />
+                    </Container>
+                    <AuthDialog
+                        product={authDialogProduct}
+                        doClose={authDialogController.close}
+                        authEntry={authDialogEntry}
+                        open={authDialogOpen}
+                        save={controller.login}
+                        onExited={authDialogController.onExited}
+                    />
+                </AtlascodeErrorBoundary>
             </AuthDialogControllerContext.Provider>
         </ConfigControllerContext.Provider>
     );

--- a/src/react/atlascode/config/configController.ts
+++ b/src/react/atlascode/config/configController.ts
@@ -24,6 +24,7 @@ import { ReducerAction, defaultActionGuard, defaultStateGuard } from '@atlassian
 import { CommonActionType } from '../../../lib/ipc/fromUI/common';
 import { ConnectionTimeout } from '../../../util/time';
 import { v4 } from 'uuid';
+import { UIErrorInfo } from 'src/analyticsTypes';
 
 export interface ConfigControllerApi {
     postMessage: PostMessageFunc<ConfigAction>;
@@ -156,6 +157,7 @@ export enum ConfigUIActionType {
 }
 
 export type ConfigUIAction =
+    | ReducerAction<CommonActionType.SendAnalytics, { errorInfo: UIErrorInfo }>
     | ReducerAction<ConfigUIActionType.Init, { data: ConfigInitMessage }>
     | ReducerAction<ConfigUIActionType.ConfigChange, { config: FlattenedConfig; target: ConfigTarget }>
     | ReducerAction<ConfigUIActionType.SectionChange, { data: SectionChangeMessage }>
@@ -222,6 +224,9 @@ function configReducer(state: ConfigState, action: ConfigUIAction): ConfigState 
         }
         case ConfigUIActionType.Loading: {
             return { ...state, ...{ isSomethingLoading: true } };
+        }
+        case CommonActionType.SendAnalytics: {
+            return state;
         }
 
         default:

--- a/src/vscAnalyticsApi.ts
+++ b/src/vscAnalyticsApi.ts
@@ -44,12 +44,14 @@ import {
     prUrlCopiedEvent,
     saveManualCodeEvent,
     startIssueCreationEvent,
+    uiErrorEvent,
     upgradedEvent,
     viewScreenEvent,
 } from './analytics';
 import { AnalyticsClient } from './analytics-node-client/src/client.min.js';
 import { DetailedSiteInfo, Product, SiteInfo } from './atlclients/authInfo';
 import { AnalyticsApi } from './lib/analyticsApi';
+import { UIErrorInfo } from './analyticsTypes';
 
 export class VSCAnalyticsApi implements AnalyticsApi {
     private _analyticsClient: AnalyticsClient;
@@ -345,6 +347,12 @@ export class VSCAnalyticsApi implements AnalyticsApi {
 
     public async firePipelineRerunEvent(site: DetailedSiteInfo, source: string) {
         return pipelineRerunEvent(site, source).then((e) => {
+            this._analyticsClient.sendTrackEvent(e);
+        });
+    }
+
+    public async fireUIErrorEvent(errorInfo: UIErrorInfo) {
+        return uiErrorEvent(errorInfo).then(async (e) => {
             this._analyticsClient.sendTrackEvent(e);
         });
     }

--- a/src/webview/common/vscCommonMessageActionHandler.ts
+++ b/src/webview/common/vscCommonMessageActionHandler.ts
@@ -111,6 +111,10 @@ export class VSCCommonMessageHandler implements CommonActionMessageHandler {
                 this._cancelMan.delete(msg.abortKey);
                 break;
             }
+            case CommonActionType.SendAnalytics: {
+                this._analytics.fireUIErrorEvent(msg.errorInfo);
+                break;
+            }
             default: {
                 defaultActionGuard(msg);
             }


### PR DESCRIPTION
### What is this?

This is the 1st PR in a series related to improving our observability when something goes wrong.

In React, there's a concept of an [Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) - a special component which is intended to address rendering errors in the tree, and which is very notably missing in our pages 😉

Further, we are already pulling [@atlaskit/analytics-next](https://atlaskit.atlassian.com/packages/analytics/analytics-next) as a dependency, which conveniently offers an [implementation](https://atlaskit.atlassian.com/packages/analytics/analytics-next/docs/error-boundary) we could use.

After the changes in this PR, we can receive an event with some data on rendering errors occuring in prod:
![image](https://github.com/user-attachments/assets/ed9f5d9c-722b-425a-a0cc-7e49b5b1f6ba)

> ⚠️ Note: The exact structure and content of the analytics event are temporary and subject to change

#### What does this PR have, mechanically?

* Basic support for firing error-related events from webviews with this architecture:
![image](https://github.com/user-attachments/assets/b7f60a35-093a-4ef9-9262-d6be24d69a50)
    * New "common" action type `SendAnalytics`
    * Handling for it in all controllers
    * Type definitions
 * `AtlascodeErrorBoundary` implementation and usage 

#### What is notably NOT included here?
 * **Tests** - I ran into dependency conflicts when trying to pull react testing utils. Might make sense to add them in a separate PR after bumping `react` version
 * `AtlascodeErrorBoundary` usage in other pages - to not overwhelm reviewers further ;D

### How was this tested?

I've introduced the new error boundary to our `Settings` page, and then added a special component that fails on rendering. With that, when running our settings page, it was possible to show alternative HTML on render errors, while also receiving an event in the analityics service:

![image](https://github.com/user-attachments/assets/937026d4-52e2-43cf-b77d-6b01bad60b4a)
(all the extra components were removed during clean-up)