### PR TITLE
[AXON-42] fix: show correct JIRA issues under "My X issues"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## What's new in 3.2.1
+
+### Bug Fixes
+
+- Issues fetched from multiple JIRA sites now display correctly in the tree
+
 ## What's New in 3.2.0
 
 ### Improvements 

--- a/src/atlclients/clientManager.ts
+++ b/src/atlclients/clientManager.ts
@@ -250,7 +250,7 @@ export class ClientManager implements Disposable {
     }
 
     private keyForSite(site: DetailedSiteInfo): string {
-        return site.credentialId;
+        return `${site.credentialId} - ${site.baseApiUrl}`;
     }
 
     private async createClient<T>(site: DetailedSiteInfo, factory: (info: AuthInfo) => any): Promise<T | undefined> {


### PR DESCRIPTION
### What is this?

A long overdue fix for a very annoying problem.

Before, when several JIRA instances shared a credential, client from one of them would be reused for everything, leading to incorrect results. Now, we properly create clients for each JIRA instance independently

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/d1ecbb72-de86-49ba-858a-dd5041a3c8cb) | ![image](https://github.com/user-attachments/assets/5a587683-f12a-4c72-8512-2b0225141e3a) |

### How was this tested?

By doing a before and after 😉