### PR TITLE
[AXON-43] chore: fix CI warnings about release actions

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -89,22 +89,14 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          release_name: Release ${{ env.RELEASE_TAG }}
+          name: Release ${{ env.RELEASE_TAG }}
           draft: false
           prerelease: true
-
-      - name: Upload Release Assets
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./atlascode-${{ env.PACKAGE_VERSION }}.vsix
-          asset_name: atlascode-${{ env.PACKAGE_VERSION }}.vsix
-          asset_content_type: application/zip
+          files: |
+            atlascode-${{ env.PACKAGE_VERSION }}.vsix
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,22 +86,14 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          release_name: Release ${{ env.RELEASE_TAG }}
+          name: Release ${{ env.RELEASE_TAG }}
           draft: false
           prerelease: false
-
-      - name: Upload Release Assets
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./atlascode-${{ env.PACKAGE_VERSION }}.vsix
-          asset_name: atlascode-${{ env.PACKAGE_VERSION }}.vsix
-          asset_content_type: application/zip
+          files: |
+            atlascode-${{ env.PACKAGE_VERSION }}.vsix
+          fail_on_unmatched_files: true


### PR DESCRIPTION
### What is this?

Small PR to fix these warnings that appear in our builds:

![image](https://github.com/user-attachments/assets/49723674-6328-47c7-93a7-dd23a5f7479e)

Apparently the official github action for releases is no longer maintained, so this makes the repo use the highest-rated proposed alternative - [softprops/action-gh-release](https://github.com/softprops/action-gh-release)

It's almost a drop-in replacement, with an added benefit of combining the upload of artifacts into one action

### How was this tested?

Test release from this branch using the new action
![image](https://github.com/user-attachments/assets/86f3f0c2-949f-415c-b899-6a8e277e3d1f)

Also, made sure that the build fails if the uploaded artifact isn't found:
![image](https://github.com/user-attachments/assets/b8a26e65-4fd4-46d4-b4dc-57e9eb888b9c)
