### PR TITLE
[AXON-41] chore: fix stack limit and webview name strings

### DIFF
--- a/src/analyticsTypes.ts
+++ b/src/analyticsTypes.ts
@@ -8,24 +8,40 @@ export enum AnalyticsChannels {
     AtlascodeUiErrors = 'atlascode.ui.errors',
 }
 
+/**
+ * Descriptions of the different pages that the extension can render as webviews.
+ * These appear in error reports, so it's best if they are verbose and descriptive.
+ *
+ * Values typically follow the pattern of `<type>:<version>:[?product]:<view>`
+ *
+ * Versions so far:
+ *  - v1: (legacy) Webviews based on AbstractReactWebview
+ *  - v2: (legacy) Webviews based on the WebviewController/WebviewControllerFactory architecture
+ */
 export enum AnalyticsView {
-    OnboardingPage = 'onboarding',
-    SettingsPage = 'settings',
-    WelcomePage = 'welcome',
+    // v1
 
-    BitbucketIssuePage = 'bitbucketIssue',
-    PullRequestPage = 'pullRequest',
+    CreateJiraIssuePage = 'page:v1:jira:createIssue',
+    JiraIssuePage = 'page:v1:jira:issue',
+    OldStartWorkPage = 'page:v1:bitbucket:startWork',
 
-    CreateBitbucketIssuePage = 'createBitbucketIssue',
-    CreatePullRequestPage = 'createPullRequest',
+    // v2
 
-    CreateJiraIssuePage = 'createJiraIssue',
-    JiraIssuePage = 'jiraIssue',
+    OnboardingPage = 'page:v2:onboarding',
+    SettingsPage = 'page:v2:settings',
+    WelcomePage = 'page:v2:welcome',
 
-    PipelineSummaryPage = 'pipelineSummary',
+    BitbucketIssuePage = 'page:v2:bitbucket:issue',
+    CreateBitbucketIssuePage = 'page:v2:bitbucket:createIssue',
 
-    StartWorkPage = 'startWork',
-    OldStartWorkPage = 'oldStartWork',
+    PullRequestPage = 'page:v2:bitbucket:pullRequest',
+    CreatePullRequestPage = 'page:v2:bitbucket:createPullRequest',
+
+    PipelineSummaryPage = 'page:v2:bitbucket:pipeline',
+
+    StartWorkPage = 'page:v2:jira:startWork',
+
+    // Reserved for future use
 
     Other = 'other',
 }

--- a/src/react/atlascode/common/ErrorBoundary.tsx
+++ b/src/react/atlascode/common/ErrorBoundary.tsx
@@ -4,7 +4,10 @@ import { AnalyticsErrorBoundary, AnalyticsListener, UIAnalyticsEvent } from '@at
 import { CommonActionType } from 'src/lib/ipc/fromUI/common';
 import { AnalyticsChannels, UIAnalyticsContext } from 'src/analyticsTypes';
 
-const STACK_LIMIT = 150;
+// Maximum limit for the simplified stack trace
+// We're using a high value deliberately for now, but it's arbitrary and can be changed in the future
+const STACK_LIMIT = 1500;
+
 const COMPONENT_GLOBAL = 'global';
 
 export type AtlascodeErrorBoundaryProps = {


### PR DESCRIPTION
### What is this?

Small follow-up from the previous AXON-41 PRs:
 * Limit for the number of characters in the shortened stack: `150` -> `1500`
 * Renamed the values of the enum for page names that show up in analytics events

Also - introduced some nomenclature for the different "legacy" page implementations, lol :D

Whatever new thing we build will be `v3` in these terms 😉 

### How was this tested?

Only the basic build tests, didn't do any special testing since this is a small change