### PR TITLE
[AXON-32] allow for testing e2e in non-VPN environments

### DIFF
--- a/e2e/tests/auth.test.ts
+++ b/e2e/tests/auth.test.ts
@@ -2,10 +2,6 @@ import { expect } from 'chai';
 import { before, after, EditorView, Workbench, By, ActivityBar, SideBarView } from 'vscode-extension-tester';
 
 describe('Auth User', async () => {
-    if (process.env.CI) {
-        console.log('Test skipped in CI environment');
-        return;
-    }
     let activityBar: ActivityBar;
     let sideBarView: SideBarView;
 

--- a/e2e/tests/no-auth.test.ts
+++ b/e2e/tests/no-auth.test.ts
@@ -20,10 +20,6 @@ describe('Atlassian Extension Activity Bar', async () => {
 });
 
 describe('Atlassian Extension SideBar', async () => {
-    if (process.env.CI) {
-        console.log('Test skipped in CI environment');
-        return;
-    }
     let activityBar: ActivityBar;
     let sideBarView: SideBarView;
 
@@ -55,10 +51,6 @@ describe('Atlassian Extension SideBar', async () => {
 });
 
 describe('Atlassian Extension Settings Page', async () => {
-    if (process.env.CI) {
-        console.log('Test skipped in CI environment');
-        return;
-    }
     // let view: WebView;
 
     before(async () => {

--- a/src/atlclients/authInfo.ts
+++ b/src/atlclients/authInfo.ts
@@ -267,14 +267,18 @@ export function getSecretForAuthInfo(info: any): string {
 export function oauthProviderForSite(site: SiteInfo): OAuthProvider | undefined {
     const hostname = site.host.split(':')[0];
 
+    // Added to allow for testing flow of AXON-32
+    if (hostname.endsWith('axontest2025.atlassian.net')) {
+        return undefined;
+    }
+
     if (hostname.endsWith('atlassian.net') || hostname.endsWith('jira.com')) {
         return OAuthProvider.JiraCloud;
     }
 
-    // Commented out to allow for testing flow of AXON-32 PR: https://github.com/atlassian/atlascode/pull/54/files
-    // if (hostname.endsWith('jira-dev.com')) {
-    //     return OAuthProvider.JiraCloudStaging;
-    // }
+    if (hostname.endsWith('jira-dev.com')) {
+        return OAuthProvider.JiraCloudStaging;
+    }
 
     if (hostname.endsWith('bitbucket.org')) {
         return OAuthProvider.BitbucketCloud;

--- a/src/atlclients/authInfo.ts
+++ b/src/atlclients/authInfo.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { ATLASCODE_TEST_HOST } from 'src/constants';
+import { ATLASCODE_TEST_HOST } from '../../src/constants';
 
 export enum AuthChangeType {
     Update = 'update',

--- a/src/atlclients/authInfo.ts
+++ b/src/atlclients/authInfo.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { ATLASCODE_TEST_HOST } from 'src/constants';
+
 export enum AuthChangeType {
     Update = 'update',
     Remove = 'remove',
@@ -268,7 +270,7 @@ export function oauthProviderForSite(site: SiteInfo): OAuthProvider | undefined 
     const hostname = site.host.split(':')[0];
 
     // Added to allow for testing flow of AXON-32
-    if (hostname.endsWith('axontest2025.atlassian.net')) {
+    if (hostname.endsWith(ATLASCODE_TEST_HOST)) {
         return undefined;
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,3 +23,6 @@ export const jiraAPIConnectivityError = new Error('cannot connect to jira api');
 export const cannotGetClientFor = 'cannot get client for';
 
 export const AuthInfoVersionKey = 'authInfoVersion';
+
+export const ATLASCODE_TEST_USER_EMAIL = 'axontest2025@gmail.com';
+export const ATLASCODE_TEST_HOST = 'axontest2025.atlassian.net';

--- a/src/container.ts
+++ b/src/container.ts
@@ -371,7 +371,7 @@ export class Container {
             return;
         }
         const authInfo = {
-            username: 'axon-test@polli.tlp.usersinbuckets.com',
+            username: 'axontest2025@gmail.com',
             password: process.env.ATLASCODE_TEST_USER_API_TOKEN,
             user: {
                 id: '',
@@ -382,7 +382,7 @@ export class Container {
             state: 0,
         };
         const site = {
-            host: 'axon-test.jira-dev.com',
+            host: 'axontest2025.atlassian.net',
             protocol: 'https:',
             product: {
                 name: 'Jira',

--- a/src/container.ts
+++ b/src/container.ts
@@ -70,6 +70,7 @@ import { EventBuilder } from './util/featureFlags/eventBuilder';
 import { AtlascodeUriHandler } from './uriHandler';
 import { CheckoutHelper } from './bitbucket/interfaces';
 import { ProductJira } from './atlclients/authInfo';
+import { ATLASCODE_TEST_USER_EMAIL, ATLASCODE_TEST_HOST } from './constants';
 
 const isDebuggingRegex = /^--(debug|inspect)\b(-brk\b|(?!-))=?/;
 const ConfigTargetKey = 'configurationTarget';
@@ -371,7 +372,7 @@ export class Container {
             return;
         }
         const authInfo = {
-            username: 'axontest2025@gmail.com',
+            username: ATLASCODE_TEST_USER_EMAIL,
             password: process.env.ATLASCODE_TEST_USER_API_TOKEN,
             user: {
                 id: '',
@@ -382,7 +383,7 @@ export class Container {
             state: 0,
         };
         const site = {
-            host: 'axontest2025.atlassian.net',
+            host: ATLASCODE_TEST_HOST,
             protocol: 'https:',
             product: {
                 name: 'Jira',

--- a/src/react/atlascode/config/auth/AuthDialog.tsx
+++ b/src/react/atlascode/config/auth/AuthDialog.tsx
@@ -85,11 +85,15 @@ const isCustomUrl = (data?: string) => {
     try {
         const url = new URL(data);
 
+        // To allow for testing flow of AXON-32
+        if (url.hostname.endsWith('axontest2025.atlassian.net')) {
+            return true;
+        }
+
         return (
             !url.hostname.endsWith('atlassian.net') &&
             !url.hostname.endsWith('jira.com') &&
-            // Commented out to allow for testing flow of AXON-32 PR: https://github.com/atlassian/atlascode/pull/54/files
-            // !url.hostname.endsWith('jira-dev.com') &&
+            !url.hostname.endsWith('jira-dev.com') &&
             !url.hostname.endsWith('bitbucket.org') &&
             !url.hostname.endsWith('bb-inf.net')
         );

--- a/src/react/atlascode/config/auth/AuthDialog.tsx
+++ b/src/react/atlascode/config/auth/AuthDialog.tsx
@@ -34,6 +34,8 @@ import {
 import { emptySiteWithAuthInfo, SiteWithAuthInfo } from '../../../../lib/ipc/toUI/config';
 import { useFormValidation } from '../../common/form/useFormValidation';
 import { validateRequiredString, validateStartsWithProtocol } from '../../util/fieldValidators';
+import { ATLASCODE_TEST_HOST } from 'src/constants';
+
 export type AuthDialogProps = {
     open: boolean;
     doClose: () => void;
@@ -86,7 +88,7 @@ const isCustomUrl = (data?: string) => {
         const url = new URL(data);
 
         // To allow for testing flow of AXON-32
-        if (url.hostname.endsWith('axontest2025.atlassian.net')) {
+        if (url.hostname.endsWith(ATLASCODE_TEST_HOST)) {
             return true;
         }
 


### PR DESCRIPTION
Our prior implementation of e2e testing relied on jira-dev.com

This was a flawed starting point, because jira-dev.com is only accessible while on the Atlassian VPN, which this GitHub repo is not. 

Idea: Use a site that is still free to use, but not protected by a VPN. 

Solution: Make a site in the free-tier of JIRA usage on atlassian.net 

Name: axontest2025.atlassian.net 

- Make an exception for handling this so we aren't forced to use OAuth. 


How was this tested? 
- I test the VPN issue with jira-dev.com by trying to visit it on a personal device without VPN access. Resulted in a 403 
- I tested this locally to confirm the e2e test can run while on VPN 
- I am raising this PR to test if the GitHub actions pipeline will allow this to work. (May the odds be ever in my favor) 

