### PR TITLE
[AXON-49] fix: prevent JIRA page crash on Reporter edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Bug Fixes
 
 - Issues fetched from multiple JIRA sites now display correctly in the tree
+- Error banner no longer causes JIRA issue page to crash
+- Added workaround to fix completion for JIRA Reporter field
 
 ## What's New in 3.2.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "@atlaskit/page-header": "^10.2.2",
                 "@atlaskit/panel": "^0.4.7",
                 "@atlaskit/radio": "^5.3.3",
-                "@atlaskit/section-message": "^6.1.4",
+                "@atlaskit/section-message": "^6.8.2",
                 "@atlaskit/select": "^15.2.4",
                 "@atlaskit/spinner": "^15.1.3",
                 "@atlaskit/table-tree": "^9.0.12",
@@ -691,6 +691,68 @@
                 "react": "^16.8.0"
             }
         },
+        "node_modules/@atlaskit/css": {
+            "version": "0.7.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.7.2.tgz",
+            "integrity": "sha512-dE1gDG7D9L6LZNUZeZIA4AUCIuPNVsvopAsyeeHqicYUo6uhpcZ3YuoBugDrcSNRmhr/D3uI9PF/ULQRAbe71g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^2.4.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/jest": "^0.10.5",
+                "@compiled/react": "^0.18.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/css/node_modules/@atlaskit/ds-lib": {
+            "version": "3.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-3.3.0.tgz",
+            "integrity": "sha512-8bgJRFvL4C9dOc3XQ0nJLze4OSXtfemmE2os2h/T80hSdQO57hPMnXB22Pl6nT/6nEP7kZ4kAH6hDuJ3vBUNPA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/css/node_modules/@atlaskit/platform-feature-flags": {
+            "version": "0.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.3.0.tgz",
+            "integrity": "sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            }
+        },
+        "node_modules/@atlaskit/css/node_modules/@atlaskit/tokens": {
+            "version": "2.5.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-2.5.0.tgz",
+            "integrity": "sha512-o7c3NRnoOC7zpjQS9dRD0sm9CJuBN20iXZSUVoY/yzDA2jPZ8Xtlt0X8WwpxjFHk+AswQFU3CZTn+5D9YFEufg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/css/node_modules/bind-event-listener": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+            "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+            "license": "MIT"
+        },
         "node_modules/@atlaskit/datetime-picker": {
             "version": "11.1.2",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/datetime-picker/-/datetime-picker-11.1.2.tgz",
@@ -790,6 +852,186 @@
                 "react": "^16.8.0"
             }
         },
+        "node_modules/@atlaskit/heading": {
+            "version": "4.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/heading/-/heading-4.0.0.tgz",
+            "integrity": "sha512-OYK/Pxw42T9gfL+KCtHzIP+nBI9QDXTxsUJ64pHTYAXJ4EZLD8We/K2WMLZWDpFDeEh4U01Rlz4eEWng92ffCw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/primitives": "^13.3.0",
+                "@atlaskit/tokens": "^2.4.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@atlaskit/app-provider": {
+            "version": "1.4.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-1.4.3.tgz",
+            "integrity": "sha512-D1/qY2ZgCVLBgtjRmUO+wlICibvYGI0rEGp+5g4e2Z4KDEq9TRz0P2ibDDedZv8paM0eo7PstrmWA3J2xmE5RQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^2.4.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@atlaskit/ds-lib": {
+            "version": "3.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-3.3.0.tgz",
+            "integrity": "sha512-8bgJRFvL4C9dOc3XQ0nJLze4OSXtfemmE2os2h/T80hSdQO57hPMnXB22Pl6nT/6nEP7kZ4kAH6hDuJ3vBUNPA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@atlaskit/platform-feature-flags": {
+            "version": "0.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.3.0.tgz",
+            "integrity": "sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@atlaskit/primitives": {
+            "version": "13.3.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-13.3.6.tgz",
+            "integrity": "sha512-KqQqwialDVfKzUbgafAnT2fVmCaDM3WjYi2/N+yFhsQOQCKKqrMWOW/Ics0se09Ejndm4DnMKb03Q10Xf506fA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^10.2.0",
+                "@atlaskit/app-provider": "^1.4.0",
+                "@atlaskit/css": "^0.7.0",
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/interaction-context": "^2.4.0",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@atlaskit/tokens": "^2.5.0",
+                "@atlaskit/visually-hidden": "^1.5.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.1",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@atlaskit/primitives/node_modules/@atlaskit/analytics-next": {
+            "version": "10.2.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/analytics-next/-/analytics-next-10.2.1.tgz",
+            "integrity": "sha512-KpabZa6OxKoz4sABtbU6nSzZk12RmnUD+CDQKRq50TUWXOsaOBFZ5iXJPQA4gD0gl4WMGHO/9RG//JYXHLK3fg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next-stable-react-context": "1.0.1",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "prop-types": "^15.5.10",
+                "use-memo-one": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.2.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@atlaskit/tokens": {
+            "version": "2.5.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-2.5.0.tgz",
+            "integrity": "sha512-o7c3NRnoOC7zpjQS9dRD0sm9CJuBN20iXZSUVoY/yzDA2jPZ8Xtlt0X8WwpxjFHk+AswQFU3CZTn+5D9YFEufg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@atlaskit/visually-hidden": {
+            "version": "1.5.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-1.5.1.tgz",
+            "integrity": "sha512-BM7tyCvc2s6KT0SrGIhzQimu5ZikpfGBtmR3qpTcDBZJ4QnBQgOe1T8bCxumF0MJRx+hT/6kZIt07qcE6T/SLw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@emotion/hash": {
+            "version": "0.9.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/heading/node_modules/@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/heading/node_modules/@emotion/serialize": {
+            "version": "1.3.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@atlaskit/heading/node_modules/@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/heading/node_modules/@emotion/utils": {
+            "version": "1.4.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/heading/node_modules/bind-event-listener": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+            "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/heading/node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/heading/node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
+        },
         "node_modules/@atlaskit/icon": {
             "version": "21.12.8",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-21.12.8.tgz",
@@ -868,9 +1110,9 @@
             }
         },
         "node_modules/@atlaskit/interaction-context": {
-            "version": "2.1.6",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/interaction-context/-/interaction-context-2.1.6.tgz",
-            "integrity": "sha512-g4pFeUNxHzEJ9o8vK4PnnmiS8CuP1+LpWFcx86pbYJxZqI1i3/irnUkO07dNEJuBDCmMLFUpWSilAgl7HbKE0w==",
+            "version": "2.4.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/interaction-context/-/interaction-context-2.4.0.tgz",
+            "integrity": "sha512-goWZypwMtdiWhGPKjAhYlnfYm49I5XNDoJ3fHlK75NApVWZmTKvTiuX5Pba3iLc+lsw1MLYFxT7dYkmRXRiuPw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime": "^7.0.0"
@@ -878,6 +1120,58 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
+        },
+        "node_modules/@atlaskit/layering": {
+            "version": "1.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/layering/-/layering-1.0.0.tgz",
+            "integrity": "sha512-lcSfDBHbu3wOkVOfRChqhwlbCEALTDXwMuJ/YUrclBzloB6bGWh/i6yJdWhheDJgnIo8RcWhYDe/fu//9uOYEw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/layering/node_modules/@atlaskit/ds-lib": {
+            "version": "3.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-3.3.0.tgz",
+            "integrity": "sha512-8bgJRFvL4C9dOc3XQ0nJLze4OSXtfemmE2os2h/T80hSdQO57hPMnXB22Pl6nT/6nEP7kZ4kAH6hDuJ3vBUNPA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/layering/node_modules/@atlaskit/platform-feature-flags": {
+            "version": "0.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.3.0.tgz",
+            "integrity": "sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            }
+        },
+        "node_modules/@atlaskit/layering/node_modules/bind-event-listener": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+            "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/layering/node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
         },
         "node_modules/@atlaskit/locale": {
             "version": "2.3.2",
@@ -1257,22 +1551,376 @@
             }
         },
         "node_modules/@atlaskit/section-message": {
-            "version": "6.1.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/section-message/-/section-message-6.1.5.tgz",
-            "integrity": "sha1-WrlZ9I6pchl5PHO1OCHbs0u/db0=",
+            "version": "6.8.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/section-message/-/section-message-6.8.2.tgz",
+            "integrity": "sha512-3HldrB/xaijXgSZa0PwCGnBlPk1OdS/OtMUN4ir36vaxYXhwLdxAMRss7JgqMZg1SDtDGLIsS3Y5+sv0EdpG3A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/button": "^16.1.0",
-                "@atlaskit/codemod-utils": "^3.4.0",
-                "@atlaskit/icon": "^21.9.0",
-                "@atlaskit/theme": "^12.0.0",
-                "@atlaskit/tokens": "^0.4.0",
-                "@babel/runtime": "^7.0.0",
-                "@emotion/core": "^10.0.9"
+                "@atlaskit/button": "^20.3.0",
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/css": "^0.7.0",
+                "@atlaskit/heading": "^4.0.0",
+                "@atlaskit/icon": "^23.0.0",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@atlaskit/primitives": "^13.3.0",
+                "@atlaskit/theme": "^14.0.0",
+                "@atlaskit/tokens": "^2.4.0",
+                "@babel/runtime": "^7.0.0"
             },
             "peerDependencies": {
-                "react": "^16.8.0"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/app-provider": {
+            "version": "1.4.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-1.4.3.tgz",
+            "integrity": "sha512-D1/qY2ZgCVLBgtjRmUO+wlICibvYGI0rEGp+5g4e2Z4KDEq9TRz0P2ibDDedZv8paM0eo7PstrmWA3J2xmE5RQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^2.4.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/button": {
+            "version": "20.3.7",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/button/-/button-20.3.7.tgz",
+            "integrity": "sha512-fcAxXv94a2o71lB+RDlp1E4C4jc3eKvNGkmIjSfzKtyPfkaiImYpuzwR2A9Dwoq/Ck88KFU9So5vi2vz9kcIEw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^10.2.0",
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/focus-ring": "^2.0.0",
+                "@atlaskit/icon": "^23.1.0",
+                "@atlaskit/interaction-context": "^2.2.0",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@atlaskit/primitives": "^13.3.0",
+                "@atlaskit/spinner": "^16.3.0",
+                "@atlaskit/theme": "^14.0.0",
+                "@atlaskit/tokens": "^2.4.0",
+                "@atlaskit/tooltip": "^19.0.0",
+                "@atlaskit/visually-hidden": "^1.5.0",
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/button/node_modules/@atlaskit/analytics-next": {
+            "version": "10.2.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/analytics-next/-/analytics-next-10.2.1.tgz",
+            "integrity": "sha512-KpabZa6OxKoz4sABtbU6nSzZk12RmnUD+CDQKRq50TUWXOsaOBFZ5iXJPQA4gD0gl4WMGHO/9RG//JYXHLK3fg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next-stable-react-context": "1.0.1",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "prop-types": "^15.5.10",
+                "use-memo-one": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.2.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/button/node_modules/@atlaskit/tooltip": {
+            "version": "19.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tooltip/-/tooltip-19.0.0.tgz",
+            "integrity": "sha512-Hy+ci5bl5nYMwhiy1XaOR4tT66UaJ/2MRT3dHmENVq6jDAxVMHYFRGV2HCdg2tpgMSDOZesgi/11U0aeGxm38Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^10.2.0",
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/layering": "^1.0.0",
+                "@atlaskit/motion": "^1.9.0",
+                "@atlaskit/popper": "^6.3.0",
+                "@atlaskit/portal": "^4.9.0",
+                "@atlaskit/theme": "^14.0.0",
+                "@atlaskit/tokens": "^2.4.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.1",
+                "@emotion/react": "^11.7.1",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/button/node_modules/@atlaskit/tooltip/node_modules/@atlaskit/portal": {
+            "version": "4.10.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/portal/-/portal-4.10.0.tgz",
+            "integrity": "sha512-ewotcbYMmKLPNEKgWa+f7f1wab3Vn/tGshTfGE7xlIEvkha6Y80XnBzT/aSxHO1JG60/4D5Rt9M2WmuQYPVBUQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@atlaskit/theme": "^14.0.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/codemod-utils": {
+            "version": "4.2.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/codemod-utils/-/codemod-utils-4.2.4.tgz",
+            "integrity": "sha512-ETeLShTnEpLvsEhm0wmIlC7toRPy9hrMGbttdsiKzyUeGQQ3VqBxvOOPZNA6Uvi0660Jjd3lS7n5u7R/Ku0OHg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/ds-lib": {
+            "version": "3.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-3.3.0.tgz",
+            "integrity": "sha512-8bgJRFvL4C9dOc3XQ0nJLze4OSXtfemmE2os2h/T80hSdQO57hPMnXB22Pl6nT/6nEP7kZ4kAH6hDuJ3vBUNPA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/focus-ring": {
+            "version": "2.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/focus-ring/-/focus-ring-2.0.0.tgz",
+            "integrity": "sha512-EjCPbwGotrIhOHKAvWiRTcCEeorzhvS2c0t3BD6I4qdOnJzdUATp6YmAn8yAhT1tYIEHg3SKthf/RzwIQWMTKw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^2.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.1",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/icon": {
+            "version": "23.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-23.1.1.tgz",
+            "integrity": "sha512-RfdxAwCz0DgTMMLT908j72QTnfldXGIhEBsuKSr9lkKmodPIZw5AH3JnnQBy8WHWI1XzQ1VCl6YICvdvY7Dasw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@atlaskit/tokens": "^2.5.0",
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/platform-feature-flags": {
+            "version": "0.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.3.0.tgz",
+            "integrity": "sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/popper": {
+            "version": "6.3.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/popper/-/popper-6.3.1.tgz",
+            "integrity": "sha512-f3g3kufpozSX5bc2cBxZRqDOpj2cyIMfLV2tM24bWJr16qIuruhSaznz1qx0dwYrKmDcWwzQXUHGdcCxONWZPg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "@popperjs/core": "^2.11.8",
+                "react-popper": "^2.3.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/popper/node_modules/react-popper": {
+            "version": "2.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-popper/-/react-popper-2.3.0.tgz",
+            "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "react-fast-compare": "^3.0.1",
+                "warning": "^4.0.2"
+            },
+            "peerDependencies": {
+                "@popperjs/core": "^2.0.0",
+                "react": "^16.8.0 || ^17 || ^18",
+                "react-dom": "^16.8.0 || ^17 || ^18"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/primitives": {
+            "version": "13.3.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-13.3.6.tgz",
+            "integrity": "sha512-KqQqwialDVfKzUbgafAnT2fVmCaDM3WjYi2/N+yFhsQOQCKKqrMWOW/Ics0se09Ejndm4DnMKb03Q10Xf506fA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^10.2.0",
+                "@atlaskit/app-provider": "^1.4.0",
+                "@atlaskit/css": "^0.7.0",
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/interaction-context": "^2.4.0",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@atlaskit/tokens": "^2.5.0",
+                "@atlaskit/visually-hidden": "^1.5.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.1",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/primitives/node_modules/@atlaskit/analytics-next": {
+            "version": "10.2.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/analytics-next/-/analytics-next-10.2.1.tgz",
+            "integrity": "sha512-KpabZa6OxKoz4sABtbU6nSzZk12RmnUD+CDQKRq50TUWXOsaOBFZ5iXJPQA4gD0gl4WMGHO/9RG//JYXHLK3fg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next-stable-react-context": "1.0.1",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "prop-types": "^15.5.10",
+                "use-memo-one": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.2.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/spinner": {
+            "version": "16.3.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/spinner/-/spinner-16.3.4.tgz",
+            "integrity": "sha512-e8KMhYIMHHr96hYd3MH8sleWkFRcHQMYaea/0DDKNSBeOFaGuO0uwqKbgh6ZC46gIzIcdGSKc/3HhTVp/joGCA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/interaction-context": "^2.1.0",
+                "@atlaskit/theme": "^14.0.0",
+                "@atlaskit/tokens": "^2.2.0",
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/theme": {
+            "version": "14.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-14.0.3.tgz",
+            "integrity": "sha512-ZUJzeGxX8tzjb482vZbVvsTVeKiOfs+M6Y7qoIAB9xquO03a1hbkK/j9NCGm1lU/VTAbjl0eQ2vq3J+wTE4ibQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/tokens": "^2.4.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/tokens": {
+            "version": "2.5.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-2.5.0.tgz",
+            "integrity": "sha512-o7c3NRnoOC7zpjQS9dRD0sm9CJuBN20iXZSUVoY/yzDA2jPZ8Xtlt0X8WwpxjFHk+AswQFU3CZTn+5D9YFEufg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^3.3.0",
+                "@atlaskit/platform-feature-flags": "^0.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@atlaskit/visually-hidden": {
+            "version": "1.5.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-1.5.1.tgz",
+            "integrity": "sha512-BM7tyCvc2s6KT0SrGIhzQimu5ZikpfGBtmR3qpTcDBZJ4QnBQgOe1T8bCxumF0MJRx+hT/6kZIt07qcE6T/SLw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@emotion/hash": {
+            "version": "0.9.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@emotion/serialize": {
+            "version": "1.3.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/section-message/node_modules/@emotion/utils": {
+            "version": "1.4.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/section-message/node_modules/bind-event-listener": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+            "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/section-message/node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/section-message/node_modules/react-fast-compare": {
+            "version": "3.2.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+            "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/section-message/node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
         },
         "node_modules/@atlaskit/select": {
             "version": "15.2.5",
@@ -2537,6 +3185,33 @@
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
+        },
+        "node_modules/@compiled/jest": {
+            "version": "0.10.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@compiled/jest/-/jest-0.10.5.tgz",
+            "integrity": "sha512-8H/FEgfcIWzmnYZ3Sezl3dv14huymhEHMtgSuX3BBw4+gxmn/xVJxFFlVLYgU1GqHr16nY+ouViCTDHLnAf8bA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "css": "^3.0.0"
+            }
+        },
+        "node_modules/@compiled/react": {
+            "version": "0.18.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@compiled/react/-/react-0.18.1.tgz",
+            "integrity": "sha512-sL2UqrWaErILSPdnkg1Mt7CyVIET+j9+TArVSU609/wE/72KN3THFIUiMMmI1P8kX7CskPY7JdkcU6q70vPmVQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "csstype": "^3.1.2"
+            },
+            "peerDependencies": {
+                "react": ">= 16.12.0"
+            }
+        },
+        "node_modules/@compiled/react/node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT"
         },
         "node_modules/@coolaj86/urequest": {
             "version": "1.3.7",
@@ -8579,6 +9254,18 @@
                 "node": ">= 4.0.0"
             }
         },
+        "node_modules/atob": {
+            "version": "2.1.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "license": "(MIT OR Apache-2.0)",
+            "bin": {
+                "atob": "bin/atob.js"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
+        },
         "node_modules/attr-accept": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.1.0.tgz",
@@ -11129,6 +11816,17 @@
                 "semver": "bin/semver"
             }
         },
+        "node_modules/css": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/css/-/css-3.0.0.tgz",
+            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "source-map": "^0.6.1",
+                "source-map-resolve": "^0.6.0"
+            }
+        },
         "node_modules/css-blank-pseudo": {
             "version": "7.0.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/css-blank-pseudo/-/css-blank-pseudo-7.0.0.tgz",
@@ -12148,6 +12846,21 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css/node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/css/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/cssdb": {
             "version": "8.1.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cssdb/-/cssdb-8.1.1.tgz",
@@ -12304,6 +13017,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decode-uri-component": {
+            "version": "0.2.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/decompress-response": {
@@ -26420,6 +27142,17 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/source-map-resolve": {
+            "version": "0.6.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+            "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+            "license": "MIT",
+            "dependencies": {
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0"
             }
         },
         "node_modules/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -1384,7 +1384,7 @@
         "@atlaskit/page-header": "^10.2.2",
         "@atlaskit/panel": "^0.4.7",
         "@atlaskit/radio": "^5.3.3",
-        "@atlaskit/section-message": "^6.1.4",
+        "@atlaskit/section-message": "^6.8.2",
         "@atlaskit/select": "^15.2.4",
         "@atlaskit/spinner": "^15.1.3",
         "@atlaskit/table-tree": "^9.0.12",

--- a/src/webviews/components/ErrorBanner.tsx
+++ b/src/webviews/components/ErrorBanner.tsx
@@ -69,20 +69,16 @@ export default class ErrorBanner extends React.Component<
 
         const title: string = this.state.errorDetails.title ? this.state.errorDetails.title : 'Something went wrong';
         return (
-            <SectionMessage
-                appearance="warning"
-                title={title}
-                actions={[
-                    {
-                        text: 'Dismiss',
-                        onClick: () => {
-                            this.setState({ errorDetails: undefined });
-                            this.props.onDismissError();
-                        },
-                    },
-                ]}
-            >
+            <SectionMessage appearance="warning" title={title}>
                 <div>{errorMarkup}</div>
+                <button
+                    onClick={() => {
+                        this.setState({ errorDetails: undefined });
+                        this.props.onDismissError();
+                    }}
+                >
+                    Dismiss
+                </button>
             </SectionMessage>
         );
     }

--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -284,9 +284,21 @@ export abstract class AbstractIssueEditorPage<
         });
     };
 
+    /**
+     * AXON-49 This is a workaround for the suggested autocomplete URL
+     * (.../user/recommend/...) not being accessible
+     */
+    protected fixAutocompleteUrl(url: string): string {
+        if (url.includes('user/recommend')) {
+            url = url.replace('user/recommend', 'user/search') + '&query=';
+        }
+
+        return url;
+    }
+
     protected loadSelectOptionsForField = (field: SelectFieldUI, input: string): Promise<any[]> => {
         this.setState({ isSomethingLoading: true, loadingField: field.key });
-        return this.loadSelectOptions(input, field.autoCompleteUrl);
+        return this.loadSelectOptions(input, this.fixAutocompleteUrl(field.autoCompleteUrl));
     };
 
     protected loadSelectOptions = (input: string, url: string): Promise<any[]> => {


### PR DESCRIPTION
### What is this?

Small rabbit hole started from chasing an easy win 🐰 

We got a user report that editing the `Reporter` field on the JIRA issue page causes the whole page to crash. 

This PR fixes the error banner used there - which was very ungracefully failing to render.

This PR ALSO addresses the root cause of the error that needed the banner in the first place - by temporarily replacing the `/rest/api/2/user/recommend` API with `/rest/api/2/user/search` for that field


#### Before

https://github.com/user-attachments/assets/19ec081a-a2b3-4492-9582-1ce18a9e58de

#### After the ErrorBanner Fix

https://github.com/user-attachments/assets/e50391ac-0dd6-4ef7-b129-3df568efb0a4

#### Final State

https://github.com/user-attachments/assets/95d4fd61-fd24-423b-bf2e-99ec38e32ded


### How was this tested

Rather painfully 😢

Built the extension, used a project where editing `Reporter` is allowed, edited the field a bunch and made sure the search works (albeit with worse UX)

The E2E test for this is notably missing in the PR 😉
