### PR TITLE
[AXON-45] chore: speed up iteration on UI with --watch (devprod)

### DIFF
--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -11,21 +11,21 @@
             "request": "launch",
             "program": "${workspaceFolder}/node_modules/.bin/extest",
             "windows": {
-              "program": "${workspaceFolder}/node_modules/vscode-extension-tester/out/cli.js",
+                "program": "${workspaceFolder}/node_modules/vscode-extension-tester/out/cli.js",
             },
             "args": [
-              "run-tests",
-              "${workspaceFolder}/.generated/atlascode/e2e/tests/*.test.js",
-              "--code_settings",
-              "${workspaceFolder}/e2e/test-settings.json",
-              "--extensions_dir",
-              ".test-extensions",
-              "--mocha_config",
-              "${workspaceFolder}/.mocharc.js"
+                "run-tests",
+                "${workspaceFolder}/.generated/atlascode/e2e/tests/*.test.js",
+                "--code_settings",
+                "${workspaceFolder}/e2e/test-settings.json",
+                "--extensions_dir",
+                ".test-extensions",
+                "--mocha_config",
+                "${workspaceFolder}/.mocharc.js"
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
-          },
+        },
         {
             "name": "Extension",
             "type": "extensionHost",
@@ -38,6 +38,20 @@
                 "${workspaceFolder}/build/**/*.js"
             ],
             "preLaunchTask": "npm: devcompile"
+        },
+        {
+            // This configuration requires npm run dev to be running externally
+            // It will pick up the re-compiled extension code but not hot-swap it 
+            "name": "Extension (watch/external)",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/build/**/*.js"
+            ],
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,7 @@
                 "autoprefixer": "^10.4.20",
                 "babel-loader": "^9.2.1",
                 "chai": "^4",
+                "concurrently": "^9.1.2",
                 "cross-env": "^7.0.2",
                 "css-loader": "^7.1.2",
                 "css-minimizer-webpack-plugin": "^7.0.0",
@@ -11337,6 +11338,158 @@
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "license": "MIT"
+        },
+        "node_modules/concurrently": {
+            "version": "9.1.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/concurrently/-/concurrently-9.1.2.tgz",
+            "integrity": "sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "lodash": "^4.17.21",
+                "rxjs": "^7.8.1",
+                "shell-quote": "^1.8.1",
+                "supports-color": "^8.1.1",
+                "tree-kill": "^1.2.2",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "conc": "dist/bin/concurrently.js",
+                "concurrently": "dist/bin/concurrently.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+            }
+        },
+        "node_modules/concurrently/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/concurrently/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/concurrently/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/concurrently/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/concurrently/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concurrently/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/concurrently/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/concurrently/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/connect-history-api-fallback": {
             "version": "2.0.0",
@@ -26572,6 +26725,23 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/rxjs": {
+            "version": "7.8.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/rxjs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/safe-array-concat": {
             "version": "1.1.2",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -28289,6 +28459,16 @@
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "license": "MIT"
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
         },
         "node_modules/treeify": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
         "devcompile": "npm-run-all --parallel devcompile:react devcompile:extension",
         "devcompile:react": "webpack --mode development --config webpack.react.dev.js",
         "devcompile:extension": "webpack --mode development --config webpack.extension.dev.js",
+
+        "watch": "concurrently -r \"npm:watch:*\"",
+        "watch:extension": "WATCH=true webpack --mode development --config webpack.react.dev.js --progress --watch",
+        "watch:react": "WATCH=true webpack --mode development --config webpack.extension.dev.js --progress --watch",
+        "dev": "concurrently -r npm:watch:extension npm:watch:react",
+
         "mui:atlascodeSettings:dark": "cross-env PAGETSX=\"config/ConfigPage.tsx\" VIEW=\"atlascodeSettingsV2\" THEME=\"dark\" webpack-dev-server --open --config webpack.mui.webview.js",
         "mui:atlascodeSettings:light": "cross-env PAGETSX=\"config/ConfigPage.tsx\" VIEW=\"atlascodeSettingsV2\" THEME=\"light\" webpack-dev-server --open --config webpack.mui.webview.js",
         "mui:atlascodeOnboarding:dark": "cross-env PAGETSX=\"onboarding/OnboardingPage.tsx\" VIEW=\"atlascodeOnboardingV2\" THEME=\"dark\" webpack-dev-server --open --config webpack.mui.webview.js",
@@ -1523,6 +1529,7 @@
         "autoprefixer": "^10.4.20",
         "babel-loader": "^9.2.1",
         "chai": "^4",
+        "concurrently": "^9.1.2",
         "cross-env": "^7.0.2",
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.0",

--- a/webpack.extension.dev.js
+++ b/webpack.extension.dev.js
@@ -13,7 +13,7 @@ dotenv.config();
 
 module.exports = [
     {
-        bail: true,
+        bail: !process.env.WATCH,
         name: 'extension',
         mode: 'development',
         target: 'node',


### PR DESCRIPTION
### What is this?

Small devprod improvement - added another launch configuration that would leverage `webpack --watch`, at least to some extent. The wall clock time of iterating in UI went from ~35 sec per build to instant

With this approach, if you run `npm run dev` in an shell somewhere, VSCode extension host starts without prerequisites, and uses whatever files are generated by `webpack` on the fly.

I've tried doing something fancier with hotswap, launch configurations, and webpack dev server - but unfortunately this is the only configuration which worked reliably enough

### How was this tested?

Pretty extensively? Iterated the UI a bunch with the new launch configuration, and some alternatives that didn't make it into this PR :D