### PR TITLE
Revert to vscode engine compatibility >=1.77.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "theme": "light"
     },
     "engines": {
-        "vscode": "^1.93.0"
+        "vscode": "^1.77.0"
     },
     "categories": [
         "Other"
@@ -1515,7 +1515,7 @@
         "@types/terser-webpack-plugin": "^2.2.0",
         "@types/turndown": "^5.0.1",
         "@types/uuid": "^3.4.7",
-        "@types/vscode": "^1.93.0",
+        "@types/vscode": "^1.77.0",
         "@types/webpack": "^5.28.5",
         "@types/webpack-manifest-plugin": "^2.1.0",
         "@types/websocket": "^1.0.0",


### PR DESCRIPTION
Project IDX looks for extensions that are compatible with the engine that it is running on. If the extension claims it runs on a higher version, it won't show up to be installed. 

To fix this, we are lowering our compatiblity requirement to match what we are actually compatible with. 

Note: we could go lower, we just haven't tested if we can. 1.77.0 is from March 2023