### PR TITLE
AXON-111 revert changes that made special chars not work for BB DC

### DIFF
--- a/src/atlclients/loginManager.ts
+++ b/src/atlclients/loginManager.ts
@@ -172,13 +172,13 @@ export class LoginManager {
                     ...getAgent(site),
                 });
                 const slugRegex = /[\[\:\/\?#@\!\$&'\(\)\*\+,;\=%\\\[\]]/gi;
-                let ausername = res.headers['x-ausername']; // bwieger 
+                let ausername = res.headers['x-ausername'];
                 // convert the %40 and similar to special characters
                 ausername = decodeURIComponent(ausername);
                 // replace special characters with underscore (_)
                 ausername = ausername.replace(slugRegex, '_');
                 siteDetailsUrl = `${apiUrl}/rest/api/1.0/users/${ausername}`;
-                avatarUrl = `${apiUrl}/users/${ausername}/avatar.png?s=64`; 
+                avatarUrl = `${apiUrl}/users/${ausername}/avatar.png?s=64`;
                 break;
         }
 

--- a/src/atlclients/loginManager.ts
+++ b/src/atlclients/loginManager.ts
@@ -171,9 +171,14 @@ export class LoginManager {
                     },
                     ...getAgent(site),
                 });
-                let ausername = res.headers['x-ausername'];
+                const slugRegex = /[\[\:\/\?#@\!\$&'\(\)\*\+,;\=%\\\[\]]/gi;
+                let ausername = res.headers['x-ausername']; // bwieger 
+                // convert the %40 and similar to special characters
+                ausername = decodeURIComponent(ausername);
+                // replace special characters with underscore (_)
+                ausername = ausername.replace(slugRegex, '_');
                 siteDetailsUrl = `${apiUrl}/rest/api/1.0/users/${ausername}`;
-                avatarUrl = `${apiUrl}/users/${ausername}/avatar.png?s=64`;
+                avatarUrl = `${apiUrl}/users/${ausername}/avatar.png?s=64`; 
                 break;
         }
 


### PR DESCRIPTION

Video of solution working: 

https://github.com/user-attachments/assets/0b8bab9e-8136-45a0-9e95-f14b1cfedacf

Issue: https://github.com/atlassian/atlascode/issues/77

Community pointing out the issue: https://github.com/atlassian/atlascode/pull/41/files 

Solution: 
1. Unfortunately, unlike before the credential object didn't contain the username. That why in the past PR, the `/rest/api/latest/build/capabilities` API was introduced to get the username info 
2. The header returns this in URI encoding eg: bwieger%40atlassian.com 
3. So that needs to be convert to standard text eg: bwieger@atlassian.com
4. And then the special characters can be replaced with the prior regex. 