### PR TITLE
[Axon 97] Fix image rendering in Jira Cloud tickets' description and comments

### DIFF
--- a/src/util/html.test.ts
+++ b/src/util/html.test.ts
@@ -1,72 +1,75 @@
 import * as html from './html';
 
 describe('html util', () => {
-
     describe('fix relative URLs in html', () => {
-
         it('replaceRelativeURLsWithAbsolute correctly replaces the relative URL', () => {
-            const baseUrl = "https://www.domain.com/path1/path2/path3";
-            const htmlText = "<p><label>/imgs/test.png</label><img src=\"/imgs/test.png\" /></p>";
+            const baseUrl = 'https://www.domain.com/path1/path2/path3';
+            const htmlText = '<p><label>/imgs/test.png</label><img src="/imgs/test.png" /></p>';
 
-            const expectedHtml = "<p><label>/imgs/test.png</label><img src=\"https://www.domain.com/path1/path2/imgs/test.png\" /></p>";
+            const expectedHtml =
+                '<p><label>/imgs/test.png</label><img src="https://www.domain.com/path1/path2/imgs/test.png" /></p>';
 
             const fixedHtml = html.replaceRelativeURLsWithAbsolute(htmlText, baseUrl);
             expect(fixedHtml).toBe(expectedHtml);
         });
 
         it('replaceRelativeURLsWithAbsolute correctly replaces all relative URLs', () => {
-            const baseUrl = "https://www.domain.com/path1/path2/path3";
-            const htmlText = "<p>" +
-                "<label>/imgs/test1.png</label><img src=\"/imgs/test1.png\" />" +
-                "<label>/imgs/test2.png</label><img src=\"/imgs/test2.png\" />" +
+            const baseUrl = 'https://www.domain.com/path1/path2/path3';
+            const htmlText =
+                '<p>' +
+                '<label>/imgs/test1.png</label><img src="/imgs/test1.png" />' +
+                '<label>/imgs/test2.png</label><img src="/imgs/test2.png" />' +
                 "<label>/imgs/test3.png</label><img src='/imgs/test3.png' />" +
                 "<label>/imgs/test4.png</label><img src='/imgs/test4.png' />" +
-                "</p>";
+                '</p>';
 
-            const expectedHtml = "<p>" +
-                "<label>/imgs/test1.png</label><img src=\"https://www.domain.com/path1/path2/imgs/test1.png\" />" +
-                "<label>/imgs/test2.png</label><img src=\"https://www.domain.com/path1/path2/imgs/test2.png\" />" +
+            const expectedHtml =
+                '<p>' +
+                '<label>/imgs/test1.png</label><img src="https://www.domain.com/path1/path2/imgs/test1.png" />' +
+                '<label>/imgs/test2.png</label><img src="https://www.domain.com/path1/path2/imgs/test2.png" />' +
                 "<label>/imgs/test3.png</label><img src='https://www.domain.com/path1/path2/imgs/test3.png' />" +
                 "<label>/imgs/test4.png</label><img src='https://www.domain.com/path1/path2/imgs/test4.png' />" +
-                "</p>";
+                '</p>';
 
             const fixedHtml = html.replaceRelativeURLsWithAbsolute(htmlText, baseUrl);
             expect(fixedHtml).toBe(expectedHtml);
         });
 
         it("replaceRelativeURLsWithAbsolute doesn't replaces absolute URLs", () => {
-            const baseUrl = "https://www.domain.com/path1/path2/path3";
-            const htmlText = "<p><label>/imgs/test.png</label><img src=\"https://www.domain.com/imgs/test.png\" /></p>";
+            const baseUrl = 'https://www.domain.com/path1/path2/path3';
+            const htmlText = '<p><label>/imgs/test.png</label><img src="https://www.domain.com/imgs/test.png" /></p>';
 
             const fixedHtml = html.replaceRelativeURLsWithAbsolute(htmlText, baseUrl);
             expect(fixedHtml).toBe(htmlText);
         });
 
         it("if there aren't relative URLs, nothing changes", () => {
-            const baseUrl = "https://www.domain.com/path1/path2/path3";
-            const htmlText = "<p><label>hello</label></p>";
+            const baseUrl = 'https://www.domain.com/path1/path2/path3';
+            const htmlText = '<p><label>hello</label></p>';
 
             const fixedHtml = html.replaceRelativeURLsWithAbsolute(htmlText, baseUrl);
             expect(fixedHtml).toBe(htmlText);
         });
 
         it('last segment of the path is ignored unless it ends with a /', () => {
-            const htmlText = "<img src=\"/imgs/test.png\" />";
+            const htmlText = '<img src="/imgs/test.png" />';
 
-            expect(html.replaceRelativeURLsWithAbsolute(htmlText, "https://www.domain.com/path1/path2")).toBe("<img src=\"https://www.domain.com/path1/imgs/test.png\" />");
-            expect(html.replaceRelativeURLsWithAbsolute(htmlText, "https://www.domain.com/path1/path2/")).toBe("<img src=\"https://www.domain.com/path1/path2/imgs/test.png\" />");
-        });        
-
-        it('nullables are correctly handled', () => {
-            expect(html.replaceRelativeURLsWithAbsolute('', "https://www.domain.com/")).toBe('');
-            expect(html.replaceRelativeURLsWithAbsolute(null!, "https://www.domain.com/")).toBe(null);
-            expect(html.replaceRelativeURLsWithAbsolute(undefined!, "https://www.domain.com/")).toBe(undefined);
-
-            expect(html.replaceRelativeURLsWithAbsolute("<p></p>", '')).toBe("<p></p>");
-            expect(html.replaceRelativeURLsWithAbsolute("<p></p>", null!)).toBe("<p></p>");
-            expect(html.replaceRelativeURLsWithAbsolute("<p></p>", undefined!)).toBe("<p></p>");
+            expect(html.replaceRelativeURLsWithAbsolute(htmlText, 'https://www.domain.com/path1/path2')).toBe(
+                '<img src="https://www.domain.com/path1/imgs/test.png" />',
+            );
+            expect(html.replaceRelativeURLsWithAbsolute(htmlText, 'https://www.domain.com/path1/path2/')).toBe(
+                '<img src="https://www.domain.com/path1/path2/imgs/test.png" />',
+            );
         });
 
-    });
+        it('nullables are correctly handled', () => {
+            expect(html.replaceRelativeURLsWithAbsolute('', 'https://www.domain.com/')).toBe('');
+            expect(html.replaceRelativeURLsWithAbsolute(null!, 'https://www.domain.com/')).toBe(null);
+            expect(html.replaceRelativeURLsWithAbsolute(undefined!, 'https://www.domain.com/')).toBe(undefined);
 
+            expect(html.replaceRelativeURLsWithAbsolute('<p></p>', '')).toBe('<p></p>');
+            expect(html.replaceRelativeURLsWithAbsolute('<p></p>', null!)).toBe('<p></p>');
+            expect(html.replaceRelativeURLsWithAbsolute('<p></p>', undefined!)).toBe('<p></p>');
+        });
+    });
 });

--- a/src/util/html.test.ts
+++ b/src/util/html.test.ts
@@ -1,0 +1,72 @@
+import * as html from './html';
+
+describe('html util', () => {
+
+    describe('fix relative URLs in html', () => {
+
+        it('replaceRelativeURLsWithAbsolute correctly replaces the relative URL', () => {
+            const baseUrl = "https://www.domain.com/path1/path2/path3";
+            const htmlText = "<p><label>/imgs/test.png</label><img src=\"/imgs/test.png\" /></p>";
+
+            const expectedHtml = "<p><label>/imgs/test.png</label><img src=\"https://www.domain.com/path1/path2/imgs/test.png\" /></p>";
+
+            const fixedHtml = html.replaceRelativeURLsWithAbsolute(htmlText, baseUrl);
+            expect(fixedHtml).toBe(expectedHtml);
+        });
+
+        it('replaceRelativeURLsWithAbsolute correctly replaces all relative URLs', () => {
+            const baseUrl = "https://www.domain.com/path1/path2/path3";
+            const htmlText = "<p>" +
+                "<label>/imgs/test1.png</label><img src=\"/imgs/test1.png\" />" +
+                "<label>/imgs/test2.png</label><img src=\"/imgs/test2.png\" />" +
+                "<label>/imgs/test3.png</label><img src='/imgs/test3.png' />" +
+                "<label>/imgs/test4.png</label><img src='/imgs/test4.png' />" +
+                "</p>";
+
+            const expectedHtml = "<p>" +
+                "<label>/imgs/test1.png</label><img src=\"https://www.domain.com/path1/path2/imgs/test1.png\" />" +
+                "<label>/imgs/test2.png</label><img src=\"https://www.domain.com/path1/path2/imgs/test2.png\" />" +
+                "<label>/imgs/test3.png</label><img src='https://www.domain.com/path1/path2/imgs/test3.png' />" +
+                "<label>/imgs/test4.png</label><img src='https://www.domain.com/path1/path2/imgs/test4.png' />" +
+                "</p>";
+
+            const fixedHtml = html.replaceRelativeURLsWithAbsolute(htmlText, baseUrl);
+            expect(fixedHtml).toBe(expectedHtml);
+        });
+
+        it("replaceRelativeURLsWithAbsolute doesn't replaces absolute URLs", () => {
+            const baseUrl = "https://www.domain.com/path1/path2/path3";
+            const htmlText = "<p><label>/imgs/test.png</label><img src=\"https://www.domain.com/imgs/test.png\" /></p>";
+
+            const fixedHtml = html.replaceRelativeURLsWithAbsolute(htmlText, baseUrl);
+            expect(fixedHtml).toBe(htmlText);
+        });
+
+        it("if there aren't relative URLs, nothing changes", () => {
+            const baseUrl = "https://www.domain.com/path1/path2/path3";
+            const htmlText = "<p><label>hello</label></p>";
+
+            const fixedHtml = html.replaceRelativeURLsWithAbsolute(htmlText, baseUrl);
+            expect(fixedHtml).toBe(htmlText);
+        });
+
+        it('last segment of the path is ignored unless it ends with a /', () => {
+            const htmlText = "<img src=\"/imgs/test.png\" />";
+
+            expect(html.replaceRelativeURLsWithAbsolute(htmlText, "https://www.domain.com/path1/path2")).toBe("<img src=\"https://www.domain.com/path1/imgs/test.png\" />");
+            expect(html.replaceRelativeURLsWithAbsolute(htmlText, "https://www.domain.com/path1/path2/")).toBe("<img src=\"https://www.domain.com/path1/path2/imgs/test.png\" />");
+        });        
+
+        it('nullables are correctly handled', () => {
+            expect(html.replaceRelativeURLsWithAbsolute('', "https://www.domain.com/")).toBe('');
+            expect(html.replaceRelativeURLsWithAbsolute(null!, "https://www.domain.com/")).toBe(null);
+            expect(html.replaceRelativeURLsWithAbsolute(undefined!, "https://www.domain.com/")).toBe(undefined);
+
+            expect(html.replaceRelativeURLsWithAbsolute("<p></p>", '')).toBe("<p></p>");
+            expect(html.replaceRelativeURLsWithAbsolute("<p></p>", null!)).toBe("<p></p>");
+            expect(html.replaceRelativeURLsWithAbsolute("<p></p>", undefined!)).toBe("<p></p>");
+        });
+
+    });
+
+});

--- a/src/util/html.ts
+++ b/src/util/html.ts
@@ -1,0 +1,13 @@
+const regex1 = / src="\/[^"]+/g;
+const regex2 = / src='\/[^']+/g;
+
+export function replaceRelativeURLsWithAbsolute(renderedHtml: string, baseApiUrl: string): string | undefined {
+    if (!renderedHtml || !baseApiUrl) {
+        return renderedHtml;
+    }
+    
+    // substring(7) because we need to get the relative url without the first '/'
+    return renderedHtml
+        .replace(regex1, x => ` src=\"${new URL(x.substring(7), baseApiUrl).href}`)
+        .replace(regex2, x => ` src=\'${new URL(x.substring(7), baseApiUrl).href}`);
+}

--- a/src/util/html.ts
+++ b/src/util/html.ts
@@ -5,9 +5,9 @@ export function replaceRelativeURLsWithAbsolute(renderedHtml: string, baseApiUrl
     if (!renderedHtml || !baseApiUrl) {
         return renderedHtml;
     }
-    
+
     // substring(7) because we need to get the relative url without the first '/'
     return renderedHtml
-        .replace(regex1, x => ` src=\"${new URL(x.substring(7), baseApiUrl).href}`)
-        .replace(regex2, x => ` src=\'${new URL(x.substring(7), baseApiUrl).href}`);
+        .replace(regex1, (x) => ` src=\"${new URL(x.substring(7), baseApiUrl).href}`)
+        .replace(regex2, (x) => ` src=\'${new URL(x.substring(7), baseApiUrl).href}`);
 }

--- a/src/util/html.ts
+++ b/src/util/html.ts
@@ -6,7 +6,9 @@ export function replaceRelativeURLsWithAbsolute(renderedHtml: string, baseApiUrl
         return renderedHtml;
     }
 
-    // substring(7) because we need to get the relative url without the first '/'
+    // The regex is searching for anything starting with ' src="/' which is 7 chars long,
+    // and we need to get the relative URL without including its first /, so anything after those 7 characters.
+    // Therefore, substring(7).
     return renderedHtml
         .replace(regex1, (x) => ` src=\"${new URL(x.substring(7), baseApiUrl).href}`)
         .replace(regex2, (x) => ` src=\'${new URL(x.substring(7), baseApiUrl).href}`);

--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -40,6 +40,7 @@ import {
 } from '../../../ipc/issueMessaging';
 import { Action, HostErrorMessage, Message } from '../../../ipc/messaging';
 import { ConnectionTimeout } from '../../../util/time';
+import { replaceRelativeURLsWithAbsolute } from '../../../util/html';
 import { colorToLozengeAppearanceMap } from '../colors';
 import * as FieldValidators from '../fieldValidators';
 import * as SelectFieldHelper from '../selectFieldHelper';
@@ -371,7 +372,7 @@ export abstract class AbstractIssueEditorPage<
         }
     }, 100);
 
-    protected getInputMarkup(field: FieldUI, editmode: boolean = false): any {
+    protected getInputMarkup(field: FieldUI, baseApiUrl: string, editmode: boolean = false): any {
         switch (field.uiType) {
             case UIType.Input: {
                 let validateFunc = this.getValidateFunction(field, editmode);
@@ -401,10 +402,12 @@ export abstract class AbstractIssueEditorPage<
                     let markup: React.ReactNode = <p></p>;
 
                     if ((field as InputFieldUI).isMultiline) {
+                        const html = this.state.fieldValues[`${field.key}.rendered`] || undefined;
+                        const fixedHtml = replaceRelativeURLsWithAbsolute(html, baseApiUrl);
                         markup = (
                             <EditRenderedTextArea
                                 text={this.state.fieldValues[`${field.key}`]}
-                                renderedText={this.state.fieldValues[`${field.key}.rendered`]}
+                                renderedText={fixedHtml}
                                 fetchUsers={async (input: string) =>
                                     (await this.fetchUsers(input)).map((user) => ({
                                         displayName: user.displayName,

--- a/src/webviews/components/issue/CommentComponent.tsx
+++ b/src/webviews/components/issue/CommentComponent.tsx
@@ -12,11 +12,13 @@ import React, { useState } from 'react';
 import { DetailedSiteInfo } from '../../../atlclients/authInfo';
 import { RenderedContent } from '../RenderedContent';
 import { TextAreaEditor } from './TextAreaEditor';
+import { replaceRelativeURLsWithAbsolute } from '../../../util/html';
 
 type Props = {
     siteDetails: DetailedSiteInfo;
     comment: JiraComment;
     isServiceDeskProject: boolean;
+    baseApiUrl: string;
     fetchUsers: (input: string) => Promise<any[]>;
     onSave: (commentBody: string, commentId?: string, restriction?: CommentVisibility) => void;
     onDelete: (commentId: string) => void;
@@ -27,6 +29,7 @@ export const CommentComponent: React.FC<Props> = ({
     siteDetails,
     comment,
     isServiceDeskProject,
+    baseApiUrl,
     fetchUsers,
     onSave,
     onDelete,
@@ -37,7 +40,7 @@ export const CommentComponent: React.FC<Props> = ({
     const [isSaving, setIsSaving] = useState(false);
 
     const prettyCreated = `${formatDistanceToNow(parseISO(comment.created))} ago`;
-    const body = comment.renderedBody ? comment.renderedBody : comment.body;
+    const body = replaceRelativeURLsWithAbsolute(comment.renderedBody!, baseApiUrl) || comment.body;
     const type = isServiceDeskProject ? (comment.jsdPublic ? 'external' : 'internal') : undefined;
 
     if (editing && !isSaving) {

--- a/src/webviews/components/issue/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/CreateIssuePage.tsx
@@ -278,11 +278,11 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
     };
 
     getCommonFieldMarkup(): any {
-        return this.commonFields.map((field) => this.getInputMarkup(field));
+        return this.commonFields.map((field) => this.getInputMarkup(field, this.state.siteDetails.baseApiUrl));
     }
 
     getAdvancedFieldMarkup(): any {
-        return this.advancedFields.map((field) => this.getInputMarkup(field));
+        return this.advancedFields.map((field) => this.getInputMarkup(field, this.state.siteDetails.baseApiUrl));
     }
 
     public render() {

--- a/src/webviews/components/issue/JiraIssuePage.tsx
+++ b/src/webviews/components/issue/JiraIssuePage.tsx
@@ -501,7 +501,14 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                             />
                         </Tooltip>
                     </div>
-                    <h2>{this.getInputMarkup(this.state.fields['summary'], this.state.siteDetails.baseApiUrl, true, 'summary')}</h2>
+                    <h2>
+                        {this.getInputMarkup(
+                            this.state.fields['summary'],
+                            this.state.siteDetails.baseApiUrl,
+                            true,
+                            'summary',
+                        )}
+                    </h2>
                 </div>
                 {this.state.isErrorBannerOpen && (
                     <ErrorBanner onDismissError={this.handleDismissError} errorDetails={this.state.errorDetails} />
@@ -516,7 +523,12 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                 {this.state.fields['description'] && (
                     <div className="ac-vpadding">
                         <label className="ac-field-label">{this.state.fields['description'].name}</label>
-                        {this.getInputMarkup(this.state.fields['description'], this.state.siteDetails.baseApiUrl, true, 'description')}
+                        {this.getInputMarkup(
+                            this.state.fields['description'],
+                            this.state.siteDetails.baseApiUrl,
+                            true,
+                            'description',
+                        )}
                     </div>
                 )}
                 {this.state.fields['attachment'] &&
@@ -552,7 +564,12 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     this.state.fieldValues['environment'].trim() !== '' && (
                         <div className="ac-vpadding">
                             <label className="ac-field-label">{this.state.fields['environment'].name}</label>
-                            {this.getInputMarkup(this.state.fields['environment'], this.state.siteDetails.baseApiUrl, true, 'environment')}
+                            {this.getInputMarkup(
+                                this.state.fields['environment'],
+                                this.state.siteDetails.baseApiUrl,
+                                true,
+                                'environment',
+                            )}
                         </div>
                     )}
 
@@ -568,7 +585,12 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     !this.state.isEpic &&
                     !this.state.fieldValues['issuetype'].subtask && (
                         <div className="ac-vpadding">
-                            {this.getInputMarkup(this.state.fields['subtasks'], this.state.siteDetails.baseApiUrl, true, 'subtasks')}
+                            {this.getInputMarkup(
+                                this.state.fields['subtasks'],
+                                this.state.siteDetails.baseApiUrl,
+                                true,
+                                'subtasks',
+                            )}
                             <IssueList
                                 issues={this.state.fieldValues['subtasks']}
                                 onIssueClick={this.handleOpenIssue}
@@ -577,7 +599,12 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     )}
                 {this.state.fields['issuelinks'] && (
                     <div className="ac-vpadding">
-                        {this.getInputMarkup(this.state.fields['issuelinks'], this.state.siteDetails.baseApiUrl, true, 'issuelinks')}
+                        {this.getInputMarkup(
+                            this.state.fields['issuelinks'],
+                            this.state.siteDetails.baseApiUrl,
+                            true,
+                            'issuelinks',
+                        )}
                         <LinkedIssues
                             issuelinks={this.state.fieldValues['issuelinks']}
                             onIssueClick={this.handleOpenIssue}
@@ -625,7 +652,12 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                                 }}
                             />
                         ))}
-                        {this.getInputMarkup(this.state.fields['comment'], this.state.siteDetails.baseApiUrl, true, 'comment')}
+                        {this.getInputMarkup(
+                            this.state.fields['comment'],
+                            this.state.siteDetails.baseApiUrl,
+                            true,
+                            'comment',
+                        )}
                     </div>
                 )}
             </div>

--- a/src/webviews/components/issue/JiraIssuePage.tsx
+++ b/src/webviews/components/issue/JiraIssuePage.tsx
@@ -79,12 +79,12 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
     // TODO: proper error handling in webviews :'(
     // This is a temporary workaround to hopefully troubleshoot
     // https://github.com/atlassian/atlascode/issues/46
-    override getInputMarkup(field: FieldUI, editmode?: boolean, context?: String) {
+    override getInputMarkup(field: FieldUI, baseApiUrl: string, editmode?: boolean, context?: String) {
         if (!field) {
             console.warn(`Field error - no field when trying to render ${context}`);
             return null;
         }
-        return super.getInputMarkup(field, editmode);
+        return super.getInputMarkup(field, baseApiUrl, editmode);
     }
 
     getProjectKey = (): string => {
@@ -501,7 +501,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                             />
                         </Tooltip>
                     </div>
-                    <h2>{this.getInputMarkup(this.state.fields['summary'], true, 'summary')}</h2>
+                    <h2>{this.getInputMarkup(this.state.fields['summary'], this.state.siteDetails.baseApiUrl, true, 'summary')}</h2>
                 </div>
                 {this.state.isErrorBannerOpen && (
                     <ErrorBanner onDismissError={this.handleDismissError} errorDetails={this.state.errorDetails} />
@@ -516,7 +516,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                 {this.state.fields['description'] && (
                     <div className="ac-vpadding">
                         <label className="ac-field-label">{this.state.fields['description'].name}</label>
-                        {this.getInputMarkup(this.state.fields['description'], true, 'description')}
+                        {this.getInputMarkup(this.state.fields['description'], this.state.siteDetails.baseApiUrl, true, 'description')}
                     </div>
                 )}
                 {this.state.fields['attachment'] &&
@@ -552,7 +552,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     this.state.fieldValues['environment'].trim() !== '' && (
                         <div className="ac-vpadding">
                             <label className="ac-field-label">{this.state.fields['environment'].name}</label>
-                            {this.getInputMarkup(this.state.fields['environment'], true, 'environment')}
+                            {this.getInputMarkup(this.state.fields['environment'], this.state.siteDetails.baseApiUrl, true, 'environment')}
                         </div>
                     )}
 
@@ -568,7 +568,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     !this.state.isEpic &&
                     !this.state.fieldValues['issuetype'].subtask && (
                         <div className="ac-vpadding">
-                            {this.getInputMarkup(this.state.fields['subtasks'], true, 'subtasks')}
+                            {this.getInputMarkup(this.state.fields['subtasks'], this.state.siteDetails.baseApiUrl, true, 'subtasks')}
                             <IssueList
                                 issues={this.state.fieldValues['subtasks']}
                                 onIssueClick={this.handleOpenIssue}
@@ -577,7 +577,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     )}
                 {this.state.fields['issuelinks'] && (
                     <div className="ac-vpadding">
-                        {this.getInputMarkup(this.state.fields['issuelinks'], true, 'issuelinks')}
+                        {this.getInputMarkup(this.state.fields['issuelinks'], this.state.siteDetails.baseApiUrl, true, 'issuelinks')}
                         <LinkedIssues
                             issuelinks={this.state.fieldValues['issuelinks']}
                             onIssueClick={this.handleOpenIssue}
@@ -604,6 +604,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                                     this.state.fieldValues['project'].projectTypeKey === 'service_desk'
                                 }
                                 comment={comment}
+                                baseApiUrl={this.state.siteDetails.baseApiUrl}
                                 fetchUsers={this.fetchUsers}
                                 onSave={this.handleUpdateComment}
                                 onDelete={this.handleDeleteComment}
@@ -624,7 +625,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                                 }}
                             />
                         ))}
-                        {this.getInputMarkup(this.state.fields['comment'], true, 'comment')}
+                        {this.getInputMarkup(this.state.fields['comment'], this.state.siteDetails.baseApiUrl, true, 'comment')}
                     </div>
                 )}
             </div>
@@ -814,7 +815,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
             field && (
                 <div className="ac-vpadding" onClick={onClick}>
                     <label className="ac-field-label">{field.name}</label>
-                    {this.getInputMarkup(field, true, key)}
+                    {this.getInputMarkup(field, this.state.siteDetails.baseApiUrl, true, key)}
                 </div>
             )
         );
@@ -831,7 +832,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                 markups.push(
                     <div className="ac-vpadding">
                         <label className="ac-field-label">{field.name}</label>
-                        {this.getInputMarkup(field, true, `Advanced sidebar`)}
+                        {this.getInputMarkup(field, this.state.siteDetails.baseApiUrl, true, `Advanced sidebar`)}
                     </div>,
                 );
             }
@@ -873,7 +874,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                 markups.push(
                     <div className="ac-vpadding">
                         <label className="ac-field-label">{field.name}</label>
-                        {this.getInputMarkup(field, true, `Advanced main`)}
+                        {this.getInputMarkup(field, this.state.siteDetails.baseApiUrl, true, `Advanced main`)}
                     </div>,
                 );
             }


### PR DESCRIPTION
To render descriptions and comments of Jira tickets, we use a "rendered html" field returned by the server.

When we request the jira ticket information, Jira DC responds with a rendered html that contains images referenced with an absolute URL, which work fine.
Jira Cloud instead responds with a rendered html that contains images referenced with a relative URL, which cannot be resolved because the `<base>` url is set to some vscode react stuff.

The fix is to pre-process the "rendered html" before displaying it, fixing the relative URLs to absolute.

Tested:
- Jira Cloud, image in description and comments
- Jira DC, image in description and comments

Before:
![image](https://github.com/user-attachments/assets/06db7cee-c862-4616-a0f5-f6ff2408da11)
![image](https://github.com/user-attachments/assets/32546ec4-4e23-481b-bf4b-e2d8b479b7e9)

After:
![image](https://github.com/user-attachments/assets/0248ecc2-a07b-4e3f-a431-5d07610d4e89)
![image](https://github.com/user-attachments/assets/cf2a9fce-20a5-47f0-a368-8245baac3bb2)
