### PR TITLE
AXON-113: Fix Bitbucket DC 8.0 and later bugs with 404s 

### DIFF
--- a/src/bitbucket/bitbucket-cloud/pullRequests.ts
+++ b/src/bitbucket/bitbucket-cloud/pullRequests.ts
@@ -337,6 +337,7 @@ export class CloudPullRequestApi implements PullRequestApi {
         const { ownerSlug, repoSlug } = pr.site;
 
         try {
+            console.log('bwieger 340');
             let { data } = await this.client.get(
                 `/repositories/${ownerSlug}/${repoSlug}/pullrequests/${pr.data.id}/tasks`,
             );
@@ -363,6 +364,7 @@ export class CloudPullRequestApi implements PullRequestApi {
 
         const commentData = commentId ? { comment: { id: commentId } } : {};
         try {
+            console.log('bwieger 367');
             const { data } = await this.client.post(
                 `/repositories/${ownerSlug}/${repoSlug}/pullrequests/${prId}/tasks/`,
                 {
@@ -386,6 +388,7 @@ export class CloudPullRequestApi implements PullRequestApi {
         const { ownerSlug, repoSlug } = site;
 
         try {
+            console.log('bwieger 391');
             const { data } = await this.client.put(
                 `/repositories/${ownerSlug}/${repoSlug}/pullrequests/${prId}/tasks/${task.id}`,
                 {
@@ -413,6 +416,7 @@ export class CloudPullRequestApi implements PullRequestApi {
         const { ownerSlug, repoSlug } = site;
 
         try {
+            console.log('bwieger 419');
             await this.client.delete(
                 `/repositories/${ownerSlug}/${repoSlug}/pullrequests/${prId}/tasks/${task.id}`,
                 {},

--- a/src/bitbucket/bitbucket-cloud/pullRequests.ts
+++ b/src/bitbucket/bitbucket-cloud/pullRequests.ts
@@ -337,7 +337,6 @@ export class CloudPullRequestApi implements PullRequestApi {
         const { ownerSlug, repoSlug } = pr.site;
 
         try {
-            console.log('bwieger 340');
             let { data } = await this.client.get(
                 `/repositories/${ownerSlug}/${repoSlug}/pullrequests/${pr.data.id}/tasks`,
             );
@@ -364,7 +363,6 @@ export class CloudPullRequestApi implements PullRequestApi {
 
         const commentData = commentId ? { comment: { id: commentId } } : {};
         try {
-            console.log('bwieger 367');
             const { data } = await this.client.post(
                 `/repositories/${ownerSlug}/${repoSlug}/pullrequests/${prId}/tasks/`,
                 {
@@ -388,7 +386,6 @@ export class CloudPullRequestApi implements PullRequestApi {
         const { ownerSlug, repoSlug } = site;
 
         try {
-            console.log('bwieger 391');
             const { data } = await this.client.put(
                 `/repositories/${ownerSlug}/${repoSlug}/pullrequests/${prId}/tasks/${task.id}`,
                 {
@@ -416,7 +413,6 @@ export class CloudPullRequestApi implements PullRequestApi {
         const { ownerSlug, repoSlug } = site;
 
         try {
-            console.log('bwieger 419');
             await this.client.delete(
                 `/repositories/${ownerSlug}/${repoSlug}/pullrequests/${prId}/tasks/${task.id}`,
                 {},

--- a/src/bitbucket/bitbucket-server/pullRequests.ts
+++ b/src/bitbucket/bitbucket-server/pullRequests.ts
@@ -246,7 +246,7 @@ export class ServerPullRequestApi implements PullRequestApi {
     private async postTask_v0(site: BitbucketSite, prId: string, content: string, commentId?: string) {
         const bbApi = await clientForSite(site);
         const repo = await bbApi.repositories.get(site);
-        const { data } = await this.client.post(`/rest/api/1.0/tasks`, {
+        const { data } = await this.client.post(`/rest/api/latest/tasks`, {
             anchor: {
                 id: commentId,
                 type: 'COMMENT',
@@ -258,6 +258,7 @@ export class ServerPullRequestApi implements PullRequestApi {
             state: 'OPEN',
             text: content,
         });
+
         return this.convertDataToTask(data, site);
     }
 
@@ -935,6 +936,7 @@ export class ServerPullRequestApi implements PullRequestApi {
         const { data } = await this.client.get(
             `/rest/api/1.0/projects/${ownerSlug}/repos/${repoSlug}/pull-requests/${prId}/tasks/count`,
         );
+
         return data;
     }
 

--- a/src/bitbucket/bitbucket-server/pullRequests.ts
+++ b/src/bitbucket/bitbucket-server/pullRequests.ts
@@ -246,7 +246,7 @@ export class ServerPullRequestApi implements PullRequestApi {
     private async postTask_v0(site: BitbucketSite, prId: string, content: string, commentId?: string) {
         const bbApi = await clientForSite(site);
         const repo = await bbApi.repositories.get(site);
-        let data = await this.client.post(`/rest/api/1.0/tasks`, {
+        const data = await this.client.post(`/rest/api/1.0/tasks`, {
             anchor: {
                 id: commentId,
                 type: 'COMMENT',
@@ -265,7 +265,7 @@ export class ServerPullRequestApi implements PullRequestApi {
         const bbApi = await clientForSite(site);
         const repo = await bbApi.repositories.get(site);
         const ownerSlug = site.ownerSlug;
-        let data = await this.client.post(
+        const data = await this.client.post(
             `/rest/api/latest/projects/${ownerSlug}/repos/${repo.name}/pull-requests/${prId}/comments`,
             {
                 id: commentId,
@@ -291,10 +291,9 @@ export class ServerPullRequestApi implements PullRequestApi {
         }
     }
 
-    private async editTask_v8(site: BitbucketSite, prId: string, task: Task) {
+    private async editTask_v8(site: BitbucketSite, pullRequestId: string, task: Task) {
         const projectKey = site.ownerSlug;
         const repositorySlug = site.repoSlug;
-        const pullRequestId = prId;
         const commentId = task.commentId;
         const { data } = await this.client.put(
             `/rest/api/1.0/projects/${projectKey}/repos/${repositorySlug}/pull-requests/${pullRequestId}/comments/${commentId}`,
@@ -333,10 +332,9 @@ export class ServerPullRequestApi implements PullRequestApi {
         }
     }
 
-    private async deleteTask_v8(site: BitbucketSite, prId: string, task: Task) {
+    private async deleteTask_v8(site: BitbucketSite, pullRequestId: string, task: Task) {
         const projectKey = site.ownerSlug;
         const repositorySlug = site.repoSlug;
-        const pullRequestId = prId;
         const commentId = task.commentId;
 
         await this.client.delete(

--- a/src/bitbucket/bitbucket-server/pullRequests.ts
+++ b/src/bitbucket/bitbucket-server/pullRequests.ts
@@ -246,7 +246,7 @@ export class ServerPullRequestApi implements PullRequestApi {
     private async postTask_v0(site: BitbucketSite, prId: string, content: string, commentId?: string) {
         const bbApi = await clientForSite(site);
         const repo = await bbApi.repositories.get(site);
-        const data = await this.client.post(`/rest/api/1.0/tasks`, {
+        const { data } = await this.client.post(`/rest/api/1.0/tasks`, {
             anchor: {
                 id: commentId,
                 type: 'COMMENT',
@@ -258,7 +258,7 @@ export class ServerPullRequestApi implements PullRequestApi {
             state: 'OPEN',
             text: content,
         });
-        return this.convertDataToTask(data.data, site);
+        return this.convertDataToTask(data, site);
     }
 
     private async postTask_v8(site: BitbucketSite, prId: string, content: string, commentId?: string) {
@@ -930,11 +930,12 @@ export class ServerPullRequestApi implements PullRequestApi {
         }
     }
 
-    private getTaskCount_v0(site: BitbucketSite, prId: string): number | PromiseLike<number> {
+    private async getTaskCount_v0(site: BitbucketSite, prId: string): Promise<number> {
         const { ownerSlug, repoSlug } = site;
-        return this.client.get(
+        const { data } = await this.client.get(
             `/rest/api/1.0/projects/${ownerSlug}/repos/${repoSlug}/pull-requests/${prId}/tasks/count`,
         );
+        return data;
     }
 
     private getTaskCount_v8(site: BitbucketSite, prId: string): number | PromiseLike<number> {

--- a/src/bitbucket/bitbucket-server/pullRequests.ts
+++ b/src/bitbucket/bitbucket-server/pullRequests.ts
@@ -21,14 +21,12 @@ import {
     PaginatedPullRequests,
     PullRequest,
     PullRequestApi,
-    Repo,
     Task,
     UnknownUser,
     User,
     WorkspaceRepo,
 } from '../model';
 import { ServerRepositoriesApi } from './repositories';
-import { Logger } from 'src/logger';
 
 export class ServerPullRequestApi implements PullRequestApi {
     private defaultReviewersCache: CacheMap = new CacheMap();
@@ -234,11 +232,11 @@ export class ServerPullRequestApi implements PullRequestApi {
 
     async postTask(site: BitbucketSite, prId: string, content: string, commentId?: string): Promise<Task> {
         try {
-            return await this.postTask_v8(site, prId, content, commentId);
+            return this.postTask_v8(site, prId, content, commentId);
         } catch (error) {
             if (error.message && error.message['status-code'] === 404) {
                 // Retry with the legacy endpoint
-                return await this.postTask_v0(site, prId, content, commentId);
+                return this.postTask_v0(site, prId, content, commentId);
             } else {
                 throw error;
             }
@@ -325,10 +323,10 @@ export class ServerPullRequestApi implements PullRequestApi {
 
     async deleteTask(site: BitbucketSite, prId: string, task: Task): Promise<void> {
         try {
-            await this.deleteTask_v8(site, prId, task);
+            return this.deleteTask_v8(site, prId, task);
         } catch (error) {
             if (error.message && error.message['status-code'] === 404) {
-                await this.deleteTask_v0(site, prId, task);
+                return this.deleteTask_v0(site, prId, task);
             } else {
                 throw error;
             }

--- a/src/bitbucket/model.ts
+++ b/src/bitbucket/model.ts
@@ -72,7 +72,6 @@ export type Repo = {
 };
 
 export type Task = {
-    // bwieger
     commentId?: string;
     creator: User;
     created: string;

--- a/src/bitbucket/model.ts
+++ b/src/bitbucket/model.ts
@@ -72,6 +72,7 @@ export type Repo = {
 };
 
 export type Task = {
+    // bwieger
     commentId?: string;
     creator: User;
     created: string;
@@ -81,6 +82,7 @@ export type Task = {
     editable: boolean;
     deletable: boolean;
     content: string;
+    version?: number;
 };
 
 export type Comment = {


### PR DESCRIPTION
Many of the bitbucket APIs that we used around tasks are now deprecated in favor of the "comments" APIs. 

Using the "tasks" API on version of BitBucket DC 8.0 and later result in 404s. 

Since we don't have a clear pattern for fetching the version of the backend we are attaching to, the solution here uses a try catch pattern looking for 404s. 

I chose to prioritize the new APIs because I !assume! that most of our future (and perhaps current) users are on 8.0 and later. 

8.0 was release around May 2022 (3 years old) 

**[BEFORE](https://www.loom.com/share/de22e2c02842496ea52b057e27e4b0f6)**

**[AFTER](https://www.loom.com/share/171712ebfeeb47c195160efb5a3f4d49?sid=278594d6-e6e6-4d3a-8100-96646b9165cf)**