### PR TITLE
[AXON-117] Fix 'Create issue webview' stuck on the loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## What's new in 3.4.7
+
+### Bug Fixes
+
+- Fixed 'Create Jira issue' page getting stuck on the loader when the first Jira server is unreachable.
+
 ## What's new in 3.4.6
 
 ### Features

--- a/src/webviews/components/issue/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/CreateIssuePage.tsx
@@ -286,10 +286,7 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
     }
 
     public render() {
-        if (
-            !this.state.fieldValues['issuetype'] ||
-            (this.state.fieldValues['issuetype'].id === '' && !this.state.isErrorBannerOpen && this.state.isOnline)
-        ) {
+        if (!this.state.fieldValues['issuetype']?.id && !this.state.isErrorBannerOpen && this.state.isOnline) {
             this.postMessage({ action: 'refresh' });
             return <AtlLoader />;
         }

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -6,6 +6,7 @@ import {
     isScreensForSite,
     isSetIssueType,
 } from '../ipc/issueActions';
+import { WebViewID } from '../lib/ipc/models/common';
 import { CreateMetaTransformerResult, FieldValues, IssueTypeUI, ValueType } from '@atlassianlabs/jira-pi-meta-models';
 import { DetailedSiteInfo, Product, ProductJira, emptySiteInfo } from '../atlclients/authInfo';
 import { IssueType, Project, emptyIssueType } from '@atlassianlabs/jira-pi-common-models';
@@ -74,7 +75,7 @@ export class CreateIssueWebview
         return 'Create Jira Issue';
     }
     public get id(): string {
-        return 'atlascodeCreateIssueScreen';
+        return WebViewID.CreateJiraIssueWebview;
     }
 
     public get siteOrUndefined(): DetailedSiteInfo | undefined {
@@ -266,16 +267,14 @@ export class CreateIssueWebview
                 };
             }
 
-            if (this._screenData) {
-                const createData: CreateIssueData = this._screenData.issueTypeUIs[
-                    this._selectedIssueTypeId
-                ] as CreateIssueData;
-                createData.type = 'update';
-                createData.transformerProblems = Container.config.jira.showCreateIssueProblems
-                    ? this._screenData.problems
-                    : {};
-                this.postMessage(createData);
-            }
+            const createData: CreateIssueData = this._screenData.issueTypeUIs[
+                this._selectedIssueTypeId
+            ] as CreateIssueData;
+            createData.type = 'update';
+            createData.transformerProblems = Container.config.jira.showCreateIssueProblems
+                ? this._screenData.problems
+                : {};
+            this.postMessage(createData);
         } catch (e) {
             const err = new Error(`error updating issue fields: ${e}`);
             Logger.error(err);


### PR DESCRIPTION
The issue repros when the first server is an unreachable server, like a shut down Jira DC.

The page was stuck, and looping on a circle of error/refresh, because of a wrong condition on the react page.
The fix is in `CreateIssuePage.tsx`, the rest of the changes are minor random improvements.