### PR TITLE
[AXON-134] Fix for 'Start work' not working when another 'Start work' tab is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - Fixed 'Create Jira issue' page getting stuck on the loader when the first Jira server is unreachable.
+- Fixed 'Start work' not working when another 'Start work' tab is open.
 
 ## What's new in 3.4.6
 

--- a/src/react/atlascode/startwork/startWorkController.ts
+++ b/src/react/atlascode/startwork/startWorkController.ts
@@ -75,7 +75,7 @@ export type StartWorkChanges = { [key: string]: any };
 function reducer(state: StartWorkState, action: StartWorkUIAction): StartWorkState {
     switch (action.type) {
         case StartWorkUIActionType.Init: {
-            console.log(`JS-1324 start work controller init repo count: ${action.data.repoData.length}`);
+            console.log(`JS-1324 start work controller init repo count: ${action.data.repoData?.length}`);
             const newstate = {
                 ...state,
                 ...action.data,

--- a/src/webview/singleViewFactory.ts
+++ b/src/webview/singleViewFactory.ts
@@ -119,15 +119,17 @@ export class SingleWebview<FD, R> implements ReactWebview<FD> {
             const { id, site, product } = this._controller.screenDetails();
             this._analyticsApi.fireViewScreenEvent(id, site, product);
         } else {
+            if (this._controller) {
+                this._controller.update(factoryData);
+                this._panel.title = this._controller.title();
+            }
+
             this._panel.webview.html = this._controllerFactory.webviewHtml(
                 this._extensionPath,
                 this._panel.webview.asWebviewUri(Uri.file(this._extensionPath)),
                 this._panel.webview.cspSource,
             );
             this._panel.reveal(column ? column : ViewColumn.Active); // , false);
-            if (this._controller) {
-                this._controller.update(factoryData);
-            }
         }
 
         // Send feature gates to the panel in a message


### PR DESCRIPTION
Couple of code bugs were preventing the existing tab to refresh correctly.

| Bug | Fixed |
|-----|-----| 
| ![axon-134-bug](https://github.com/user-attachments/assets/247466c8-cddf-46b6-9992-11f0bc36bbd2) | ![axon-134-fixed](https://github.com/user-attachments/assets/393f4895-28b5-4e3f-9815-01ec187e24d6) | 


