### PR TITLE
[AXON-46] Add remote auth flow using atlascode-backend

### DIFF
--- a/src/atlclients/authInfo.ts
+++ b/src/atlclients/authInfo.ts
@@ -41,6 +41,7 @@ export enum OAuthProvider {
     BitbucketCloudStaging = 'bbcloudstaging',
     JiraCloud = 'jiracloud',
     JiraCloudStaging = 'jiracloudstaging',
+    JiraCloudRemote = 'jiracloudremote',
 }
 export interface AuthInfoV1 {
     access: string;

--- a/src/atlclients/loginManager.ts
+++ b/src/atlclients/loginManager.ts
@@ -53,6 +53,23 @@ export class LoginManager {
         this.saveDetails(provider, site, resp, isOnboarding);
     }
 
+    public async initRemoteAuth(state: Object) {
+        this._dancer.doInitRemoteDance(state);
+    }
+
+    public async finishRemoteAuth(code: string): Promise<void> {
+        const provider = OAuthProvider.JiraCloudRemote;
+        const site = {
+            host: 'https://jira.atlassian.com',
+            product: ProductJira,
+        };
+
+        const resp = await this._dancer.doFinishRemoteDance(provider, site, code);
+
+        // TODO: change false here when this is reachable from the onboarding flow
+        this.saveDetails(provider, site, resp, false);
+    }
+
     private async saveDetails(provider: OAuthProvider, site: SiteInfo, resp: OAuthResponse, isOnboarding?: boolean) {
         try {
             const oauthInfo: OAuthInfo = {

--- a/src/atlclients/strategy.test.ts
+++ b/src/atlclients/strategy.test.ts
@@ -60,7 +60,7 @@ const expectedData = {
         },
         tokenRefreshData:
             '{"grant_type":"refresh_token","client_id":"bJChVgBQd0aNUPuFZ8YzYBVZz3X4QTe2","refresh_token":"refreshToken"}',
-        profileUrl: '',
+        profileUrl: 'https://api.atlassian.com/me',
         emailsUrl: '',
     },
     jiracloudstaging: {
@@ -77,7 +77,7 @@ const expectedData = {
         },
         tokenRefreshData:
             '{"grant_type":"refresh_token","client_id":"pmzXmUav3Rr5XEL0Sie7Biec0WGU8BKg","refresh_token":"refreshToken"}',
-        profileUrl: '',
+        profileUrl: 'https://api.stg.atlassian.com/me',
         emailsUrl: '',
     },
 };

--- a/src/atlclients/strategyData.ts
+++ b/src/atlclients/strategyData.ts
@@ -1,0 +1,188 @@
+import { OAuthProvider, Product, ProductBitbucket, ProductJira } from './authInfo';
+
+export type StrategyProps = {
+    /**  What does this strategy refer to? Essentially, strategy ID */
+    provider: OAuthProvider;
+    /** Is this for JIRA or Bitbucket? */
+    product: Product;
+    /**
+     * Client ID of the OAuth app. Docs:
+     *  - Jira: https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/
+     *  - Bitbucket: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/
+     */
+    clientID: string;
+    /**
+     * Base URL for the initial authorization request
+     */
+    authorizationURL: string;
+    /**
+     * Base URL for getting access tokens
+     */
+    tokenURL: string;
+    /**
+     * Base URL for getting user profile information
+     */
+    profileURL: string;
+    /**
+     * The callback URL this strategy will supply to the OAuth provider.
+     * Must be exactly as configured in the OAuth app.
+     */
+    callbackURL: string;
+    /**
+     * Base URL for the API calls. Used to
+     */
+    apiURL: string;
+
+    /**
+     * Present only in non-PKCE environments
+     */
+    clientSecret?: string;
+
+    /**
+     * Jira-only
+     * Base URL for getting accessible resources
+     */
+    accessibleResourcesURL?: string;
+    /**
+     * Jira-only
+     * Scope for the OAuth request, as seen in a classic Jira platform REST API authorization URL
+     * (e.g. "manage:jira-project offline_access")
+     * See developer.atlassian.com 3LO docs
+     */
+    scope?: string;
+    /**
+     * Jira-only
+     * Additional parameters for the OAuth request
+     * See developer.atlassian.com 3LO docs
+     */
+    authParams?: {
+        /**
+         * The audience parameter for the OAuth request
+         */
+        audience: string;
+        /**
+         * The prompt parameter for the OAuth request
+         */
+        prompt: string;
+    };
+
+    /**
+     * Bitbucket-only
+     * Base URL for getting user emails
+     */
+    emailsURL?: string;
+};
+
+/**
+ * Temporary bit of logic to get remote auth config from environment.
+ * It's fine if this is not set in prod - the new remote auth isn't invoked anywhere yet.
+ */
+type RemoteAuthConfig = {
+    clientID: string;
+    clientSecret: string;
+    callbackURL: string;
+};
+
+const getRemoteAuthConfig = () => {
+    const DEFAULT_REMOTE_AUTH_CONFIG = {
+        clientID: '',
+        clientSecret: '',
+        callbackURL: '',
+    };
+
+    try {
+        const config = JSON.parse(process.env.ATLASCODE_REMOTE_AUTH_CONFIG || '{}') as RemoteAuthConfig;
+        if (config.clientID && config.clientSecret && config.callbackURL) {
+            return config;
+        } else {
+            return DEFAULT_REMOTE_AUTH_CONFIG;
+        }
+    } catch (e) {
+        console.log('Failed to parse remote auth config', e);
+        return DEFAULT_REMOTE_AUTH_CONFIG;
+    }
+};
+
+const remoteAuthConfig = getRemoteAuthConfig();
+
+export class OAuthStrategyData {
+    static readonly JiraRemote: StrategyProps = {
+        provider: OAuthProvider.JiraCloud,
+        product: ProductJira,
+        clientID: remoteAuthConfig.clientID,
+        clientSecret: remoteAuthConfig.clientSecret,
+        authorizationURL: 'https://auth.atlassian.com/authorize',
+        tokenURL: 'https://auth.atlassian.com/oauth/token',
+        profileURL: 'https://api.atlassian.com/me',
+        accessibleResourcesURL: 'https://api.atlassian.com/oauth/token/accessible-resources',
+        callbackURL: remoteAuthConfig.callbackURL,
+        apiURL: 'api.atlassian.com',
+        scope: 'read:jira-user read:jira-work write:jira-work offline_access manage:jira-project',
+        authParams: {
+            audience: 'api.atlassian.com',
+            prompt: 'consent',
+        },
+    };
+
+    static readonly JiraProd: StrategyProps = {
+        provider: OAuthProvider.JiraCloud,
+        product: ProductJira,
+        clientID: 'bJChVgBQd0aNUPuFZ8YzYBVZz3X4QTe2',
+        clientSecret: '',
+        authorizationURL: 'https://auth.atlassian.com/authorize',
+        tokenURL: 'https://auth.atlassian.com/oauth/token',
+        profileURL: 'https://api.atlassian.com/me',
+        accessibleResourcesURL: 'https://api.atlassian.com/oauth/token/accessible-resources',
+        callbackURL: 'http://127.0.0.1:31415/' + OAuthProvider.JiraCloud,
+        apiURL: 'api.atlassian.com',
+        scope: 'read:jira-user read:jira-work write:jira-work offline_access manage:jira-project',
+        authParams: {
+            audience: 'api.atlassian.com',
+            prompt: 'consent',
+        },
+    };
+
+    static readonly JiraStaging: StrategyProps = {
+        provider: OAuthProvider.JiraCloudStaging,
+        product: ProductJira,
+        clientID: 'pmzXmUav3Rr5XEL0Sie7Biec0WGU8BKg',
+        clientSecret: '',
+        authorizationURL: 'https://auth.stg.atlassian.com/authorize',
+        tokenURL: 'https://auth.stg.atlassian.com/oauth/token',
+        profileURL: 'https://api.stg.atlassian.com/me',
+        accessibleResourcesURL: 'https://api.stg.atlassian.com/oauth/token/accessible-resources',
+        callbackURL: 'http://127.0.0.1:31415/' + OAuthProvider.JiraCloudStaging,
+        apiURL: 'api.stg.atlassian.com',
+        scope: 'read:jira-user read:jira-work write:jira-work offline_access manage:jira-project',
+        authParams: {
+            audience: 'api.stg.atlassian.com',
+            prompt: 'consent',
+        },
+    };
+
+    static readonly BitbucketProd: StrategyProps = {
+        provider: OAuthProvider.BitbucketCloud,
+        product: ProductBitbucket,
+        clientID: '3hasX42a7Ugka2FJja',
+        clientSecret: 'st7a4WtBYVh7L2mZMU8V5ehDtvQcWs9S',
+        authorizationURL: 'https://bitbucket.org/site/oauth2/authorize',
+        tokenURL: 'https://bitbucket.org/site/oauth2/access_token',
+        profileURL: 'https://api.bitbucket.org/2.0/user',
+        emailsURL: 'https://api.bitbucket.org/2.0/user/emails',
+        callbackURL: 'http://127.0.0.1:31415/' + OAuthProvider.BitbucketCloud,
+        apiURL: 'https://bitbucket.org',
+    };
+
+    static readonly BitbucketStaging = {
+        provider: OAuthProvider.BitbucketCloudStaging,
+        product: ProductBitbucket,
+        clientID: '7jspxC7fgemuUbnWQL',
+        clientSecret: 'sjHugFh6SVVshhVE7PUW3bgXbbQDVjJD',
+        authorizationURL: 'https://staging.bb-inf.net/site/oauth2/authorize',
+        tokenURL: 'https://staging.bb-inf.net/site/oauth2/access_token',
+        profileURL: 'https://api-staging.bb-inf.net/2.0/user',
+        emailsURL: 'https://api-staging.bb-inf.net/2.0/user/emails',
+        callbackURL: 'http://127.0.0.1:31415/' + OAuthProvider.BitbucketCloudStaging,
+        apiURL: 'https://staging.bb-inf.net',
+    };
+}

--- a/src/lib/ipc/fromUI/config.ts
+++ b/src/lib/ipc/fromUI/config.ts
@@ -6,6 +6,7 @@ import { ReducerAction } from '@atlassianlabs/guipi-core-controller';
 
 export enum ConfigActionType {
     Login = 'login',
+    RemoteLogin = 'remoteLogin',
     Logout = 'logout',
     SaveSettings = 'saveSettings',
     OpenJSON = 'openJson',
@@ -22,6 +23,7 @@ export enum ConfigActionType {
 
 export type ConfigAction =
     | ReducerAction<ConfigActionType.Login, LoginAuthAction>
+    | ReducerAction<ConfigActionType.RemoteLogin>
     | ReducerAction<ConfigActionType.Logout, LogoutAuthAction>
     | ReducerAction<ConfigActionType.SaveSettings, SaveSettingsAction>
     | ReducerAction<ConfigActionType.OpenJSON, OpenJsonAction>

--- a/src/lib/webview/controller/config/configWebviewController.ts
+++ b/src/lib/webview/controller/config/configWebviewController.ts
@@ -13,6 +13,13 @@ import { Logger } from '../../../logger';
 import { WebViewID } from '../../../ipc/models/common';
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import { formatError } from '../../formatError';
+import uuid from 'uuid';
+
+// TODO AXON-46 - figure out why linter is mad here
+// This is most likely a configuration error, since it makes sense to prevent imports of
+// `vscode` and `container` in react files - but this is NOT a react file :thinking:
+import vscode from 'vscode'; // eslint-disable-line
+import { Container } from '../../../../container'; //eslint-disable-line
 
 export const id: string = 'atlascodeSettingsV2';
 
@@ -136,6 +143,14 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                     this._api.authenticateCloud(msg.siteInfo, this._settingsUrl);
                 }
                 this._analytics.fireAuthenticateButtonEvent(id, msg.siteInfo, isCloud);
+                break;
+            }
+            case ConfigActionType.RemoteLogin: {
+                const uri = vscode.Uri.parse('vscode://atlassian.atlascode/auth');
+                vscode.env.asExternalUri(uri).then((uri) => {
+                    const state = { deeplink: uri.toString(true), attemptId: uuid.v4() };
+                    Container.loginManager.initRemoteAuth(state);
+                });
                 break;
             }
             case ConfigActionType.Logout: {

--- a/src/react/atlascode/config/auth/SiteAuthenticator.tsx
+++ b/src/react/atlascode/config/auth/SiteAuthenticator.tsx
@@ -7,6 +7,7 @@ import DomainIcon from '@material-ui/icons/Domain';
 import { Product, ProductJira } from '../../../../atlclients/authInfo';
 import { SiteList } from './SiteList';
 import { SiteWithAuthInfo } from '../../../../lib/ipc/toUI/config';
+import { ConfigControllerContext } from '../configController';
 
 type SiteAuthenticatorProps = {
     product: Product;
@@ -17,9 +18,14 @@ type SiteAuthenticatorProps = {
 export const SiteAuthenticator: React.FunctionComponent<SiteAuthenticatorProps> = memo(
     ({ product, isRemote, sites }) => {
         const authDialogController = useContext(AuthDialogControllerContext);
+        const configController = useContext(ConfigControllerContext);
         const openProductAuth = useCallback(() => {
             authDialogController.openDialog(product, undefined);
         }, [authDialogController, product]);
+
+        const remoteAuth = useCallback(() => {
+            configController.remoteLogin();
+        }, [configController]);
 
         const handleEdit = useCallback(
             (swa: SiteWithAuthInfo) => {
@@ -27,6 +33,9 @@ export const SiteAuthenticator: React.FunctionComponent<SiteAuthenticatorProps> 
             },
             [authDialogController, product],
         );
+
+        // TODO AXON-46: feature flag this when closer to release
+        const [isRemoteAuthButtonVisible] = React.useState(false);
 
         return (
             <Box flexGrow={1}>
@@ -38,6 +47,8 @@ export const SiteAuthenticator: React.FunctionComponent<SiteAuthenticatorProps> 
                             openProductAuth={openProductAuth}
                             sites={sites}
                             handleEdit={handleEdit}
+                            remoteAuth={remoteAuth}
+                            isRemoteAuthButtonVisible={isRemoteAuthButtonVisible}
                         />
                     ) : (
                         <LegacyAuthContainer
@@ -46,6 +57,8 @@ export const SiteAuthenticator: React.FunctionComponent<SiteAuthenticatorProps> 
                             openProductAuth={openProductAuth}
                             sites={sites}
                             handleEdit={handleEdit}
+                            remoteAuth={remoteAuth}
+                            isRemoteAuthButtonVisible={isRemoteAuthButtonVisible}
                         />
                     )}
                 </Grid>
@@ -60,9 +73,19 @@ interface AuthContainerProps {
     openProductAuth: () => void;
     sites: SiteWithAuthInfo[];
     handleEdit: (swa: SiteWithAuthInfo) => void;
+    remoteAuth: () => void;
+    isRemoteAuthButtonVisible: boolean;
 }
 
-const LegacyAuthContainer = ({ isRemote, product, openProductAuth, sites, handleEdit }: AuthContainerProps) => (
+const LegacyAuthContainer = ({
+    isRemote,
+    product,
+    openProductAuth,
+    sites,
+    handleEdit,
+    remoteAuth,
+    isRemoteAuthButtonVisible,
+}: AuthContainerProps) => (
     <React.Fragment>
         <Grid item hidden={isRemote === false}>
             <Typography>
@@ -95,6 +118,11 @@ const LegacyAuthContainer = ({ isRemote, product, openProductAuth, sites, handle
                                 {`Add Custom ${product.name} Site`}
                             </Button>
                         </Grid>
+                        {isRemoteAuthButtonVisible && (
+                            <Grid item>
+                                <Button onClick={remoteAuth}>Remote Auth</Button>
+                            </Grid>
+                        )}
                     </Grid>
                 </Grid>
                 <Grid item>
@@ -105,7 +133,15 @@ const LegacyAuthContainer = ({ isRemote, product, openProductAuth, sites, handle
     </React.Fragment>
 );
 
-const AuthContainer = ({ isRemote, product, openProductAuth, sites, handleEdit }: AuthContainerProps) => (
+const AuthContainer = ({
+    isRemote,
+    product,
+    openProductAuth,
+    sites,
+    handleEdit,
+    remoteAuth,
+    isRemoteAuthButtonVisible,
+}: AuthContainerProps) => (
     <React.Fragment>
         <Grid item>
             <Grid container direction="column" spacing={2}>
@@ -121,6 +157,11 @@ const AuthContainer = ({ isRemote, product, openProductAuth, sites, handleEdit }
                                         {`Other options...`}
                                     </Button>
                                 </Grid>
+                                {isRemoteAuthButtonVisible && (
+                                    <Grid item>
+                                        <Button onClick={remoteAuth}>Remote Auth</Button>
+                                    </Grid>
+                                )}
                             </React.Fragment>
                         )}
                         {isRemote && (

--- a/src/react/atlascode/config/configController.ts
+++ b/src/react/atlascode/config/configController.ts
@@ -33,6 +33,7 @@ export interface ConfigControllerApi {
     refresh: () => void;
     openLink: (linkId: KnownLinkID) => void;
     login: (site: SiteInfo, auth: AuthInfo) => void;
+    remoteLogin: () => void;
     logout: (site: DetailedSiteInfo) => void;
     fetchJqlOptions: (site: DetailedSiteInfo) => Promise<JqlAutocompleteRestData>;
     fetchJqlSuggestions: (
@@ -73,6 +74,9 @@ export const emptyApi: ConfigControllerApi = {
         return;
     },
     login: (site: SiteInfo, auth: AuthInfo) => {
+        return;
+    },
+    remoteLogin: () => {
         return;
     },
     logout: (site: DetailedSiteInfo) => {
@@ -314,6 +318,11 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
         [postMessage],
     );
 
+    const remoteLogin = useCallback(() => {
+        dispatch({ type: ConfigUIActionType.Loading });
+        postMessage({ type: ConfigActionType.RemoteLogin });
+    }, [postMessage]);
+
     const logout = useCallback(
         (site: DetailedSiteInfo) => {
             dispatch({ type: ConfigUIActionType.Loading });
@@ -503,6 +512,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
             refresh: sendRefresh,
             openLink: openLink,
             login: login,
+            remoteLogin: remoteLogin,
             logout: logout,
             fetchJqlSuggestions: fetchJqlSuggestions,
             fetchJqlOptions: fetchJqlOptions,
@@ -516,6 +526,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
     }, [
         handleConfigChange,
         login,
+        remoteLogin,
         logout,
         openLink,
         postMessage,

--- a/src/uriHandler/actions/simpleCallback.ts
+++ b/src/uriHandler/actions/simpleCallback.ts
@@ -13,7 +13,7 @@ import { UriHandlerAction } from '../uriHandlerAction';
 export class SimpleCallbackAction implements UriHandlerAction {
     constructor(
         private uriSuffix: string,
-        private callback: () => Promise<void>,
+        private callback: (uri: Uri) => Promise<void>,
     ) {}
 
     isAccepted(uri: Uri): boolean {
@@ -21,6 +21,6 @@ export class SimpleCallbackAction implements UriHandlerAction {
     }
 
     async handle(uri: Uri): Promise<void> {
-        return await this.callback();
+        return await this.callback(uri);
     }
 }

--- a/src/uriHandler/atlascodeUriHandler.ts
+++ b/src/uriHandler/atlascodeUriHandler.ts
@@ -50,6 +50,10 @@ export class AtlascodeUriHandler implements Disposable, UriHandler {
         jiraIssueFetcher: JiraIssueFetcher = new JiraIssueFetcher(),
     ) {
         return new AtlascodeUriHandler([
+            new SimpleCallbackAction('auth', async (uri) => {
+                const params = new URLSearchParams(uri.query);
+                Container.loginManager.finishRemoteAuth(params.get('code')!);
+            }),
             new SimpleCallbackAction('openSettings', () => Container.settingsWebviewFactory.createOrShow()),
             new SimpleCallbackAction('openOnboarding', () => Container.onboardingWebviewFactory.createOrShow()),
             new CheckoutBranchUriHandlerAction(bitbucketHelper, analyticsApi),


### PR DESCRIPTION
### What is this?

The next PR in the chain to enable a smooth 3LO-from-anywhere experience in the extension ;)

With this, we can now use an external service to bounce authentication from - in this PR it's referred to as the `JiraRemote` OAuth strategy

Short recap of the changes:
 * Fork the existing monolithic OAuth process, split it in 2 parts (start via user action / finish via deeplink)
 * Add a button (completely invisible to everyone, FF pending) to trigger the new oauth
 * Add an ability to configure OAuth client from the environment on the fly, for dev purposes
 * Move OAuth strategy data into their own file, now with a bunch of docs
 * Implement URIHandler path for `/auth`
 * A whooooole lot of IPC/messaging boilerplate 😞 
 
What's notably missing:
 * OAuth attempt/session management
 * The way to trigger new auth outside of dev environment is effectively hidden
 * PKCE for the new Jira auth
 * Bitbucket remote auth

There are also some known issues - for instance, the credentials seemingly get bundled between the strategies and somehow invalidate themselves - rather inconsistently, at that 😞

![image](https://github.com/user-attachments/assets/c3128a4b-81e5-4b56-b55d-5a9750071321)

I'm leaving the follow-up to follow-up PRs. Also, some of the issues might be addressed by #79  

### How was this tested

* Unit tests, especially the new one on `Strategy`/`StrategyData` to prevent regressions
* E2E tested the new flow
* E2E tested the old flow