### PR TITLE
[AXON-145] Added branch name validation for space characters

### DIFF
--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -181,6 +181,8 @@ const StartWorkPage: React.FunctionComponent = () => {
 
     const handleLocalBranchChange = useCallback(
         (event: React.ChangeEvent<{ name?: string | undefined; value: string }>) => {
+            // spaces are not allowed in branch names
+            event.target.value = event.target.value.replace(/ /g, '-');
             setLocalBranch(event.target.value);
         },
         [setLocalBranch],


### PR DESCRIPTION
From: https://bitbucket.org/atlassianlabs/atlascode/issues/771/error-start-work-failed-because-of-a-space

If the branch name contains a space, or ends with a space, the branch can't be created.

The cleanest way to solve this is adding a field validation on the UI itself, so it doesn't allow the space character to be typed. To be consistent with other logic, the space character is being replaced with a dash `-` while typing.

Typing "This is a branch" will result in typing "This-is-a-branch".

![AXON-125-fixed](https://github.com/user-attachments/assets/8e55ccd7-d972-4858-96c7-5bb3369ed83a)
