### PR TITLE
[AXON-109] Expose toggle switch to push branch to remote (Start work)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## What's new in 3.4.8
+
+### Features
+
+- Added a new toggle switch in 'Start work' page to choose if the new branch should be automatically pushed to remote.
+
 ## What's new in 3.4.7
 
 ### Features

--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -20,11 +20,8 @@ function setProcessPlatform(platform: NodeJS.Platform) {
 describe('viewScreenEvent', () => {
     const originalPlatform = process.platform;
 
-    beforeAll(() => {
-        setProcessPlatform('win32');
-    });
-
     beforeEach(() => {
+        setProcessPlatform('win32');
         mockedData.getFirstAAID_value = true;
     });
 

--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -1,0 +1,106 @@
+import { viewScreenEvent } from './analytics';
+
+interface MockedData {
+    getFirstAAID_value?: boolean;
+}
+
+const mockedData: MockedData = {};
+
+jest.mock('./container', () => ({
+    Container: { siteManager: { getFirstAAID: () => mockedData.getFirstAAID_value } },
+}));
+
+function setProcessPlatform(platform: NodeJS.Platform) {
+    Object.defineProperty(process, 'platform', {
+        value: platform,
+        writable: false,
+    });
+}
+
+describe('viewScreenEvent', () => {
+    const originalPlatform = process.platform;
+
+    beforeAll(() => {
+        setProcessPlatform('win32');
+    });
+
+    beforeEach(() => {
+        mockedData.getFirstAAID_value = true;
+    });
+
+    afterAll(() => {
+        setProcessPlatform(originalPlatform);
+    });
+
+    it('should create a screen event with the correct screen name', async () => {
+        const screenName = 'testScreen';
+        const event = await viewScreenEvent(screenName);
+        expect(event.name).toEqual(screenName);
+        expect(event.screenEvent.attributes).toBeUndefined();
+    });
+
+    it('should exclude from activity if screen name is atlascodeWelcomeScreen', async () => {
+        const screenName = 'atlascodeWelcomeScreen';
+        const event = await viewScreenEvent(screenName);
+        expect(event.screenEvent.attributes.excludeFromActivity).toBeTruthy();
+    });
+
+    it('should include site information if provided (cloud)', async () => {
+        const screenName = 'testScreen';
+        const site: any = {
+            id: 'siteId',
+            product: { name: 'Jira', key: 'jira' },
+            isCloud: true,
+        };
+        const event = await viewScreenEvent(screenName, site);
+        expect(event.screenEvent.attributes.instanceType).toEqual('cloud');
+        expect(event.screenEvent.attributes.hostProduct).toEqual('Jira');
+    });
+
+    it('should include site information if provided (server)', async () => {
+        const screenName = 'testScreen';
+        const site: any = {
+            id: 'siteId',
+            product: { name: 'Jira', key: 'jira' },
+            isCloud: false,
+        };
+        const event = await viewScreenEvent(screenName, site);
+        expect(event.screenEvent.attributes.instanceType).toEqual('server');
+        expect(event.screenEvent.attributes.hostProduct).toEqual('Jira');
+    });
+
+    it('should include product information if provided', async () => {
+        const screenName = 'testScreen';
+        const product = { name: 'Bitbucket', key: 'bitbucket' };
+        const event = await viewScreenEvent(screenName, undefined, product);
+        expect(event.screenEvent.attributes.hostProduct).toEqual('Bitbucket');
+    });
+
+    it('should set platform based on process.platform (win32)', async () => {
+        setProcessPlatform('win32');
+        const screenName = 'testScreen';
+        const event = await viewScreenEvent(screenName);
+        expect(event.screenEvent.platform).toEqual('windows');
+    });
+
+    it('should set platform based on process.platform (darwin)', async () => {
+        setProcessPlatform('darwin');
+        const screenName = 'testScreen';
+        const event = await viewScreenEvent(screenName);
+        expect(event.screenEvent.platform).toEqual('mac');
+    });
+
+    it('should set platform based on process.platform (linux)', async () => {
+        setProcessPlatform('linux');
+        const screenName = 'testScreen';
+        const event = await viewScreenEvent(screenName);
+        expect(event.screenEvent.platform).toEqual('linux');
+    });
+
+    it('should set platform based on process.platform (aix)', async () => {
+        setProcessPlatform('aix');
+        const screenName = 'testScreen';
+        const event = await viewScreenEvent(screenName);
+        expect(event.screenEvent.platform).toEqual('desktop');
+    });
+});

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -21,7 +21,7 @@ export const Registry = {
 };
 
 class AnalyticsPlatform {
-    private static nodeJsPlatformMapping: Record<string, any> = {
+    private static nodeJsPlatformMapping: Record<NodeJS.Platform, string> = {
         aix: 'desktop',
         android: 'android',
         darwin: 'mac',
@@ -31,9 +31,11 @@ class AnalyticsPlatform {
         sunos: 'desktop',
         win32: 'windows',
         cygwin: 'windows',
+        haiku: 'unknown',
+        netbsd: 'unknown',
     };
 
-    static for(p: string): string {
+    static for(p: NodeJS.Platform): string {
         return this.nodeJsPlatformMapping[p] || 'unknown';
     }
 }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -667,13 +667,13 @@ function instanceType(
     site?: DetailedSiteInfo,
     product?: Product,
 ): Record<string, any> {
-    eventProps.attributes = eventProps.attributes || {};
-
     if (product) {
+        eventProps.attributes = eventProps.attributes || {};
         eventProps.attributes.hostProduct = product.name;
     }
 
     if (site && !isEmptySiteInfo(site)) {
+        eventProps.attributes = eventProps.attributes || {};
         eventProps.attributes.instanceType = site.isCloud ? 'cloud' : 'server';
         eventProps.attributes.hostProduct = site.product.name;
     }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -21,7 +21,7 @@ export const Registry = {
 };
 
 class AnalyticsPlatform {
-    private static nodeJsPlatformMapping = {
+    private static nodeJsPlatformMapping: Record<string, any> = {
         aix: 'desktop',
         android: 'android',
         darwin: 'mac',
@@ -107,8 +107,13 @@ export async function issueCommentEvent(site: DetailedSiteInfo): Promise<TrackEv
     return instanceTrackEvent(site, 'created', 'issueComment');
 }
 
-export async function issueWorkStartedEvent(site: DetailedSiteInfo): Promise<TrackEvent> {
-    return instanceTrackEvent(site, 'workStarted', 'issue');
+export async function issueWorkStartedEvent(
+    site: DetailedSiteInfo,
+    pushBranchToRemoteChecked: boolean,
+): Promise<TrackEvent> {
+    const attributesObject = instanceType({}, site);
+    attributesObject.attributes.pushBranchToRemoteChecked = pushBranchToRemoteChecked;
+    return instanceTrackEvent(site, 'workStarted', 'issue', attributesObject);
 }
 
 export async function issueUpdatedEvent(
@@ -164,7 +169,7 @@ export async function prCommentEvent(site: DetailedSiteInfo): Promise<TrackEvent
 }
 
 export async function prTaskEvent(site: DetailedSiteInfo, source: string): Promise<TrackEvent> {
-    const attributesObject: any = instanceType({}, site);
+    const attributesObject = instanceType({}, site);
     attributesObject.attributes.source = source;
     return trackEvent('created', 'pullRequestComment', attributesObject);
 }
@@ -657,33 +662,27 @@ function tenantOrNull<T>(e: Object, tenantId?: string): T {
     return newObj as T;
 }
 
-function instanceType(eventProps: Object, site?: DetailedSiteInfo, product?: Product): Object {
-    let attrs: Object | undefined = undefined;
-    const newObj = eventProps;
+function instanceType(
+    eventProps: Record<string, any>,
+    site?: DetailedSiteInfo,
+    product?: Product,
+): Record<string, any> {
+    eventProps.attributes = eventProps.attributes || {};
 
     if (product) {
-        attrs = { hostProduct: product.name };
+        eventProps.attributes.hostProduct = product.name;
     }
 
     if (site && !isEmptySiteInfo(site)) {
-        const instanceType: string = site.isCloud ? 'cloud' : 'server';
-        attrs = { instanceType: instanceType, hostProduct: site.product.name };
+        eventProps.attributes.instanceType = instanceType;
+        eventProps.attributes.hostProduct = site.product.name;
     }
 
-    if (attrs) {
-        newObj['attributes'] = { ...newObj['attributes'], ...attrs };
-    }
-
-    return newObj;
+    return eventProps;
 }
 
-function excludeFromActivity(eventProps: Object): Object {
-    const newObj = eventProps;
-
-    if (newObj['attributes']) {
-        newObj['attributes'] = { ...newObj['attributes'], ...{ excludeFromActivity: true } };
-    } else {
-        Object.assign(newObj, { attributes: { excludeFromActivity: true } });
-    }
-    return newObj;
+function excludeFromActivity(eventProps: Record<string, any>): Record<string, any> {
+    eventProps.attributes = eventProps.attributes || {};
+    eventProps.attributes.excludeFromActivity = true;
+    return eventProps;
 }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -674,7 +674,7 @@ function instanceType(
     }
 
     if (site && !isEmptySiteInfo(site)) {
-        eventProps.attributes.instanceType = instanceType;
+        eventProps.attributes.instanceType = site.isCloud ? 'cloud' : 'server';
         eventProps.attributes.hostProduct = site.product.name;
     }
 

--- a/src/ipc/issueActions.ts
+++ b/src/ipc/issueActions.ts
@@ -120,7 +120,7 @@ export interface StartWorkAction extends Action {
     remoteName: string;
     setupJira: boolean;
     setupBitbucket: boolean;
-    pushBranchToOrigin: boolean;
+    pushBranchToRemote: boolean;
 }
 
 export interface OpenStartWorkPageAction extends Action {

--- a/src/ipc/issueActions.ts
+++ b/src/ipc/issueActions.ts
@@ -120,6 +120,7 @@ export interface StartWorkAction extends Action {
     remoteName: string;
     setupJira: boolean;
     setupBitbucket: boolean;
+    pushBranchToOrigin: boolean;
 }
 
 export interface OpenStartWorkPageAction extends Action {

--- a/src/lib/analyticsApi.ts
+++ b/src/lib/analyticsApi.ts
@@ -12,7 +12,7 @@ export interface AnalyticsApi {
     fireIssueTransitionedEvent(site: DetailedSiteInfo, issueKey: string): Promise<void>;
     fireIssueUrlCopiedEvent(): Promise<void>;
     fireIssueCommentEvent(site: DetailedSiteInfo): Promise<void>;
-    fireIssueWorkStartedEvent(site: DetailedSiteInfo): Promise<void>;
+    fireIssueWorkStartedEvent(site: DetailedSiteInfo, pushBranchToRemoteChecked: boolean): Promise<void>;
     fireIssueUpdatedEvent(site: DetailedSiteInfo, issueKey: string, fieldName: string, fieldKey: string): Promise<void>;
     fireStartIssueCreationEvent(source: string, product: Product): Promise<void>;
     fireBBIssueCreatedEvent(site: DetailedSiteInfo): Promise<void>;

--- a/src/lib/ipc/fromUI/startWork.ts
+++ b/src/lib/ipc/fromUI/startWork.ts
@@ -27,6 +27,7 @@ export interface StartRequestAction {
     sourceBranch: Branch;
     targetBranch: string;
     upstream: string;
+    pushBranchToOrigin: boolean;
 }
 
 export interface OpenSettingsAction {

--- a/src/lib/ipc/fromUI/startWork.ts
+++ b/src/lib/ipc/fromUI/startWork.ts
@@ -27,7 +27,7 @@ export interface StartRequestAction {
     sourceBranch: Branch;
     targetBranch: string;
     upstream: string;
-    pushBranchToOrigin: boolean;
+    pushBranchToRemote: boolean;
 }
 
 export interface OpenSettingsAction {

--- a/src/lib/webview/controller/startwork/startWorkActionApi.ts
+++ b/src/lib/webview/controller/startwork/startWorkActionApi.ts
@@ -17,7 +17,7 @@ export interface StartWorkActionApi {
         destinationBranch: string,
         sourceBranch: Branch,
         remote: string,
-        pushBranchToOrigin: boolean,
+        pushBranchToRemote: boolean,
     ): Promise<void>;
     closePage(): void;
     getStartWorkConfig(): StartWorkBranchTemplate;

--- a/src/lib/webview/controller/startwork/startWorkActionApi.ts
+++ b/src/lib/webview/controller/startwork/startWorkActionApi.ts
@@ -17,6 +17,7 @@ export interface StartWorkActionApi {
         destinationBranch: string,
         sourceBranch: Branch,
         remote: string,
+        pushBranchToOrigin: boolean,
     ): Promise<void>;
     closePage(): void;
     getStartWorkConfig(): StartWorkBranchTemplate;

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -143,7 +143,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                         branch: msg.branchSetupEnabled ? msg.targetBranch : undefined,
                         upstream: msg.branchSetupEnabled ? msg.upstream : undefined,
                     });
-                    this.analytics.fireIssueWorkStartedEvent(this.initData.issue.siteDetails);
+                    this.analytics.fireIssueWorkStartedEvent(this.initData.issue.siteDetails, msg.pushBranchToRemote);
                 } catch (e) {
                     this.logger.error(new Error(`error executing start work action: ${e}`));
                     this.postMessage({

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -134,7 +134,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                             msg.targetBranch,
                             msg.sourceBranch,
                             msg.upstream,
-                            msg.pushBranchToOrigin,
+                            msg.pushBranchToRemote,
                         );
                     }
                     this.postMessage({

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -134,6 +134,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                             msg.targetBranch,
                             msg.sourceBranch,
                             msg.upstream,
+                            msg.pushBranchToOrigin,
                         );
                     }
                     this.postMessage({

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -181,6 +181,8 @@ const StartWorkPage: React.FunctionComponent = () => {
 
     const handleLocalBranchChange = useCallback(
         (event: React.ChangeEvent<{ name?: string | undefined; value: string }>) => {
+            // spaces are not allowed in branch names
+            event.target.value = event.target.value.replace(/ /g, '-');
             setLocalBranch(event.target.value);
         },
         [setLocalBranch],

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -95,6 +95,7 @@ const StartWorkPage: React.FunctionComponent = () => {
 
     const [transitionIssueEnabled, setTransitionIssueEnabled] = useState(true);
     const [branchSetupEnabled, setbranchSetupEnabled] = useState(true);
+    const [pushBranchEnabled, setPushBranchEnabled] = useState(false);
     const [transition, setTransition] = useState<Transition>(emptyTransition);
     const [repository, setRepository] = useState<RepoData>(emptyRepoData);
     const [branchType, setBranchType] = useState<BranchType>(emptyPrefix);
@@ -119,6 +120,8 @@ const StartWorkPage: React.FunctionComponent = () => {
         () => setbranchSetupEnabled(!branchSetupEnabled),
         [branchSetupEnabled],
     );
+
+    const togglePushBranchEnabled = useCallback(() => setPushBranchEnabled(!pushBranchEnabled), [pushBranchEnabled]);
 
     const handleTransitionChange = useCallback(
         (event: React.ChangeEvent<{ name?: string | undefined; value: any }>) => {
@@ -248,6 +251,7 @@ const StartWorkPage: React.FunctionComponent = () => {
                 sourceBranch,
                 localBranch,
                 upstream,
+                pushBranchEnabled,
             );
             setSubmitState('submit-success');
             setSubmitResponse(response);
@@ -264,6 +268,7 @@ const StartWorkPage: React.FunctionComponent = () => {
         sourceBranch,
         localBranch,
         upstream,
+        pushBranchEnabled,
     ]);
 
     const handleOpenSettings = useCallback(() => {
@@ -703,6 +708,28 @@ const StartWorkPage: React.FunctionComponent = () => {
                                                     </Grid>
                                                 </Grid>
                                             </Collapse>
+                                        </Grid>
+                                        <Grid item hidden={submitState === 'submit-success'}>
+                                            <Divider />
+                                        </Grid>
+                                        <Grid item hidden={submitState === 'submit-success'}>
+                                            <Grid container spacing={1} direction="row">
+                                                <Grid item>
+                                                    <Switch
+                                                        color="primary"
+                                                        size="small"
+                                                        checked={pushBranchEnabled}
+                                                        onClick={togglePushBranchEnabled}
+                                                    />
+                                                </Grid>
+                                                <Grid item>
+                                                    <Typography variant="h4">
+                                                        <Box fontWeight="fontWeightBold">
+                                                            Push the new branch to origin
+                                                        </Box>
+                                                    </Typography>
+                                                </Grid>
+                                            </Grid>
                                         </Grid>
                                         <Grid item hidden={submitState === 'submit-success'}>
                                             <Button

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -725,7 +725,7 @@ const StartWorkPage: React.FunctionComponent = () => {
                                                 <Grid item>
                                                     <Typography variant="h4">
                                                         <Box fontWeight="fontWeightBold">
-                                                            Push the new branch to origin
+                                                            Push the new branch to remote
                                                         </Box>
                                                     </Typography>
                                                 </Grid>

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -95,7 +95,7 @@ const StartWorkPage: React.FunctionComponent = () => {
 
     const [transitionIssueEnabled, setTransitionIssueEnabled] = useState(true);
     const [branchSetupEnabled, setbranchSetupEnabled] = useState(true);
-    const [pushBranchEnabled, setPushBranchEnabled] = useState(false);
+    const [pushBranchEnabled, setPushBranchEnabled] = useState(true);
     const [transition, setTransition] = useState<Transition>(emptyTransition);
     const [repository, setRepository] = useState<RepoData>(emptyRepoData);
     const [branchType, setBranchType] = useState<BranchType>(emptyPrefix);

--- a/src/react/atlascode/startwork/startWorkController.ts
+++ b/src/react/atlascode/startwork/startWorkController.ts
@@ -30,7 +30,7 @@ export interface StartWorkControllerApi {
         sourceBranch: Branch,
         targetBranch: string,
         upstream: string,
-        pushBranchToOrigin: boolean,
+        pushBranchToRemote: boolean,
     ) => Promise<{ transistionStatus?: string; branch?: string; upstream?: string }>;
     closePage: () => void;
     openJiraIssue: () => void;
@@ -123,7 +123,7 @@ export function useStartWorkController(): [StartWorkState, StartWorkControllerAp
             sourceBranch: Branch,
             targetBranch: string,
             upstream: string,
-            pushBranchToOrigin: boolean,
+            pushBranchToRemote: boolean,
         ): Promise<StartWorkResponseMessage> => {
             return new Promise<StartWorkResponseMessage>((resolve, reject) => {
                 (async () => {
@@ -138,7 +138,7 @@ export function useStartWorkController(): [StartWorkState, StartWorkControllerAp
                                 sourceBranch,
                                 targetBranch,
                                 upstream,
-                                pushBranchToOrigin,
+                                pushBranchToRemote,
                             },
                             StartWorkMessageType.StartWorkResponse,
                             ConnectionTimeout,

--- a/src/react/atlascode/startwork/startWorkController.ts
+++ b/src/react/atlascode/startwork/startWorkController.ts
@@ -30,6 +30,7 @@ export interface StartWorkControllerApi {
         sourceBranch: Branch,
         targetBranch: string,
         upstream: string,
+        pushBranchToOrigin: boolean,
     ) => Promise<{ transistionStatus?: string; branch?: string; upstream?: string }>;
     closePage: () => void;
     openJiraIssue: () => void;
@@ -122,6 +123,7 @@ export function useStartWorkController(): [StartWorkState, StartWorkControllerAp
             sourceBranch: Branch,
             targetBranch: string,
             upstream: string,
+            pushBranchToOrigin: boolean,
         ): Promise<StartWorkResponseMessage> => {
             return new Promise<StartWorkResponseMessage>((resolve, reject) => {
                 (async () => {
@@ -136,6 +138,7 @@ export function useStartWorkController(): [StartWorkState, StartWorkControllerAp
                                 sourceBranch,
                                 targetBranch,
                                 upstream,
+                                pushBranchToOrigin,
                             },
                             StartWorkMessageType.StartWorkResponse,
                             ConnectionTimeout,

--- a/src/vscAnalyticsApi.ts
+++ b/src/vscAnalyticsApi.ts
@@ -124,8 +124,8 @@ export class VSCAnalyticsApi implements AnalyticsApi {
         });
     }
 
-    public async fireIssueWorkStartedEvent(site: DetailedSiteInfo): Promise<void> {
-        return issueWorkStartedEvent(site).then((e) => {
+    public async fireIssueWorkStartedEvent(site: DetailedSiteInfo, pushBranchToRemoteChecked: boolean): Promise<void> {
+        return issueWorkStartedEvent(site, pushBranchToRemoteChecked).then((e) => {
             this._analyticsClient.sendTrackEvent(e);
         });
     }

--- a/src/webview/startwork/vscStartWorkActionApi.ts
+++ b/src/webview/startwork/vscStartWorkActionApi.ts
@@ -50,6 +50,7 @@ export class VSCStartWorkActionApi implements StartWorkActionApi {
         destinationBranch: string,
         sourceBranch: Branch,
         remote: string,
+        pushBranchToOrigin: boolean,
     ): Promise<void> {
         const scm = Container.bitbucketContext.getRepositoryScm(wsRepo.rootUri)!;
 
@@ -74,8 +75,10 @@ export class VSCStartWorkActionApi implements StartWorkActionApi {
             true,
             `${sourceBranch.type === RefType.RemoteHead ? 'remotes/' : ''}${sourceBranch.name}`,
         );
-        await scm.push(remote, destinationBranch, true);
-        return;
+
+        if (pushBranchToOrigin) {
+            await scm.push(remote, destinationBranch, true);
+        }
     }
 
     getStartWorkConfig(): StartWorkBranchTemplate {

--- a/src/webview/startwork/vscStartWorkActionApi.ts
+++ b/src/webview/startwork/vscStartWorkActionApi.ts
@@ -50,7 +50,7 @@ export class VSCStartWorkActionApi implements StartWorkActionApi {
         destinationBranch: string,
         sourceBranch: Branch,
         remote: string,
-        pushBranchToOrigin: boolean,
+        pushBranchToRemote: boolean,
     ): Promise<void> {
         const scm = Container.bitbucketContext.getRepositoryScm(wsRepo.rootUri)!;
 
@@ -76,7 +76,7 @@ export class VSCStartWorkActionApi implements StartWorkActionApi {
             `${sourceBranch.type === RefType.RemoteHead ? 'remotes/' : ''}${sourceBranch.name}`,
         );
 
-        if (pushBranchToOrigin) {
+        if (pushBranchToRemote) {
             await scm.push(remote, destinationBranch, true);
         }
     }

--- a/src/webviews/components/issue/StartWorkPage.tsx
+++ b/src/webviews/components/issue/StartWorkPage.tsx
@@ -261,7 +261,7 @@ export default class StartWorkPage extends WebviewComponent<Emit, Accept, {}, St
             transition: this.state.transition,
             setupJira: this.state.jiraSetupEnabled,
             setupBitbucket: this.isEmptyRepo(this.state.repo) ? false : this.state.bitbucketSetupEnabled,
-            pushBranchToOrigin: false,
+            pushBranchToRemote: false,
         });
     };
 

--- a/src/webviews/components/issue/StartWorkPage.tsx
+++ b/src/webviews/components/issue/StartWorkPage.tsx
@@ -261,6 +261,7 @@ export default class StartWorkPage extends WebviewComponent<Emit, Accept, {}, St
             transition: this.state.transition,
             setupJira: this.state.jiraSetupEnabled,
             setupBitbucket: this.isEmptyRepo(this.state.repo) ? false : this.state.bitbucketSetupEnabled,
+            pushBranchToOrigin: false,
         });
     };
 

--- a/src/webviews/startWorkOnBitbucketIssueWebview.ts
+++ b/src/webviews/startWorkOnBitbucketIssueWebview.ts
@@ -105,6 +105,7 @@ export class StartWorkOnBitbucketIssueWebview
                                     e.targetBranchName,
                                     e.sourceBranch,
                                     e.remoteName,
+                                    e.pushBranchToOrigin,
                                 );
                             }
 
@@ -138,6 +139,7 @@ export class StartWorkOnBitbucketIssueWebview
         destBranch: string,
         sourceBranch: Branch,
         remote: string,
+        pushBranchToOrigin: boolean,
     ): Promise<void> {
         // checkout if a branch exists already
         try {
@@ -160,7 +162,11 @@ export class StartWorkOnBitbucketIssueWebview
             true,
             `${sourceBranch.type === RefType.RemoteHead ? 'remotes/' : ''}${sourceBranch.name}`,
         );
-        await repo.push(remote, destBranch, true);
+
+        if (pushBranchToOrigin) {
+            await repo.push(remote, destBranch, true);
+        }
+
         return;
     }
 

--- a/src/webviews/startWorkOnBitbucketIssueWebview.ts
+++ b/src/webviews/startWorkOnBitbucketIssueWebview.ts
@@ -105,7 +105,7 @@ export class StartWorkOnBitbucketIssueWebview
                                     e.targetBranchName,
                                     e.sourceBranch,
                                     e.remoteName,
-                                    e.pushBranchToOrigin,
+                                    e.pushBranchToRemote,
                                 );
                             }
 
@@ -139,7 +139,7 @@ export class StartWorkOnBitbucketIssueWebview
         destBranch: string,
         sourceBranch: Branch,
         remote: string,
-        pushBranchToOrigin: boolean,
+        pushBranchToRemote: boolean,
     ): Promise<void> {
         // checkout if a branch exists already
         try {
@@ -163,7 +163,7 @@ export class StartWorkOnBitbucketIssueWebview
             `${sourceBranch.type === RefType.RemoteHead ? 'remotes/' : ''}${sourceBranch.name}`,
         );
 
-        if (pushBranchToOrigin) {
+        if (pushBranchToRemote) {
             await repo.push(remote, destBranch, true);
         }
 

--- a/src/webviews/startWorkOnIssueWebview.ts
+++ b/src/webviews/startWorkOnIssueWebview.ts
@@ -69,7 +69,6 @@ export class StartWorkOnIssueWebview
             });
         }
         this.updateIssue(data);
-        return;
     }
 
     public async invalidate() {
@@ -113,6 +112,7 @@ export class StartWorkOnIssueWebview
                                     e.targetBranchName,
                                     e.sourceBranch,
                                     e.remoteName,
+                                    e.pushBranchToOrigin,
                                 );
                             }
                             const currentUserId = issue.siteDetails.userId;
@@ -151,6 +151,7 @@ export class StartWorkOnIssueWebview
         destBranch: string,
         sourceBranch: Branch,
         remote: string,
+        pushBranchToOrigin: boolean,
     ): Promise<void> {
         // checkout if a branch exists already
         try {
@@ -173,8 +174,10 @@ export class StartWorkOnIssueWebview
             true,
             `${sourceBranch.type === RefType.RemoteHead ? 'remotes/' : ''}${sourceBranch.name}`,
         );
-        await repo.push(remote, destBranch, true);
-        return;
+
+        if (pushBranchToOrigin) {
+            await repo.push(remote, destBranch, true);
+        }
     }
 
     public async updateIssue(issue: MinimalIssue<DetailedSiteInfo>) {

--- a/src/webviews/startWorkOnIssueWebview.ts
+++ b/src/webviews/startWorkOnIssueWebview.ts
@@ -132,7 +132,7 @@ export class StartWorkOnIssueWebview
                                         : ''
                                 }</ul>`,
                             });
-                            issueWorkStartedEvent(issue.siteDetails).then((e) => {
+                            issueWorkStartedEvent(issue.siteDetails, e.pushBranchToRemote).then((e) => {
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {

--- a/src/webviews/startWorkOnIssueWebview.ts
+++ b/src/webviews/startWorkOnIssueWebview.ts
@@ -112,7 +112,7 @@ export class StartWorkOnIssueWebview
                                     e.targetBranchName,
                                     e.sourceBranch,
                                     e.remoteName,
-                                    e.pushBranchToOrigin,
+                                    e.pushBranchToRemote,
                                 );
                             }
                             const currentUserId = issue.siteDetails.userId;
@@ -151,7 +151,7 @@ export class StartWorkOnIssueWebview
         destBranch: string,
         sourceBranch: Branch,
         remote: string,
-        pushBranchToOrigin: boolean,
+        pushBranchToRemote: boolean,
     ): Promise<void> {
         // checkout if a branch exists already
         try {
@@ -175,7 +175,7 @@ export class StartWorkOnIssueWebview
             `${sourceBranch.type === RefType.RemoteHead ? 'remotes/' : ''}${sourceBranch.name}`,
         );
 
-        if (pushBranchToOrigin) {
+        if (pushBranchToRemote) {
             await repo.push(remote, destBranch, true);
         }
     }


### PR DESCRIPTION
With this PR, the Start Work view exposes a toggle switch to control if the new branch should be automatically pushed to remote or not.
The toggle switch is defaulted to `true`, to keep parity with today's behavior.

The status of the new toggle is being instrumented within the `workStarted` event.

This addresses the following open issues:
[Add settings to not push instantly to remote](https://github.com/atlassian/atlascode/issues/90) #90
[Create branch as a local branch during "Start work"](https://bitbucket.org/atlassianlabs/atlascode/issues/538/create-branch-as-a-local-branch-during)

Here how it looks like:
![image](https://github.com/user-attachments/assets/82e2f89f-efc1-44a8-9da6-68ac8a8872b7)

