### PR TITLE
[AXON-161] Update default issue creation keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1178,14 +1178,22 @@
                     },
                     "default": [
                         "TODO",
+                        "todo",
+                        "Todo",
+                        "ToDo",
                         "BUG",
+                        "bug",
+                        "Bug",
                         "FIXME",
+                        "fixme",
+                        "Fixme",
+                        "FixMe",
                         "ISSUE",
-                        "NOTE",
-                        "OPTIMIZE",
+                        "issue",
+                        "Issue",
                         "HACK",
-                        "XXX",
-                        "FIX"
+                        "hack",
+                        "Hack"
                     ],
                     "description": "Strings that will trigger the Jira issue create Code Lens",
                     "scope": "window"

--- a/package.json
+++ b/package.json
@@ -1177,10 +1177,15 @@
                         "type": "string"
                     },
                     "default": [
-                        "TODO:",
-                        "BUG:",
-                        "FIXME:",
-                        "ISSUE:"
+                        "TODO",
+                        "BUG",
+                        "FIXME",
+                        "ISSUE",
+                        "NOTE",
+                        "OPTIMIZE",
+                        "HACK",
+                        "XXX",
+                        "FIX"
                     ],
                     "description": "Strings that will trigger the Jira issue create Code Lens",
                     "scope": "window"


### PR DESCRIPTION
### What is this?

Context - currently, we have a pretty strict syntax that requires `TODO:` for the `Create JIRA Issue` annotation to pop up:
![image](https://github.com/user-attachments/assets/82ac455c-bad3-4ea8-87e0-c33345134a49)

Update to the default keywords for ticket creation, per suggestion in Slack:
 * Removed trailing `:`
 * Added a bunch of extra options

Please note that this is just the default values. The docs aren't very clear - but I'm pretty sure this wouldn't affect users who already made changes to these settings

### How was this tested?

It was edited right in GH UI, so it kind of wasn't :) TBD in next nightly or manual build