### PR TITLE
[AXON-149] (WIP) re-enable auth UI for bitbucket in RDE

### DIFF
--- a/src/react/atlascode/config/auth/SiteAuthenticator.tsx
+++ b/src/react/atlascode/config/auth/SiteAuthenticator.tsx
@@ -1,10 +1,9 @@
-import { Box, Button, Grid, Typography } from '@material-ui/core';
+import { Box, Button, Grid } from '@material-ui/core';
 import React, { memo, useCallback, useContext } from 'react';
 
 import { AuthDialogControllerContext } from './useAuthDialog';
 import { CloudAuthButton } from './CloudAuthButton';
-import DomainIcon from '@material-ui/icons/Domain';
-import { Product, ProductJira } from '../../../../atlclients/authInfo';
+import { Product } from '../../../../atlclients/authInfo';
 import { SiteList } from './SiteList';
 import { SiteWithAuthInfo } from '../../../../lib/ipc/toUI/config';
 import { ConfigControllerContext } from '../configController';
@@ -40,27 +39,15 @@ export const SiteAuthenticator: React.FunctionComponent<SiteAuthenticatorProps> 
         return (
             <Box flexGrow={1}>
                 <Grid container direction="column" spacing={2}>
-                    {product.key === ProductJira.key ? (
-                        <AuthContainer
-                            isRemote={isRemote}
-                            product={product}
-                            openProductAuth={openProductAuth}
-                            sites={sites}
-                            handleEdit={handleEdit}
-                            remoteAuth={remoteAuth}
-                            isRemoteAuthButtonVisible={isRemoteAuthButtonVisible}
-                        />
-                    ) : (
-                        <LegacyAuthContainer
-                            isRemote={isRemote}
-                            product={product}
-                            openProductAuth={openProductAuth}
-                            sites={sites}
-                            handleEdit={handleEdit}
-                            remoteAuth={remoteAuth}
-                            isRemoteAuthButtonVisible={isRemoteAuthButtonVisible}
-                        />
-                    )}
+                    <AuthContainer
+                        isRemote={isRemote}
+                        product={product}
+                        openProductAuth={openProductAuth}
+                        sites={sites}
+                        handleEdit={handleEdit}
+                        remoteAuth={remoteAuth}
+                        isRemoteAuthButtonVisible={isRemoteAuthButtonVisible}
+                    />
                 </Grid>
             </Box>
         );
@@ -76,62 +63,6 @@ interface AuthContainerProps {
     remoteAuth: () => void;
     isRemoteAuthButtonVisible: boolean;
 }
-
-const LegacyAuthContainer = ({
-    isRemote,
-    product,
-    openProductAuth,
-    sites,
-    handleEdit,
-    remoteAuth,
-    isRemoteAuthButtonVisible,
-}: AuthContainerProps) => (
-    <React.Fragment>
-        <Grid item hidden={isRemote === false}>
-            <Typography>
-                <Box component="span" fontWeight="fontWeightBold">
-                    ⚠️ Authentication cannot be done while running remotely
-                </Box>
-            </Typography>
-            <Typography>
-                To authenticate with a new site open this (or another) workspace locally. Accounts added when running
-                locally <em>will</em> be accessible during remote development.
-            </Typography>
-        </Grid>
-        <Grid item style={{ cursor: isRemote ? 'not-allowed' : 'default' }}>
-            <Grid
-                container
-                direction="column"
-                spacing={2}
-                style={{
-                    pointerEvents: isRemote ? 'none' : 'inherit',
-                    opacity: isRemote ? 0.6 : 'inherit',
-                }}
-            >
-                <Grid item>
-                    <Grid container spacing={2}>
-                        <Grid item>
-                            <CloudAuthButton product={product} />
-                        </Grid>
-                        <Grid item>
-                            <Button color="primary" startIcon={<DomainIcon />} onClick={openProductAuth}>
-                                {`Add Custom ${product.name} Site`}
-                            </Button>
-                        </Grid>
-                        {isRemoteAuthButtonVisible && (
-                            <Grid item>
-                                <Button onClick={remoteAuth}>Remote Auth</Button>
-                            </Grid>
-                        )}
-                    </Grid>
-                </Grid>
-                <Grid item>
-                    <SiteList product={product} sites={sites} editServer={handleEdit} />
-                </Grid>
-            </Grid>
-        </Grid>
-    </React.Fragment>
-);
 
 const AuthContainer = ({
     isRemote,

--- a/src/react/atlascode/config/auth/dialog/AuthDialog.tsx
+++ b/src/react/atlascode/config/auth/dialog/AuthDialog.tsx
@@ -196,7 +196,12 @@ export const AuthDialog: React.FunctionComponent<AuthDialogProps> = memo(
                     </Grid>
                 </DialogContent>
                 <DialogActions>
-                    <Button disabled={!isValid} onClick={handleSubmit(handleSave)} variant="contained" color="primary">
+                    <Button
+                        disabled={!isValid && authFormType !== AuthFormType.None}
+                        onClick={handleSubmit(handleSave)}
+                        variant="contained"
+                        color="primary"
+                    >
                         Save Site
                     </Button>
                     <Button onClick={doClose} color="primary">


### PR DESCRIPTION
### What is this?

> ⚠️ Note: found some issues while submitting the PR - hence draft
>   * ~~url parsing might be borked after rebase, somehow~~ - tested, works now
>   * ~~would be good to disable the `save` button in BB cloud~~ - maybe in a follow-up
> * Please note that this specifically DOESN'T address BB cloud auth, and targets BasicAuth/PAT on BB DC/server instead

This PR enables the custom auth flow for Bitbucket in RDE, in the same way as JIRA - except using BB [app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) turned out to be a _really_ poor substitute for JIRA API token, so that's not available ;)

The rationale here is to enable folks who use BB Server/DC to authenticate remotely from RDEs via PAT/basic auth

| | Old | New |
|-|-|-|
| Local<br/> (no change) | ![image](https://github.com/user-attachments/assets/cb0b1a0e-83c1-47b8-8977-c15c6260622a) | ![image](https://github.com/user-attachments/assets/05cc7012-ddc8-4650-9a5c-92b2877fb04d) |
| Remote | ![image](https://github.com/user-attachments/assets/f7e9ec31-bedd-4eea-9ca6-028621b3b2e1) | ![image](https://github.com/user-attachments/assets/0f3f3fa3-536a-43e7-b35e-a97e5027a4cf) |

UI after this:
![image](https://github.com/user-attachments/assets/fd168de1-3941-4abd-81e5-e9ef3c25dc06)


### How was this tested?

 * Via dev-container, managed to authenticate against an available instance of BB DC