### PR TITLE
AXON-192: add AA exp code to features init

### DIFF
--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -5,11 +5,17 @@ export enum Features {
 
 export enum Experiments {
     NewAuthUI = 'atlascode_new_auth_ui',
+    AtlascodeAA = 'atlascode_aa_experiment',
 }
 
 export const ExperimentGates: ExperimentGate = {
     [Experiments.NewAuthUI]: {
         gate: 'atlascode_new_auth_ui',
+        parameter: 'isEnabled',
+        defaultValue: false,
+    },
+    [Experiments.AtlascodeAA]: {
+        gate: 'atlascode_aa_experiment',
         parameter: 'isEnabled',
         defaultValue: false,
     },


### PR DESCRIPTION
<img width="419" alt="Screenshot 2025-02-28 at 3 38 52 PM" src="https://github.com/user-attachments/assets/6a303c91-f7eb-44c8-89cf-3ae829e9d5c4" />

* Added AA exp value to FeatureFlagClient init