### PR TITLE
Loading state for "Checkout Source Branch" button

### DIFF
--- a/src/react/atlascode/pullrequest/PullRequestDetailsPage.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestDetailsPage.tsx
@@ -184,7 +184,8 @@ export const PullRequestDetailsPage: React.FunctionComponent = () => {
                                                 <Grid item>
                                                     <Button
                                                         disabled={
-                                                            state.pr.data.source.branchName === state.currentBranchName
+                                                            state.pr.data.source.branchName ===
+                                                                state.currentBranchName || state.isCheckingOutBranch
                                                         }
                                                         onClick={controller.checkoutBranch}
                                                         color={'primary'}
@@ -192,7 +193,9 @@ export const PullRequestDetailsPage: React.FunctionComponent = () => {
                                                         <Typography variant="button" noWrap>
                                                             {state.pr.data.source.branchName === state.currentBranchName
                                                                 ? 'Source branch checked out'
-                                                                : 'Checkout source branch'}
+                                                                : state.isCheckingOutBranch
+                                                                  ? 'Checking out...'
+                                                                  : 'Checkout source branch'}
                                                         </Typography>
                                                     </Button>
                                                 </Grid>


### PR DESCRIPTION
**Customer Problem**

The 'Checkout source Branch' button in the Pull Request view doesn't have a loading state, and it gives the impression that nothing is happening, and suddenly, it changes to 'Source branch Checkout out.'  

This PR will add a loading state to the 'Checkout source Branch' button, which will help to ensure that the checkout is in progress instead of clicking the button multiple times.

Loom Video: https://www.loom.com/share/c58dda9fb5bd494f979cbd940a955f6a?sid=43894cfe-7c32-4438-ad13-cbabec5ec227



