### PR TITLE
Hiding Approve PR Button for author of the PR

### DIFF
--- a/src/react/atlascode/pullrequest/PullRequestDetailsPage.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestDetailsPage.tsx
@@ -128,7 +128,7 @@ export const PullRequestDetailsPage: React.FunctionComponent = () => {
                             <Box marginLeft={1} hidden={state.loadState.basicData}>
                                 <ApproveButton
                                     hidden={
-                                        !state.pr.site.details.isCloud &&
+                                        state.pr.site.details.isCloud &&
                                         state.currentUser.accountId === state.pr.data.author.accountId
                                     }
                                     status={currentUserApprovalStatus}


### PR DESCRIPTION
Ideally PR author should not be seeing/allowed to approve the PR. So hiding the approve PR button for author of PR.