### PR TITLE
Fix exceptions due to failures in FeatureFlagClient initialization

### DIFF
--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -24,20 +24,27 @@ export class FeatureFlagClient {
     }
 
     public static async initialize(options: FeatureFlagClientOptions): Promise<void> {
-        const targetApp = process.env.ATLASCODE_FX3_TARGET_APP || '';
-        const environment =
-            (process.env.ATLASCODE_FX3_ENVIRONMENT as FeatureGateEnvironment) || FeatureGateEnvironment.Production;
+        const targetApp = process.env.ATLASCODE_FX3_TARGET_APP;
+        const environment = process.env.ATLASCODE_FX3_ENVIRONMENT as FeatureGateEnvironment;
+        const apiKey = process.env.ATLASCODE_FX3_API_KEY;
+        const timeout = process.env.ATLASCODE_FX3_TIMEOUT;
+
+        if (!targetApp || !environment || !apiKey || !timeout) {
+            this._featureGates = this.evaluateFeatures();
+            this._experimentValues = this.evaluateExperiments();
+            return;
+        }
 
         console.log(`FeatureGates: initializing, target: ${targetApp}, environment: ${environment}`);
         this.analyticsClient = new AnalyticsClientMapper(options.analyticsClient, options.identifiers);
         this.eventBuilder = options.eventBuilder;
 
-        return FeatureGates.initialize(
+        await FeatureGates.initialize(
             {
-                apiKey: process.env.ATLASCODE_FX3_API_KEY || '',
+                apiKey,
                 environment,
                 targetApp,
-                fetchTimeoutMs: Number.parseInt(process.env.ATLASCODE_FX3_TIMEOUT || '2000'),
+                fetchTimeoutMs: Number.parseInt(timeout),
                 analyticsWebClient: Promise.resolve(this.analyticsClient),
             },
             options.identifiers,
@@ -47,29 +54,27 @@ export class FeatureFlagClient {
                 this.eventBuilder.featureFlagClientInitializedEvent().then((e) => {
                     options.analyticsClient.sendTrackEvent(e);
                 });
-            })
-            .then(() => {
+
                 // console log all feature gates and values
                 for (const feat of Object.values(Features)) {
                     console.log(`FeatureGates: ${feat} -> ${FeatureGates.checkGate(feat)}`);
                 }
             })
-            .then(async () => {
-                this._featureGates = await this.evaluateFeatures();
-                this._experimentValues = await this.evaluateExperiments();
-            })
             .catch((err) => {
                 console.warn(`FeatureGates: Failed to initialize client. ${err}`);
-                console.warn('FeatureGates: Disabling feature flags');
                 this.eventBuilder
                     .featureFlagClientInitializationFailedEvent()
                     .then((e) => options.analyticsClient.sendTrackEvent(e));
+            })
+            .finally(async () => {
+                this._featureGates = this.evaluateFeatures();
+                this._experimentValues = this.evaluateExperiments();
             });
     }
 
-    public static checkGate(gate: string): boolean {
+    private static checkGate(gate: Features): boolean {
         let gateValue = false;
-        if (FeatureGates === null) {
+        if (!FeatureGates) {
             console.warn('FeatureGates: FeatureGates is not initialized. Defaulting to False');
         } else {
             // FeatureGates.checkGate returns false if any errors
@@ -79,20 +84,18 @@ export class FeatureFlagClient {
         return gateValue;
     }
 
-    public static checkExperimentValue(experiment: string): any {
-        let gateValue: any;
+    private static checkExperimentValue(experiment: Experiments): any {
         const experimentGate = ExperimentGates[experiment];
         if (!experimentGate) {
             return undefined;
         }
-        if (FeatureGates === null) {
-            console.warn(
-                `FeatureGates: FeatureGates is not initialized. Returning default value: ${experimentGate.defaultValue}`,
-            );
-            gateValue = experimentGate.defaultValue;
+
+        let gateValue = experimentGate.defaultValue;
+        if (!FeatureGates) {
+            console.warn(`FeatureGates: FeatureGates is not initialized. Returning default value: ${gateValue}`);
         } else {
             gateValue = FeatureGates.getExperimentValue(
-                experimentGate.gate,
+                experiment,
                 experimentGate.parameter,
                 experimentGate.defaultValue,
             );
@@ -101,29 +104,25 @@ export class FeatureFlagClient {
         return gateValue;
     }
 
-    public static async evaluateFeatures() {
-        const featureFlags = await Promise.all(
-            Object.values(Features).map(async (feature) => {
-                return {
-                    // eslint-disable-next-line @typescript-eslint/await-thenable
-                    [feature]: await this.checkGate(feature),
-                };
-            }),
-        );
+    private static evaluateFeatures(): FeatureGateValues {
+        const featureFlags = Object.values(Features).map(async (feature) => {
+            return {
+                // eslint-disable-next-line @typescript-eslint/await-thenable
+                [feature]: this.checkGate(feature),
+            };
+        });
 
-        return featureFlags.reduce((acc, val) => ({ ...acc, ...val }), {});
+        return featureFlags.reduce((acc, val) => ({ ...acc, ...val }), {}) as FeatureGateValues;
     }
 
-    public static async evaluateExperiments() {
-        const experimentGates = await Promise.all(
-            Object.values(Experiments).map(async (experiment) => {
-                return {
-                    [experiment]: await this.checkExperimentValue(experiment),
-                };
-            }),
-        );
+    private static evaluateExperiments(): ExperimentGateValues {
+        const experimentGates = Object.values(Experiments).map(async (experiment) => {
+            return {
+                [experiment]: this.checkExperimentValue(experiment),
+            };
+        });
 
-        return experimentGates.reduce((acc, val) => ({ ...acc, ...val }), {});
+        return experimentGates.reduce((acc, val) => ({ ...acc, ...val }), {}) as ExperimentGateValues;
     }
 
     static dispose() {

--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -66,7 +66,7 @@ export class FeatureFlagClient {
                     .featureFlagClientInitializationFailedEvent()
                     .then((e) => options.analyticsClient.sendTrackEvent(e));
             })
-            .finally(async () => {
+            .finally(() => {
                 this._featureGates = this.evaluateFeatures();
                 this._experimentValues = this.evaluateExperiments();
             });

--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -107,7 +107,6 @@ export class FeatureFlagClient {
     private static evaluateFeatures(): FeatureGateValues {
         const featureFlags = Object.values(Features).map(async (feature) => {
             return {
-                // eslint-disable-next-line @typescript-eslint/await-thenable
                 [feature]: this.checkGate(feature),
             };
         });

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -10,20 +10,18 @@ export enum Experiments {
 
 export const ExperimentGates: ExperimentGate = {
     [Experiments.NewAuthUI]: {
-        gate: 'atlascode_new_auth_ui',
         parameter: 'isEnabled',
         defaultValue: false,
     },
     [Experiments.AtlascodeAA]: {
-        gate: 'atlascode_aa_experiment',
         parameter: 'isEnabled',
         defaultValue: false,
     },
 };
 
-type ExperimentPayload = { gate: string; parameter: string; defaultValue: any };
-type ExperimentGate = Record<string, ExperimentPayload>;
+type ExperimentPayload = { parameter: string; defaultValue: any };
+type ExperimentGate = Record<Experiments, ExperimentPayload>;
 
-export type FeatureGateValues = Record<string, boolean>;
+export type FeatureGateValues = Record<Features, boolean>;
 
-export type ExperimentGateValues = Record<string, any>;
+export type ExperimentGateValues = Record<Experiments, any>;


### PR DESCRIPTION
The code was throwing exceptions because when failing to retrieve the data from the server (e.g., missing `.env` file), the fields `FeatureFlagClient._featureGates` and `FeatureFlagClient._experimentValues` were left uninitialized.