### PR TITLE
Decoupling ChangedFiles & Conflicts API

### DIFF
--- a/src/bitbucket/bitbucket-cloud/pullRequests.ts
+++ b/src/bitbucket/bitbucket-cloud/pullRequests.ts
@@ -217,25 +217,25 @@ export class CloudPullRequestApi implements PullRequestApi {
             Logger.error(error);
         }
 
-        const conflictUrl = `https://api.bitbucket.org/internal/repositories/${ownerSlug}/${repoSlug}/pullrequests/${pr.data.id}/conflicts`;
-        let resp = { data: [] };
-        try {
-            resp = await this.client.get(conflictUrl);
-        } catch (ex) {
-            const error = new Error(`Fetching conflict data failed for the PR: ${pr.data.id}} with error: ${ex}`);
-            Logger.error(error);
-        }
-        const conflictData = resp.data;
-        const prTypeUrl = `https://api.bitbucket.org/internal/repositories/${ownerSlug}/${repoSlug}/pullrequests/${pr.data.id}`;
-        let prTypeData = { data: { diff_type: '' } };
-        try {
-            prTypeData = await this.client.get(prTypeUrl);
-        } catch (ex) {
-            const error = new Error(`Fetching prTypeData failed for the PR: ${pr.data.id}} with error: ${ex}`);
-            Logger.error(error);
-        }
+        // const conflictUrl = `https://api.bitbucket.org/internal/repositories/${ownerSlug}/${repoSlug}/pullrequests/${pr.data.id}/conflicts`;
+        // let resp = { data: [] };
+        // try {
+        //     resp = await this.client.get(conflictUrl);
+        // } catch (ex) {
+        //     const error = new Error(`Fetching conflict data failed for the PR: ${pr.data.id}} with error: ${ex}`);
+        //     Logger.error(error);
+        // }
+        // const conflictData = resp.data;
+        // const prTypeUrl = `https://api.bitbucket.org/internal/repositories/${ownerSlug}/${repoSlug}/pullrequests/${pr.data.id}`;
+        // let prTypeData = { data: { diff_type: '' } };
+        // try {
+        //     prTypeData = await this.client.get(prTypeUrl);
+        // } catch (ex) {
+        //     const error = new Error(`Fetching prTypeData failed for the PR: ${pr.data.id}} with error: ${ex}`);
+        //     Logger.error(error);
+        // }
 
-        const diffType = prTypeData.data.diff_type;
+        // const diffType = prTypeData.data.diff_type;
         if (!data.values) {
             return [];
         }
@@ -261,16 +261,16 @@ export class CloudPullRequestApi implements PullRequestApi {
                 newPathDeletions: [],
                 newPathContextMap: {},
             },
-            isConflicted: this.isFileConflicted(diffType, diffStat, conflictData),
+            // isConflicted: this.isFileConflicted(diffType, diffStat, conflictData),
         }));
     }
 
     // Topic diffs no longer indicate a conflict in the status field so we have to check the results of the conflict endpoint.
-    private isFileConflicted(diffType: string, diffStat: any, conflictData: any[]): boolean | undefined {
-        const oldPath = diffStat.old?.path;
-        const newPath = diffStat.new?.path;
-        return diffType === 'TOPIC' && conflictData.some((c) => c.path === newPath || oldPath);
-    }
+    // private isFileConflicted(diffType: string, diffStat: any, conflictData: any[]): boolean | undefined {
+    //     const oldPath = diffStat.old?.path;
+    //     const newPath = diffStat.new?.path;
+    //     return diffType === 'TOPIC' && conflictData.some((c) => c.path === newPath || oldPath);
+    // }
 
     private mapStatusWordsToFileStatus(status: string): FileStatus {
         if (status === 'added') {

--- a/src/bitbucket/bitbucket-server/pullRequests.ts
+++ b/src/bitbucket/bitbucket-server/pullRequests.ts
@@ -487,6 +487,16 @@ export class ServerPullRequestApi implements PullRequestApi {
 
         return result;
     }
+    /**
+     *
+     * @param pr The Pull request for which conflict data is to be calculated
+     * @returns [''] -> Empty String Array
+     * We don't seem to have the concept of conflicted Files in Server from the getChangedFiles method above
+     * but this has been implemented here because Server extends the common interface PullRequestApi which has this method
+     */
+    async getConflictedFiles(pr: PullRequest): Promise<string[]> {
+        return [];
+    }
 
     async getCurrentUser(site: DetailedSiteInfo): Promise<User> {
         const userSlug = site.userId;

--- a/src/bitbucket/model.ts
+++ b/src/bitbucket/model.ts
@@ -209,10 +209,6 @@ export interface FileDiff {
         // NOT using Map here as Map does not serialize to JSON
         newPathContextMap: Record<string, number>;
     };
-
-    // Indicates whether or not the file has a conflict. Only defined on topic diffs - recent (approx 2022 and forward) BB server diffs.
-    // If it's undefined fall back to looking for FileStatus.CONFLICT
-    isConflicted?: boolean;
 }
 
 export type CreatePullRequestData = {
@@ -349,6 +345,7 @@ export interface PullRequestApi {
     get(site: BitbucketSite, prId: string, workspaceRepo?: WorkspaceRepo): Promise<PullRequest>;
     getById(site: BitbucketSite, prId: number): Promise<PullRequest>;
     getChangedFiles(pr: PullRequest, spec?: string): Promise<FileDiff[]>;
+    getConflictedFiles(pr: PullRequest): Promise<string[]>;
     getCommits(pr: PullRequest): Promise<Commit[]>;
     getComments(pr: PullRequest, commitHash?: string): Promise<PaginatedComments>;
     editComment(

--- a/src/lib/ipc/toUI/pullRequestDetails.ts
+++ b/src/lib/ipc/toUI/pullRequestDetails.ts
@@ -40,6 +40,7 @@ export enum PullRequestDetailsMessageType {
     UpdateRelatedJiraIssues = 'updateRelatedJiraIssues',
     UpdateRelatedBitbucketIssues = 'updateRelatedBitbucketIssues',
     UpdateTasks = 'updateTasks',
+    UpdateConflictedFiles = 'updateConflictedFiles',
 }
 
 export type PullRequestDetailsMessage =
@@ -52,6 +53,7 @@ export type PullRequestDetailsMessage =
     | ReducerAction<PullRequestDetailsMessageType.CheckoutBranch, PullRequestDetailsCheckoutBranchMessage>
     | ReducerAction<PullRequestDetailsMessageType.UpdateComments, PullRequestDetailsCommentsMessage>
     | ReducerAction<PullRequestDetailsMessageType.UpdateFileDiffs, PullRequestDetailsFileDiffsMessage>
+    | ReducerAction<PullRequestDetailsMessageType.UpdateConflictedFiles, PullRequestDetailsConflictedFilesMessage>
     | ReducerAction<PullRequestDetailsMessageType.UpdateBuildStatuses, PullRequestDetailsBuildStatusesMessage>
     | ReducerAction<PullRequestDetailsMessageType.UpdateMergeStrategies, PullRequestDetailsMergeStrategiesMessage>
     | ReducerAction<PullRequestDetailsMessageType.UpdateRelatedJiraIssues, PullRequestDetailsRelatedJiraIssuesMessage>
@@ -79,6 +81,7 @@ export interface PullRequestDetailsInitMessage {
     comments: Comment[];
     tasks: Task[];
     fileDiffs: FileDiff[];
+    conflictedFiles: string[];
     mergeStrategies: MergeStrategy[];
     buildStatuses: BuildStatus[];
     relatedJiraIssues: MinimalIssue<DetailedSiteInfo>[];
@@ -135,6 +138,10 @@ export interface PullRequestDetailsFileDiffsMessage {
     fileDiffs: FileDiff[];
 }
 
+export interface PullRequestDetailsConflictedFilesMessage {
+    conflictedFiles: string[];
+}
+
 export interface PullRequestDetailsMergeStrategiesMessage {
     mergeStrategies: MergeStrategy[];
 }
@@ -180,4 +187,5 @@ export const emptyPullRequestDetailsInitMessage: PullRequestDetailsInitMessage =
         mergeStrategies: true,
         buildStatuses: true,
     },
+    conflictedFiles: [],
 };

--- a/src/lib/webview/controller/pullrequest/pullRequestDetailsActionApi.ts
+++ b/src/lib/webview/controller/pullrequest/pullRequestDetailsActionApi.ts
@@ -31,6 +31,7 @@ export interface PullRequestDetailsActionApi {
     editComment(comments: Comment[], pr: PullRequest, content: string, commentId: string): Promise<Comment[]>;
     deleteComment(pr: PullRequest, comment: Comment): Promise<Comment[]>;
     getFileDiffs(pr: PullRequest, inlineComments: Comment[]): Promise<FileDiff[]>;
+    getConflictedFiles(pr: PullRequest): Promise<string[]>;
     openDiffViewForFile(pr: PullRequest, fileDiff: FileDiff, comments: Comment[]): Promise<void>;
     updateBuildStatuses(pr: PullRequest): Promise<BuildStatus[]>;
     updateMergeStrategies(pr: PullRequest): Promise<MergeStrategy[]>;

--- a/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.ts
+++ b/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.ts
@@ -167,6 +167,13 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                 });
             });
 
+            this.api.getConflictedFiles(this.pr).then((conflictedFiles: string[]) => {
+                this.postMessage({
+                    type: PullRequestDetailsMessageType.UpdateConflictedFiles,
+                    conflictedFiles,
+                });
+            });
+
             //In order to get related issues, we need comments and commits. We already have comments,
             //so now we wait for commits. These two promises can be launched concurrently.
             this.commits = await commitPromise;

--- a/src/react/atlascode/pullrequest/CreatePullRequestPage.tsx
+++ b/src/react/atlascode/pullrequest/CreatePullRequestPage.tsx
@@ -516,6 +516,7 @@ const CreatePullRequestPage: React.FunctionComponent = () => {
                                             <DiffList
                                                 fileDiffs={state.fileDiffs}
                                                 openDiffHandler={controller.openDiff}
+                                                conflictedFiles={[]}
                                             />
                                         </Grid>
                                     </Grid>

--- a/src/react/atlascode/pullrequest/DiffList.tsx
+++ b/src/react/atlascode/pullrequest/DiffList.tsx
@@ -52,6 +52,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export const DiffList: React.FunctionComponent<{
     fileDiffs: FileDiff[];
     openDiffHandler: (filediff: FileDiff) => void;
+    conflictedFiles: string[];
 }> = (props) => {
     const classes = useStyles();
 
@@ -93,9 +94,11 @@ export const DiffList: React.FunctionComponent<{
         }
     };
 
-    const ConflictChip = (fileDiff: FileDiff) => {
-        // Is either undefined or false
-        if (!fileDiff.isConflicted) {
+    const ConflictChip = (fileDiff: FileDiff, conflictedFiles: string[]) => {
+        // Is fileDiff's old or new path doesn't exists in conflictedFiles
+        const newPath = fileDiff.newPath || '';
+        const oldPath = fileDiff.oldPath || '';
+        if (!conflictedFiles.includes(newPath) || !conflictedFiles.includes(oldPath)) {
             return <div></div>;
         }
         return (
@@ -113,7 +116,6 @@ export const DiffList: React.FunctionComponent<{
             </Tooltip>
         );
     };
-
     return (
         <TableContainer>
             <Table size="small" className={classes.table} aria-label="commits list">
@@ -153,7 +155,9 @@ export const DiffList: React.FunctionComponent<{
                                     />
                                 </Tooltip>
                             </TableCell>
-                            <TableCell className={classes.tableCell}>{ConflictChip(row)}</TableCell>
+                            <TableCell className={classes.tableCell}>
+                                {ConflictChip(row, props.conflictedFiles)}
+                            </TableCell>
                             <TableCell className={classes.tableCell}>
                                 <Link onClick={() => props.openDiffHandler(row)}>
                                     <Typography>{row.file}</Typography>

--- a/src/react/atlascode/pullrequest/PullRequestDetailsPage.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestDetailsPage.tsx
@@ -273,6 +273,7 @@ export const PullRequestDetailsPage: React.FunctionComponent = () => {
                                                 <DiffList
                                                     fileDiffs={state.fileDiffs}
                                                     openDiffHandler={controller.openDiff}
+                                                    conflictedFiles={state.conflictedFiles}
                                                 />
                                             </BasicPanel>
                                         </Grid>

--- a/src/react/atlascode/pullrequest/pullRequestDetailsController.ts
+++ b/src/react/atlascode/pullrequest/pullRequestDetailsController.ts
@@ -37,6 +37,7 @@ import {
     PullRequestDetailsSummaryMessage,
     PullRequestDetailsTasksMessage,
     PullRequestDetailsTitleMessage,
+    PullRequestDetailsConflictedFilesMessage,
 } from '../../../lib/ipc/toUI/pullRequestDetails';
 import { ConnectionTimeout } from '../../../util/time';
 import { PostMessageFunc, useMessagingApi } from '../messagingApi';
@@ -127,6 +128,7 @@ export enum PullRequestDetailsUIActionType {
     UpdateTasks = 'updateTasks',
     AddComment = 'addComment',
     UpdateFileDiffs = 'updateFileDiffs',
+    UpdateConflictedFiles = 'updateConflictedFiles',
     UpdateBuildStatuses = 'updateBuildStatuses',
     UpdateMergeStrategies = 'updateMergeStrategies',
     UpdateRelatedJiraIssues = 'updateRelatedJiraIssues',
@@ -144,6 +146,10 @@ export type PullRequestDetailsUIAction =
     | ReducerAction<PullRequestDetailsUIActionType.UpdateComments, { data: PullRequestDetailsCommentsMessage }>
     | ReducerAction<PullRequestDetailsUIActionType.UpdateTasks, { data: PullRequestDetailsTasksMessage }>
     | ReducerAction<PullRequestDetailsUIActionType.UpdateFileDiffs, { data: PullRequestDetailsFileDiffsMessage }>
+    | ReducerAction<
+          PullRequestDetailsUIActionType.UpdateConflictedFiles,
+          { data: PullRequestDetailsConflictedFilesMessage }
+      >
     | ReducerAction<
           PullRequestDetailsUIActionType.UpdateBuildStatuses,
           { data: PullRequestDetailsBuildStatusesMessage }
@@ -255,6 +261,13 @@ function pullRequestDetailsReducer(
         case PullRequestDetailsUIActionType.UpdateFileDiffs: {
             return { ...state, fileDiffs: action.data.fileDiffs, loadState: { ...state.loadState, diffs: false } };
         }
+        case PullRequestDetailsUIActionType.UpdateConflictedFiles: {
+            return {
+                ...state,
+                conflictedFiles: action.data.conflictedFiles,
+                loadState: { ...state.loadState, diffs: false },
+            };
+        }
         case PullRequestDetailsUIActionType.UpdateBuildStatuses: {
             return {
                 ...state,
@@ -331,6 +344,10 @@ export function usePullRequestDetailsController(): [PullRequestDetailsState, Pul
             }
             case PullRequestDetailsMessageType.UpdateFileDiffs: {
                 dispatch({ type: PullRequestDetailsUIActionType.UpdateFileDiffs, data: message });
+                break;
+            }
+            case PullRequestDetailsMessageType.UpdateConflictedFiles: {
+                dispatch({ type: PullRequestDetailsUIActionType.UpdateConflictedFiles, data: message });
                 break;
             }
             case PullRequestDetailsMessageType.UpdateBuildStatuses: {

--- a/src/views/nodes/commitNode.ts
+++ b/src/views/nodes/commitNode.ts
@@ -30,12 +30,13 @@ export class CommitNode extends AbstractBaseNode {
         try {
             const bbApi = await clientForSite(this.pr.site);
             const diffs = await bbApi.pullrequests.getChangedFiles(this.pr, this.commit.hash);
+            const conflictedFiles = await bbApi.pullrequests.getConflictedFiles(this.pr);
             const paginatedComments = await bbApi.pullrequests.getComments(this.pr, this.commit.hash);
 
             //TODO: pass tasks if commit-level tasks exist
             //TODO: if there is more than one parent, there should probably be a notification about diff ambiguity, unless I can figure
             //out a way to resolve this
-            const children = await createFileChangesNodes(this.pr, paginatedComments, diffs, [], {
+            const children = await createFileChangesNodes(this.pr, paginatedComments, diffs, conflictedFiles, [], {
                 lhs: this.commit.parentHashes?.[0] ?? '', //The only time I can think of this being undefined is for an initial commit, but what should the parent be there?
                 rhs: this.commit.hash,
             });

--- a/src/views/pullrequest/diffViewHelper.ts
+++ b/src/views/pullrequest/diffViewHelper.ts
@@ -84,6 +84,7 @@ function traverse(n: Comment): Comment[] {
 export async function getArgsForDiffView(
     allComments: PaginatedComments,
     fileDiff: FileDiff,
+    conflictedFiles: string[],
     pr: PullRequest,
     commentController: PullRequestCommentController,
     commitRange?: { lhs: string; rhs: string },
@@ -203,7 +204,8 @@ export async function getArgsForDiffView(
             fileDisplayName: fileDisplayName,
             fileDiffStatus: fileDiff.status,
             numberOfComments: comments.length ? comments.length : 0,
-            isConflicted: fileDiff.isConflicted,
+            isConflicted:
+                conflictedFiles.includes(fileDiff.newPath || '') || conflictedFiles.includes(fileDiff.oldPath || ''),
         },
     };
 }
@@ -260,6 +262,7 @@ export async function createFileChangesNodes(
     pr: PullRequest,
     allComments: PaginatedComments,
     fileDiffs: FileDiff[],
+    conflictedFiles: string[],
     tasks: Task[],
     commitRange?: { lhs: string; rhs: string },
 ): Promise<AbstractBaseNode[]> {
@@ -269,6 +272,7 @@ export async function createFileChangesNodes(
             return await getArgsForDiffView(
                 commentsWithTasks,
                 fileDiff,
+                conflictedFiles,
                 pr,
                 Container.bitbucketContext.prCommentController,
                 commitRange,

--- a/src/webview/pullrequest/vscPullRequestDetailsActionApi.ts
+++ b/src/webview/pullrequest/vscPullRequestDetailsActionApi.ts
@@ -183,10 +183,18 @@ export class VSCPullRequestDetailsActionApi implements PullRequestDetailsActionA
         return fileDiffs;
     }
 
+    async getConflictedFiles(pr: PullRequest): Promise<string[]> {
+        const bbApi = await clientForSite(pr.site);
+        const conflictedFiles = await bbApi.pullrequests.getConflictedFiles(pr);
+        return conflictedFiles;
+    }
+
     async openDiffViewForFile(pr: PullRequest, fileDiff: FileDiff, comments: Comment[]): Promise<void> {
+        const conflictedFiles = await this.getConflictedFiles(pr);
         const diffViewArgs = await getArgsForDiffView(
             { data: comments },
             fileDiff,
+            conflictedFiles,
             pr,
             Container.bitbucketContext.prCommentController,
         );


### PR DESCRIPTION
We found that for larger repos the conflicts API would always time out within 30 seconds and the UI wouldn't load. In order to fix that I have decoupled the changedFiles & conflicts API calls.

Now isConflicted is nomore the property on diffstats and is instead stored as an array of conflictedFiles in state. The rendering component would then compare this array with the fileName and if fileName exists in conflictedArray then mark this as a conflicted file. 

Loom video explaining the changes - https://www.loom.com/share/097ef30c0301409d95e0b6e12d9e5a63

Loom Video trying the changes on larger repos - https://www.loom.com/share/8681ec2bf2cf4026b3869afdff78c802
