### PR TITLE
[DRAFT] [WIP] Use existing authToken from user machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1378,6 +1378,12 @@
                     "default": true,
                     "description": "Shows the help explorer treeview",
                     "scope": "window"
+                },
+                "atlascode.bitbucket.readAuthToken": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use auth token from environment variable for Bitbucket authentication",
+                    "scope": "application"
                 }
             }
         }

--- a/src/atlclients/authInfo.ts
+++ b/src/atlclients/authInfo.ts
@@ -79,7 +79,7 @@ export interface AuthInfo {
 
 export interface OAuthInfo extends AuthInfo {
     access: string;
-    refresh: string;
+    refresh?: string;
     expirationDate?: number;
     iat?: number;
     recievedAt: number;

--- a/src/atlclients/authStore.ts
+++ b/src/atlclients/authStore.ts
@@ -319,7 +319,7 @@ export class CredentialManager implements Disposable {
 
         const provider: OAuthProvider | undefined = oauthProviderForSite(site);
         const newTokens = undefined;
-        if (provider && credentials) {
+        if (provider && credentials && credentials.refresh) {
             const tokenResponse = await this._refresher.getNewTokens(provider, credentials.refresh);
             if (tokenResponse.tokens) {
                 const newTokens = tokenResponse.tokens;

--- a/src/atlclients/oauthDancer.ts
+++ b/src/atlclients/oauthDancer.ts
@@ -296,4 +296,8 @@ export class OAuthDancer implements Disposable {
 
         this._shutdownCheck = setInterval(this.maybeShutdown, this._shutdownCheckInterval);
     }
+
+    public getAxiosInstance(): AxiosInstance {
+        return this._axios;
+    }
 }

--- a/src/atlclients/responseHandlers/BitbucketResponseHandler.ts
+++ b/src/atlclients/responseHandlers/BitbucketResponseHandler.ts
@@ -34,7 +34,7 @@ export class BitbucketResponseHandler extends ResponseHandler {
         }
     }
 
-    public async user(accessToken: string, resource: AccessibleResource): Promise<UserInfo> {
+    public async user(accessToken: string): Promise<UserInfo> {
         try {
             const userResponse = await this.axios(this.strategy.profileUrl(), {
                 method: 'GET',

--- a/src/config/model.ts
+++ b/src/config/model.ts
@@ -129,6 +129,7 @@ export interface BitbucketConfig {
     pipelines: BitbucketPipelinesConfig;
     issues: BitbucketIssuesConfig;
     preferredRemotes: string[];
+    readAuthToken?: boolean;
 }
 
 export interface BitbucketPipelinesConfig {
@@ -317,6 +318,7 @@ export const emptyBitbucketConfig: BitbucketConfig = {
     pipelines: emptyPipelinesConfig,
     issues: emptyIssuesConfig,
     preferredRemotes: ['upstream', 'origin'],
+    readAuthToken: false,
 };
 
 export const emptyConfig: IConfig = {

--- a/src/container.ts
+++ b/src/container.ts
@@ -219,7 +219,7 @@ export class Container {
         analyticsApi: VSCAnalyticsApi,
         bitbucketHelper: CheckoutHelper,
     ) {
-        if (FeatureFlagClient.featureGates[Features.EnableNewUriHandler]) {
+        if (FeatureFlagClient.featureGates && FeatureFlagClient.featureGates[Features.EnableNewUriHandler]) {
             console.log('Using new URI handler');
             context.subscriptions.push(AtlascodeUriHandler.create(analyticsApi, bitbucketHelper));
         } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,11 @@ export async function activate(context: ExtensionContext) {
             CommandContext.IsBBAuthenticated,
             Container.siteManager.productHasAtLeastOneSite(ProductBitbucket),
         );
+
+        if (Container.config.bitbucket.readAuthToken) {
+            Logger.debug('readAuthToken is enabled, attempting to authenticate with Bitbucket token');
+            await Container.loginManager.authenticateWithBitbucketToken();
+        }
     } catch (e) {
         Logger.error(e, 'Error initializing atlascode!');
     }


### PR DESCRIPTION
Customer Need: 

We are planning this extension inside RDE which already has Bitbucket authToken. We are planning to feed the BB authToken directly to the atlascode extension without needing to go through the authorization flow and auth dance.

The token refresh will be handled externally so we need to avoid token refresh as well.

TBD:
Right now, the authToken is passed as an env variable. I intend to change this implementation to be more robust as the auth token will change. 
- Loom recording
