### PR TITLE
Revert "[AXON-17] (WIP) fix weird site list behaviour"

### DIFF
--- a/src/atlclients/authInfo.ts
+++ b/src/atlclients/authInfo.ts
@@ -19,7 +19,6 @@ export interface RemoveAuthInfoEvent extends AuthInfoEvent {
     type: AuthChangeType.Remove;
     product: Product;
     credentialId: string;
-    host: string;
 }
 
 export interface Product {
@@ -120,10 +119,6 @@ export interface DetailedSiteInfo extends SiteInfo {
     isCloud: boolean;
     userId: string;
     credentialId: string;
-}
-
-export function getSiteInfoKey(site: DetailedSiteInfo): string {
-    return `${site.product.key} - ${site.host} - ${site.credentialId}`;
 }
 
 // You MUST send source

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -111,9 +111,7 @@ export class SiteManager extends Disposable {
 
     onDidAuthChange(e: AuthInfoEvent) {
         if (isRemoveAuthEvent(e)) {
-            const deadSites = this.getSitesAvailable(e.product).filter(
-                (site) => site.credentialId === e.credentialId && site.host === e.host,
-            );
+            const deadSites = this.getSitesAvailable(e.product).filter((site) => site.credentialId === e.credentialId);
             deadSites.forEach((s) => this.removeSite(s));
             if (deadSites.length > 0) {
                 this._onDidSitesAvailableChange.fire({


### PR DESCRIPTION
### What is this?

This is a PR where we revert the change in how site information is stored (credential ID vs credential ID+extra info). See [original PR](https://github.com/atlassian/atlascode/pull/79) for a before-and-after

We suspect this change might have been causing friction in the auth experience. The exact root cause is pending confirmation, but we've decided to roll this back anyway to err on the side of caution moving forward

### How was this tested?

Compiled the extension, did a couple rounds of authentication, poked around with JIRA functionality