### PR TITLE
Axon 201 implement experiment flow split

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -79,7 +79,7 @@ const isDebuggingRegex = /^--(debug|inspect)\b(-brk\b|(?!-))=?/;
 const ConfigTargetKey = 'configurationTarget';
 
 export class Container {
-    static initialize(context: ExtensionContext, config: IConfig, version: string) {
+    static async initialize(context: ExtensionContext, config: IConfig, version: string) {
         const analyticsEnv: string = this.isDebugging ? 'staging' : 'prod';
 
         this._analyticsClient = analyticsClient({
@@ -187,7 +187,7 @@ export class Container {
 
         this._loginManager = new LoginManager(this._credentialManager, this._siteManager, this._analyticsClient);
         this._bitbucketHelper = new BitbucketCheckoutHelper(context.globalState);
-        FeatureFlagClient.initialize({
+        await FeatureFlagClient.initialize({
             analyticsClient: this._analyticsClient,
             identifiers: {
                 analyticsAnonymousId: env.machineId,

--- a/src/container.ts
+++ b/src/container.ts
@@ -65,7 +65,7 @@ import { VSCWelcomeActionApi } from './webview/welcome/vscWelcomeActionApi';
 import { VSCWelcomeWebviewControllerFactory } from './webview/welcome/vscWelcomeWebviewControllerFactory';
 import { WelcomeAction } from './lib/ipc/fromUI/welcome';
 import { WelcomeInitMessage } from './lib/ipc/toUI/welcome';
-import { FeatureFlagClient, Features } from './util/featureFlags';
+import { Experiments, FeatureFlagClient, Features } from './util/featureFlags';
 import { EventBuilder } from './util/featureFlags/eventBuilder';
 import { AtlascodeUriHandler } from './uriHandler';
 import { CheckoutHelper } from './bitbucket/interfaces';
@@ -200,6 +200,7 @@ export class Container {
             .finally(() => {
                 this.initializeUriHandler(context, this._analyticsApi, this._bitbucketHelper);
                 this.initializeNewSidebarView(context, config);
+                this.initializeAAExperiment();
             });
 
         context.subscriptions.push((this._helpExplorer = new HelpExplorer()));
@@ -209,7 +210,9 @@ export class Container {
         const telemetryConfig = workspace.getConfiguration('telemetry');
         return telemetryConfig.get<boolean>('enableTelemetry', true);
     }
-
+    static initializeAAExperiment() {
+        FeatureFlagClient.checkExperimentValue(Experiments.AtlascodeAA);
+    }
     static initializeUriHandler(
         context: ExtensionContext,
         analyticsApi: VSCAnalyticsApi,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,36 +62,9 @@ export async function activate(context: ExtensionContext) {
         Container.clientManager.requestSite(site);
     });
 
-    FeatureFlagClient.checkExperimentValue(Experiments.AtlascodeAA);
     // new user for auth exp
     if (previousVersion === undefined) {
-        let onboardingFlow = FeatureFlagClient.checkExperimentValue(Experiments.NewAuthUI);
-        Logger.debug(`Onboarding Experiment flow: ${onboardingFlow}`);
-        if (!onboardingFlow) {
-            onboardingFlow = 'control';
-        }
-
-        switch (onboardingFlow) {
-            case 'settings': {
-                commands.executeCommand(Commands.ShowConfigPage);
-                break;
-            }
-            case 'legacy': {
-                commands.executeCommand(Commands.ShowOnboardingPage);
-                break;
-            }
-            case 'new': {
-                commands.executeCommand(Commands.ShowOnboardingPage);
-                break;
-            }
-            default: {
-                // control
-                if (window.state.focused) {
-                    commands.executeCommand(Commands.ShowOnboardingPage);
-                }
-                break;
-            }
-        }
+        initializeNewAuthExperiment();
     } else {
         showWelcomePage(atlascodeVersion, previousVersion);
     }
@@ -193,6 +166,35 @@ async function sendAnalytics(version: string, globalState: Memento) {
     });
 }
 
+function initializeNewAuthExperiment() {
+    let onboardingFlow = FeatureFlagClient.checkExperimentValue(Experiments.NewAuthUI);
+    Logger.debug(`Onboarding Experiment flow: ${onboardingFlow}`);
+    if (!onboardingFlow) {
+        onboardingFlow = 'control';
+    }
+
+    switch (onboardingFlow) {
+        case 'settings': {
+            commands.executeCommand(Commands.ShowConfigPage);
+            break;
+        }
+        case 'legacy': {
+            commands.executeCommand(Commands.ShowOnboardingPage);
+            break;
+        }
+        case 'new': {
+            commands.executeCommand(Commands.ShowOnboardingPage);
+            break;
+        }
+        default: {
+            // control
+            if (window.state.focused) {
+                commands.executeCommand(Commands.ShowOnboardingPage);
+            }
+            break;
+        }
+    }
+}
 // this method is called when your extension is deactivated
 export function deactivate() {
     FeatureFlagClient.dispose();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(context: ExtensionContext) {
     const start = process.hrtime();
     const atlascode = extensions.getExtension('atlassian.atlascode')!;
     const atlascodeVersion = atlascode.packageJSON.version;
-    const previousVersion = undefined;
+    const previousVersion = context.globalState.get<string>(GlobalStateVersionKey);
     registerResources(context);
 
     Configuration.configure(context);
@@ -66,12 +66,12 @@ export async function activate(context: ExtensionContext) {
     // new user for auth exp
     if (previousVersion === undefined) {
         let onboardingFlow = FeatureFlagClient.checkExperimentValue(Experiments.NewAuthUI);
-        console.log(onboardingFlow);
+        Logger.debug(`Onboarding Experiment flow: ${onboardingFlow}`);
         if (!onboardingFlow) {
             onboardingFlow = 'control';
         }
 
-        switch (onboardingFlow as string) {
+        switch (onboardingFlow) {
             case 'settings': {
                 commands.executeCommand(Commands.ShowConfigPage);
                 break;
@@ -88,12 +88,12 @@ export async function activate(context: ExtensionContext) {
                 // control
                 if (window.state.focused) {
                     commands.executeCommand(Commands.ShowOnboardingPage);
-                } else {
-                    showWelcomePage(atlascodeVersion, previousVersion);
                 }
                 break;
             }
         }
+    } else {
+        showWelcomePage(atlascodeVersion, previousVersion);
     }
 
     const delay = Math.floor(Math.random() * Math.floor(AnalyticDelay));

--- a/src/react/atlascode/onboarding/OnboardingPage.tsx
+++ b/src/react/atlascode/onboarding/OnboardingPage.tsx
@@ -60,7 +60,6 @@ export const OnboardingPage: React.FunctionComponent = () => {
     const [state, controller] = useOnboardingController();
     const { authDialogController, authDialogOpen, authDialogProduct, authDialogEntry } = useAuthDialog();
     const [activeStep, setActiveStep] = React.useState(0);
-    // const [authExpEnabled, setAuthExpEnabled] = React.useState(false);
     const [useAuthUI, setUseAuthUI] = React.useState(false);
     const [jiraSignInText, setJiraSignInText] = useState('Sign In to Jira Cloud');
     const [bitbucketSignInText, setBitbucketSignInText] = useState('Sign In to Bitbucket Cloud');

--- a/src/react/atlascode/onboarding/OnboardingPage.tsx
+++ b/src/react/atlascode/onboarding/OnboardingPage.tsx
@@ -15,10 +15,10 @@ import { OnboardingControllerContext, useOnboardingController } from './onboardi
 import ProductSelector from './ProductSelector';
 import { SimpleSiteAuthenticator } from './SimpleSiteAuthenticator';
 import { AtlascodeErrorBoundary } from '../common/ErrorBoundary';
-import { AnalyticsView } from 'src/analyticsTypes';
-import { Features } from 'src/util/featureFlags';
-import { CommonMessageType } from 'src/lib/ipc/toUI/common';
-import { OnboardingActionType } from 'src/lib/ipc/fromUI/onboarding';
+import { AnalyticsView } from '../../../analyticsTypes';
+import { Experiments, Features } from '../../../util/featureFlags';
+import { CommonMessageType } from '../../../lib/ipc/toUI/common';
+import { OnboardingActionType } from '../../../lib/ipc/fromUI/onboarding';
 import { JiraOnboarding } from './JiraOnboarding';
 import { BitbucketOnboarding } from './BitbucketOnboarding';
 
@@ -60,6 +60,7 @@ export const OnboardingPage: React.FunctionComponent = () => {
     const [state, controller] = useOnboardingController();
     const { authDialogController, authDialogOpen, authDialogProduct, authDialogEntry } = useAuthDialog();
     const [activeStep, setActiveStep] = React.useState(0);
+    const [authExpEnabled, setAuthExpEnabled] = React.useState(false);
     const [useAuthUI, setUseAuthUI] = React.useState(false);
     const [jiraSignInText, setJiraSignInText] = useState('Sign In to Jira Cloud');
     const [bitbucketSignInText, setBitbucketSignInText] = useState('Sign In to Bitbucket Cloud');
@@ -71,10 +72,13 @@ export const OnboardingPage: React.FunctionComponent = () => {
             const message = event.data;
             if (message.command === CommonMessageType.UpdateFeatureFlags) {
                 const featureValue = message.featureFlags[Features.EnableAuthUI];
-                setUseAuthUI(featureValue);
+                setAuthExpEnabled(featureValue);
+            } else if (message.command === CommonMessageType.UpdateExperimentValues) {
+                const experimentValue = message.experimentValues[Experiments.NewAuthUI];
+                setUseAuthUI(authExpEnabled && experimentValue === 'new');
             }
         });
-    }, [controller]);
+    }, [authExpEnabled, controller]);
     function getSteps() {
         if (useAuthUI) {
             return ['Setup Jira', 'Setup BitBucket', 'Explore'];

--- a/src/react/atlascode/onboarding/OnboardingPage.tsx
+++ b/src/react/atlascode/onboarding/OnboardingPage.tsx
@@ -16,7 +16,7 @@ import ProductSelector from './ProductSelector';
 import { SimpleSiteAuthenticator } from './SimpleSiteAuthenticator';
 import { AtlascodeErrorBoundary } from '../common/ErrorBoundary';
 import { AnalyticsView } from '../../../analyticsTypes';
-import { Experiments, Features } from '../../../util/featureFlags';
+import { Experiments } from '../../../util/featureFlags';
 import { CommonMessageType } from '../../../lib/ipc/toUI/common';
 import { OnboardingActionType } from '../../../lib/ipc/fromUI/onboarding';
 import { JiraOnboarding } from './JiraOnboarding';
@@ -60,7 +60,7 @@ export const OnboardingPage: React.FunctionComponent = () => {
     const [state, controller] = useOnboardingController();
     const { authDialogController, authDialogOpen, authDialogProduct, authDialogEntry } = useAuthDialog();
     const [activeStep, setActiveStep] = React.useState(0);
-    const [authExpEnabled, setAuthExpEnabled] = React.useState(false);
+    // const [authExpEnabled, setAuthExpEnabled] = React.useState(false);
     const [useAuthUI, setUseAuthUI] = React.useState(false);
     const [jiraSignInText, setJiraSignInText] = useState('Sign In to Jira Cloud');
     const [bitbucketSignInText, setBitbucketSignInText] = useState('Sign In to Bitbucket Cloud');
@@ -70,15 +70,14 @@ export const OnboardingPage: React.FunctionComponent = () => {
     React.useEffect(() => {
         window.addEventListener('message', (event) => {
             const message = event.data;
-            if (message.command === CommonMessageType.UpdateFeatureFlags) {
-                const featureValue = message.featureFlags[Features.EnableAuthUI];
-                setAuthExpEnabled(featureValue);
-            } else if (message.command === CommonMessageType.UpdateExperimentValues) {
+            if (message.command === CommonMessageType.UpdateExperimentValues) {
                 const experimentValue = message.experimentValues[Experiments.NewAuthUI];
-                setUseAuthUI(authExpEnabled && experimentValue === 'new');
+                if (typeof experimentValue === 'string' && experimentValue !== undefined && experimentValue !== null) {
+                    setUseAuthUI(experimentValue === 'new');
+                }
             }
         });
-    }, [authExpEnabled, controller]);
+    }, [controller]);
     function getSteps() {
         if (useAuthUI) {
             return ['Setup Jira', 'Setup BitBucket', 'Explore'];

--- a/src/util/featureFlags/client.test.ts
+++ b/src/util/featureFlags/client.test.ts
@@ -102,19 +102,21 @@ describe('FeatureFlagClient', () => {
             expect(FeatureFlagClient.featureGates[featureName]).toBe(true);
         });
 
-        it('experiments default values are correctly assigned', async () => {
-            await FeatureFlagClient.initialize(options);
-            expect(FeatureGates.getExperimentValue).toHaveBeenCalled();
-            expect(Object.keys(FeatureFlagClient.experimentValues).length).toBe(1);
-            expect(FeatureFlagClient.experimentValues[experimentName]).toBeDefined();
-            expect(FeatureFlagClient.experimentValues[experimentName]).toBe('a default value');
-        });
-
         it('experiments overrides are correctly applied', async () => {
             process.env.ATLASCODE_EXP_OVERRIDES_STRING = `${experimentName}=another value`;
             await FeatureFlagClient.initialize(options);
             expect(FeatureFlagClient.experimentValues[experimentName]).toBeDefined();
             expect(FeatureFlagClient.experimentValues[experimentName]).toBe('another value');
+        });
+    });
+
+    describe('checkExperimentValue', () => {
+        it('should return the value of the experiment and save value in client', async () => {
+            await FeatureFlagClient.initialize(options);
+            const value = FeatureFlagClient.checkExperimentValue(experimentName);
+            expect(FeatureFlagClient.experimentValues[experimentName]).toBeDefined();
+            expect(FeatureFlagClient.experimentValues[experimentName]).toBe('a default value');
+            expect(value).toBe('a default value');
         });
     });
 });

--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -72,7 +72,7 @@ export class FeatureFlagClient {
 
     private static finalizeInit(): void {
         this._featureGates = this.evaluateFeatures();
-        this._experimentValues = this.evaluateExperiments();
+        this._experimentValues = {} as ExperimentGateValues;
 
         const ffSplit = (process.env.ATLASCODE_FF_OVERRIDES || '')
             .split(',')
@@ -136,7 +136,7 @@ export class FeatureFlagClient {
         return gateValue;
     }
 
-    private static checkExperimentValue(experiment: Experiments): any {
+    static checkExperimentValue(experiment: Experiments): any {
         const experimentGate = ExperimentGates[experiment];
         if (!experimentGate) {
             return undefined;
@@ -153,6 +153,7 @@ export class FeatureFlagClient {
             );
         }
         console.log(`ExperimentGateValue: ${experiment} -> ${gateValue}`);
+        this._experimentValues[experiment] = gateValue;
         return gateValue;
     }
 
@@ -160,12 +161,6 @@ export class FeatureFlagClient {
         const featureFlags = {} as FeatureGateValues;
         Object.values(Features).forEach((feature) => (featureFlags[feature] = this.checkGate(feature)));
         return featureFlags;
-    }
-
-    private static evaluateExperiments(): ExperimentGateValues {
-        const experimentGates = {} as ExperimentGateValues;
-        Object.values(Experiments).forEach((exp) => (experimentGates[exp] = this.checkExperimentValue(exp)));
-        return experimentGates;
     }
 
     static dispose() {

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -11,8 +11,8 @@ export enum Experiments {
 
 export const ExperimentGates: Record<Experiments, ExperimentPayload> = {
     [Experiments.NewAuthUI]: {
-        parameter: 'isEnabled',
-        defaultValue: false,
+        parameter: 'onboardingFlow',
+        defaultValue: 'control',
     },
     [Experiments.AtlascodeAA]: {
         parameter: 'isEnabled',


### PR DESCRIPTION
Loom: https://www.loom.com/share/19e0e4b8bfc347d58404b0bb4c75cfa3

Due to the nature of this experiment (only first time installers will be put into cohorts):
* changed experiment fetching to be outside of initialization
* implemented exp flow in `extension.ts` 

Now, only users whose `previousVersion === undefined` will be placed into exp cohorts:
* A - control
* B - jump to settings page auth
* C - jump to legacy auth flow
* D - jump to new auth flow