### PR TITLE
[AXON-198] add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+### What Is This Change?
+
+<!--
+Thanks for considering making a PR to this repository!👋
+
+Please give us a brief description of what the proposed change is.
+
+As reviewers, we'd really appreciate if you could elaborate on the context of the change.
+* If there is an issue related to the change, please make sure to link it!
+* If not - please describe the change from a user perspective.
+* Is there a user concern the change is addressing that we might not be aware of?
+
+If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
+-->
+
+### How Has This Been Tested?
+
+<!--
+🔧 Did you make sure the proposed change works, before submitting the PR?
+If yes, please tell us how!
+
+If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.
+
+In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
+-->
+
+Basic checks:
+
+- [ ] `npm run lint`
+- [ ] `npm run test`


### PR DESCRIPTION
### What is this?

A fairly barebones template for pull request messages, outlining the guidance for what to include in the description, featuring:

* The stuff we outlined as often missing
* My own very subjective preferences
* Help from mr. copilot

The guidance text itself is largely hidden, if unchanged the PR message would render to this:

![image](https://github.com/user-attachments/assets/1e45c24f-76c3-4a6d-b12e-f09294f070a8)

### How was this tested?

I'll test it and amend if necessary if there's any issues after this is in `main`