### PR TITLE
AXON-189: adding status commands + new issueNode testing + put behind fg

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,18 @@
     "contributes": {
         "commands": [
             {
+                "command": "atlascode.jira.todoIssue",
+                "title": "To Do"
+            },
+            {
+                "command": "atlascode.jira.inProgressIssue",
+                "title": "In Progress"
+            },
+            {
+                "command": "atlascode.jira.doneIssue",
+                "title": "Done"
+            },
+            {
                 "command": "atlascode.jira.createIssue",
                 "title": "Create Jira Issue",
                 "icon": {
@@ -643,23 +655,38 @@
             ],
             "view/item/context": [
                 {
+                    "command": "atlascode.jira.todoIssue",
+                    "when": "viewItem == todoJiraIssue && atlascode:isJiraAuthenticated",
+                    "group": "inline"
+                },
+                {
+                    "command": "atlascode.jira.inProgressIssue",
+                    "when": "viewItem == inProgressJiraIssue && atlascode:isJiraAuthenticated",
+                    "group": "inline"
+                },
+                {
+                    "command": "atlascode.jira.doneIssue",
+                    "when": "viewItem == doneJiraIssue && atlascode:isJiraAuthenticated",
+                    "group": "inline"
+                },
+                {
                     "command": "atlascode.jira.assignIssueToMe",
-                    "when": "viewItem == jiraIssue && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue|todoJiraIssue|inProgressJiraIssue|doneJiraIssue)/ && atlascode:isJiraAuthenticated",
                     "group": "jiraContextMenuGroup1"
                 },
                 {
                     "command": "atlascode.jira.startWorkOnIssue",
-                    "when": "viewItem == jiraIssue && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue|todoJiraIssue|inProgressJiraIssue|doneJiraIssue)/ && atlascode:isJiraAuthenticated",
                     "group": "jiraContextMenuGroup1"
                 },
                 {
                     "command": "atlascode.viewInWebBrowser",
-                    "when": "viewItem == jiraIssue && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue|todoJiraIssue|inProgressJiraIssue|doneJiraIssue)/ && atlascode:isJiraAuthenticated",
                     "group": "jiraContextMenuGroup1"
                 },
                 {
                     "command": "atlascode.jira.createIssue",
-                    "when": "viewItem == jiraIssue && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue|todoJiraIssue|inProgressJiraIssue|doneJiraIssue)/ && atlascode:isJiraAuthenticated",
                     "group": "jiraContextMenuGroup2"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -100,15 +100,15 @@
         "commands": [
             {
                 "command": "atlascode.jira.todoIssue",
-                "title": "To Do"
+                "title": "TO DO"
             },
             {
                 "command": "atlascode.jira.inProgressIssue",
-                "title": "In Progress"
+                "title": "IN PROGRESS"
             },
             {
                 "command": "atlascode.jira.doneIssue",
-                "title": "Done"
+                "title": "DONE"
             },
             {
                 "command": "atlascode.jira.createIssue",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -96,6 +96,9 @@ export enum Commands {
     DisableHelpExplorer = 'atlascode.disableHelpExplorer',
     CreateNewJql = 'atlascode.jira.createNewJql',
     RemoveFromSidebar = 'atlascode.jira.removeFromSidebar',
+    ToDoIssue = 'atlascode.jira.todoIssue',
+    InProgressIssue = 'atlascode.jira.inProgressIssue',
+    DoneIssue = 'atlascode.jira.doneIssue',
 }
 
 export function registerCommands(vscodeContext: ExtensionContext) {
@@ -193,6 +196,15 @@ export function registerCommands(vscodeContext: ExtensionContext) {
         commands.registerCommand(
             Commands.ShowIssueForSiteIdAndKey,
             async (siteId: string, issueKey: string) => await showIssueForSiteIdAndKey(siteId, issueKey),
+        ),
+        commands.registerCommand(Commands.ToDoIssue, (issueNode) =>
+            commands.executeCommand(Commands.ShowIssue, issueNode.issue),
+        ),
+        commands.registerCommand(Commands.InProgressIssue, (issueNode) =>
+            commands.executeCommand(Commands.ShowIssue, issueNode.issue),
+        ),
+        commands.registerCommand(Commands.DoneIssue, (issueNode) =>
+            commands.executeCommand(Commands.ShowIssue, issueNode.issue),
         ),
         commands.registerCommand(Commands.AssignIssueToMe, (issueNode: IssueNode) => assignIssue(issueNode)),
         commands.registerCommand(

--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -163,6 +163,19 @@ export class FeatureFlagClient {
         return featureFlags;
     }
 
+    static areFeaturesInitialized(): boolean {
+        try {
+            for (const feature of Object.values(Features)) {
+                if (FeatureFlagClient.featureGates[feature] === undefined) {
+                    return false;
+                }
+            }
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
     static dispose() {
         FeatureGates.shutdownStatsig();
     }

--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -163,19 +163,6 @@ export class FeatureFlagClient {
         return featureFlags;
     }
 
-    static areFeaturesInitialized(): boolean {
-        try {
-            for (const feature of Object.values(Features)) {
-                if (FeatureFlagClient.featureGates[feature] === undefined) {
-                    return false;
-                }
-            }
-            return true;
-        } catch {
-            return false;
-        }
-    }
-
     static dispose() {
         FeatureGates.shutdownStatsig();
     }

--- a/src/views/jira/treeViews/constants.ts
+++ b/src/views/jira/treeViews/constants.ts
@@ -1,3 +1,7 @@
 export const CUSTOM_JQL_VIEW_PROVIDER_ID = 'atlascode.views.jira.customJqlTreeView';
 export const CONFIGURE_JQL_STRING = 'Configure JQL entries in settings to view Jira issues';
 export const SEARCH_JIRA_ISSUE_PLACEHOLDER = 'Search for an issue key or summary';
+export const TO_DO_ISSUE_ID = 'todoJiraIssue';
+export const IN_PROGRESS_ISSUE_ID = 'inProgressJiraIssue';
+export const DONE_ISSUE_ID = 'doneJiraIssue';
+export const ISSUE_NODE_CONTEXT_VALUE = 'jiraIssue';

--- a/src/views/jira/treeViews/customJqlViewProvider.test.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.test.ts
@@ -37,7 +37,18 @@ jest.mock('../../../container', () => ({
         },
     },
 }));
-
+jest.mock('../../../util/featureFlags', () => {
+    return {
+        FeatureFlagClient: {
+            featureGates: {
+                NewSidebarTreeView: true,
+            },
+        },
+        Features: {
+            NewSidebarTreeView: 'atlascode-new-sidebar-treeview',
+        },
+    };
+});
 const mockExecuteQuery = jest.fn().mockReturnValue(Promise.resolve([]));
 jest.mock('../customJqlTree', () => {
     return {

--- a/src/views/nodes/issueNode.test.ts
+++ b/src/views/nodes/issueNode.test.ts
@@ -20,11 +20,9 @@ jest.mock('../../commands', () => {
         },
     };
 });
-const mockAreFeatureGatesEnabled = jest.fn().mockReturnValue(true);
 jest.mock('../../util/featureFlags', () => {
     return {
         FeatureFlagClient: {
-            areFeaturesInitialized: mockAreFeatureGatesEnabled,
             featureGates: mockFeatureGateValues,
         },
         Features: {
@@ -100,48 +98,45 @@ import * as vscode from 'vscode';
 describe('IssueNode', () => {
     describe('getTreeItem', () => {
         it('should return a TreeItem with the issue key and summary if the new sidebar tree view feature flag is enabled', () => {
-            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            mockFeatureGateValues['atlascode-new-sidebar-treeview'] = true;
             const issueNode = new IssueNode(mockIssue, undefined);
             const treeItem = issueNode.getTreeItem();
             expect(treeItem.label).toBe(mockIssue.key);
             expect(treeItem.description).toBe(mockIssue.summary);
         });
         it('should return a TreeItem with the issue key and summary in title if the new sidebar tree view feature flag is disabled', () => {
-            mockAreFeatureGatesEnabled.mockReturnValue(false);
+            mockFeatureGateValues['atlascode-new-sidebar-treeview'] = false;
             const issueNode = new IssueNode(mockIssue, undefined);
             const treeItem = issueNode.getTreeItem();
             expect(treeItem.label).toBe(`${mockIssue.key} ${mockIssue.summary}`);
             expect(treeItem.description).toBeUndefined();
         });
         it('should return a TreeItem with a collapsible state of Expanded if the issue has subtasks or epic children', () => {
-            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            mockFeatureGateValues['atlascode-new-sidebar-treeview'] = true;
             const issueNode = new IssueNode({ ...mockIssue, subtasks: [mockIssue] }, undefined);
             const treeItem = issueNode.getTreeItem();
             expect(treeItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
         });
 
         it('should return a TreeItem with a collapsible state of None if the issue does not have subtasks or epic children', () => {
-            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            mockFeatureGateValues['atlascode-new-sidebar-treeview'] = true;
             const issueNode = new IssueNode(mockIssue, undefined);
             const treeItem = issueNode.getTreeItem();
             expect(treeItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
         });
 
         it('should return a TreeItem with a command to show the issue', () => {
-            mockAreFeatureGatesEnabled.mockReturnValue(true);
             const issueNode = new IssueNode(mockIssue, undefined);
             const treeItem = issueNode.getTreeItem();
             expect(treeItem.command).toEqual({ command: 'showIssue', title: 'Show Issue', arguments: [mockIssue] });
         });
 
         it('should return a TreeItem with Todo contextValue if the issue is a Todo statusCategory', () => {
-            mockAreFeatureGatesEnabled.mockReturnValue(true);
             const issueNode = new IssueNode(mockIssue, undefined);
             const treeItem = issueNode.getTreeItem();
             expect(treeItem.contextValue).toBe('todoJiraIssue');
         });
         it('should return a TreeItem with InProgress contextValue if the issue is an In Progress statusCategory', () => {
-            mockAreFeatureGatesEnabled.mockReturnValue(true);
             const issueNode = new IssueNode(
                 {
                     ...mockIssue,
@@ -156,7 +151,6 @@ describe('IssueNode', () => {
             expect(treeItem.contextValue).toBe('inProgressJiraIssue');
         });
         it('should return a TreeItem with Done contextValue if the issue is a Done statusCategory', () => {
-            mockAreFeatureGatesEnabled.mockReturnValue(true);
             const issueNode = new IssueNode(
                 {
                     ...mockIssue,

--- a/src/views/nodes/issueNode.test.ts
+++ b/src/views/nodes/issueNode.test.ts
@@ -1,0 +1,196 @@
+import { MinimalORIssueLink } from '@atlassianlabs/jira-pi-common-models';
+import { DetailedSiteInfo, ProductJira } from '../../atlclients/authInfo';
+const mockFeatureGateValues = {
+    'atlascode-new-sidebar-treeview': true,
+};
+jest.mock('./simpleJiraIssueNode', () => {
+    return {
+        SimpleJiraIssueNode: jest.fn().mockImplementation(() => {
+            return {
+                getTreeItem: jest.fn().mockReturnValue({}),
+            };
+        }),
+    };
+});
+jest.mock('../../commands', () => {
+    return {
+        Commands: {
+            WorkbenchOpenRepository: 'workbench.openRepository',
+            ShowIssue: 'showIssue',
+        },
+    };
+});
+const mockAreFeatureGatesEnabled = jest.fn().mockReturnValue(true);
+jest.mock('../../util/featureFlags', () => {
+    return {
+        FeatureFlagClient: {
+            areFeaturesInitialized: mockAreFeatureGatesEnabled,
+            featureGates: mockFeatureGateValues,
+        },
+        Features: {
+            NewSidebarTreeView: 'atlascode-new-sidebar-treeview',
+        },
+    };
+});
+jest.mock('@atlassianlabs/jira-pi-common-models', () => {
+    return {
+        isMinimalIssue: jest.fn(() => true),
+    };
+});
+const mockIssue: MinimalORIssueLink<DetailedSiteInfo> = {
+    descriptionHtml: '<p>This is a test issue description</p>',
+    issuelinks: [],
+    transitions: [],
+    siteDetails: {
+        userId: 'user123',
+        id: '',
+        name: '',
+        avatarUrl: '',
+        baseLinkUrl: '',
+        baseApiUrl: '',
+        isCloud: false,
+        credentialId: '',
+        host: '',
+        product: ProductJira,
+    },
+    epicLink: '',
+    id: '1',
+    self: 'https://example.com/issue/TEST-123',
+    updated: new Date('2023-01-01T00:00:00.000Z'),
+    description: 'This is a test issue description',
+    key: 'TEST-123',
+    summary: 'Test Issue',
+    status: {
+        name: 'To Do',
+        statusCategory: {
+            name: 'To Do',
+            colorName: 'blue-gray',
+            id: 1,
+            key: 'key',
+            self: '',
+        },
+        id: '1',
+        iconUrl: 'https://example.com/status-icon.png',
+        self: '',
+        description: 'This is a test issue status',
+    },
+    isEpic: false,
+    epicName: '',
+    subtasks: [],
+    epicChildren: [],
+    issuetype: {
+        id: '10001',
+        name: 'Bug',
+        description: 'A problem which impairs or prevents the functions of the product.',
+        iconUrl: 'https://example.com/bug-icon.png',
+        subtask: false,
+        self: '',
+        avatarId: 10002,
+        epic: false,
+    },
+    priority: {
+        id: '2',
+        name: 'High',
+        iconUrl: 'https://example.com/high-priority-icon.png',
+    },
+};
+
+import { IssueNode } from './issueNode';
+import * as vscode from 'vscode';
+describe('IssueNode', () => {
+    describe('getTreeItem', () => {
+        it('should return a TreeItem with the issue key and summary if the new sidebar tree view feature flag is enabled', () => {
+            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            const issueNode = new IssueNode(mockIssue, undefined);
+            const treeItem = issueNode.getTreeItem();
+            expect(treeItem.label).toBe(mockIssue.key);
+            expect(treeItem.description).toBe(mockIssue.summary);
+        });
+        it('should return a TreeItem with the issue key and summary in title if the new sidebar tree view feature flag is disabled', () => {
+            mockAreFeatureGatesEnabled.mockReturnValue(false);
+            const issueNode = new IssueNode(mockIssue, undefined);
+            const treeItem = issueNode.getTreeItem();
+            expect(treeItem.label).toBe(`${mockIssue.key} ${mockIssue.summary}`);
+            expect(treeItem.description).toBeUndefined();
+        });
+        it('should return a TreeItem with a collapsible state of Expanded if the issue has subtasks or epic children', () => {
+            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            const issueNode = new IssueNode({ ...mockIssue, subtasks: [mockIssue] }, undefined);
+            const treeItem = issueNode.getTreeItem();
+            expect(treeItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
+        });
+
+        it('should return a TreeItem with a collapsible state of None if the issue does not have subtasks or epic children', () => {
+            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            const issueNode = new IssueNode(mockIssue, undefined);
+            const treeItem = issueNode.getTreeItem();
+            expect(treeItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+        });
+
+        it('should return a TreeItem with a command to show the issue', () => {
+            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            const issueNode = new IssueNode(mockIssue, undefined);
+            const treeItem = issueNode.getTreeItem();
+            expect(treeItem.command).toEqual({ command: 'showIssue', title: 'Show Issue', arguments: [mockIssue] });
+        });
+
+        it('should return a TreeItem with Todo contextValue if the issue is a Todo statusCategory', () => {
+            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            const issueNode = new IssueNode(mockIssue, undefined);
+            const treeItem = issueNode.getTreeItem();
+            expect(treeItem.contextValue).toBe('todoJiraIssue');
+        });
+        it('should return a TreeItem with InProgress contextValue if the issue is an In Progress statusCategory', () => {
+            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            const issueNode = new IssueNode(
+                {
+                    ...mockIssue,
+                    status: {
+                        ...mockIssue.status,
+                        statusCategory: { ...mockIssue.status.statusCategory, name: 'In Progress' },
+                    },
+                },
+                undefined,
+            );
+            const treeItem = issueNode.getTreeItem();
+            expect(treeItem.contextValue).toBe('inProgressJiraIssue');
+        });
+        it('should return a TreeItem with Done contextValue if the issue is a Done statusCategory', () => {
+            mockAreFeatureGatesEnabled.mockReturnValue(true);
+            const issueNode = new IssueNode(
+                {
+                    ...mockIssue,
+                    status: {
+                        ...mockIssue.status,
+                        statusCategory: { ...mockIssue.status.statusCategory, name: 'Done' },
+                    },
+                },
+                undefined,
+            );
+            const treeItem = issueNode.getTreeItem();
+            expect(treeItem.contextValue).toBe('doneJiraIssue');
+        });
+    });
+
+    describe('getChildren', () => {
+        it('should return an empty array if the issue does not have subtasks or epic children', async () => {
+            const issueNode = new IssueNode(mockIssue, undefined);
+            const children = await issueNode.getChildren();
+            expect(children).toEqual([]);
+        });
+
+        it('should return an array of IssueNodes for each subtask if the issue has subtasks', async () => {
+            const issueNode = new IssueNode({ ...mockIssue, subtasks: [mockIssue] }, undefined);
+            const children = await issueNode.getChildren();
+            expect(children).toHaveLength(1);
+            expect(children[0]).toBeInstanceOf(IssueNode);
+        });
+
+        it('should return an array of IssueNodes for each epic child if the issue has epic children', async () => {
+            const issueNode = new IssueNode({ ...mockIssue, epicChildren: [mockIssue] }, undefined);
+            const children = await issueNode.getChildren();
+            expect(children).toHaveLength(1);
+            expect(children[0]).toBeInstanceOf(IssueNode);
+        });
+    });
+});

--- a/src/views/nodes/issueNode.ts
+++ b/src/views/nodes/issueNode.ts
@@ -3,41 +3,68 @@ import * as vscode from 'vscode';
 import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { Commands } from '../../commands';
 import { AbstractBaseNode } from './abstractBaseNode';
+import { Features, FeatureFlagClient } from '../../util/featureFlags';
+import {
+    DONE_ISSUE_ID,
+    IN_PROGRESS_ISSUE_ID,
+    ISSUE_NODE_CONTEXT_VALUE,
+    TO_DO_ISSUE_ID,
+} from '../jira/treeViews/constants';
 
-export const getIssueResourceUri = (issue: MinimalORIssueLink<DetailedSiteInfo>) => {
-    const params = {
-        type: ISSUE_NODE_CONTEXT_VALUE,
-        statusCategory: issue.status.statusCategory.name,
-    };
-    return vscode.Uri.parse(`${issue.siteDetails.baseLinkUrl}/browse/${issue.key}`).with({
-        query: JSON.stringify(params),
-    });
+const getIssueContextValue = (issue: MinimalORIssueLink<DetailedSiteInfo>) => {
+    const statusCategory = issue.status.statusCategory.name;
+    switch (statusCategory.toLowerCase()) {
+        case 'to do':
+            return TO_DO_ISSUE_ID;
+        case 'in progress':
+            return IN_PROGRESS_ISSUE_ID;
+        case 'done':
+            return DONE_ISSUE_ID;
+        default:
+            return ISSUE_NODE_CONTEXT_VALUE;
+    }
 };
 
-const ISSUE_NODE_CONTEXT_VALUE = 'jiraIssue';
 export class IssueNode extends AbstractBaseNode {
     public issue: MinimalORIssueLink<DetailedSiteInfo>;
-
+    private _newPanelFG: boolean = false;
     constructor(_issue: MinimalORIssueLink<DetailedSiteInfo>, parent: AbstractBaseNode | undefined) {
         super(parent);
         this.issue = _issue;
+        this._newPanelFG = FeatureFlagClient.areFeaturesInitialized()
+            ? FeatureFlagClient.featureGates[Features.NewSidebarTreeView]
+            : false;
     }
 
     getTreeItem(): vscode.TreeItem {
-        const title = isMinimalIssue(this.issue) && this.issue.isEpic ? this.issue.epicName : this.issue.summary;
+        let title: string;
+        let description: string | undefined;
+        let contextValue: string;
+        const summary = isMinimalIssue(this.issue) && this.issue.isEpic ? this.issue.epicName : this.issue.summary;
+
+        if (this._newPanelFG) {
+            title = this.issue.key;
+            description = summary;
+            contextValue = getIssueContextValue(this.issue);
+        } else {
+            title = `${this.issue.key} ${summary}`;
+            description = undefined;
+            contextValue = ISSUE_NODE_CONTEXT_VALUE;
+        }
+
         const treeItem = new vscode.TreeItem(
-            this.issue.key,
+            title,
             isMinimalIssue(this.issue) && (this.issue.subtasks.length > 0 || this.issue.epicChildren.length > 0)
                 ? vscode.TreeItemCollapsibleState.Expanded
                 : vscode.TreeItemCollapsibleState.None,
         );
-        treeItem.description = title;
+        treeItem.description = description;
         treeItem.command = { command: Commands.ShowIssue, title: 'Show Issue', arguments: [this.issue] };
         treeItem.iconPath = vscode.Uri.parse(this.issue.issuetype.iconUrl);
-        treeItem.contextValue = ISSUE_NODE_CONTEXT_VALUE;
+        treeItem.contextValue = contextValue;
         treeItem.tooltip = `${this.issue.key} - ${this.issue.summary}\n\n${this.issue.priority.name}    |    ${this.issue.status.name}`;
 
-        treeItem.resourceUri = getIssueResourceUri(this.issue);
+        treeItem.resourceUri = vscode.Uri.parse(`${this.issue.siteDetails.baseLinkUrl}/browse/${this.issue.key}`);
         return treeItem;
     }
 


### PR DESCRIPTION
### What Is This Change?

To follow new designs for the sidebar tree view, this PR:
* adds `statusCategory` (to do, in prog, done) tags onto the side of each IssueNode on hover
* when new tag is clicked => open issue
* added testing for issueNode

Loom: 
https://www.loom.com/share/721aeda9fef64617a99a476289f5f1e0?sid=e4b1450f-bfe9-4c98-9b47-b8fdc30790e2

### How Has This Been Tested?

Added UT for IssueNode in `issueNode.test.ts`

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
