### PR TITLE
AXON-206: fix explorer not refreshing on issue status transition

### DIFF
--- a/src/jira/transitionIssue.ts
+++ b/src/jira/transitionIssue.ts
@@ -40,6 +40,7 @@ async function performTransition(issueKey: string, transition: Transition, site:
         await client.transitionIssue(issueKey, transition.id);
 
         vscode.commands.executeCommand(Commands.RefreshJiraExplorer);
+        vscode.commands.executeCommand(Commands.RefreshCustomJqlExplorer);
 
         issueTransitionedEvent(site, issueKey).then((e) => {
             Container.analyticsClient.sendTrackEvent(e);


### PR DESCRIPTION
### What Is This Change?

When transitioning an issue's status, the new customJQL sidebar view would not automatically refresh. In this PR, I added the fix to this issue

Loom: https://www.loom.com/share/e558849edea248f7b908fc46f80f1ac7?sid=9d1345b4-8e04-447b-93ef-40745d20d245

### How Has This Been Tested?

Test + demo in loom

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`
