### PR TITLE
Improving performance of large repo PRs by dividing APIs into critical and non-critical flows

### DIFF
--- a/src/views/nodes/commitSectionNode.ts
+++ b/src/views/nodes/commitSectionNode.ts
@@ -3,14 +3,18 @@ import { Commit, PullRequest } from '../../bitbucket/model';
 import { AbstractBaseNode } from './abstractBaseNode';
 import { CommitNode } from './commitNode';
 import { IssueNode } from './issueNode';
+import { SimpleNode } from './simpleNode';
 
 export class CommitSectionNode extends AbstractBaseNode {
     private pr: PullRequest;
     private commits: Commit[];
-    constructor(pr: PullRequest, commits: Commit[]) {
+    private loading: boolean;
+
+    constructor(pr: PullRequest, commits: Commit[], loading?: boolean) {
         super();
         this.pr = pr;
         this.commits = commits;
+        this.loading = loading ?? false;
     }
 
     getTreeItem(): vscode.TreeItem {
@@ -19,7 +23,10 @@ export class CommitSectionNode extends AbstractBaseNode {
         return item;
     }
 
-    async getChildren(element?: IssueNode): Promise<CommitNode[]> {
+    async getChildren(element?: IssueNode): Promise<CommitNode[] | SimpleNode[]> {
+        if (this.commits.length === 0 && this.loading) {
+            return [new SimpleNode('Loading...')];
+        }
         return this.commits.map((commit) => new CommitNode(this.pr, commit));
     }
 }

--- a/src/views/pullrequest/pullRequestNode.ts
+++ b/src/views/pullrequest/pullRequestNode.ts
@@ -101,7 +101,11 @@ export class PullRequestTitlesNode extends AbstractBaseNode {
             ]);
 
             const fileChangedNodes = await createFileChangesNodes(this.pr, allComments, fileDiffs, [], []);
-            this.loadedChildren = [new DescriptionNode(this.pr, this), ...fileChangedNodes];
+            this.loadedChildren = [
+                new DescriptionNode(this.pr, this),
+                ...(this.pr.site.details.isCloud ? [new CommitSectionNode(this.pr, [], true)] : []),
+                ...fileChangedNodes,
+            ];
         } catch (error) {
             Logger.debug('error fetching pull request details', error);
             this.loadedChildren = [new SimpleNode('⚠️ Error: fetching pull request details failed')];

--- a/src/views/pullrequest/pullRequestNode.ts
+++ b/src/views/pullrequest/pullRequestNode.ts
@@ -86,7 +86,7 @@ export class PullRequestTitlesNode extends AbstractBaseNode {
             return;
         }
         this.isLoading = true;
-        this.loadedChildren = [new DescriptionNode(this.pr, this)];
+        this.loadedChildren = [new DescriptionNode(this.pr, this), new SimpleNode('Loading...')];
         const bbApi = await clientForSite(this.pr.site);
         let fileDiffs: FileDiff[] = [];
         let allComments: PaginatedComments = { data: [] };
@@ -95,6 +95,8 @@ export class PullRequestTitlesNode extends AbstractBaseNode {
             fileDiffs = await bbApi.pullrequests.getChangedFiles(this.pr);
             allComments = await bbApi.pullrequests.getComments(this.pr);
             const fileChangedNodes = await createFileChangesNodes(this.pr, allComments, fileDiffs, [], []);
+            this.loadedChildren = [];
+            this.loadedChildren.push(new DescriptionNode(this.pr, this));
             this.loadedChildren.push(...fileChangedNodes);
             this.refresh();
         } catch (error) {

--- a/src/views/pullrequest/pullRequestNode.ts
+++ b/src/views/pullrequest/pullRequestNode.ts
@@ -102,14 +102,14 @@ export class PullRequestTitlesNode extends AbstractBaseNode {
 
             const fileChangedNodes = await createFileChangesNodes(this.pr, allComments, fileDiffs, [], []);
             this.loadedChildren = [new DescriptionNode(this.pr, this), ...fileChangedNodes];
-            this.refresh();
         } catch (error) {
             Logger.debug('error fetching pull request details', error);
             this.loadedChildren = [new SimpleNode('⚠️ Error: fetching pull request details failed')];
             this.isLoading = false;
             return;
+        } finally {
+            this.refresh();
         }
-
         // Additional data - conflicts, commits, tasks
         try {
             const [conflictedFiles, commits, tasks] = await Promise.all([


### PR DESCRIPTION
### What Is This Change?
https://www.loom.com/share/4dc7f309eb42458383b5f42e32384dbb
TLDR -> I am trying to load PR data asynchronously. This way whatever data is needed is loaded first and other non-critical data is loaded later and treeItem is then refreshed.

### How Has This Been Tested?
I have tested this by running the debug mode and verifying that this opens up for larger repos. Also you can see in the loom video the test runs

Basic checks:

- [✅  ] `npm run lint` 
- [ ✅ ] `npm run test`

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/779c4b3e-f75a-4388-8cc9-6d4cba421595" />

