### PR TITLE
Align the implementation of the new sidebar UI views

### DIFF
--- a/package.json
+++ b/package.json
@@ -677,37 +677,37 @@
             "view/item/context": [
                 {
                     "command": "atlascode.jira.todoIssue",
-                    "when": "viewItem == todoJiraIssue && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue_todo|assignedJiraIssue_todo)/ && atlascode:isJiraAuthenticated",
                     "group": "inline"
                 },
                 {
                     "command": "atlascode.jira.inProgressIssue",
-                    "when": "viewItem == inProgressJiraIssue && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue_inProgress|assignedJiraIssue_inProgress)/ && atlascode:isJiraAuthenticated",
                     "group": "inline"
                 },
                 {
                     "command": "atlascode.jira.doneIssue",
-                    "when": "viewItem == doneJiraIssue && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue_done|assignedJiraIssue_done)/ && atlascode:isJiraAuthenticated",
                     "group": "inline"
                 },
                 {
                     "command": "atlascode.jira.assignIssueToMe",
-                    "when": "viewItem =~ /(jiraIssue|todoJiraIssue|inProgressJiraIssue|doneJiraIssue)/ && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue|jiraIssue_.+)/ && atlascode:isJiraAuthenticated",
                     "group": "jiraContextMenuGroup1"
                 },
                 {
                     "command": "atlascode.jira.startWorkOnIssue",
-                    "when": "viewItem =~ /(jiraIssue|assignedJiraIssue|todoJiraIssue|inProgressJiraIssue|doneJiraIssue)/ && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue|assignedJiraIssue|jiraIssue_.+|assignedJiraIssue_.+)/ && atlascode:isJiraAuthenticated",
                     "group": "jiraContextMenuGroup1"
                 },
                 {
                     "command": "atlascode.viewInWebBrowser",
-                    "when": "viewItem =~ /(jiraIssue|assignedJiraIssue|todoJiraIssue|inProgressJiraIssue|doneJiraIssue)/ && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue|assignedJiraIssue|jiraIssue_.+|assignedJiraIssue_.+)/ && atlascode:isJiraAuthenticated",
                     "group": "jiraContextMenuGroup1"
                 },
                 {
                     "command": "atlascode.jira.createIssue",
-                    "when": "viewItem =~ /(jiraIssue|assignedJiraIssue|todoJiraIssue|inProgressJiraIssue|doneJiraIssue)/ && atlascode:isJiraAuthenticated",
+                    "when": "viewItem =~ /(jiraIssue|assignedJiraIssue|jiraIssue_.+|assignedJiraIssue_.+)/ && atlascode:isJiraAuthenticated",
                     "group": "jiraContextMenuGroup2"
                 },
                 {

--- a/src/commands/jira/assignIssue.ts
+++ b/src/commands/jira/assignIssue.ts
@@ -4,6 +4,8 @@ import { Container } from '../../container';
 import { Logger } from '../../logger';
 import { IssueNode } from '../../views/nodes/issueNode';
 import { currentUserJira } from './currentUser';
+import { Commands } from '../../commands';
+import { commands } from 'vscode';
 
 export async function assignIssue(param: MinimalIssue<DetailedSiteInfo> | IssueNode, accountId?: string) {
     const issue = isMinimalIssue(param) ? param : param.issue;
@@ -16,7 +18,10 @@ export async function assignIssue(param: MinimalIssue<DetailedSiteInfo> | IssueN
 
     const response = await client.assignIssue(issue.id, accountId);
     Logger.info(response);
-    Container.jiraExplorer.refresh();
+
+    commands.executeCommand(Commands.RefreshJiraExplorer);
+    commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
+    commands.executeCommand(Commands.RefreshCustomJqlExplorer);
 }
 
 export async function unassignIssue(issue: MinimalIssue<DetailedSiteInfo>) {
@@ -24,5 +29,8 @@ export async function unassignIssue(issue: MinimalIssue<DetailedSiteInfo>) {
 
     const response = await client.assignIssue(issue.id, undefined);
     Logger.info(response);
-    Container.jiraExplorer.refresh();
+
+    commands.executeCommand(Commands.RefreshJiraExplorer);
+    commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
+    commands.executeCommand(Commands.RefreshCustomJqlExplorer);
 }

--- a/src/views/jira/treeViews/constants.ts
+++ b/src/views/jira/treeViews/constants.ts
@@ -1,4 +1,0 @@
-export const TO_DO_ISSUE_ID = 'todoJiraIssue';
-export const IN_PROGRESS_ISSUE_ID = 'inProgressJiraIssue';
-export const DONE_ISSUE_ID = 'doneJiraIssue';
-export const ISSUE_NODE_CONTEXT_VALUE = 'jiraIssue';

--- a/src/views/jira/treeViews/constants.ts
+++ b/src/views/jira/treeViews/constants.ts
@@ -1,6 +1,3 @@
-export const CUSTOM_JQL_VIEW_PROVIDER_ID = 'atlascode.views.jira.customJqlTreeView';
-export const CONFIGURE_JQL_STRING = 'Configure JQL entries in settings to view Jira issues';
-export const SEARCH_JIRA_ISSUE_PLACEHOLDER = 'Search for an issue key or summary';
 export const TO_DO_ISSUE_ID = 'todoJiraIssue';
 export const IN_PROGRESS_ISSUE_ID = 'inProgressJiraIssue';
 export const DONE_ISSUE_ID = 'doneJiraIssue';

--- a/src/views/jira/treeViews/customJqlViewProvider.test.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.test.ts
@@ -89,15 +89,6 @@ jest.mock('../searchJiraHelper', () => ({
     },
 }));
 
-const mockCheckForNewIssues = jest.fn();
-jest.mock('../../../jira/newIssueMonitor', () => {
-    return {
-        NewIssueMonitor: jest.fn().mockImplementation(() => ({
-            checkForNewIssues: mockCheckForNewIssues,
-        })),
-    };
-});
-
 function forceCastTo<T>(obj: any): T {
     return obj as unknown as T;
 }

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -1,46 +1,62 @@
-import { DetailedSiteInfo, Product, ProductJira } from '../../../atlclients/authInfo';
+import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
+import { ProductJira } from '../../../atlclients/authInfo';
+import { DetailedSiteInfo } from '../../../atlclients/authInfo';
 import { JQLEntry } from '../../../config/model';
 import { Container } from '../../../container';
-import { AbstractBaseNode } from '../../nodes/abstractBaseNode';
-import { BaseTreeDataProvider } from '../../Explorer';
-import { CustomJQLTree } from '../customJqlTree';
-import { ConfigureJQLNode } from '../configureJQLNode';
-import { CONFIGURE_JQL_STRING, CUSTOM_JQL_VIEW_PROVIDER_ID } from './constants';
-import { MinimalORIssueLink } from '@atlassianlabs/jira-pi-common-models';
-import { commands, Disposable, EventEmitter, Event, window, ConfigurationChangeEvent } from 'vscode';
-import { Logger } from '../../../logger';
 import { CommandContext, setCommandContext } from '../../../commandContext';
 import { Commands } from '../../../commands';
-import { NewIssueMonitor } from '../../../jira/newIssueMonitor';
-import { SearchJiraHelper } from '../searchJiraHelper';
 import { configuration } from '../../../config/configuration';
-import { SimpleJiraIssueNode } from '../../../views/nodes/simpleJiraIssueNode';
-export class CustomJQLViewProvider extends BaseTreeDataProvider {
+import { fetchMinimalIssue } from '../../../jira/fetchIssue';
+import {
+    Disposable,
+    TreeDataProvider,
+    TreeItem,
+    TreeItemCollapsibleState,
+    ConfigurationChangeEvent,
+    EventEmitter,
+    commands,
+    window,
+} from 'vscode';
+import { JiraIssueNode, executeJqlQuery, createLabelItem } from './utils';
+
+const enum ViewStrings {
+    LoginToJiraMessage = 'Please login to Jira',
+    ConfigureJqlMessage = 'Configure JQL entries in settings to view Jira issues',
+    NoIssuesMessage = 'No issues match this query',
+}
+
+export class CustomJQLViewProvider implements TreeDataProvider<TreeItem>, Disposable {
+    private static readonly _treeItemLoginToJiraMessage = createLabelItem(ViewStrings.LoginToJiraMessage, {
+        command: Commands.ShowConfigPage,
+        title: 'Login to Jira',
+        arguments: [ProductJira],
+    });
+    private static readonly _treeItemConfigureJqlMessage = createLabelItem(ViewStrings.ConfigureJqlMessage, {
+        command: Commands.ShowJiraIssueSettings,
+        title: 'Configure Filters',
+        arguments: ['ConfigureJQLNode'],
+    });
+    private static readonly _id = 'atlascode.views.jira.customJqlTreeView';
+
     private _disposable: Disposable;
-    private _id: string = CUSTOM_JQL_VIEW_PROVIDER_ID;
-    private _jqlEntries: JQLEntry[];
-    private _children: CustomJQLTree[];
-    private _newIssueMonitor: NewIssueMonitor;
-    private _onDidChangeTreeData = new EventEmitter<AbstractBaseNode | null>();
-    public get onDidChangeTreeData(): Event<AbstractBaseNode | null> {
-        return this._onDidChangeTreeData.event;
-    }
+
+    private _onDidChangeTreeData = new EventEmitter<TreeItem | undefined | void>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
     constructor() {
-        super();
-
-        this._jqlEntries = Container.jqlManager.enabledJQLEntries();
-        this._newIssueMonitor = new NewIssueMonitor();
-        this._children = [];
         this._disposable = Disposable.from(
             Container.jqlManager.onDidJQLChange(this.refresh, this),
             Container.siteManager.onDidSitesAvailableChange(this.refresh, this),
             commands.registerCommand(Commands.RefreshCustomJqlExplorer, this.refresh, this),
         );
-        window.createTreeView(this.viewId(), { treeDataProvider: this });
+
+        window.createTreeView(CustomJQLViewProvider._id, { treeDataProvider: this });
+
         setCommandContext(CommandContext.CustomJQLExplorer, true);
 
         Container.context.subscriptions.push(configuration.onDidChange(this.onConfigurationChanged, this));
+
+        this.refresh();
     }
 
     onConfigurationChanged(e: ConfigurationChangeEvent) {
@@ -49,78 +65,114 @@ export class CustomJQLViewProvider extends BaseTreeDataProvider {
         }
     }
 
-    viewId(): string {
-        return this._id;
-    }
-
-    product(): Product {
-        return ProductJira;
-    }
-
     dispose() {
-        this._children.forEach((child) => {
-            child.dispose();
-        });
         this._disposable.dispose();
     }
 
-    async refresh() {
-        await Container.jqlManager.updateFilters();
-        this._children.forEach((child) => {
-            child.dispose();
+    getTreeItem(element: TreeItem): TreeItem {
+        return element;
+    }
+
+    async getChildren(element?: TreeItem): Promise<TreeItem[]> {
+        if (element instanceof JiraIssueQueryNode || element instanceof JiraIssueNode) {
+            return await element.getChildren();
+        } else if (!Container.siteManager.productHasAtLeastOneSite(ProductJira)) {
+            return [CustomJQLViewProvider._treeItemLoginToJiraMessage];
+        } else {
+            const jqlEntries = Container.jqlManager.getCustomJQLEntries();
+            return jqlEntries.length
+                ? jqlEntries.map((jqlEntry) => new JiraIssueQueryNode(jqlEntry))
+                : [CustomJQLViewProvider._treeItemConfigureJqlMessage];
+        }
+    }
+
+    private refresh() {
+        this._onDidChangeTreeData.fire();
+    }
+}
+
+class JiraIssueQueryNode extends TreeItem {
+    private static readonly _treeItemNoIssuesMessage = createLabelItem(ViewStrings.NoIssuesMessage);
+
+    constructor(private jqlEntry: JQLEntry) {
+        super(jqlEntry.name, TreeItemCollapsibleState.Collapsed);
+        this.id = jqlEntry.id;
+    }
+
+    public async getChildren(): Promise<TreeItem[]> {
+        let issues = await executeJqlQuery(this.jqlEntry);
+        if (!issues || !issues.length) {
+            return [JiraIssueQueryNode._treeItemNoIssuesMessage];
+        }
+
+        issues = Container.config.jira.explorer.nestSubtasks ? await this.constructIssueTree(issues) : issues;
+
+        return issues.map((issue) => new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, issue));
+    }
+
+    private async constructIssueTree(
+        jqlIssues: MinimalIssue<DetailedSiteInfo>[],
+    ): Promise<MinimalIssue<DetailedSiteInfo>[]> {
+        const parentIssues = await this.fetchMissingAncestorIssues(jqlIssues);
+        const jqlAndParents = [...jqlIssues, ...parentIssues];
+
+        const rootIssues: MinimalIssue<DetailedSiteInfo>[] = [];
+        jqlAndParents.forEach((i) => {
+            const parentKey = i.parentKey ?? i.epicLink;
+            if (parentKey) {
+                const parent = jqlAndParents.find((i2) => parentKey === i2.key);
+                if (parent) {
+                    parent.subtasks.push(i);
+                }
+            } else {
+                rootIssues.push(i);
+            }
         });
-        this._children = [];
-        this._jqlEntries = Container.jqlManager.enabledJQLEntries();
 
-        this._onDidChangeTreeData.fire(null);
-        SearchJiraHelper.clearIssues(this.viewId()); // so no duplicates
-        await this._newIssueMonitor.checkForNewIssues();
+        return [...rootIssues];
     }
 
-    getTreeItem(element: AbstractBaseNode) {
-        return element.getTreeItem();
+    // Fetch any parents and grandparents that might be missing from the set to ensure that the a path can be drawn all
+    // the way from a subtask to an epic.
+    private async fetchMissingAncestorIssues(
+        newIssues: MinimalIssue<DetailedSiteInfo>[],
+    ): Promise<MinimalIssue<DetailedSiteInfo>[]> {
+        if (!newIssues.length) {
+            return [];
+        }
+        const site = newIssues[0].siteDetails;
+
+        const missingParentKeys = this.calculateMissingParentKeys(newIssues);
+        const parentIssues = await this.fetchIssuesForKeys(site, missingParentKeys);
+
+        // If a jqlIssue is a sub-task we make a second call to make sure we get its parent's epic.
+        const missingGrandparentKeys = this.calculateMissingParentKeys([...newIssues, ...parentIssues]);
+        const grandparentIssues = await this.fetchIssuesForKeys(site, missingGrandparentKeys);
+
+        return [...parentIssues, ...grandparentIssues];
     }
 
-    async getChildren(element?: AbstractBaseNode | undefined) {
-        if (!Container.siteManager.productHasAtLeastOneSite(ProductJira)) {
-            return Promise.resolve([
-                new SimpleJiraIssueNode(
-                    'Please login to Jira',
-                    {
-                        command: Commands.ShowConfigPage,
-                        title: 'Login to Jira',
-                        arguments: [ProductJira],
-                    },
-                    undefined,
-                ),
-            ]);
-        }
-        let allIssues: MinimalORIssueLink<DetailedSiteInfo>[] = [];
-        if (element) {
-            return element.getChildren();
-        }
+    private calculateMissingParentKeys(issues: MinimalIssue<DetailedSiteInfo>[]): string[] {
+        // On NextGen projects epics are considered parents to issues and parentKey points to them. On classic projects
+        // issues parentKey doesn't point to its epic, but its epicLink does. In both cases parentKey points to the
+        // parent task for subtasks. Since they're disjoint we can just take both and treat them the same.
+        const parentKeys = issues.map((i) => i.parentKey).filter((x): x is string => !!x);
+        const epicKeys = issues.map((i) => i.epicLink).filter((x) => !!x);
+        const uniqueParentKeys = Array.from(new Set([...parentKeys, ...epicKeys]));
+        return uniqueParentKeys.filter((k) => !issues.some((i) => i.key === k));
+    }
 
-        if (this._jqlEntries.length === 0) {
-            return [new ConfigureJQLNode(CONFIGURE_JQL_STRING)];
-        }
-
-        if (this._children.length === 0) {
-            this._children = await Promise.all(
-                this._jqlEntries.map(async (jql: JQLEntry) => {
-                    const childTree = new CustomJQLTree(jql);
-                    const flattenedIssueList = await childTree.executeQuery().catch((e) => {
-                        Logger.error(new Error(`Error executing JQL: ${e}`));
-                        return [];
-                    });
-                    childTree.setNumIssues(flattenedIssueList.length);
-                    allIssues.push(...flattenedIssueList);
-                    return childTree;
-                }),
-            );
-            allIssues = [...new Map(allIssues.map((issue) => [issue.key, issue])).values()];
-            SearchJiraHelper.setIssues(allIssues, this.viewId());
-        }
-
-        return [...this._children];
+    private async fetchIssuesForKeys(
+        site: DetailedSiteInfo,
+        keys: string[],
+    ): Promise<MinimalIssue<DetailedSiteInfo>[]> {
+        return await Promise.all(
+            keys.map(async (issueKey) => {
+                const parent = await fetchMinimalIssue(issueKey, site);
+                // we only need the parent information here, we already have all the subtasks that satisfy the jql query
+                parent.subtasks = [];
+                return parent;
+            }),
+        );
     }
 }

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -15,7 +15,7 @@ const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     key: 'AXON-1',
     isEpic: false,
     summary: 'summary1',
-    status: { name: 'statusName' },
+    status: { name: 'statusName', statusCategory: { name: 'To Do' } },
     priority: { name: 'priorityName' },
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
@@ -26,7 +26,18 @@ const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     key: 'AXON-2',
     isEpic: false,
     summary: 'summary2',
-    status: { name: 'statusName' },
+    status: { name: 'statusName', statusCategory: { name: 'In Progress' } },
+    priority: { name: 'priorityName' },
+    siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
+    issuetype: { iconUrl: '/issueType/' },
+    subtasks: [],
+});
+
+const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+    key: 'AXON-3',
+    isEpic: false,
+    summary: 'summary3',
+    status: { name: 'statusName', statusCategory: { name: 'Done' } },
     priority: { name: 'priorityName' },
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
@@ -122,19 +133,23 @@ describe('AssignedWorkItemsViewProvider', () => {
 
         expect(PromiseRacerMockClass.LastInstance).toBeDefined();
 
-        PromiseRacerMockClass.LastInstance?.mockData([mockedIssue1, mockedIssue2]);
+        PromiseRacerMockClass.LastInstance?.mockData([mockedIssue1, mockedIssue2, mockedIssue3]);
         const children = await provider.getChildren();
 
         expect(PromiseRacerMockClass.LastInstance?.isEmpty).toHaveBeenCalled();
         expect(PromiseRacerMockClass.LastInstance?.next).toHaveBeenCalled();
-        expect(children).toHaveLength(2);
+        expect(children).toHaveLength(3);
 
         expect(children[0].label).toBe(mockedIssue1.key);
         expect(children[0].description).toBe(mockedIssue1.summary);
-        expect(children[0].contextValue).toBe('assignedJiraIssue');
+        expect(children[0].contextValue).toBe('assignedJiraIssue_todo');
 
         expect(children[1].label).toBe(mockedIssue2.key);
         expect(children[1].description).toBe(mockedIssue2.summary);
-        expect(children[1].contextValue).toBe('assignedJiraIssue');
+        expect(children[1].contextValue).toBe('assignedJiraIssue_inProgress');
+
+        expect(children[2].label).toBe(mockedIssue3.key);
+        expect(children[2].description).toBe(mockedIssue3.summary);
+        expect(children[2].contextValue).toBe('assignedJiraIssue_done');
     });
 });

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -4,12 +4,34 @@ import { JQLManager } from 'src/jira/jqlManager';
 import { SiteManager } from 'src/siteManager';
 import { Disposable } from 'vscode';
 import { JQLEntry } from '../../../config/model';
-import { MinimalORIssueLink } from '@atlassianlabs/jira-pi-common-models';
+import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import { DetailedSiteInfo } from 'src/atlclients/authInfo';
 
 function forceCastTo<T>(obj: any): T {
     return obj as unknown as T;
 }
+
+const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+    key: 'AXON-1',
+    isEpic: false,
+    summary: 'summary1',
+    status: { name: 'statusName' },
+    priority: { name: 'priorityName' },
+    siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
+    issuetype: { iconUrl: '/issueType/' },
+    subtasks: [],
+});
+
+const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+    key: 'AXON-2',
+    isEpic: false,
+    summary: 'summary2',
+    status: { name: 'statusName' },
+    priority: { name: 'priorityName' },
+    siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
+    issuetype: { iconUrl: '/issueType/' },
+    subtasks: [],
+});
 
 jest.mock('../searchJiraHelper');
 jest.mock('../../../container', () => ({
@@ -59,12 +81,12 @@ describe('AssignedWorkItemsViewProvider', () => {
     let provider: AssignedWorkItemsViewProvider | undefined;
 
     beforeEach(() => {
-        jest.clearAllMocks();
         provider = undefined;
     });
 
     afterEach(() => {
         provider?.dispose();
+        jest.restoreAllMocks();
     });
 
     it('should initialize with configure Jira message if no JQL entries', async () => {
@@ -72,64 +94,47 @@ describe('AssignedWorkItemsViewProvider', () => {
         provider = new AssignedWorkItemsViewProvider();
 
         const children = await provider.getChildren();
-        expect(children.length).toBe(1);
+        expect(children).toHaveLength(1);
         expect(children[0].label).toBe('Please login to Jira');
+        expect(children[0].command).toBeDefined();
 
         expect(PromiseRacerMockClass.LastInstance).toBeUndefined();
     });
 
-    it('should initialize with JQL promises if JQL entries exist', async () => {
+    it('should initialize with JQL promises if JQL entries exist, returns empty', async () => {
         const jqlEntries = [forceCastTo<JQLEntry>({ siteId: 'site1', query: 'query1' })];
         jest.spyOn(Container.jqlManager, 'getAllDefaultJQLEntries').mockReturnValue(jqlEntries);
         provider = new AssignedWorkItemsViewProvider();
 
         expect(PromiseRacerMockClass.LastInstance).toBeDefined();
-
-        await provider.getChildren();
-
-        expect(PromiseRacerMockClass.LastInstance?.isEmpty).toHaveBeenCalled();
-        expect(PromiseRacerMockClass.LastInstance?.next).toHaveBeenCalled();
-    });
-
-    it('should initialize with JQL promises if JQL entries exist', async () => {
-        const jqlEntries = [forceCastTo<JQLEntry>({ siteId: 'site1', query: 'query1' })];
-        jest.spyOn(Container.jqlManager, 'getAllDefaultJQLEntries').mockReturnValue(jqlEntries);
-        provider = new AssignedWorkItemsViewProvider();
-
-        expect(PromiseRacerMockClass.LastInstance).toBeDefined();
-
-        const issue1 = forceCastTo<MinimalORIssueLink<DetailedSiteInfo>>({
-            key: 'AXON-1',
-            isEpic: false,
-            summary: 'summary1',
-            status: { name: 'statusName' },
-            priority: { name: 'priorityName' },
-            siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
-            issuetype: { iconUrl: '/issueType/' },
-        });
-        const issue2 = forceCastTo<MinimalORIssueLink<DetailedSiteInfo>>({
-            key: 'AXON-2',
-            isEpic: false,
-            summary: 'summary2',
-            status: { name: 'statusName' },
-            priority: { name: 'priorityName' },
-            siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
-            issuetype: { iconUrl: '/issueType/' },
-        });
-        PromiseRacerMockClass.LastInstance?.mockData([issue1, issue2]);
 
         const children = await provider.getChildren();
 
         expect(PromiseRacerMockClass.LastInstance?.isEmpty).toHaveBeenCalled();
         expect(PromiseRacerMockClass.LastInstance?.next).toHaveBeenCalled();
-        expect(children.length).toBe(2);
+        expect(children).toHaveLength(0);
+    });
 
-        expect(children[0].label).toBe(issue1.key);
-        expect(children[0].description).toBe(issue1.summary);
+    it('should initialize with JQL promises if JQL entries exist, returns issues', async () => {
+        const jqlEntries = [forceCastTo<JQLEntry>({ siteId: 'site1', query: 'query1' })];
+        jest.spyOn(Container.jqlManager, 'getAllDefaultJQLEntries').mockReturnValue(jqlEntries);
+        provider = new AssignedWorkItemsViewProvider();
+
+        expect(PromiseRacerMockClass.LastInstance).toBeDefined();
+
+        PromiseRacerMockClass.LastInstance?.mockData([mockedIssue1, mockedIssue2]);
+        const children = await provider.getChildren();
+
+        expect(PromiseRacerMockClass.LastInstance?.isEmpty).toHaveBeenCalled();
+        expect(PromiseRacerMockClass.LastInstance?.next).toHaveBeenCalled();
+        expect(children).toHaveLength(2);
+
+        expect(children[0].label).toBe(mockedIssue1.key);
+        expect(children[0].description).toBe(mockedIssue1.summary);
         expect(children[0].contextValue).toBe('assignedJiraIssue');
 
-        expect(children[1].label).toBe(issue2.key);
-        expect(children[1].description).toBe(issue2.summary);
+        expect(children[1].label).toBe(mockedIssue2.key);
+        expect(children[1].description).toBe(mockedIssue2.summary);
         expect(children[1].contextValue).toBe('assignedJiraIssue');
     });
 });

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -11,13 +11,14 @@ const enum ViewStrings {
     ConfigureJiraMessage = 'Please login to Jira',
 }
 
+const AssignedWorkItemsViewProviderId = 'atlascode.views.jira.assignedWorkItemsTreeView';
+
 export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>, Disposable {
     private static readonly _treeItemConfigureJiraMessage = createLabelItem(ViewStrings.ConfigureJiraMessage, {
         command: Commands.ShowConfigPage,
         title: 'Login to Jira',
         arguments: [ProductJira],
     });
-    private static readonly _id = 'atlascode.views.jira.assignedWorkItemsTreeView';
 
     private _onDidChangeTreeData = new EventEmitter<TreeItem | undefined | void>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
@@ -33,7 +34,7 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
             commands.registerCommand(Commands.RefreshAssignedWorkItemsExplorer, this.refresh, this),
         );
 
-        window.createTreeView(AssignedWorkItemsViewProvider._id, { treeDataProvider: this });
+        window.createTreeView(AssignedWorkItemsViewProviderId, { treeDataProvider: this });
 
         const jqlEntries = Container.jqlManager.getAllDefaultJQLEntries();
         if (jqlEntries.length) {
@@ -77,7 +78,7 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
                     continue;
                 }
 
-                SearchJiraHelper.appendIssues(issues, AssignedWorkItemsViewProvider._id);
+                SearchJiraHelper.appendIssues(issues, AssignedWorkItemsViewProviderId);
                 this._initChildren.push(...this.buildTreeItemsFromIssues(issues));
                 break;
             }
@@ -97,7 +98,7 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
             }
 
             const allIssues = (await Promise.all(jqlEntries.map(executeJqlQuery))).flat();
-            SearchJiraHelper.setIssues(allIssues, AssignedWorkItemsViewProvider._id);
+            SearchJiraHelper.setIssues(allIssues, AssignedWorkItemsViewProviderId);
             return this.buildTreeItemsFromIssues(allIssues);
         }
     }

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -54,11 +54,29 @@ export class JiraIssueNode extends TreeItem {
         this.description = isMinimalIssue(issue) && issue.isEpic ? issue.epicName : issue.summary;
         this.command = { command: Commands.ShowIssue, title: 'Show Issue', arguments: [issue] };
         this.iconPath = Uri.parse(issue.issuetype.iconUrl);
-        this.contextValue = nodeType;
+        this.contextValue = this.getIssueContextValue(nodeType, issue);
         this.tooltip = `${issue.key} - ${issue.summary}\n\n${issue.priority.name}    |    ${issue.status.name}`;
         this.resourceUri = Uri.parse(`${issue.siteDetails.baseLinkUrl}/browse/${issue.key}`);
 
         this.children = issue.subtasks.map((x: MinimalIssue<DetailedSiteInfo>) => new JiraIssueNode(nodeType, x));
+    }
+
+    private getIssueContextValue(nodeType: JiraIssueNode.NodeType, issue: MinimalIssue<DetailedSiteInfo>): string {
+        const TO_DO_ISSUE_POSTFIX = '_todo';
+        const IN_PROGRESS_ISSUE_POSTFIX = '_inProgress';
+        const DONE_ISSUE_POSTFIX = '_done';
+
+        const statusCategory = issue.status.statusCategory.name;
+        switch (statusCategory.toLowerCase()) {
+            case 'to do':
+                return nodeType + TO_DO_ISSUE_POSTFIX;
+            case 'in progress':
+                return nodeType + IN_PROGRESS_ISSUE_POSTFIX;
+            case 'done':
+                return nodeType + DONE_ISSUE_POSTFIX;
+            default:
+                return nodeType;
+        }
     }
 
     async getTreeItem(): Promise<any> {

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -1,0 +1,80 @@
+import { isMinimalIssue, MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
+import { DetailedSiteInfo, ProductJira } from '../../../atlclients/authInfo';
+import { JQLEntry } from '../../../config/model';
+import { Container } from '../../../container';
+import { Commands } from '../../../commands';
+import { Logger } from '../../../logger';
+import { issuesForJQL } from '../../../jira/issuesForJql';
+import { TreeItem, TreeItemCollapsibleState, Command, Uri } from 'vscode';
+
+export function createLabelItem(label: string, command?: Command): TreeItem {
+    const item = new TreeItem(label);
+    item.command = command;
+    return item;
+}
+
+/** This function returns a Promise that never rejects. */
+export async function executeJqlQuery(jqlEntry: JQLEntry): Promise<MinimalIssue<DetailedSiteInfo>[]> {
+    try {
+        if (jqlEntry) {
+            const jqlSite = Container.siteManager.getSiteForId(ProductJira, jqlEntry.siteId);
+            if (jqlSite) {
+                const issues = await issuesForJQL(jqlEntry.query, jqlSite);
+
+                // We already have everything that matches the JQL. The subtasks likely include things that
+                // don't match the query so we get rid of them.
+                issues.forEach((i) => {
+                    i.subtasks = [];
+                });
+
+                return issues;
+            }
+        }
+    } catch (e) {
+        Logger.error(new Error(`Failed to execute default JQL query for site "${jqlEntry.siteId}": ${e}`));
+    }
+
+    return [];
+}
+
+export class JiraIssueNode extends TreeItem {
+    private children: JiraIssueNode[];
+
+    constructor(
+        nodeType: JiraIssueNode.NodeType,
+        public issue: MinimalIssue<DetailedSiteInfo>,
+    ) {
+        const collapsibleState = issue.subtasks.length
+            ? TreeItemCollapsibleState.Expanded
+            : TreeItemCollapsibleState.None;
+        super(issue.key, collapsibleState);
+
+        this.id = `${issue.key}_${issue.siteDetails.id}`;
+
+        this.description = isMinimalIssue(issue) && issue.isEpic ? issue.epicName : issue.summary;
+        this.command = { command: Commands.ShowIssue, title: 'Show Issue', arguments: [issue] };
+        this.iconPath = Uri.parse(issue.issuetype.iconUrl);
+        this.contextValue = nodeType;
+        this.tooltip = `${issue.key} - ${issue.summary}\n\n${issue.priority.name}    |    ${issue.status.name}`;
+        this.resourceUri = Uri.parse(`${issue.siteDetails.baseLinkUrl}/browse/${issue.key}`);
+
+        this.children = issue.subtasks.map((x: MinimalIssue<DetailedSiteInfo>) => new JiraIssueNode(nodeType, x));
+    }
+
+    async getTreeItem(): Promise<any> {
+        return {
+            resourceUri: this.resourceUri,
+        };
+    }
+
+    getChildren(): Promise<TreeItem[]> {
+        return Promise.resolve(this.children);
+    }
+}
+
+export namespace JiraIssueNode {
+    export enum NodeType {
+        JiraAssignedIssuesNode = 'assignedJiraIssue',
+        CustomJqlQueriesNode = 'jiraIssue',
+    }
+}

--- a/src/views/nodes/issueNode.test.ts
+++ b/src/views/nodes/issueNode.test.ts
@@ -131,40 +131,6 @@ describe('IssueNode', () => {
             const treeItem = issueNode.getTreeItem();
             expect(treeItem.command).toEqual({ command: 'showIssue', title: 'Show Issue', arguments: [mockIssue] });
         });
-
-        it('should return a TreeItem with Todo contextValue if the issue is a Todo statusCategory', () => {
-            const issueNode = new IssueNode(mockIssue, undefined);
-            const treeItem = issueNode.getTreeItem();
-            expect(treeItem.contextValue).toBe('todoJiraIssue');
-        });
-        it('should return a TreeItem with InProgress contextValue if the issue is an In Progress statusCategory', () => {
-            const issueNode = new IssueNode(
-                {
-                    ...mockIssue,
-                    status: {
-                        ...mockIssue.status,
-                        statusCategory: { ...mockIssue.status.statusCategory, name: 'In Progress' },
-                    },
-                },
-                undefined,
-            );
-            const treeItem = issueNode.getTreeItem();
-            expect(treeItem.contextValue).toBe('inProgressJiraIssue');
-        });
-        it('should return a TreeItem with Done contextValue if the issue is a Done statusCategory', () => {
-            const issueNode = new IssueNode(
-                {
-                    ...mockIssue,
-                    status: {
-                        ...mockIssue.status,
-                        statusCategory: { ...mockIssue.status.statusCategory, name: 'Done' },
-                    },
-                },
-                undefined,
-            );
-            const treeItem = issueNode.getTreeItem();
-            expect(treeItem.contextValue).toBe('doneJiraIssue');
-        });
     });
 
     describe('getChildren', () => {

--- a/src/views/nodes/issueNode.ts
+++ b/src/views/nodes/issueNode.ts
@@ -4,26 +4,6 @@ import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { Commands } from '../../commands';
 import { AbstractBaseNode } from './abstractBaseNode';
 import { Features, FeatureFlagClient } from '../../util/featureFlags';
-import {
-    DONE_ISSUE_ID,
-    IN_PROGRESS_ISSUE_ID,
-    ISSUE_NODE_CONTEXT_VALUE,
-    TO_DO_ISSUE_ID,
-} from '../jira/treeViews/constants';
-
-const getIssueContextValue = (issue: MinimalORIssueLink<DetailedSiteInfo>) => {
-    const statusCategory = issue.status.statusCategory.name;
-    switch (statusCategory.toLowerCase()) {
-        case 'to do':
-            return TO_DO_ISSUE_ID;
-        case 'in progress':
-            return IN_PROGRESS_ISSUE_ID;
-        case 'done':
-            return DONE_ISSUE_ID;
-        default:
-            return ISSUE_NODE_CONTEXT_VALUE;
-    }
-};
 
 export class IssueNode extends AbstractBaseNode {
     public issue: MinimalORIssueLink<DetailedSiteInfo>;
@@ -77,12 +57,12 @@ export class IssueNode extends AbstractBaseNode {
             ? {
                   title: this.issue.key,
                   description: summary,
-                  contextValue: getIssueContextValue(this.issue),
+                  contextValue: 'jiraIssue',
               }
             : {
                   title: `${this.issue.key} ${summary}`,
                   description: undefined,
-                  contextValue: ISSUE_NODE_CONTEXT_VALUE,
+                  contextValue: 'jiraIssue',
               };
     }
 }


### PR DESCRIPTION
### What Is This Change?

This change refactors the implementation of the Custom JQL panel, removing its dependency from the classes `BaseTreeDataProvider` and `AbstractBaseNode`.
It also speeds up the rendering of the panel, returning the JQL nodes immediately and fetching their items in background.

It also fixes:
- the 'Assign to me' context menu in the Custom JQL panel
- showing only the customized JQLs, and not all of them
- jira issue status indicator in "Assigned Jira issues" view items

### How Has This Been Tested?

- [X] Manual tests
- [X] UTs
