### PR TITLE
AXON-193: make customJqlTreeView only visible when user has custom JQLs + fix bug + add util tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,11 @@ module.exports = {
     projects: ['<rootDir>/jest.react.config.js', '<rootDir>/jest.unit.config.js'],
     verbose: true,
     collectCoverage: true,
-    collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
+    collectCoverageFrom: [
+        'src/**/*.{ts,tsx}',
+        '!src/**/*.d.ts',
+        '!src/**/*.{spec,test}.{ts,tsx,js,jsx}', // Exclude test files
+    ],
     coverageDirectory: 'coverage',
     coverageReporters: ['json', 'lcov', 'text-summary', 'clover'],
 };

--- a/package.json
+++ b/package.json
@@ -225,9 +225,10 @@
                 "category": "Atlassian"
             },
             {
-                "command": "atlascode.jira.removeFromSidebar",
-                "title": "Remove from sidebar",
-                "category": "Atlassian"
+                "command": "atlascode.jira.addJiraSite",
+                "title": "Add Jira Site",
+                "category": "Atlassian",
+                "shortTitle": "Add another Jira site"
             },
             {
                 "command": "atlascode.jira.refreshAssignedWorkItemsExplorer",
@@ -254,7 +255,9 @@
                     "dark": "resources/dark/settings.svg",
                     "light": "resources/light/settings.svg"
                 },
-                "category": "Atlassian"
+                "category": "Atlassian",
+                "shortTitle": "View settings"
+                
             },
             {
                 "command": "atlascode.jira.showIssueForKey",
@@ -489,12 +492,12 @@
                 {
                     "id": "atlascode.views.jira.assignedWorkItemsTreeView",
                     "name": "Assigned Jira Work Items",
-                    "when": "config.atlascode.jira.enabled && atlascode:customJQLExplorerEnabled"
+                    "when": "atlascode:assignedIssueExplorerEnabled && config.atlascode.jira.enabled"
                 },
                 {
                     "id": "atlascode.views.jira.customJqlTreeView",
                     "name": "Custom Jql Filters",
-                    "when": "config.atlascode.jira.enabled && atlascode:customJQLExplorerEnabled"
+                    "when": "atlascode:assignedIssueExplorerEnabled && config.atlascode.jira.enabled && atlascode:customJQLExplorerEnabled"
                 },
                 {
                     "id": "atlascode.views.bb.pullrequestsTreeView",
@@ -583,7 +586,7 @@
             "view/title": [
                 {
                     "command": "atlascode.jira.createIssue",
-                    "when": "view =~ /(atlascode.views.jira.customJql)/ && atlascode:isJiraAuthenticated",
+                    "when": "view =~ /(atlascode.views.jira.customJql|atlascode.views.jira.assignedWorkItemsTreeView)/ && atlascode:isJiraAuthenticated",
                     "group": "navigation@1"
                 },
                 {
@@ -593,7 +596,7 @@
                 },
                 {
                     "command": "atlascode.jira.searchIssues",
-                    "when": "view == atlascode.views.jira.customJqlTreeView && atlascode:isJiraAuthenticated",
+                    "when": "view =~ /(atlascode.views.jira.customJqlTreeView|atlascode.views.jira.assignedWorkItemsTreeView)/ && atlascode:isJiraAuthenticated",
                     "group": "navigation@3"
                 },
                 {
@@ -607,10 +610,6 @@
                     "group": "navigation@2"
                 },
                 {
-                    "command": "atlascode.jira.removeFromSidebar",
-                    "when": "view =~ /(atlascode.views.jira.customJqlTreeView)/ && atlascode:isJiraAuthenticated"
-                },
-                {
                     "command": "atlascode.jira.createNewJql",
                     "when": "view =~ /(atlascode.views.jira.customJqlTreeView)/ && atlascode:isJiraAuthenticated"
                 },
@@ -618,6 +617,14 @@
                     "command": "atlascode.jira.showJiraIssueSettings",
                     "when": "view == atlascode.views.jira.customJql",
                     "group": "navigation@4"
+                },
+                {
+                    "command": "atlascode.jira.addJiraSite",
+                    "when": "view == atlascode.views.jira.assignedWorkItemsTreeView && atlascode:isJiraAuthenticated"
+                },
+                {
+                    "command": "atlascode.jira.showJiraIssueSettings",
+                    "when": "view =~ /(atlascode.views.jira.assignedWorkItemsTreeView|atlascode.views.jira.customJqlTreeView)/"
                 },
                 {
                     "command": "atlascode.bb.createPullRequest",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "extension:package:prerelease": "npm run extension:clean && vsce package --pre-release --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/",
         "extension:package": "npm run extension:clean && vsce package --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/",
         "extension:install": "npm run extension:package && code --install-extension ./atlascode-*.vsix --force",
-        "test": "jest",
+        "test": "jest --config jest.config.js",
         "test:unit": "jest --selectProjects unit",
         "test:react": "jest --selectProjects react",
         "test:e2e": "echo 'token length' && echo ${#ATLASCODE_TEST_USER_API_TOKEN} && npm run test:e2e:compile && e2e/scripts/run",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "extension:package:prerelease": "npm run extension:clean && vsce package --pre-release --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/",
         "extension:package": "npm run extension:clean && vsce package --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/",
         "extension:install": "npm run extension:package && code --install-extension ./atlascode-*.vsix --force",
-        "test": "jest --config jest.config.js",
+        "test": "jest",
         "test:unit": "jest --selectProjects unit",
         "test:react": "jest --selectProjects react",
         "test:e2e": "echo 'token length' && echo ${#ATLASCODE_TEST_USER_API_TOKEN} && npm run test:e2e:compile && e2e/scripts/run",

--- a/src/commandContext.ts
+++ b/src/commandContext.ts
@@ -3,6 +3,7 @@ import { commands } from 'vscode';
 export enum CommandContext {
     JiraExplorer = 'atlascode:jiraExplorerEnabled',
     CustomJQLExplorer = 'atlascode:customJQLExplorerEnabled',
+    AssignedIssueExplorer = 'atlascode:assignedIssueExplorerEnabled',
     BitbucketExplorer = 'atlascode:bitbucketExplorerEnabled',
     PipelineExplorer = 'atlascode:pipelineExplorerEnabled',
     BitbucketIssuesExplorer = 'atlascode:bitbucketIssuesExplorerEnabled',

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,7 +24,6 @@ import { ConfigSection, ConfigSubSection } from './lib/ipc/models/config';
 import { AbstractBaseNode } from './views/nodes/abstractBaseNode';
 import { IssueNode } from './views/nodes/issueNode';
 import { PipelineNode } from './views/pipelines/PipelinesTree';
-import { CommandContext, setCommandContext } from './commandContext';
 
 export enum Commands {
     BitbucketSelectContainer = 'atlascode.bb.selectContainer',
@@ -57,6 +56,7 @@ export enum Commands {
     RefreshJiraExplorer = 'atlascode.jira.refreshExplorer',
     RefreshAssignedWorkItemsExplorer = 'atlascode.jira.refreshAssignedWorkItemsExplorer',
     RefreshCustomJqlExplorer = 'atlascode.jira.refreshCustomJqlExplorer',
+    AddJiraSite = 'atlascode.jira.addJiraSite',
     ShowJiraIssueSettings = 'atlascode.jira.showJiraIssueSettings',
     ShowPullRequestSettings = 'atlascode.bb.showPullRequestSettings',
     ShowPipelineSettings = 'atlascode.bb.showPipelineSettings',
@@ -96,7 +96,6 @@ export enum Commands {
     CloneRepository = 'atlascode.cloneRepository',
     DisableHelpExplorer = 'atlascode.disableHelpExplorer',
     CreateNewJql = 'atlascode.jira.createNewJql',
-    RemoveFromSidebar = 'atlascode.jira.removeFromSidebar',
     ToDoIssue = 'atlascode.jira.todoIssue',
     InProgressIssue = 'atlascode.jira.inProgressIssue',
     DoneIssue = 'atlascode.jira.doneIssue',
@@ -104,8 +103,11 @@ export enum Commands {
 
 export function registerCommands(vscodeContext: ExtensionContext) {
     vscodeContext.subscriptions.push(
-        commands.registerCommand(Commands.RemoveFromSidebar, () =>
-            setCommandContext(CommandContext.CustomJQLExplorer, false),
+        commands.registerCommand(Commands.AddJiraSite, () =>
+            Container.settingsWebviewFactory.createOrShow({
+                section: ConfigSection.Jira,
+                subSection: ConfigSubSection.Auth,
+            }),
         ),
         commands.registerCommand(Commands.CreateNewJql, () =>
             Container.settingsWebviewFactory.createOrShow({

--- a/src/views/jira/treeViews/customJqlViewProvider.test.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.test.ts
@@ -82,17 +82,6 @@ jest.mock('../../../container', () => ({
     },
 }));
 
-const mockExecuteQuery = jest.fn().mockReturnValue(Promise.resolve([]));
-jest.mock('../customJqlTree', () => {
-    return {
-        CustomJQLTree: jest.fn().mockImplementation(() => ({
-            dispose: jest.fn(),
-            executeQuery: mockExecuteQuery,
-            setNumIssues: jest.fn(),
-        })),
-    };
-});
-
 jest.mock('../searchJiraHelper');
 
 function forceCastTo<T>(obj: any): T {

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -118,8 +118,11 @@ class JiraIssueQueryNode extends TreeItem {
                 return [JiraIssueQueryNode._treeItemNoIssuesMessage];
             }
 
-            issues = Container.config.jira.explorer.nestSubtasks ? await this.constructIssueTree(issues) : issues;
+            // index only issues that are directly retrieved with the JQL queries, and not
+            // the extra parent items retrieved to rebuild the issues hierarchy
             SearchJiraHelper.appendIssues(issues, CustomJQLViewProviderId);
+
+            issues = Container.config.jira.explorer.nestSubtasks ? await this.constructIssueTree(issues) : issues;
 
             return issues.map((issue) => new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, issue));
         })();

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -40,8 +40,6 @@ export class CustomJQLViewProvider implements TreeDataProvider<TreeItem>, Dispos
     private _onDidChangeTreeData = new EventEmitter<TreeItem | undefined | void>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-    private _jqlEntries: JQLEntry[] = [];
-
     constructor() {
         this._disposable = Disposable.from(
             Container.jqlManager.onDidJQLChange(this.refresh, this),
@@ -49,11 +47,11 @@ export class CustomJQLViewProvider implements TreeDataProvider<TreeItem>, Dispos
             commands.registerCommand(Commands.RefreshCustomJqlExplorer, this.refresh, this),
         );
 
-        this._jqlEntries = Container.jqlManager.getCustomJQLEntries();
-
         window.createTreeView(CustomJQLViewProviderId, { treeDataProvider: this });
 
-        if (this._jqlEntries.length > 0) {
+        const jqlEntries = Container.jqlManager.getCustomJQLEntries();
+
+        if (jqlEntries.length > 0) {
             setCommandContext(CommandContext.CustomJQLExplorer, Container.config.jira.explorer.enabled);
         }
 
@@ -64,8 +62,8 @@ export class CustomJQLViewProvider implements TreeDataProvider<TreeItem>, Dispos
 
     private onConfigurationChanged(e: ConfigurationChangeEvent) {
         if (configuration.changed(e, 'jira.jqlList') || configuration.changed(e, 'jira.explorer')) {
-            this._jqlEntries = Container.jqlManager.getCustomJQLEntries();
-            if (this._jqlEntries.length > 0) {
+            const jqlEntries = Container.jqlManager.getCustomJQLEntries();
+            if (jqlEntries.length > 0) {
                 setCommandContext(CommandContext.CustomJQLExplorer, Container.config.jira.explorer.enabled);
             } else {
                 setCommandContext(CommandContext.CustomJQLExplorer, false);
@@ -90,9 +88,9 @@ export class CustomJQLViewProvider implements TreeDataProvider<TreeItem>, Dispos
         } else {
             SearchJiraHelper.clearIssues(CustomJQLViewProviderId);
 
-            this._jqlEntries = Container.jqlManager.getCustomJQLEntries();
-            return this._jqlEntries.length
-                ? this._jqlEntries.map((jqlEntry) => new JiraIssueQueryNode(jqlEntry))
+            const jqlEntries = Container.jqlManager.getCustomJQLEntries();
+            return jqlEntries.length
+                ? jqlEntries.map((jqlEntry) => new JiraIssueQueryNode(jqlEntry))
                 : [CustomJQLViewProvider._treeItemConfigureJqlMessage];
         }
     }

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -90,9 +90,9 @@ export class CustomJQLViewProvider implements TreeDataProvider<TreeItem>, Dispos
         } else {
             SearchJiraHelper.clearIssues(CustomJQLViewProviderId);
 
-            const jqlEntries = Container.jqlManager.getCustomJQLEntries();
-            return jqlEntries.length
-                ? jqlEntries.map((jqlEntry) => new JiraIssueQueryNode(jqlEntry))
+            this._jqlEntries = Container.jqlManager.getCustomJQLEntries();
+            return this._jqlEntries.length
+                ? this._jqlEntries.map((jqlEntry) => new JiraIssueQueryNode(jqlEntry))
                 : [CustomJQLViewProvider._treeItemConfigureJqlMessage];
         }
     }

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -1,11 +1,11 @@
 import { AssignedWorkItemsViewProvider } from './jiraAssignedWorkItemsViewProvider';
 import { Container } from '../../../container';
-import { JQLManager } from 'src/jira/jqlManager';
-import { SiteManager } from 'src/siteManager';
+import { JQLManager } from '../../../jira/jqlManager';
+import { SiteManager } from '../../../siteManager';
 import { Disposable } from 'vscode';
 import { JQLEntry } from '../../../config/model';
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
-import { DetailedSiteInfo } from 'src/atlclients/authInfo';
+import { DetailedSiteInfo } from '../../../atlclients/authInfo';
 
 function forceCastTo<T>(obj: any): T {
     return obj as unknown as T;
@@ -55,6 +55,18 @@ jest.mock('../../../container', () => ({
         siteManager: {
             onDidSitesAvailableChange: () => new Disposable(() => {}),
         } as Partial<SiteManager>,
+        context: {
+            subscriptions: {
+                push: jest.fn(),
+            },
+        },
+        config: {
+            jira: {
+                explorer: {
+                    enabled: true,
+                },
+            },
+        },
     },
 }));
 

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -44,6 +44,7 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
             this._initPromises = new PromiseRacer(jqlEntries.map(executeJqlQuery));
         }
         Container.context.subscriptions.push(configuration.onDidChange(this.onConfigurationChanged, this));
+        this._onDidChangeTreeData.fire();
     }
 
     private onConfigurationChanged(e: ConfigurationChangeEvent) {

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -1,24 +1,26 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
-import { DetailedSiteInfo, ProductJira } from '../../../atlclients/authInfo';
+import { DetailedSiteInfo } from '../../../atlclients/authInfo';
 import { Container } from '../../../container';
 import { Commands } from '../../../commands';
 import { SearchJiraHelper } from '../searchJiraHelper';
 import { PromiseRacer } from '../../../util/promises';
-import { Disposable, TreeDataProvider, TreeItem, EventEmitter, commands, window } from 'vscode';
-import { JiraIssueNode, executeJqlQuery, createLabelItem } from './utils';
-
-const enum ViewStrings {
-    ConfigureJiraMessage = 'Please login to Jira',
-}
+import {
+    Disposable,
+    TreeDataProvider,
+    TreeItem,
+    EventEmitter,
+    commands,
+    window,
+    ConfigurationChangeEvent,
+} from 'vscode';
+import { JiraIssueNode, executeJqlQuery, loginToJiraMessageNode } from './utils';
+import { configuration } from '../../../config/configuration';
+import { CommandContext, setCommandContext } from '../../../commandContext';
 
 const AssignedWorkItemsViewProviderId = 'atlascode.views.jira.assignedWorkItemsTreeView';
 
 export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>, Disposable {
-    private static readonly _treeItemConfigureJiraMessage = createLabelItem(ViewStrings.ConfigureJiraMessage, {
-        command: Commands.ShowConfigPage,
-        title: 'Login to Jira',
-        arguments: [ProductJira],
-    });
+    private static readonly _treeItemConfigureJiraMessage = loginToJiraMessageNode;
 
     private _onDidChangeTreeData = new EventEmitter<TreeItem | undefined | void>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
@@ -36,12 +38,21 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
 
         window.createTreeView(AssignedWorkItemsViewProviderId, { treeDataProvider: this });
 
+        setCommandContext(CommandContext.AssignedIssueExplorer, Container.config.jira.explorer.enabled);
         const jqlEntries = Container.jqlManager.getAllDefaultJQLEntries();
         if (jqlEntries.length) {
             this._initPromises = new PromiseRacer(jqlEntries.map(executeJqlQuery));
         }
+        Container.context.subscriptions.push(configuration.onDidChange(this.onConfigurationChanged, this));
+    }
 
-        this._onDidChangeTreeData.fire();
+    private onConfigurationChanged(e: ConfigurationChangeEvent) {
+        if (configuration.changed(e, 'jira.explorer.enabled')) {
+            setCommandContext(CommandContext.AssignedIssueExplorer, Container.config.jira.explorer.enabled);
+            this.refresh();
+        } else if (configuration.changed(e, 'jira.explorer')) {
+            this.refresh();
+        }
     }
 
     dispose() {

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -51,8 +51,6 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
         if (configuration.changed(e, 'jira.explorer.enabled')) {
             setCommandContext(CommandContext.AssignedIssueExplorer, Container.config.jira.explorer.enabled);
             this.refresh();
-        } else if (configuration.changed(e, 'jira.explorer')) {
-            this.refresh();
         }
     }
 

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -39,10 +39,13 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
         window.createTreeView(AssignedWorkItemsViewProviderId, { treeDataProvider: this });
 
         setCommandContext(CommandContext.AssignedIssueExplorer, Container.config.jira.explorer.enabled);
+
         const jqlEntries = Container.jqlManager.getAllDefaultJQLEntries();
+
         if (jqlEntries.length) {
             this._initPromises = new PromiseRacer(jqlEntries.map(executeJqlQuery));
         }
+
         Container.context.subscriptions.push(configuration.onDidChange(this.onConfigurationChanged, this));
         this._onDidChangeTreeData.fire();
     }
@@ -50,6 +53,8 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
     private onConfigurationChanged(e: ConfigurationChangeEvent) {
         if (configuration.changed(e, 'jira.explorer.enabled')) {
             setCommandContext(CommandContext.AssignedIssueExplorer, Container.config.jira.explorer.enabled);
+            this.refresh();
+        } else if (configuration.changed(e, 'jira.explorer.showIssueIcons')) {
             this.refresh();
         }
     }

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -54,7 +54,7 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
         if (configuration.changed(e, 'jira.explorer.enabled')) {
             setCommandContext(CommandContext.AssignedIssueExplorer, Container.config.jira.explorer.enabled);
             this.refresh();
-        } else if (configuration.changed(e, 'jira.explorer.showIssueIcons')) {
+        } else if (configuration.changed(e, 'jira.explorer')) {
             this.refresh();
         }
     }

--- a/src/views/jira/treeViews/utils.test.ts
+++ b/src/views/jira/treeViews/utils.test.ts
@@ -1,0 +1,104 @@
+import { DetailedSiteInfo } from 'src/atlclients/authInfo';
+import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
+import { JiraIssueNode } from './utils';
+import { Uri } from 'vscode';
+
+function forceCastTo<T>(obj: any): T {
+    return obj as unknown as T;
+}
+jest.mock('vscode', () => {
+    return {
+        TreeItem: class {
+            constructor(label: string) {}
+            command = { command: '', title: '' };
+        },
+        TreeItemCollapsibleState: {
+            None: 0,
+            Collapsed: 1,
+        },
+        Uri: {
+            parse: jest.fn((a) => a as Uri),
+        },
+    };
+});
+jest.mock('../../../container', () => ({
+    Container: {
+        siteManager: {
+            getSiteForId: jest.fn(() =>
+                forceCastTo<DetailedSiteInfo>({ id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' }),
+            ),
+        },
+    },
+}));
+jest.mock('../../../commands', () => ({
+    Commands: {
+        ShowConfigPage: 'atlascode.showConfigPage',
+        ShowIssue: 'atlascode.jira.showIssue',
+    },
+}));
+jest.mock('../../../logger', () => ({
+    Logger: {
+        error: jest.fn(),
+    },
+}));
+const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+    key: 'AXON-1',
+    isEpic: false,
+    summary: 'summary1',
+    status: { name: 'statusName', statusCategory: { name: 'To Do' } },
+    priority: { name: 'priorityName' },
+    siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
+    issuetype: { iconUrl: '/issueType/' },
+    subtasks: [],
+});
+
+const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+    key: 'AXON-2',
+    isEpic: false,
+    summary: 'summary2',
+    status: { name: 'statusName', statusCategory: { name: 'In Progress' } },
+    priority: { name: 'priorityName' },
+    siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
+    issuetype: { iconUrl: '/issueType/' },
+    subtasks: [mockedIssue1],
+});
+
+const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+    key: 'AXON-3',
+    isEpic: false,
+    summary: 'summary3',
+    status: { name: 'statusName', statusCategory: { name: 'Done' } },
+    priority: { name: 'priorityName' },
+    siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
+    issuetype: { iconUrl: '/issueType/' },
+    subtasks: [],
+});
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+describe('utils', () => {
+    describe('JiraIssueNode', () => {
+        it('should create a JiraIssueNode', () => {
+            const jiraIssueNode = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue1);
+            expect(jiraIssueNode).toBeDefined();
+        });
+        it('should append correct contextValues', () => {
+            const jiraIssueNode1 = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue1);
+            const jiraIssueNode2 = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue2);
+            const jiraIssueNode3 = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue3);
+            expect(jiraIssueNode1.contextValue).toBe('jiraIssue_todo');
+            expect(jiraIssueNode2.contextValue).toBe('jiraIssue_inProgress');
+            expect(jiraIssueNode3.contextValue).toBe('jiraIssue_done');
+        });
+        it('getChildren should return children', async () => {
+            const jiraIssueNode = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue2);
+            const children = await jiraIssueNode.getChildren();
+            expect(children).toHaveLength(1);
+        });
+        it('getTreeItem should return resourceUri', async () => {
+            const jiraIssueNode = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue1);
+            const treeItem = await jiraIssueNode.getTreeItem();
+            expect(treeItem.resourceUri).toEqual(Uri.parse('/siteDetails/browse/AXON-1'));
+        });
+    });
+});

--- a/src/views/jira/treeViews/utils.test.ts
+++ b/src/views/jira/treeViews/utils.test.ts
@@ -73,9 +73,11 @@ const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
 });
-beforeEach(() => {
+
+afterEach(() => {
     jest.clearAllMocks();
 });
+
 describe('utils', () => {
     describe('JiraIssueNode', () => {
         it('should create a JiraIssueNode', () => {

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -42,6 +42,7 @@ export const loginToJiraMessageNode = createLabelItem('Please login to Jira', {
     title: 'Login to Jira',
     arguments: [ProductJira],
 });
+
 export class JiraIssueNode extends TreeItem {
     private children: JiraIssueNode[];
 

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -37,6 +37,11 @@ export async function executeJqlQuery(jqlEntry: JQLEntry): Promise<MinimalIssue<
     return [];
 }
 
+export const loginToJiraMessageNode = createLabelItem('Please login to Jira', {
+    command: Commands.ShowConfigPage,
+    title: 'Login to Jira',
+    arguments: [ProductJira],
+});
 export class JiraIssueNode extends TreeItem {
     private children: JiraIssueNode[];
 

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -322,6 +322,8 @@ export class JiraIssueWebview
                         });
 
                         commands.executeCommand(Commands.RefreshJiraExplorer);
+                        commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
+                        commands.executeCommand(Commands.RefreshCustomJqlExplorer);
                     } catch (e) {
                         Logger.error(new Error(`error updating issue: ${e}`));
                         this.postMessage({


### PR DESCRIPTION
### What Is This Change?

* Made `customJqlTreeView` to only be visible when user has custom JQLs enabled
* Made `assignedToMeTreeView `and `customJqlTreeview` only visible when Jira Explorer is enabled
* fixed bug where assigning yourself in Issue view does not refresh the tree
* Add util tests for new JiraIssueNode for coverage on statusCategory tag assignment
* added relevant commands to AssignedToMeView

Loom:
https://www.loom.com/share/7b1f04900c164c08a83e2d7dd8ac85d7?sid=1546e877-1257-4ac0-a3f2-4a0c29ad4e8d

### How Has This Been Tested?

Unit testing + Manual testing

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
