### PR TITLE
no-issue: fix bug where custom jql view does not disappear when jira unauth

### DIFF
--- a/package.json
+++ b/package.json
@@ -497,7 +497,7 @@
                 {
                     "id": "atlascode.views.jira.customJqlTreeView",
                     "name": "Custom Jql Filters",
-                    "when": "atlascode:assignedIssueExplorerEnabled && config.atlascode.jira.enabled && atlascode:customJQLExplorerEnabled"
+                    "when": "atlascode:assignedIssueExplorerEnabled && config.atlascode.jira.enabled && atlascode:customJQLExplorerEnabled&& atlascode:isJiraAuthenticated"
                 },
                 {
                     "id": "atlascode.views.bb.pullrequestsTreeView",

--- a/package.json
+++ b/package.json
@@ -497,7 +497,7 @@
                 {
                     "id": "atlascode.views.jira.customJqlTreeView",
                     "name": "Custom Jql Filters",
-                    "when": "atlascode:assignedIssueExplorerEnabled && config.atlascode.jira.enabled && atlascode:customJQLExplorerEnabled&& atlascode:isJiraAuthenticated"
+                    "when": "atlascode:assignedIssueExplorerEnabled && config.atlascode.jira.enabled && atlascode:customJQLExplorerEnabled && atlascode:isJiraAuthenticated"
                 },
                 {
                     "id": "atlascode.views.bb.pullrequestsTreeView",

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -61,7 +61,11 @@ export class CustomJQLViewProvider implements TreeDataProvider<TreeItem>, Dispos
     }
 
     private onConfigurationChanged(e: ConfigurationChangeEvent) {
-        if (configuration.changed(e, 'jira.jqlList') || configuration.changed(e, 'jira.explorer')) {
+        if (
+            configuration.changed(e, 'jira.jqlList') ||
+            configuration.changed(e, 'jira.explorer') ||
+            configuration.changed(e, 'jira.explorer.enabled')
+        ) {
             const jqlEntries = Container.jqlManager.getCustomJQLEntries();
             if (jqlEntries.length > 0) {
                 setCommandContext(CommandContext.CustomJQLExplorer, Container.config.jira.explorer.enabled);


### PR DESCRIPTION
### What Is This Change?

Fix bug where custom jql view does not hide when unauthenitcating jia

loom: https://www.loom.com/share/d23c6526bbfa46bf811efe4bbee98efa?sid=203472a6-90e4-40ac-9f1c-59fd6138bcea

### How Has This Been Tested?

UT + manual test

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
