### PR TITLE
[AXON-220] Fixed broken link after creating new issue within new SidebarUI experiment

### DIFF
--- a/src/jira/fetchIssue.ts
+++ b/src/jira/fetchIssue.ts
@@ -3,6 +3,7 @@ import { MinimalIssue, minimalIssueFromJsonObject, MinimalORIssueLink } from '@a
 import { CreateMetaTransformerResult } from '@atlassianlabs/jira-pi-meta-models';
 import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { Container } from '../container';
+import { SearchJiraHelper } from '../views/jira/searchJiraHelper';
 
 export async function fetchCreateIssueUI(
     siteDetails: DetailedSiteInfo,
@@ -27,7 +28,7 @@ export async function getCachedOrFetchMinimalIssue(
 }
 
 export async function getCachedIssue(issueKey: string): Promise<MinimalORIssueLink<DetailedSiteInfo> | undefined> {
-    return await Container.jiraExplorer.findIssue(issueKey);
+    return SearchJiraHelper.findIssue(issueKey) ?? (await Container.jiraExplorer?.findIssue(issueKey));
 }
 
 export async function fetchMinimalIssue(

--- a/src/views/jira/searchJiraHelper.test.ts
+++ b/src/views/jira/searchJiraHelper.test.ts
@@ -1,0 +1,86 @@
+import { SearchJiraHelper } from './searchJiraHelper';
+import { MinimalORIssueLink } from '@atlassianlabs/jira-pi-common-models';
+import { DetailedSiteInfo } from 'src/atlclients/authInfo';
+import * as vscode from 'vscode';
+
+function forceCastTo<T>(obj: any): T {
+    return obj as unknown as T;
+}
+
+jest.mock('@atlassianlabs/jira-pi-common-models');
+jest.mock('../../analytics');
+jest.mock('../../commands');
+jest.mock('../../container');
+jest.mock('../../atlclients/authInfo');
+jest.mock('vscode');
+
+const issue1 = forceCastTo<MinimalORIssueLink<DetailedSiteInfo>>({ key: 'ISSUE-1', summary: 'Test Issue' });
+const issue2 = forceCastTo<MinimalORIssueLink<DetailedSiteInfo>>({ key: 'ISSUE-2', summary: 'Another Issue' });
+
+describe('SearchJiraHelper', () => {
+    beforeEach(() => {
+        jest.spyOn(vscode.commands, 'registerCommand').mockImplementation();
+        jest.spyOn(vscode.commands, 'executeCommand').mockImplementation();
+        jest.spyOn(vscode.window, 'showQuickPick').mockImplementation();
+    });
+
+    afterEach(() => {
+        SearchJiraHelper.clearIssues();
+        jest.restoreAllMocks();
+    });
+
+    it('initialize should register the JiraSearchIssues command', () => {
+        SearchJiraHelper.initialize();
+        expect(vscode.commands.registerCommand).toHaveBeenCalledWith(
+            'atlascode.jira.searchIssues',
+            expect.any(Function),
+        );
+    });
+
+    it('findIssue finds issues after setIssues', () => {
+        SearchJiraHelper.setIssues([issue1, issue2], 'provider1');
+
+        expect(SearchJiraHelper.findIssue(issue1.key)).toBe(issue1);
+        expect(SearchJiraHelper.findIssue(issue2.key)).toBe(issue2);
+        expect(SearchJiraHelper.findIssue('NONE-1')).toBeUndefined();
+    });
+
+    it('clearIssues clears all the issues', () => {
+        SearchJiraHelper.setIssues([issue1, issue2], 'provider1');
+        SearchJiraHelper.clearIssues();
+
+        expect(SearchJiraHelper.findIssue(issue1.key)).toBeUndefined();
+        expect(SearchJiraHelper.findIssue(issue2.key)).toBeUndefined();
+    });
+
+    it("setIssues replaces the provider's issues", () => {
+        SearchJiraHelper.setIssues([issue1], 'provider1');
+        SearchJiraHelper.setIssues([issue2], 'provider1');
+
+        expect(SearchJiraHelper.findIssue(issue1.key)).toBeUndefined();
+        expect(SearchJiraHelper.findIssue(issue2.key)).toBe(issue2);
+    });
+
+    it('setIssues stores different providers separately', () => {
+        SearchJiraHelper.setIssues([issue1], 'provider1');
+        SearchJiraHelper.setIssues([issue2], 'provider2');
+
+        expect(SearchJiraHelper.findIssue(issue1.key)).toBe(issue1);
+        expect(SearchJiraHelper.findIssue(issue2.key)).toBe(issue2);
+    });
+
+    it('appendIssues append issues for the same provider', () => {
+        SearchJiraHelper.setIssues([issue1], 'provider1');
+        SearchJiraHelper.appendIssues([issue2], 'provider1');
+
+        expect(SearchJiraHelper.findIssue(issue1.key)).toBe(issue1);
+        expect(SearchJiraHelper.findIssue(issue2.key)).toBe(issue2);
+    });
+
+    it('appendIssues works standalone', () => {
+        SearchJiraHelper.appendIssues([issue1, issue2], 'provider1');
+
+        expect(SearchJiraHelper.findIssue(issue1.key)).toBe(issue1);
+        expect(SearchJiraHelper.findIssue(issue2.key)).toBe(issue2);
+    });
+});

--- a/src/views/jira/searchJiraHelper.ts
+++ b/src/views/jira/searchJiraHelper.ts
@@ -55,6 +55,18 @@ export class SearchJiraHelper {
         this._searchableIssueMap = {};
     }
 
+    static findIssue(issueKey: string): MinimalORIssueLink<DetailedSiteInfo> | undefined {
+        for (const issuesList of Object.values(this._searchableIssueMap)) {
+            for (const issue of issuesList) {
+                if (issue.key === issueKey) {
+                    return issue;
+                }
+            }
+        }
+
+        return undefined;
+    }
+
     // This method is called when the user clicks on the "Search Jira" button in the Jira Tree View
     private static createIssueQuickPick() {
         searchIssuesEvent(ProductJira).then((e) => {

--- a/src/views/jira/searchJiraHelper.ts
+++ b/src/views/jira/searchJiraHelper.ts
@@ -10,10 +10,9 @@ interface QuickPickIssue extends QuickPickItem {
 }
 
 export class SearchJiraHelper {
-    private static _searchableIssueMap: Record<string, MinimalORIssueLink<DetailedSiteInfo>[]>;
+    private static _searchableIssueMap: Record<string, MinimalORIssueLink<DetailedSiteInfo>[]> = {};
 
     static initialize() {
-        this._searchableIssueMap = {};
         commands.registerCommand(Commands.JiraSearchIssues, () => this.createIssueQuickPick());
     }
 

--- a/src/views/jira/searchJiraHelper.ts
+++ b/src/views/jira/searchJiraHelper.ts
@@ -10,14 +10,11 @@ interface QuickPickIssue extends QuickPickItem {
 }
 
 export class SearchJiraHelper {
+    private static _searchableIssueMap: Record<string, MinimalORIssueLink<DetailedSiteInfo>[]>;
+
     static initialize() {
         this._searchableIssueMap = {};
         commands.registerCommand(Commands.JiraSearchIssues, () => this.createIssueQuickPick());
-    }
-
-    private static _searchableIssueMap: Record<string, MinimalORIssueLink<DetailedSiteInfo>[]>;
-    static get searchableIssueMap() {
-        return this._searchableIssueMap;
     }
 
     /***


### PR DESCRIPTION
This PR fixes this link that is broken when the new SidebarUI experiment is turned on

![image](https://github.com/user-attachments/assets/e4fa550f-7c2e-4f25-b2cd-d0c56ec1adf1)

The root cause was the undefined JiraExplorer object being used to find the issue from the cache.
JiraExplorer is undefined because it represents the old jira issues view, which is turned off when the new views are enabled.

The fix is simply null-checking JiraExplorer before invoking it.
Additionally, I've wired up the SearchJiraHelper to use it as a cache.

Tested:
- [X] Manual tests
- [X] New UTs