### PR TITLE
AXON-133: Comment on BB PR now work. Issue 212, 24 and BB Issue 762

### DIFF
--- a/src/views/pullrequest/prCommentController.ts
+++ b/src/views/pullrequest/prCommentController.ts
@@ -282,7 +282,7 @@ export class PullRequestCommentController implements vscode.Disposable {
                     const newComment: Comment = await bbApi.pullrequests.editComment(
                         comment.site,
                         comment.prId,
-                        comment.body.toString(),
+                        this.extractCommentText(comment),
                         comment.id,
                         comment.commitHash,
                     );
@@ -308,6 +308,16 @@ export class PullRequestCommentController implements vscode.Disposable {
 
         await this.createOrUpdateThread(commentThreadId!, comment.parent!.uri, comment.parent!.range, comments);
         vscode.commands.executeCommand(Commands.RefreshPullRequestExplorerNode, vscode.Uri.parse(comment.prHref));
+    }
+
+    private extractCommentText(comment: PullRequestComment): string {
+        return typeof comment.body === 'string'
+            ? comment.body
+            : comment.body instanceof MarkdownString
+              ? comment.body.value
+              : (() => {
+                    throw new Error('Invalid comment body type');
+                })();
     }
 
     async toggleCommentsVisibility(uri: vscode.Uri) {

--- a/src/views/pullrequest/prCommentController.ts
+++ b/src/views/pullrequest/prCommentController.ts
@@ -311,13 +311,13 @@ export class PullRequestCommentController implements vscode.Disposable {
     }
 
     private extractCommentText(comment: PullRequestComment): string {
-        return typeof comment.body === 'string'
-            ? comment.body
-            : comment.body instanceof MarkdownString
-              ? comment.body.value
-              : (() => {
-                    throw new Error('Invalid comment body type');
-                })();
+        if (comment.body instanceof MarkdownString) {
+            return comment.body.value;
+        }
+        if (typeof comment.body === 'string') {
+            return comment.body;
+        }
+        throw new Error('Invalid comment body type');
     }
 
     async toggleCommentsVisibility(uri: vscode.Uri) {


### PR DESCRIPTION
### What Is This Change?

Fixes #212 #24 
And BB Issue https://bitbucket.org/atlassianlabs/atlascode/issues/762/pr-comments-are-changed-to-object-object

### How Has This Been Tested?

Test on DC and Cloud 
See Loom: https://www.loom.com/share/3bd6debe9230489f91d3c27f1a3cec20

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)


**BEFORE (when editing a comment on a PR):** 
![image](https://github.com/user-attachments/assets/f3efa7d1-cea8-4888-b3fa-d33e6dd2e541)

**AFTER** 
![image](https://github.com/user-attachments/assets/66c2c460-06a8-4a8d-808b-1d66ce31a83d)

