### PR TITLE
Changelog for bug fix, change to PR template to remind PR authors about changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,3 +31,6 @@ Basic checks:
 
 Advanced checks: 
 - [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)
+
+Recommendations:
+- [ ] Update the CHANGELOG if making a user facing change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## What's new in 3.4.15
+
+### Improvements
+
+### Bug Fixes
+
+- Editting comments in PRs work. 
+
 ## What's new in 3.4.14
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Editting comments in PRs work. 
+- Editing comments in PRs work. 
 
 ## What's new in 3.4.14
 


### PR DESCRIPTION
### What Is This Change?

- Changelog for https://github.com/atlassian/atlascode/pull/214
- PR Template update to remind PR Authors about the change log 

### How Has This Been Tested?

- No tests needed 

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)