### PR TITLE
[AXON-239] Fix TreeItem id to allow same issue to appear twice

### DIFF
--- a/src/jira/jqlManager.ts
+++ b/src/jira/jqlManager.ts
@@ -91,7 +91,7 @@ export class JQLManager extends Disposable {
 
     public getAllDefaultJQLEntries(): JQLEntry[] {
         const sites = Container.siteManager.getSitesAvailable(ProductJira);
-        return sites.map((site) => this.defaultJQLEntryForSite(site));
+        return sites.map((site) => this.defaultJQLEntryForSite(site, () => site.id));
     }
 
     public getCustomJQLEntries(): JQLEntry[] {
@@ -109,7 +109,7 @@ export class JQLManager extends Disposable {
             for (const site of sites) {
                 if (!allList.some((j) => j.siteId === site.id)) {
                     // only initialize if there are no jql entries for this site
-                    allList.push(this.defaultJQLEntryForSite(site));
+                    allList.push(this.defaultJQLEntryForSite(site, v4));
                 }
             }
 
@@ -123,9 +123,9 @@ export class JQLManager extends Disposable {
             : 'assignee = currentUser() ORDER BY lastViewed DESC';
     }
 
-    private defaultJQLEntryForSite(site: DetailedSiteInfo): JQLEntry {
+    private defaultJQLEntryForSite(site: DetailedSiteInfo, idFunc: () => string): JQLEntry {
         return {
-            id: v4(),
+            id: idFunc(),
             enabled: true,
             name: `My ${site.name} Issues`,
             query: this.defaultJQLQueryForSite(site),

--- a/src/views/jira/treeViews/customJqlViewProvider.test.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.test.ts
@@ -1,8 +1,8 @@
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import { DetailedSiteInfo, ProductBitbucket, ProductJira } from '../../../atlclients/authInfo';
 import { Container } from '../../../container';
 import { CustomJQLViewProvider } from './customJqlViewProvider';
 import { SitesAvailableUpdateEvent } from '../../../siteManager';
+import { TreeViewIssue } from './utils';
 import * as utils from './utils';
 
 const mockJqlEntries = [
@@ -24,7 +24,7 @@ const mockJqlEntries = [
     },
 ];
 
-const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+const mockedIssue1 = forceCastTo<TreeViewIssue>({
     key: 'AXON-1',
     isEpic: false,
     summary: 'summary1',
@@ -33,9 +33,11 @@ const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
+    jqlSource: mockJqlEntries[0],
+    children: [],
 });
 
-const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+const mockedIssue2 = forceCastTo<TreeViewIssue>({
     key: 'AXON-2',
     isEpic: false,
     summary: 'summary2',
@@ -44,9 +46,11 @@ const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
+    jqlSource: mockJqlEntries[0],
+    children: [],
 });
 
-const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+const mockedIssue3 = forceCastTo<TreeViewIssue>({
     key: 'AXON-3',
     isEpic: false,
     summary: 'summary3',
@@ -55,6 +59,8 @@ const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
+    jqlSource: mockJqlEntries[0],
+    children: [],
 });
 
 jest.mock('../../../container', () => ({

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -11,6 +11,10 @@ function forceCastTo<T>(obj: any): T {
     return obj as unknown as T;
 }
 
+const mockedJqlEntry = forceCastTo<JQLEntry>({
+    id: 'jqlId',
+});
+
 const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     key: 'AXON-1',
     isEpic: false,
@@ -20,6 +24,8 @@ const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
+    jqlSource: mockedJqlEntry,
+    children: [],
 });
 
 const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
@@ -31,6 +37,8 @@ const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
+    jqlSource: mockedJqlEntry,
+    children: [],
 });
 
 const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
@@ -42,6 +50,8 @@ const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
+    jqlSource: mockedJqlEntry,
+    children: [],
 });
 
 jest.mock('../searchJiraHelper');

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -1,5 +1,4 @@
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
-import { DetailedSiteInfo, ProductJira } from '../../../atlclients/authInfo';
+import { ProductJira } from '../../../atlclients/authInfo';
 import { Container } from '../../../container';
 import { Commands } from '../../../commands';
 import { SearchJiraHelper } from '../searchJiraHelper';
@@ -13,7 +12,7 @@ import {
     window,
     ConfigurationChangeEvent,
 } from 'vscode';
-import { JiraIssueNode, executeJqlQuery, loginToJiraMessageNode } from './utils';
+import { JiraIssueNode, TreeViewIssue, executeJqlQuery, loginToJiraMessageNode } from './utils';
 import { configuration } from '../../../config/configuration';
 import { CommandContext, setCommandContext } from '../../../commandContext';
 import { SitesAvailableUpdateEvent } from '../../../siteManager';
@@ -27,7 +26,7 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
     private _disposable: Disposable;
-    private _initPromises: PromiseRacer<MinimalIssue<DetailedSiteInfo>[]> | undefined;
+    private _initPromises: PromiseRacer<TreeViewIssue[]> | undefined;
     private _initChildren: TreeItem[] = [];
 
     constructor() {
@@ -125,7 +124,7 @@ export class AssignedWorkItemsViewProvider implements TreeDataProvider<TreeItem>
         }
     }
 
-    private buildTreeItemsFromIssues(issues?: MinimalIssue<DetailedSiteInfo>[]): TreeItem[] {
+    private buildTreeItemsFromIssues(issues?: TreeViewIssue[]): TreeItem[] {
         return issues
             ? issues.map((issue) => new JiraIssueNode(JiraIssueNode.NodeType.JiraAssignedIssuesNode, issue))
             : [];

--- a/src/views/jira/treeViews/utils.test.ts
+++ b/src/views/jira/treeViews/utils.test.ts
@@ -1,11 +1,12 @@
 import { DetailedSiteInfo } from 'src/atlclients/authInfo';
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
-import { JiraIssueNode } from './utils';
+import { JiraIssueNode, TreeViewIssue } from './utils';
 import { Uri } from 'vscode';
+import { JQLEntry } from 'src/config/model';
 
 function forceCastTo<T>(obj: any): T {
     return obj as unknown as T;
 }
+
 jest.mock('vscode', () => {
     return {
         TreeItem: class {
@@ -41,7 +42,12 @@ jest.mock('../../../logger', () => ({
         error: jest.fn(),
     },
 }));
-const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+
+const mockedJqlEntry = forceCastTo<JQLEntry>({
+    id: 'jqlId',
+});
+
+const mockedIssue1 = forceCastTo<TreeViewIssue>({
     key: 'AXON-1',
     isEpic: false,
     summary: 'summary1',
@@ -50,9 +56,11 @@ const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
+    jqlSource: mockedJqlEntry,
+    children: [],
 });
 
-const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+const mockedIssue2 = forceCastTo<TreeViewIssue>({
     key: 'AXON-2',
     isEpic: false,
     summary: 'summary2',
@@ -60,10 +68,12 @@ const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     priority: { name: 'priorityName' },
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
     issuetype: { iconUrl: '/issueType/' },
-    subtasks: [mockedIssue1],
+    subtasks: [],
+    jqlSource: mockedJqlEntry,
+    children: [mockedIssue1],
 });
 
-const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
+const mockedIssue3 = forceCastTo<TreeViewIssue>({
     key: 'AXON-3',
     isEpic: false,
     summary: 'summary3',
@@ -72,6 +82,8 @@ const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
+    jqlSource: mockedJqlEntry,
+    children: [],
 });
 
 afterEach(() => {
@@ -84,6 +96,7 @@ describe('utils', () => {
             const jiraIssueNode = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue1);
             expect(jiraIssueNode).toBeDefined();
         });
+
         it('should append correct contextValues', () => {
             const jiraIssueNode1 = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue1);
             const jiraIssueNode2 = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue2);
@@ -92,11 +105,13 @@ describe('utils', () => {
             expect(jiraIssueNode2.contextValue).toBe('jiraIssue_inProgress');
             expect(jiraIssueNode3.contextValue).toBe('jiraIssue_done');
         });
+
         it('getChildren should return children', async () => {
             const jiraIssueNode = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue2);
             const children = await jiraIssueNode.getChildren();
             expect(children).toHaveLength(1);
         });
+
         it('getTreeItem should return resourceUri', async () => {
             const jiraIssueNode = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue1);
             const treeItem = await jiraIssueNode.getTreeItem();


### PR DESCRIPTION
### What Is This Change?

The bug is the following error when configuring two distinct custom JQL queries that return the same Jira issue:
![image](https://github.com/user-attachments/assets/dcb185f0-df1c-4d6b-a4ac-fdeb6eae93cd)

The reason for this error is because we build the TreeItem id as `{issueKey}_{siteId}`, which is the same for the same issue across different JQL queries.

The solution is building the TreeItem id as `{issueKey}_{siteId}_{jqlEntryId}`.

To accomodate this solution, some other changes are required:
- in jqlManager, the jqlEntry for retrieving the default jql queries for the assigned jira work items needs to have a stable id, so depending for the reason it's generated (site initialization vs retrieve default queries) the id is generated differently
- a new TreeViewIssue interface is introduced to extend the fields of a MinimalIssue, and carry the jql source for it

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)