### PR TITLE
Add feature gates and experiment exposure telemetry events

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -91,13 +91,15 @@ export async function featureFlagClientInitializedEvent(success: true): Promise<
 export async function featureFlagClientInitializedEvent(
     success: false,
     errorType: ClientInitializedErrorType,
+    reason: string,
 ): Promise<TrackEvent>;
 export async function featureFlagClientInitializedEvent(
     success: boolean,
     errorType?: ClientInitializedErrorType,
+    reason?: string,
 ): Promise<TrackEvent> {
     return trackEvent('initialized', 'featureFlagClient', {
-        attributes: { success, errorType: errorType ?? 0 },
+        attributes: { success, errorType: errorType ?? 0, reason },
     });
 }
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -102,9 +102,14 @@ export async function featureFlagClientInitializedEvent(
 }
 
 // debugging event, meant to measure the exposure rate of a feature flag or an experiment
-export async function featureGateExposureBoolEvent(ffName: string, value: boolean): Promise<TrackEvent> {
+export async function featureGateExposureBoolEvent(
+    ffName: string,
+    success: boolean,
+    value: boolean,
+    errorType: number,
+): Promise<TrackEvent> {
     return trackEvent('gateExposureBool', 'featureFlagClient', {
-        attributes: { ffName, value },
+        attributes: { ffName, success, value, errorType },
     });
 }
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -101,6 +101,13 @@ export async function featureFlagClientInitializedEvent(
     });
 }
 
+// debugging event, meant to measure the exposure rate of a feature flag or an experiment
+export async function featureGateExposureBoolEvent(ffName: string, value: boolean): Promise<TrackEvent> {
+    return trackEvent('gateExposureBool', 'featureFlagClient', {
+        attributes: { ffName, value },
+    });
+}
+
 // Jira issue events
 
 export async function issueCreatedEvent(site: DetailedSiteInfo, issueKey: string): Promise<TrackEvent> {

--- a/src/container.ts
+++ b/src/container.ts
@@ -212,18 +212,16 @@ export class Container {
             });
         }
 
+        FeatureFlagClient.checkExperimentBooleanValueWithInstrumentation(Experiments.AtlascodeAA);
+        FeatureFlagClient.checkGateValueWithInstrumentation(Features.NoOpFeature);
+
         this.initializeUriHandler(context, this._analyticsApi, this._bitbucketHelper);
         this.initializeNewSidebarView(context, config);
-        this.initializeAAExperiment();
     }
 
     private static getAnalyticsEnable(): boolean {
         const telemetryConfig = workspace.getConfiguration('telemetry');
         return telemetryConfig.get<boolean>('enableTelemetry', true);
-    }
-
-    private static initializeAAExperiment() {
-        FeatureFlagClient.checkExperimentValue(Experiments.AtlascodeAA);
     }
 
     private static initializeUriHandler(

--- a/src/container.ts
+++ b/src/container.ts
@@ -207,7 +207,7 @@ export class Container {
         } catch (err) {
             const error = err as FeatureFlagClientInitError;
             Logger.debug(`FeatureFlagClient: Failed to initialize the client: ${error.reason}`);
-            featureFlagClientInitializedEvent(false, error.errorType).then((e) => {
+            featureFlagClientInitializedEvent(false, error.errorType, error.reason).then((e) => {
                 this.analyticsClient.sendTrackEvent(e);
             });
         }

--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -18,7 +18,8 @@ export class FeatureFlagClientInitError {
 }
 
 export abstract class FeatureFlagClient {
-    private static analyticsClient: AnalyticsClientMapper;
+    private static analyticsClient: AnalyticsClient;
+    private static analyticsClientMapper: AnalyticsClientMapper;
 
     private static featureGateOverrides: FeatureGateValues;
     private static experimentValueOverride: ExperimentGateValues;
@@ -44,7 +45,9 @@ export abstract class FeatureFlagClient {
         }
 
         Logger.debug(`FeatureGates: initializing, target: ${targetApp}, environment: ${environment}`);
-        this.analyticsClient = new AnalyticsClientMapper(options.analyticsClient, options.identifiers);
+
+        this.analyticsClient = options.analyticsClient;
+        this.analyticsClientMapper = new AnalyticsClientMapper(options.analyticsClient, options.identifiers);
 
         try {
             await FeatureGates.initialize(
@@ -53,7 +56,7 @@ export abstract class FeatureFlagClient {
                     environment,
                     targetApp,
                     fetchTimeoutMs: Number.parseInt(timeout),
-                    analyticsWebClient: Promise.resolve(this.analyticsClient),
+                    analyticsWebClient: Promise.resolve(this.analyticsClientMapper),
                 },
                 options.identifiers,
             );
@@ -162,7 +165,9 @@ export abstract class FeatureFlagClient {
     static checkGateValueWithInstrumentation(gate: Features): any {
         if (this.featureGateOverrides.hasOwnProperty(gate)) {
             const value = this.featureGateOverrides[gate];
-            featureGateExposureBoolEvent(gate, false, value, 3);
+            featureGateExposureBoolEvent(gate, false, value, 3).then((e) => {
+                this.analyticsClient.sendTrackEvent(e);
+            });
             return value;
         }
 
@@ -170,9 +175,13 @@ export abstract class FeatureFlagClient {
         if (FeatureGates.initializeCompleted()) {
             // FeatureGates.checkGate returns false if any errors
             gateValue = FeatureGates.checkGate(gate);
-            featureGateExposureBoolEvent(gate, true, gateValue, 0);
+            featureGateExposureBoolEvent(gate, true, gateValue, 0).then((e) => {
+                this.analyticsClient.sendTrackEvent(e);
+            });
         } else {
-            featureGateExposureBoolEvent(gate, false, gateValue, 1);
+            featureGateExposureBoolEvent(gate, false, gateValue, 1).then((e) => {
+                this.analyticsClient.sendTrackEvent(e);
+            });
         }
 
         Logger.debug(`FeatureGates ${gate} -> ${gateValue}`);
@@ -182,13 +191,17 @@ export abstract class FeatureFlagClient {
     static checkExperimentBooleanValueWithInstrumentation(experiment: Experiments): any {
         // unknown experiment name
         if (!ExperimentGates.hasOwnProperty(experiment)) {
-            featureGateExposureBoolEvent(experiment, false, false, 2);
+            featureGateExposureBoolEvent(experiment, false, false, 2).then((e) => {
+                this.analyticsClient.sendTrackEvent(e);
+            });
             return undefined;
         }
 
         if (this.experimentValueOverride.hasOwnProperty(experiment)) {
             const value = this.experimentValueOverride[experiment];
-            featureGateExposureBoolEvent(experiment, false, value, 3);
+            featureGateExposureBoolEvent(experiment, false, value, 3).then((e) => {
+                this.analyticsClient.sendTrackEvent(e);
+            });
             return value;
         }
 
@@ -199,12 +212,18 @@ export abstract class FeatureFlagClient {
 
             if (gateValue === 'N/A') {
                 gateValue = experimentGate.defaultValue;
-                featureGateExposureBoolEvent(experiment, false, gateValue, 4);
+                featureGateExposureBoolEvent(experiment, false, gateValue, 4).then((e) => {
+                    this.analyticsClient.sendTrackEvent(e);
+                });
             } else {
-                featureGateExposureBoolEvent(experiment, true, gateValue, 0);
+                featureGateExposureBoolEvent(experiment, true, gateValue, 0).then((e) => {
+                    this.analyticsClient.sendTrackEvent(e);
+                });
             }
         } else {
-            featureGateExposureBoolEvent(experiment, false, gateValue, 1);
+            featureGateExposureBoolEvent(experiment, false, gateValue, 1).then((e) => {
+                this.analyticsClient.sendTrackEvent(e);
+            });
         }
 
         Logger.debug(`Experiment ${experiment} -> ${gateValue}`);

--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -2,7 +2,7 @@ import FeatureGates, { FeatureGateEnvironment, Identifiers } from '@atlaskit/fea
 import { AnalyticsClient } from '../../analytics-node-client/src/client.min';
 import { AnalyticsClientMapper } from './analytics';
 import { ExperimentGates, ExperimentGateValues, Experiments, FeatureGateValues, Features } from './features';
-import { ClientInitializedErrorType } from '../../analytics';
+import { ClientInitializedErrorType, featureGateExposureBoolEvent } from '../../analytics';
 import { Logger } from '../../logger';
 
 export type FeatureFlagClientOptions = {
@@ -157,6 +157,26 @@ export abstract class FeatureFlagClient {
 
         Logger.debug(`Experiment ${experiment} -> ${gateValue}`);
         return gateValue;
+    }
+
+    static checkGateValueWithInstrumentation(gate: Features): any {
+        const value = this.checkGate(gate);
+
+        if (value && typeof value === 'boolean') {
+            featureGateExposureBoolEvent(gate, value);
+        }
+
+        return value;
+    }
+
+    static checkExperimentBooleanValueWithInstrumentation(experiment: Experiments): any {
+        const value = this.checkExperimentValue(experiment);
+
+        if (value && typeof value === 'boolean') {
+            featureGateExposureBoolEvent(experiment, value);
+        }
+
+        return value;
     }
 
     static dispose() {

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -1,6 +1,7 @@
 export const enum Features {
     EnableNewUriHandler = 'atlascode-enable-new-uri-handler',
     NewSidebarTreeView = 'atlascode-new-sidebar-treeview',
+    NoOpFeature = 'atlascode-noop',
 }
 
 export const enum Experiments {


### PR DESCRIPTION
### What Is This Change?

This change is adding the `gateExposureBool` telemetry event to track the exposure of feature flags and experiments with boolean parameters.

The purpose of this new telemetry event is for debugging only, to verify that the stat-sig library is correctly evaluating feature flags and experiments, and the outcome of the check is what we expect.

Also, added the failure reason in telemetry for when initialization fails.

The new telemetry event will be reverted once the debugging is complete.

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)