### PR TITLE
Fixed debug telemetry for AA experiment

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -115,6 +115,18 @@ export async function featureGateExposureBoolEvent(
     });
 }
 
+// debugging event, meant to measure the exposure rate of a feature flag or an experiment
+export async function featureGateExposureStringEvent(
+    ffName: string,
+    success: boolean,
+    value: string,
+    errorType: number,
+): Promise<TrackEvent> {
+    return trackEvent('gateExposureString', 'featureFlagClient', {
+        attributes: { ffName, success, value, errorType },
+    });
+}
+
 // Jira issue events
 
 export async function issueCreatedEvent(site: DetailedSiteInfo, issueKey: string): Promise<TrackEvent> {

--- a/src/container.ts
+++ b/src/container.ts
@@ -212,7 +212,7 @@ export class Container {
             });
         }
 
-        FeatureFlagClient.checkExperimentBooleanValueWithInstrumentation(Experiments.AtlascodeAA);
+        FeatureFlagClient.checkExperimentStringValueWithInstrumentation(Experiments.AtlascodeAA);
         FeatureFlagClient.checkGateValueWithInstrumentation(Features.NoOpFeature);
 
         this.initializeUriHandler(context, this._analyticsApi, this._bitbucketHelper);

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -15,8 +15,8 @@ export const ExperimentGates: Record<Experiments, ExperimentPayload> = {
         defaultValue: 'control',
     },
     [Experiments.AtlascodeAA]: {
-        parameter: 'isEnabled',
-        defaultValue: false,
+        parameter: 'isEnabled2',
+        defaultValue: 'Default',
     },
 };
 


### PR DESCRIPTION
### What Is This Change?

Passing `"N/A"` as default value for a boolean experiment's parameter makes the function to fail.
Switched to a string parameter where the possible values are "Control" and "Test", and using a different value "Default" as the default value to distinguish them.