### PR TITLE
better error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## What's new in 3.4.18 
+
+- Were you experiencing issues with commands not being found for the Atlassian extension? Please follow steps here after installing this version: 
+    - Delete all auths under Settings > Jira > Authentication section
+    - Re-authenticate. 
+    - If you are still experiencing issues, please comment on https://github.com/atlassian/atlascode/issues/219
+
+
 ## What's new in 3.4.17
 
 - Internal changes only.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,8 +42,6 @@ export async function activate(context: ExtensionContext) {
     try {
         await Container.initialize(context, configuration.get<IConfig>(), atlascodeVersion);
 
-        await JQLManager.backFillOldDetailedSiteInfo();
-
         registerCommands(context);
         activateCodebucket(context);
 
@@ -55,6 +53,8 @@ export async function activate(context: ExtensionContext) {
             CommandContext.IsBBAuthenticated,
             Container.siteManager.productHasAtLeastOneSite(ProductBitbucket),
         );
+
+        await JQLManager.backFillOldDetailedSiteInfos();
     } catch (e) {
         Logger.error(e, 'Error initializing atlascode!');
     }


### PR DESCRIPTION
### What Is This Change?

- Users are reporting issues with commands not being registers. This appears to be due to poor error handling. #219 
- Although we haven't pinpointed were the errors are coming from, we have improved the error handling allow users to manually reset themselves by deleting all of their auths in the Settings > Jira > Authentication section and then re-authenticating 


### How Has This Been Tested?
- Manually tested with a user who was experiencing this. Unfortunately, we didn't grab the log before hand to understand the cause of the error. But the solution worked. 

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change