### PR TITLE
Refactor common test utilities into their folder

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-#registry=https://packages.atlassian.com/api/npm/npm-remote
-unsafe-perm = true

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -22,6 +22,7 @@ nightlyver.sh
 package.json
 readme.md
 setupTests.js
+setupTestsReact.js
 tsconfig.notest.json
 tsconfig.ui-test.json
 ui-test-settings.json
@@ -36,6 +37,7 @@ scripts/
 out/test/**
 out/**/*.map
 src/**
+testsutil/**
 patches/**
 .gitignore
 bitbucket-pipelines.yml
@@ -55,4 +57,6 @@ devhtml/**
 .yalc/**
 .storybook/**
 jest.config.js
+jest.react.config.js
+jest.unit.config.js
 .test-extensions/** 

--- a/src/atlclients/loginManager.test.ts
+++ b/src/atlclients/loginManager.test.ts
@@ -1,3 +1,4 @@
+import { forceCastTo } from '../../testsutil';
 import { LoginManager } from './loginManager';
 import { CredentialManager } from './authStore';
 import { SiteManager } from '../siteManager';
@@ -22,10 +23,6 @@ import { JiraClient } from '@atlassianlabs/jira-pi-client';
 import * as authInfo from './authInfo';
 import * as analytics from '../analytics';
 import * as jira_client_providers from '../jira/jira-client/providers';
-
-function forceCastTo<T>(obj: any): T {
-    return obj as unknown as T;
-}
 
 jest.mock('./authStore');
 jest.mock('../siteManager');

--- a/src/util/featureFlags/client.test.ts
+++ b/src/util/featureFlags/client.test.ts
@@ -1,7 +1,3 @@
-function forceCastTo<T>(obj: any): T {
-    return obj as unknown as T;
-}
-
 const MockedFeatureGates_Features: Record<any, boolean> = {
     'some-very-real-feature': true,
     'another-very-real-feature': true,
@@ -36,6 +32,7 @@ jest.mock('@atlaskit/feature-gate-js-client', () => {
     };
 });
 
+import { forceCastTo } from '../../../testsutil';
 import FeatureGates from '@atlaskit/feature-gate-js-client';
 import { FeatureFlagClient, FeatureFlagClientOptions, FeatureFlagClientInitError } from './client';
 import { ClientInitializedErrorType } from '../../analytics';

--- a/src/views/jira/searchJiraHelper.test.ts
+++ b/src/views/jira/searchJiraHelper.test.ts
@@ -1,11 +1,8 @@
+import { forceCastTo } from '../../../testsutil';
 import { SearchJiraHelper } from './searchJiraHelper';
 import { MinimalORIssueLink } from '@atlassianlabs/jira-pi-common-models';
 import { DetailedSiteInfo } from 'src/atlclients/authInfo';
 import * as vscode from 'vscode';
-
-function forceCastTo<T>(obj: any): T {
-    return obj as unknown as T;
-}
 
 jest.mock('@atlassianlabs/jira-pi-common-models');
 jest.mock('../../analytics');

--- a/src/views/jira/treeViews/customJqlViewProvider.test.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.test.ts
@@ -1,3 +1,4 @@
+import { forceCastTo } from '../../../../testsutil';
 import { DetailedSiteInfo, ProductBitbucket, ProductJira } from '../../../atlclients/authInfo';
 import { Container } from '../../../container';
 import { CustomJQLViewProvider } from './customJqlViewProvider';
@@ -91,10 +92,6 @@ jest.mock('../../../container', () => ({
 }));
 
 jest.mock('../searchJiraHelper');
-
-function forceCastTo<T>(obj: any): T {
-    return obj as unknown as T;
-}
 
 describe('CustomJqlViewProvider', () => {
     let provider: CustomJQLViewProvider | undefined;

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -1,3 +1,4 @@
+import { forceCastTo } from '../../../../testsutil';
 import { AssignedWorkItemsViewProvider } from './jiraAssignedWorkItemsViewProvider';
 import { Container } from '../../../container';
 import { JQLManager } from '../../../jira/jqlManager';
@@ -6,10 +7,6 @@ import { Disposable } from 'vscode';
 import { JQLEntry } from '../../../config/model';
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import { DetailedSiteInfo } from '../../../atlclients/authInfo';
-
-function forceCastTo<T>(obj: any): T {
-    return obj as unknown as T;
-}
 
 const mockedJqlEntry = forceCastTo<JQLEntry>({
     id: 'jqlId',

--- a/src/views/jira/treeViews/utils.test.ts
+++ b/src/views/jira/treeViews/utils.test.ts
@@ -1,11 +1,8 @@
+import { forceCastTo } from '../../../../testsutil';
 import { DetailedSiteInfo } from 'src/atlclients/authInfo';
 import { JiraIssueNode, TreeViewIssue } from './utils';
 import { Uri } from 'vscode';
 import { JQLEntry } from 'src/config/model';
-
-function forceCastTo<T>(obj: any): T {
-    return obj as unknown as T;
-}
 
 jest.mock('vscode', () => {
     return {

--- a/testsutil/index.ts
+++ b/testsutil/index.ts
@@ -1,0 +1,3 @@
+import { forceCastTo } from './miscFunctions';
+
+export { forceCastTo };

--- a/testsutil/miscFunctions.ts
+++ b/testsutil/miscFunctions.ts
@@ -1,0 +1,3 @@
+export function forceCastTo<T>(obj: any): T {
+    return obj as unknown as T;
+}


### PR DESCRIPTION
### What Is This Change?

Created a root folder `testsutil` where we can implement UT utility functions.

For now, we only have `forceCastTo<>`.
More to come 😄 