### PR TITLE
[AXON-247] Ship the new sidebar UI panels

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -238,13 +238,12 @@ export class Container {
     }
 
     private static initializeNewSidebarView(context: ExtensionContext, config: IConfig) {
-        if (FeatureFlagClient.checkGate(Features.NewSidebarTreeView)) {
-            Logger.debug('Using new custom JQL view');
+        if (FeatureFlagClient.checkGate(Features.OldSidebarTreeView)) {
+            this.initializeLegacySidebarView(context, config);
+        } else {
             SearchJiraHelper.initialize();
             context.subscriptions.push(new CustomJQLViewProvider());
             context.subscriptions.push(new AssignedWorkItemsViewProvider());
-        } else {
-            this.initializeLegacySidebarView(context, config);
         }
     }
 

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -1,6 +1,6 @@
 export const enum Features {
     EnableNewUriHandler = 'atlascode-enable-new-uri-handler',
-    NewSidebarTreeView = 'atlascode-new-sidebar-treeview',
+    OldSidebarTreeView = 'atlascode-old-sidebar-treeview',
     NoOpFeature = 'atlascode-noop',
 }
 


### PR DESCRIPTION
### What Is This Change?

This changes removes the existing `Jira issues` sidebar panel, and it ships the two new sidebar panels `Assigned Jira work items` and `Custom JQL filters`:

| ![image](https://github.com/user-attachments/assets/722cd348-153d-4418-9ac3-e695c4b6ee8c) | ![image](https://github.com/user-attachments/assets/40437593-dbfd-4e32-925d-31e7b7d3bf92) |
|---|---|

The first panel shows all and only the issues assigned to the authenticated user, in a flat (non-hierarchical) view.
The second panel only shows the customized JQLs, and behaves similarly to the old `Jira issues` panel.

The second panel stays hidden if there aren't any customized JQL.

A new feature flag `atlascode-old-sidebar-treeview` has been introduced to quickly return to the old view in case of emergency.

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change