### PR TITLE
Added tests related to the TreeView ID and JQL logic

### DIFF
--- a/src/jira/jqlManager.test.ts
+++ b/src/jira/jqlManager.test.ts
@@ -1,0 +1,233 @@
+import { expansionCastTo } from '../../testsutil';
+import { JiraClient } from '@atlassianlabs/jira-pi-client';
+import { JQLManager } from './jqlManager';
+import { Container } from '../container';
+import { DetailedSiteInfo, ProductJira } from '../atlclients/authInfo';
+import { JQLEntry } from '../config/model';
+import { it } from '@jest/globals';
+import { configuration } from '../config/configuration';
+//import { EventEmitter } from 'vscode';
+
+const mockedSites = [
+    expansionCastTo<DetailedSiteInfo>({
+        id: 'siteDetailsId1',
+        name: 'MockedSite1',
+        hasResolutionField: true,
+    }),
+    expansionCastTo<DetailedSiteInfo>({
+        id: 'siteDetailsId2',
+        name: 'MockedSite2',
+        hasResolutionField: false,
+    }),
+];
+
+const mockedJqlEntries = [
+    expansionCastTo<JQLEntry>({
+        id: 'jqlId1',
+        siteId: 'siteDetailsId1',
+        query: 'assignee = currentUser() AND resolution = Unresolved ORDER BY lastViewed DESC',
+        enabled: true,
+        monitor: true,
+    }),
+    expansionCastTo<JQLEntry>({
+        id: 'jqlId2',
+        siteId: 'siteDetailsId2',
+        query: 'assignee = currentUser() ORDER BY lastViewed DESC',
+        enabled: true,
+        monitor: true,
+    }),
+    expansionCastTo<JQLEntry>({
+        id: 'jqlId3',
+        siteId: 'siteDetailsId1',
+        query: 'assignee = currentUser() AND isCustomQuery = true ORDER BY lastViewed DESC',
+        enabled: true,
+        monitor: true,
+    }),
+    expansionCastTo<JQLEntry>({
+        id: 'jqlId3',
+        siteId: 'siteDetailsId2',
+        query: 'assignee = currentUser() AND isCustomQuery = true ORDER BY lastViewed DESC',
+        enabled: true,
+        monitor: true,
+    }),
+    expansionCastTo<JQLEntry>({
+        id: 'jqlId4',
+        siteId: 'siteDetailsId1',
+        query: 'assignee = currentUser() AND isCustomQuery = true ORDER BY lastViewed DESC',
+        enabled: true,
+        monitor: false,
+    }),
+    expansionCastTo<JQLEntry>({
+        id: 'jqlId5',
+        siteId: 'siteDetailsId2',
+        query: 'assignee = currentUser() AND isCustomQuery = true ORDER BY lastViewed DESC',
+        enabled: false,
+        monitor: true,
+    }),
+    expansionCastTo<JQLEntry>({
+        id: 'jqlId6',
+        siteId: 'siteDetailsId1',
+        query: 'assignee = currentUser() AND isCustomQuery = true ORDER BY lastViewed DESC',
+        enabled: false,
+        monitor: false,
+    }),
+];
+
+jest.mock('../logger');
+jest.mock('../config/configuration', () => ({
+    configuration: {
+        onDidChange: () => {},
+        update: () => {},
+    },
+}));
+jest.mock('../container', () => ({
+    Container: {
+        config: {
+            jira: {
+                jqlList: [],
+            },
+        },
+        siteManager: {
+            getSitesAvailable: () => [],
+            getSiteForId: (product: any, id: string) => {
+                throw new Error(`${id} not found`);
+            },
+            addOrUpdateSite: () => {},
+        },
+        clientManager: {
+            jiraClient: () => Promise.reject("Shouldn't have been called"),
+        },
+    },
+}));
+
+describe('JQLManager', () => {
+    let jqlManager: JQLManager;
+
+    beforeEach(() => {
+        Container.config.jira.jqlList = mockedJqlEntries;
+
+        jest.spyOn(Container.siteManager, 'getSitesAvailable').mockImplementation((product) => {
+            if (product.key === ProductJira.key) {
+                return mockedSites;
+            } else {
+                throw new Error("JQLManager is not supposed to call 'getSitesAvailable' for BitBucket.");
+            }
+        });
+
+        jest.spyOn(Container.siteManager, 'getSiteForId').mockImplementation((product, id) => {
+            if (product.key === ProductJira.key) {
+                const site = mockedSites.find((x) => x.id === id);
+                if (!site) {
+                    throw new Error(`${id} not found`);
+                }
+                return site;
+            } else {
+                throw new Error("JQLManager is not supposed to call 'getSitesAvailable' for BitBucket.");
+            }
+        });
+
+        jqlManager = new JQLManager();
+    });
+
+    afterEach(() => {
+        jqlManager.dispose();
+        jest.restoreAllMocks();
+    });
+
+    it('notifiableJQLEntries retrieves all the enabled and monitored entries', () => {
+        const entries = jqlManager.notifiableJQLEntries();
+        expect(entries).toHaveLength(4);
+        expect(entries).toEqual([mockedJqlEntries[0], mockedJqlEntries[1], mockedJqlEntries[2], mockedJqlEntries[3]]);
+    });
+
+    it('enabledJQLEntries retrieves all the enabled entries', () => {
+        const entries = jqlManager.enabledJQLEntries();
+        expect(entries).toHaveLength(5);
+        expect(entries).toEqual([
+            mockedJqlEntries[0],
+            mockedJqlEntries[1],
+            mockedJqlEntries[2],
+            mockedJqlEntries[3],
+            mockedJqlEntries[4],
+        ]);
+    });
+
+    it('getAllDefaultJQLEntries returns a list of default JQL entries for every site', () => {
+        const entries = jqlManager.getAllDefaultJQLEntries();
+
+        expect(entries).toHaveLength(2);
+
+        entries.forEach((entry) => {
+            expect(entry.query).toEqual('assignee = currentUser() AND StatusCategory != Done ORDER BY updated DESC');
+            expect(entry.enabled).toBeTruthy();
+            expect(entry.monitor).toBeTruthy();
+        });
+
+        expect(entries[0].id).toEqual('siteDetailsId1');
+        expect(entries[1].id).toEqual('siteDetailsId2');
+    });
+
+    it('getCustomJQLEntries retrieves the list of customized and enabled JQL entries', () => {
+        const entries = jqlManager.getCustomJQLEntries();
+
+        expect(entries).toHaveLength(3);
+        expect(entries).toEqual([mockedJqlEntries[2], mockedJqlEntries[3], mockedJqlEntries[4]]);
+    });
+
+    it.each([
+        ['resolution', true],
+        ['anotherField', false],
+    ])(
+        'backFillOldDetailedSiteInfos should backfill old site info with resolution field',
+        async (fieldId, expectedHasResolutionField) => {
+            const mockSite = expansionCastTo<DetailedSiteInfo>({
+                id: 'site1',
+                name: 'Site 1',
+                hasResolutionField: undefined,
+            });
+
+            (Container.siteManager.getSitesAvailable as jest.Mock).mockReturnValue([mockSite]);
+            jest.spyOn(Container.clientManager, 'jiraClient').mockResolvedValue(
+                expansionCastTo<JiraClient<DetailedSiteInfo>>({
+                    getFields: jest.fn().mockResolvedValue([{ id: fieldId }]),
+                }),
+            );
+
+            jest.spyOn(Container.siteManager, 'addOrUpdateSite');
+
+            await JQLManager.backFillOldDetailedSiteInfos();
+
+            expect(Container.siteManager.addOrUpdateSite).toHaveBeenCalledWith(mockSite);
+            expect(mockSite.hasResolutionField).toBe(expectedHasResolutionField);
+        },
+    );
+
+    it('initializeJQL should initialize JQL entries for new sites', async () => {
+        const mockSite = expansionCastTo<DetailedSiteInfo>({
+            id: 'site1',
+            name: 'Site 1',
+            hasResolutionField: undefined,
+        });
+
+        let actualValue: JQLEntry[] = [];
+
+        jest.spyOn(configuration, 'update').mockImplementation((section, value, target) => {
+            actualValue = value;
+            return Promise.resolve();
+        });
+
+        Container.config.jira.jqlList = [];
+        await jqlManager.initializeJQL([mockSite]);
+
+        expect(configuration.update).toHaveBeenCalledWith(
+            'jira.jqlList',
+            expect.anything(),
+            1 /*vscode.ConfigurationTarget.Global*/,
+        );
+        expect(actualValue).toHaveLength(1);
+
+        expect(actualValue[0].siteId).toBe('site1');
+        expect(actualValue[0].id).toBeDefined();
+        expect(actualValue[0].id).not.toEqual(actualValue[0].siteId);
+    });
+});

--- a/src/jira/jqlManager.ts
+++ b/src/jira/jqlManager.ts
@@ -133,7 +133,7 @@ export class JQLManager extends Disposable {
 
     private defaultJQLEntryForSiteStorage(site: DetailedSiteInfo): JQLEntry {
         return {
-            id: v4(),
+            id: v4(), // In Custom JQL filters we can have multiple queries per site, so we need something unique
             enabled: true,
             name: `My ${site.name} Issues`,
             query: this.defaultJQLQueryForSite(site),
@@ -144,7 +144,7 @@ export class JQLManager extends Disposable {
 
     private defaultJQLEntryForJiraExplorer(site: DetailedSiteInfo): JQLEntry {
         return {
-            id: site.id,
+            id: site.id, // in Assigned Jira Work Items we only have 1 query per site, so this id works well
             enabled: true,
             name: 'My issues',
             query: 'assignee = currentUser() AND StatusCategory != Done ORDER BY updated DESC',

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -59,6 +59,8 @@ export class JiraIssueNode extends TreeItem {
             : TreeItemCollapsibleState.None;
         super(issue.key, collapsibleState);
 
+        // this id is constructed to ensure unique values for the same jira issue across multiple jql queries.
+        // therefore, multiple jql entries must have a unique id for the same site.
         this.id = `${issue.key}_${issue.siteDetails.id}_${issue.jqlSource.id}`;
 
         this.description = isMinimalIssue(issue) && issue.isEpic ? issue.epicName : issue.summary;

--- a/testsutil/index.ts
+++ b/testsutil/index.ts
@@ -1,3 +1,3 @@
-import { forceCastTo } from './miscFunctions';
+import { expansionCastTo, forceCastTo } from './miscFunctions';
 
-export { forceCastTo };
+export { expansionCastTo, forceCastTo };

--- a/testsutil/miscFunctions.ts
+++ b/testsutil/miscFunctions.ts
@@ -1,3 +1,16 @@
+/** Expands a partial implementation of T into T. This is just a cast, it doesn't mock extra values.
+ * 
+ * Useful to keep type-checking working while mocking objects.
+ */
+export function expansionCastTo<T>(obj: Partial<T>): T {
+    return obj as T;
+}
+
+/** Forcefully casts anything to whatever you want.
+ * 
+ * Use it at your own risk.
+ */
 export function forceCastTo<T>(obj: any): T {
     return obj as unknown as T;
 }
+


### PR DESCRIPTION
### What Is This Change?

Added UTs for the `jqlManager` and `util` related to JQLEntry creation and their ids.

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change