### PR TITLE
During onboarding, use the words "Sign In" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## What's new in 3.4.22
+
+### Improvements 
+- Changed text in the onboarding flow to "Sign in to ____." Used to be "What version of {product} do you use?"
+
 ## What's new in 3.4.21
 
 ### Bug Fixes

--- a/src/react/atlascode/common/onboarding/JiraBitbucketOnboarding.test.tsx
+++ b/src/react/atlascode/common/onboarding/JiraBitbucketOnboarding.test.tsx
@@ -32,7 +32,7 @@ const MockJiraComponent = ({ callback }: { callback?: () => void }) => {
 describe('JiraBitbucketOnboarding', () => {
     it('should render with correct title', async () => {
         render(<MockJiraComponent />);
-        expect(screen.getByText('What version of Jira do you use?')).toBeTruthy();
+        expect(screen.getByText('Sign in to Jira')).toBeTruthy();
     });
     it('should render with correct radio options', async () => {
         render(<MockJiraComponent />);

--- a/src/react/atlascode/common/onboarding/JiraBitbucketOnboarding.tsx
+++ b/src/react/atlascode/common/onboarding/JiraBitbucketOnboarding.tsx
@@ -71,7 +71,7 @@ export const JiraBitbucketOnboarding: React.FC<Props> = ({
         <Container style={{ justifyContent: 'center' }} maxWidth="xs">
             <Box style={wrapperStyles} flexDirection="column">
                 {product === 'Jira' ? <JiraOnboardingLogo /> : <BitbucketOnboardingLogo />}
-                <Typography variant="h2">What version of {product} do you use?</Typography>
+                <Typography variant="h2">Sign in to {product}</Typography>
                 <Box flexDirection="column" style={radioGroupStyles}>
                     <OnboardingRadio
                         checked={checked}


### PR DESCRIPTION
### What Is This Change?
Only 35-40% of users click on the sign-in button during onboarding. 
One hypothesis is that the text in the onboarding makes users not understand that this is a sign-in screen. Especially when the screen height is small the and the button to sign in is covered up. 
This change is to make the text more clear to the user. 

### How Has This Been Tested?

Manual visual testing

![Screenshot 2025-03-28 at 3 01 27 PM](https://github.com/user-attachments/assets/d7ab7c43-a6de-49a5-ad9e-35b0668c1043)
![Screenshot 2025-03-28 at 3 01 32 PM](https://github.com/user-attachments/assets/98ac6c0a-e6a6-469c-9382-ac0209d562c5)


Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change