### PR TITLE
[AUTHENTICATION] Remove IAT and receivedAt checks for OAuth Cred updates - #245 

### DIFF
--- a/src/atlclients/authStore.ts
+++ b/src/atlclients/authStore.ts
@@ -75,22 +75,6 @@ export class CredentialManager implements Disposable {
 
         const existingInfo = await this.getAuthInfo(site, false);
 
-        if (isOAuthInfo(existingInfo) && isOAuthInfo(info)) {
-            const effectiveExistingIat = existingInfo.iat ?? 0;
-            const effectiveNewIat = info.iat ?? 0;
-            if (effectiveExistingIat > effectiveNewIat) {
-                Logger.debug(`Not replacing credentials because the existing credentials have a later iat.`);
-                return;
-            }
-
-            if (effectiveExistingIat === effectiveNewIat && existingInfo.recievedAt > info.recievedAt) {
-                Logger.debug(
-                    `Not replacing credentials because the existing credentials have were received at a later time (despite having the same iat).`,
-                );
-                return;
-            }
-        }
-
         this._memStore.set(site.product.key, productAuths.set(site.credentialId, info));
 
         const hasNewInfo =


### PR DESCRIPTION
### What Is This Change?
#245 Mentions that a user is struggling to get out of a "bad auth" state. They can go through the flow of authentication, but cannot update their credential due to a log: `Not replacing credentials because the existing credentials have a later iat.`

### How Has This Been Tested?

Manually debugging to confirm that it gets set up correctly. Though to be fair, a lot of this code is blackbox to me. 

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change