### PR TITLE
Cleanup unused onDidJQLChange event

### DIFF
--- a/src/jira/jqlManager.ts
+++ b/src/jira/jqlManager.ts
@@ -1,6 +1,6 @@
 import PQueue from 'p-queue/dist';
 import { v4 } from 'uuid';
-import { ConfigurationChangeEvent, ConfigurationTarget, Disposable, Event, EventEmitter } from 'vscode';
+import { ConfigurationChangeEvent, ConfigurationTarget, Disposable } from 'vscode';
 import { DetailedSiteInfo, ProductJira } from '../atlclients/authInfo';
 import { configuration } from '../config/configuration';
 import { JQLEntry } from '../config/model';
@@ -14,11 +14,6 @@ export type JQLUpdateEvent = {
 export class JQLManager extends Disposable {
     private _disposable: Disposable;
     private _queue = new PQueue({ concurrency: 1 });
-
-    private _onDidJQLChange = new EventEmitter<JQLUpdateEvent>();
-    public get onDidJQLChange(): Event<JQLUpdateEvent> {
-        return this._onDidJQLChange.event;
-    }
 
     // In this PR: https://github.com/atlassian/atlascode/pull/169
     // we have introduced a new field in DetailedSiteInfo that is populated at auth time.
@@ -52,7 +47,6 @@ export class JQLManager extends Disposable {
 
     dispose() {
         this._disposable.dispose();
-        this._onDidJQLChange.dispose();
     }
 
     public async updateFilters() {

--- a/src/views/jira/customJqlRoot.ts
+++ b/src/views/jira/customJqlRoot.ts
@@ -37,7 +37,6 @@ export class CustomJQLRoot extends BaseTreeDataProvider {
 
         this._disposable = Disposable.from(
             Container.siteManager.onDidSitesAvailableChange(this.refresh, this),
-            Container.jqlManager.onDidJQLChange(this.refresh, this),
             commands.registerCommand(Commands.JiraSearchIssues, this.createIssueQuickPick),
         );
 

--- a/src/views/jira/treeViews/customJqlViewProvider.test.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.test.ts
@@ -187,19 +187,6 @@ describe('CustomJqlViewProvider', () => {
         });
     });
 
-    describe('onDidJQLChange', () => {
-        it('onDidJQLChange is registered during construction', async () => {
-            let onDidJQLChangeCallback = undefined;
-            jest.spyOn(Container.jqlManager, 'onDidJQLChange').mockImplementation((func: any, parent: any): any => {
-                onDidJQLChangeCallback = (...args: any[]) => func.apply(parent, args);
-            });
-
-            provider = new CustomJQLViewProvider();
-
-            expect(onDidJQLChangeCallback).toBeDefined();
-        });
-    });
-
     describe('onDidSitesAvailableChange', () => {
         it('onDidSitesAvailableChange is registered during construction', async () => {
             let onDidSitesAvailableChangeCallback = undefined;

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -49,7 +49,6 @@ export class CustomJQLViewProvider extends Disposable implements TreeDataProvide
         treeView.onDidChangeVisibility((e) => this.onDidChangeVisibility(e));
 
         this._disposable = Disposable.from(
-            Container.jqlManager.onDidJQLChange(this.refresh, this),
             Container.siteManager.onDidSitesAvailableChange(this.onSitesDidChange, this),
             new RefreshTimer('jira.explorer.enabled', 'jira.explorer.refreshInterval', () => this.refresh()),
             commands.registerCommand(Commands.RefreshCustomJqlExplorer, this.refresh, this),

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -180,19 +180,6 @@ describe('AssignedWorkItemsViewProvider', () => {
         });
     });
 
-    describe('onDidJQLChange', () => {
-        it('onDidJQLChange is registered during construction', async () => {
-            let onDidJQLChangeCallback = undefined;
-            jest.spyOn(Container.jqlManager, 'onDidJQLChange').mockImplementation((func: any, parent: any): any => {
-                onDidJQLChangeCallback = (...args: any[]) => func.apply(parent, args);
-            });
-
-            provider = new AssignedWorkItemsViewProvider();
-
-            expect(onDidJQLChangeCallback).toBeDefined();
-        });
-    });
-
     describe('onDidSitesAvailableChange', () => {
         it('onDidSitesAvailableChange is registered during construction', async () => {
             let onDidSitesAvailableChangeCallback = undefined;

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -44,7 +44,6 @@ export class AssignedWorkItemsViewProvider extends Disposable implements TreeDat
         treeView.onDidChangeVisibility((e) => this.onDidChangeVisibility(e));
 
         this._disposable = Disposable.from(
-            Container.jqlManager.onDidJQLChange(this.refresh, this),
             Container.siteManager.onDidSitesAvailableChange(this.onSitesDidChange, this),
             new RefreshTimer('jira.explorer.enabled', 'jira.explorer.refreshInterval', () => this.refresh()),
             commands.registerCommand(Commands.RefreshAssignedWorkItemsExplorer, this.refresh, this),


### PR DESCRIPTION
### What Is This Change?

It looks like the event `onDidJQLChange` in jqlManager is never fired, so this is cleaning it up.
Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change