### PR TITLE
No issue/fix status category color fallback

### DIFF
--- a/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
+++ b/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
@@ -100,10 +100,15 @@ export const StatusTransitionMenu: React.FC<Props> = (props) => {
 };
 
 const getDynamicStyles = (colorName: string) => {
-    const { border, bg } = statusCategoryToColorTokenMap[colorName];
+    let fields = { border: '', bg: '' };
+    if (!statusCategoryToColorTokenMap[colorName]) {
+        fields = statusCategoryToColorTokenMap['default'];
+    } else {
+        fields = statusCategoryToColorTokenMap[colorName];
+    }
     return {
-        border: `1px solid ${border}`,
-        background: bg,
+        border: `1px solid ${fields.border}`,
+        background: fields.bg,
     };
 };
 

--- a/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
+++ b/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
@@ -114,4 +114,8 @@ const statusCategoryToColorTokenMap: { [key: string]: { border: string; bg: stri
         border: '#B0BEC5',
         bg: '#B0BEC533',
     },
+    default: {
+        border: '#B0BEC5',
+        bg: '#B0BEC533',
+    },
 };

--- a/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
+++ b/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
@@ -31,7 +31,9 @@ export const StatusTransitionMenu: React.FC<Props> = (props) => {
     const [isHovered, setIsHovered] = React.useState(false);
     const [isOpen, setIsOpen] = React.useState(false);
 
-    const { border, background } = getDynamicStyles(props.currentStatus.statusCategory.colorName);
+    const { border, background } = getDynamicStyles(props.currentStatus.statusCategory.colorName)
+        ? getDynamicStyles(props.currentStatus.statusCategory.colorName)
+        : getDynamicStyles('default');
     const shouldShowTransitionName = props.transitions.some((t) => t.name !== t.to.name);
     return (
         <Box

--- a/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
+++ b/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
@@ -31,9 +31,7 @@ export const StatusTransitionMenu: React.FC<Props> = (props) => {
     const [isHovered, setIsHovered] = React.useState(false);
     const [isOpen, setIsOpen] = React.useState(false);
 
-    const { border, background } = getDynamicStyles(props.currentStatus.statusCategory.colorName)
-        ? getDynamicStyles(props.currentStatus.statusCategory.colorName)
-        : getDynamicStyles('default');
+    const { border, background } = getDynamicStyles(props.currentStatus.statusCategory.colorName);
     const shouldShowTransitionName = props.transitions.some((t) => t.name !== t.to.name);
     return (
         <Box


### PR DESCRIPTION
### What Is This Change?

Fix bug in DC where view issue page crashes when undefined statusCategory colorName

### How Has This Been Tested?

manual testing
Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change