### PR TITLE
Refactor PR Details page components and state

### DIFF
--- a/src/bitbucket/bitbucket-cloud/pullRequests.ts
+++ b/src/bitbucket/bitbucket-cloud/pullRequests.ts
@@ -890,6 +890,7 @@ export class CloudPullRequestApi implements PullRequestApi {
                 state: pr.state!,
                 closeSourceBranch: !!pr.close_source_branch,
                 taskCount: pr.task_count || 0,
+                draft: pr.draft!,
             },
         };
     }

--- a/src/bitbucket/bitbucket-server/pullRequests.ts
+++ b/src/bitbucket/bitbucket-server/pullRequests.ts
@@ -1019,6 +1019,7 @@ export class ServerPullRequestApi implements PullRequestApi {
                 closeSourceBranch: false,
                 taskCount: taskCount,
                 buildStatuses: [],
+                draft: data.draft,
             },
         };
     }

--- a/src/bitbucket/model.ts
+++ b/src/bitbucket/model.ts
@@ -248,12 +248,13 @@ export type PullRequestData = {
     title: string;
     htmlSummary: string;
     rawSummary: string;
-    ts: string;
-    updatedTs: string;
+    ts: string | number;
+    updatedTs: string | number;
     state: 'MERGED' | 'SUPERSEDED' | 'OPEN' | 'DECLINED';
     closeSourceBranch: boolean;
     taskCount: number;
     buildStatuses?: BuildStatus[];
+    draft: boolean;
 };
 
 export interface PullRequest {
@@ -289,6 +290,7 @@ const emptyPullRequestData: PullRequestData = {
     state: 'OPEN',
     closeSourceBranch: false,
     taskCount: 0,
+    draft: false,
 };
 export const emptyPullRequest: PullRequest = {
     site: emptyBitbucketSite,

--- a/src/react/atlascode/pipelines/PipelineSummaryPage.tsx
+++ b/src/react/atlascode/pipelines/PipelineSummaryPage.tsx
@@ -16,7 +16,7 @@ import {
 import AccessTimeIcon from '@material-ui/icons/AccessTime';
 import CalendarTodayIcon from '@material-ui/icons/CalendarToday';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { format, formatDistanceToNow, parseISO } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import React, { useCallback, useMemo } from 'react';
 import { AnalyticsView } from 'src/analyticsTypes';
 
@@ -39,6 +39,7 @@ import NotRunIcon from '../icons/NotRunIcon';
 import PausedIcon from '../icons/PausedIcon';
 import StoppedIcon from '../icons/StoppedIcon';
 import SuccessIcon from '../icons/SuccessIcon';
+import { formatTime } from '../util/date-fns';
 import { PipelineSummaryControllerContext, usePipelineSummaryController } from './pipelineSummaryController';
 
 const failureRed = 'rgb(255, 86, 48)';
@@ -215,19 +216,6 @@ function dateString(completed_on?: string): string {
     }
 
     return format(parseISO(completed_on), 'MMM do yyyy, h:mm:ss aaa');
-}
-
-function formatTime(dateString: string | undefined): string {
-    if (!dateString) {
-        return '';
-    }
-
-    const date = parseISO(dateString);
-
-    if (!date) {
-        return '';
-    }
-    return `${formatDistanceToNow(date)} ago`;
 }
 
 function isPaused(step: PipelineStep) {

--- a/src/react/atlascode/pullrequest/PullRequestDetailsPage.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestDetailsPage.tsx
@@ -1,53 +1,33 @@
-import { InlineTextEditor, RefreshButton } from '@atlassianlabs/guipi-core-components';
+import { InlineTextEditor } from '@atlassianlabs/guipi-core-components';
 import {
-    AppBar,
-    Avatar,
     Box,
     Button,
-    CircularProgress,
     Container,
     Divider,
     Grid,
-    Link,
     makeStyles,
     Paper,
     Theme,
-    Toolbar,
-    Tooltip,
     Typography,
     useMediaQuery,
     useTheme,
 } from '@material-ui/core';
 import AwesomeDebouncePromise from 'awesome-debounce-promise';
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import { AnalyticsView } from 'src/analyticsTypes';
 
-import { ApprovalStatus, User } from '../../../bitbucket/model';
-import { BasicPanel } from '../common/BasicPanel';
-import CommentForm from '../common/CommentForm';
-import { CopyLinkButton } from '../common/CopyLinkButton';
+import { User } from '../../../bitbucket/model';
 import { AtlascodeErrorBoundary } from '../common/ErrorBoundary';
-import { ErrorDisplay } from '../common/ErrorDisplay';
-import { ApproveButton } from './ApproveButton';
-import { formatDate } from './bitbucketDateFormatter';
 import { BranchInfo } from './BranchInfo';
-import { Commits } from './Commits';
-import { DiffList } from './DiffList';
-import { MergeDialog } from './MergeDialog';
-import { NestedCommentList } from './NestedCommentList';
-import { PageTaskList } from './PageTaskList';
-import { PRBuildStatus } from './PRBuildStatus';
 import {
     PullRequestDetailsControllerApi,
     PullRequestDetailsControllerContext,
     PullRequestDetailsState,
     usePullRequestDetailsController,
 } from './pullRequestDetailsController';
-import { RelatedBitbucketIssues } from './RelatedBitbucketIssues';
-import { RelatedJiraIssues } from './RelatedJiraIssues';
-import { RequestChangesButton } from './RequestChangesButton';
-import { Reviewers } from './Reviewers';
-import { SummaryPanel } from './SummaryPanel';
+import { PullRequestHeader } from './PullRequestHeader';
+import { PullRequestMainContent } from './PullRequestMainContent';
+import { PullRequestSidebar } from './PullRequestSideBar';
 
 const useStyles = makeStyles((theme: Theme) => ({
     grow: {
@@ -81,77 +61,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         },
     },
 }));
-
-interface PullRequestHeaderProps {
-    state: PullRequestDetailsState;
-    controller: PullRequestDetailsControllerApi;
-    currentUserApprovalStatus: ApprovalStatus;
-    isSomethingLoading: () => boolean;
-}
-
-const PullRequestHeader: React.FC<PullRequestHeaderProps> = ({
-    state,
-    controller,
-    currentUserApprovalStatus,
-    isSomethingLoading,
-}) => {
-    return (
-        <AppBar position="relative">
-            <Toolbar>
-                <Box flexGrow={1}>
-                    <Typography variant={'h3'}>
-                        <Link color="textPrimary" href={state.pr.data.url}>
-                            {`${state.pr.data.destination!.repo.displayName}: Pull request #${state.pr.data.id}`}
-                        </Link>
-                    </Typography>
-                </Box>
-                <CopyLinkButton
-                    tooltip="Copy link to pull request"
-                    url={state.pr.data.url}
-                    onClick={controller.copyLink}
-                />
-                <Box marginLeft={1} hidden={state.loadState.basicData}>
-                    <RequestChangesButton
-                        hidden={
-                            !state.pr.site.details.isCloud &&
-                            state.currentUser.accountId === state.pr.data.author.accountId
-                        }
-                        status={currentUserApprovalStatus}
-                        onApprove={controller.updateApprovalStatus}
-                    />
-                </Box>
-                <Box marginLeft={1} hidden={state.loadState.basicData}>
-                    <ApproveButton
-                        hidden={
-                            !state.pr.site.details.isCloud &&
-                            state.currentUser.accountId === state.pr.data.author.accountId
-                        }
-                        status={currentUserApprovalStatus}
-                        onApprove={controller.updateApprovalStatus}
-                    />
-                </Box>
-                <Box marginLeft={1} hidden={state.loadState.basicData}>
-                    <MergeDialog
-                        prData={state.pr.data}
-                        commits={state.commits}
-                        relatedJiraIssues={state.relatedJiraIssues}
-                        relatedBitbucketIssues={state.relatedBitbucketIssues}
-                        mergeStrategies={state.mergeStrategies}
-                        loadState={{
-                            basicData: state.loadState.basicData,
-                            commits: state.loadState.commits,
-                            mergeStrategies: state.loadState.mergeStrategies,
-                            relatedJiraIssues: state.loadState.relatedJiraIssues,
-                            relatedBitbucketIssues: state.loadState.relatedBitbucketIssues,
-                        }}
-                        merge={controller.merge}
-                    />
-                </Box>
-                <RefreshButton loading={isSomethingLoading()} onClick={controller.refresh} />
-            </Toolbar>
-        </AppBar>
-    );
-};
 
 interface PullRequestTitleSectionProps {
     state: PullRequestDetailsState;
@@ -203,270 +112,8 @@ const PullRequestTitleSection: React.FC<PullRequestTitleSectionProps> = ({ state
     );
 };
 
-interface PullRequestMainContentProps {
-    state: PullRequestDetailsState;
-    controller: PullRequestDetailsControllerApi;
-    handleFetchUsers: (input: string, abortSignal?: AbortSignal) => Promise<User[]>;
-    taskTitle: () => string;
-}
-
-const PullRequestMainContent: React.FC<PullRequestMainContentProps> = ({
-    state,
-    controller,
-    handleFetchUsers,
-    taskTitle,
-}) => {
-    return (
-        <Box margin={2}>
-            <Grid container spacing={3} direction="column" justify="center">
-                <ErrorDisplay />
-
-                <Grid item>
-                    <SummaryPanel
-                        rawSummary={state.pr.data.rawSummary}
-                        htmlSummary={state.pr.data.htmlSummary}
-                        fetchUsers={handleFetchUsers}
-                        isLoading={state.loadState.basicData}
-                        summaryChange={controller.updateSummary}
-                    />
-                </Grid>
-                {state.relatedJiraIssues.length > 0 && (
-                    <Grid item>
-                        <BasicPanel
-                            title={'Related Jira Issues'}
-                            subtitle={`${state.relatedJiraIssues.length} issues`}
-                            isLoading={state.loadState.relatedJiraIssues}
-                            hidden={state.relatedJiraIssues.length === 0}
-                        >
-                            <RelatedJiraIssues
-                                relatedIssues={state.relatedJiraIssues}
-                                openJiraIssue={controller.openJiraIssue}
-                            />
-                        </BasicPanel>
-                    </Grid>
-                )}
-                {state.relatedBitbucketIssues.length > 0 && (
-                    <Grid item>
-                        <BasicPanel
-                            title={'Related Bitbucket Issues'}
-                            subtitle={`${state.relatedBitbucketIssues.length} issues`}
-                            isLoading={state.loadState.relatedBitbucketIssues}
-                            hidden={state.relatedBitbucketIssues.length === 0}
-                        >
-                            <RelatedBitbucketIssues
-                                relatedIssues={state.relatedBitbucketIssues}
-                                openBitbucketIssue={controller.openBitbucketIssue}
-                            />
-                        </BasicPanel>
-                    </Grid>
-                )}
-                <Grid item>
-                    <BasicPanel
-                        title={'Commits'}
-                        subtitle={`${state.commits.length} commits`}
-                        isDefaultExpanded
-                        isLoading={state.loadState.commits}
-                    >
-                        <Commits commits={state.commits} />
-                    </BasicPanel>
-                </Grid>
-                <Grid item>
-                    <BasicPanel
-                        title={'Files Changed'}
-                        subtitle={'Click on file names to open diff in editor'}
-                        isDefaultExpanded
-                        isLoading={state.loadState.diffs}
-                    >
-                        <DiffList
-                            fileDiffs={state.fileDiffs}
-                            openDiffHandler={controller.openDiff}
-                            conflictedFiles={state.conflictedFiles}
-                        />
-                    </BasicPanel>
-                </Grid>
-                <Grid item>
-                    <BasicPanel title={'Comments'} isDefaultExpanded isLoading={state.loadState.comments}>
-                        <Grid container spacing={2} direction="column">
-                            <Grid item>
-                                <NestedCommentList
-                                    comments={state.comments}
-                                    currentUser={state.currentUser}
-                                    fetchUsers={handleFetchUsers}
-                                    onDelete={controller.deleteComment}
-                                />
-                            </Grid>
-                            <Grid item>
-                                <CommentForm
-                                    currentUser={state.currentUser}
-                                    fetchUsers={handleFetchUsers}
-                                    onSave={controller.postComment}
-                                />
-                            </Grid>
-                        </Grid>
-                    </BasicPanel>
-                </Grid>
-            </Grid>
-        </Box>
-    );
-};
-
-interface PullRequestSidebarProps {
-    state: PullRequestDetailsState;
-    controller: PullRequestDetailsControllerApi;
-    taskTitle: () => string;
-}
-
-const PullRequestSidebar: React.FC<PullRequestSidebarProps> = ({ state, controller, taskTitle }) => {
-    return (
-        <Box margin={2}>
-            <Grid container spacing={1} direction={'column'}>
-                <Grid item>
-                    <Typography variant="h6">
-                        <strong>Author</strong>
-                    </Typography>
-                    <Box hidden={state.loadState.basicData}>
-                        <Grid container spacing={1} direction="row" alignItems="center">
-                            <Grid item>
-                                {' '}
-                                <Tooltip title={state.pr.data.author.displayName}>
-                                    <Avatar
-                                        alt={state.pr.data.author.displayName}
-                                        src={state.pr.data.author.avatarUrl}
-                                    />
-                                </Tooltip>
-                            </Grid>
-
-                            <Grid item>
-                                <Typography>{state.pr.data.author.displayName}</Typography>
-                            </Grid>
-                        </Grid>
-                    </Box>
-                    <Box hidden={!state.loadState.basicData}>
-                        <CircularProgress />
-                    </Box>
-                </Grid>
-
-                <Grid item>
-                    <Typography variant="h6">
-                        <strong>Reviewers</strong>
-                    </Typography>
-                    <Box marginLeft={2} marginTop={1}>
-                        <Reviewers
-                            site={state.pr.site}
-                            participants={state.pr.data.participants}
-                            onUpdateReviewers={controller.updateReviewers}
-                            isLoading={state.loadState.basicData}
-                        />
-                    </Box>
-                </Grid>
-
-                <Grid item>
-                    <Typography variant="h6">
-                        <strong>Created</strong>
-                    </Typography>
-                    <Tooltip title={state.pr.data.ts || 'unknown'}>
-                        <Typography>{formatDate(state.pr.data.ts)}</Typography>
-                    </Tooltip>
-                </Grid>
-
-                <Grid item>
-                    <Typography variant="h6">
-                        <strong>Updated</strong>
-                    </Typography>
-                    <Tooltip title={state.pr.data.updatedTs || 'unknown'}>
-                        <Typography>{formatDate(state.pr.data.updatedTs)}</Typography>
-                    </Tooltip>
-                </Grid>
-
-                <Grid item>
-                    <Typography variant="h6">
-                        <strong>Created</strong>
-                    </Typography>
-                    <Tooltip title={state.pr.data.ts || 'unknown'}>
-                        <Typography>{formatDate(state.pr.data.ts)}</Typography>
-                    </Tooltip>
-                </Grid>
-
-                <Grid item>
-                    <Typography variant="h6">
-                        <strong>Updated</strong>
-                    </Typography>
-                    <Tooltip title={state.pr.data.updatedTs || 'unknown'}>
-                        <Typography>{formatDate(state.pr.data.updatedTs)}</Typography>
-                    </Tooltip>
-                </Grid>
-
-                <Grid item>
-                    <BasicPanel
-                        isLoading={state.loadState.buildStatuses}
-                        isDefaultExpanded
-                        hidden={state.buildStatuses.length === 0}
-                        title={`${
-                            state.buildStatuses.filter((status) => status.state === 'SUCCESSFUL').length
-                        } of ${state.buildStatuses.length} build${state.buildStatuses.length > 0 ? 's' : ''} passed`}
-                    >
-                        <PRBuildStatus
-                            buildStatuses={state.buildStatuses}
-                            openBuildStatus={controller.openBuildStatus}
-                        />
-                    </BasicPanel>
-                </Grid>
-
-                <Grid item>
-                    <BasicPanel
-                        title={'Tasks'}
-                        subtitle={taskTitle()}
-                        isDefaultExpanded
-                        isLoading={state.loadState.tasks}
-                    >
-                        <PageTaskList
-                            tasks={state.tasks}
-                            onEdit={controller.editTask}
-                            onDelete={controller.deleteTask}
-                        />
-                    </BasicPanel>
-                </Grid>
-            </Grid>
-        </Box>
-    );
-};
-
 export const PullRequestDetailsPage: React.FunctionComponent = () => {
-    const classes = useStyles();
-    const theme = useTheme();
     const [state, controller] = usePullRequestDetailsController();
-    const [currentUserApprovalStatus, setCurrentUserApprovalStatus] = useState<ApprovalStatus>('UNAPPROVED');
-
-    const handleFetchUsers = AwesomeDebouncePromise(
-        async (input: string, abortSignal?: AbortSignal): Promise<User[]> => {
-            return await controller.fetchUsers(state.pr.site, input, abortSignal);
-        },
-        300,
-        { leading: false },
-    );
-
-    const isSomethingLoading = useCallback(() => {
-        return Object.entries(state.loadState).some(
-            (entry) => entry[1] /* Second index is the value in the key/value pair */,
-        );
-    }, [state.loadState]);
-
-    const taskTitle = useCallback(() => {
-        const numTasks = state.tasks.length;
-        const numCompletedTasks = state.tasks.filter((task) => task.isComplete).length;
-        return numTasks === 0 ? '0 tasks' : `${numCompletedTasks} of ${numTasks} complete`;
-    }, [state.tasks]);
-
-    useEffect(() => {
-        const foundCurrentUser = state.pr.data.participants.find(
-            (participant) => participant.accountId === state.currentUser.accountId,
-        );
-        if (foundCurrentUser) {
-            setCurrentUserApprovalStatus(foundCurrentUser.status);
-        }
-    }, [state.pr.data.participants, state.currentUser.accountId]);
-
-    const isWideScreen = useMediaQuery(theme.breakpoints.up('md'));
 
     return (
         <PullRequestDetailsControllerContext.Provider value={controller}>
@@ -475,43 +122,58 @@ export const PullRequestDetailsPage: React.FunctionComponent = () => {
                 postMessageFunc={controller.postMessage}
             >
                 <Container maxWidth="xl">
-                    <PullRequestHeader
-                        state={state}
-                        controller={controller}
-                        currentUserApprovalStatus={currentUserApprovalStatus}
-                        isSomethingLoading={isSomethingLoading}
-                    />
-                    <Divider />
-                    <Box marginTop={1} />
-                    <Grid container spacing={1} direction="row">
-                        <Grid item xs={12} md={9} lg={9} xl={9}>
-                            <Paper className={classes.paper100}>
-                                <PullRequestTitleSection state={state} controller={controller} />
-                                <PullRequestMainContent
-                                    state={state}
-                                    controller={controller}
-                                    handleFetchUsers={handleFetchUsers}
-                                    taskTitle={taskTitle}
-                                />
-                            </Paper>
-                        </Grid>
-                        <Grid
-                            item
-                            xs={12}
-                            md={3}
-                            lg={3}
-                            xl={3}
-                            style={{ borderLeft: isWideScreen ? '1px solid var(--vscode-input-border)' : 'none' }}
-                        >
-                            <Paper className={classes.paperOverflow}>
-                                <PullRequestSidebar state={state} controller={controller} taskTitle={taskTitle} />
-                            </Paper>
-                        </Grid>
-                    </Grid>
+                    <PullRequestDetailsPageContent state={state} controller={controller} />
                 </Container>
             </AtlascodeErrorBoundary>
         </PullRequestDetailsControllerContext.Provider>
     );
 };
 
+interface PullRequestDetailsPageContentProps {
+    state: PullRequestDetailsState;
+    controller: PullRequestDetailsControllerApi;
+}
+function PullRequestDetailsPageContent({ state, controller }: PullRequestDetailsPageContentProps) {
+    const classes = useStyles();
+    const theme = useTheme();
+    const isWideScreen = useMediaQuery(theme.breakpoints.up('md'));
+    const handleFetchUsers = AwesomeDebouncePromise(
+        async (input: string, abortSignal?: AbortSignal): Promise<User[]> => {
+            return await controller.fetchUsers(state.pr.site, input, abortSignal);
+        },
+        300,
+        { leading: false },
+    );
+    return (
+        <>
+            <PullRequestHeader state={state} controller={controller} />
+            <Divider />
+            <Box marginTop={1} />
+            <Grid container spacing={1} direction="row">
+                <Grid item xs={12} md={9} lg={9} xl={9}>
+                    <Paper className={classes.paper100}>
+                        <PullRequestTitleSection state={state} controller={controller} />
+                        <PullRequestMainContent
+                            state={state}
+                            controller={controller}
+                            handleFetchUsers={handleFetchUsers}
+                        />
+                    </Paper>
+                </Grid>
+                <Grid
+                    item
+                    xs={12}
+                    md={3}
+                    lg={3}
+                    xl={3}
+                    style={{ borderLeft: isWideScreen ? '1px solid var(--vscode-input-border)' : 'none' }}
+                >
+                    <Paper className={classes.paperOverflow}>
+                        <PullRequestSidebar state={state} controller={controller} />
+                    </Paper>
+                </Grid>
+            </Grid>
+        </>
+    );
+}
 export default PullRequestDetailsPage;

--- a/src/react/atlascode/pullrequest/PullRequestHeader.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestHeader.tsx
@@ -1,0 +1,27 @@
+import { AppBar, Box, Link, Toolbar, Typography } from '@material-ui/core';
+import React from 'react';
+
+import { PullRequestDetailsControllerApi, PullRequestDetailsState } from './pullRequestDetailsController';
+import { PullRequestHeaderActions } from './PullRequestHeaderActions';
+
+interface PullRequestHeaderProps {
+    state: PullRequestDetailsState;
+    controller: PullRequestDetailsControllerApi;
+}
+
+export const PullRequestHeader: React.FC<PullRequestHeaderProps> = ({ state, controller }) => {
+    return (
+        <AppBar position="relative">
+            <Toolbar>
+                <Box flexGrow={1}>
+                    <Typography variant={'h3'}>
+                        <Link color="textPrimary" href={state.pr.data.url}>
+                            {`${state.pr.data.destination!.repo.displayName}: Pull request #${state.pr.data.id}`}
+                        </Link>
+                    </Typography>
+                </Box>
+                <PullRequestHeaderActions state={state} controller={controller} />
+            </Toolbar>
+        </AppBar>
+    );
+};

--- a/src/react/atlascode/pullrequest/PullRequestHeaderActions.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestHeaderActions.tsx
@@ -1,0 +1,77 @@
+import { RefreshButton } from '@atlassianlabs/guipi-core-components';
+import { Box } from '@material-ui/core';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { ApprovalStatus } from '../../../bitbucket/model';
+import { CopyLinkButton } from '../common/CopyLinkButton';
+import { ApproveButton } from './ApproveButton';
+import { MergeDialog } from './MergeDialog';
+import { PullRequestDetailsControllerApi } from './pullRequestDetailsController';
+import { PullRequestDetailsState } from './pullRequestDetailsController';
+import { RequestChangesButton } from './RequestChangesButton';
+
+export interface PullRequestHeaderActionsProps {
+    state: PullRequestDetailsState;
+    controller: PullRequestDetailsControllerApi;
+}
+
+export const PullRequestHeaderActions: React.FC<PullRequestHeaderActionsProps> = ({ state, controller }) => {
+    const [currentUserApprovalStatus, setCurrentUserApprovalStatus] = useState<ApprovalStatus>('UNAPPROVED');
+
+    useEffect(() => {
+        const foundCurrentUser = state.pr.data.participants.find(
+            (participant) => participant.accountId === state.currentUser.accountId,
+        );
+        if (foundCurrentUser) {
+            setCurrentUserApprovalStatus(foundCurrentUser.status);
+        }
+    }, [state.pr.data.participants, state.currentUser.accountId]);
+
+    const isSomethingLoading = useMemo(() => {
+        return Object.entries(state.loadState).some(
+            (entry) => entry[1] /* Second index is the value in the key/value pair */,
+        );
+    }, [state.loadState]);
+
+    return (
+        <>
+            <CopyLinkButton tooltip="Copy link to pull request" url={state.pr.data.url} onClick={controller.copyLink} />
+            <Box marginLeft={1} hidden={state.loadState.basicData}>
+                <RequestChangesButton
+                    hidden={
+                        !state.pr.site.details.isCloud && state.currentUser.accountId === state.pr.data.author.accountId
+                    }
+                    status={currentUserApprovalStatus}
+                    onApprove={controller.updateApprovalStatus}
+                />
+            </Box>
+            <Box marginLeft={1} hidden={state.loadState.basicData}>
+                <ApproveButton
+                    hidden={
+                        !state.pr.site.details.isCloud && state.currentUser.accountId === state.pr.data.author.accountId
+                    }
+                    status={currentUserApprovalStatus}
+                    onApprove={controller.updateApprovalStatus}
+                />
+            </Box>
+            <Box marginLeft={1} hidden={state.loadState.basicData}>
+                <MergeDialog
+                    prData={state.pr.data}
+                    commits={state.commits}
+                    relatedJiraIssues={state.relatedJiraIssues}
+                    relatedBitbucketIssues={state.relatedBitbucketIssues}
+                    mergeStrategies={state.mergeStrategies}
+                    loadState={{
+                        basicData: state.loadState.basicData,
+                        commits: state.loadState.commits,
+                        mergeStrategies: state.loadState.mergeStrategies,
+                        relatedJiraIssues: state.loadState.relatedJiraIssues,
+                        relatedBitbucketIssues: state.loadState.relatedBitbucketIssues,
+                    }}
+                    merge={controller.merge}
+                />
+            </Box>
+            <RefreshButton loading={isSomethingLoading} onClick={controller.refresh} />
+        </>
+    );
+};

--- a/src/react/atlascode/pullrequest/PullRequestMainContent.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestMainContent.tsx
@@ -1,0 +1,119 @@
+import { Box, Grid } from '@material-ui/core';
+import React from 'react';
+
+import { User } from '../../../bitbucket/model';
+import { BasicPanel } from '../common/BasicPanel';
+import CommentForm from '../common/CommentForm';
+import { ErrorDisplay } from '../common/ErrorDisplay';
+import { Commits } from './Commits';
+import { DiffList } from './DiffList';
+import { NestedCommentList } from './NestedCommentList';
+import { PullRequestDetailsControllerApi, PullRequestDetailsState } from './pullRequestDetailsController';
+import { RelatedBitbucketIssues } from './RelatedBitbucketIssues';
+import { RelatedJiraIssues } from './RelatedJiraIssues';
+import { SummaryPanel } from './SummaryPanel';
+
+interface PullRequestMainContentProps {
+    state: PullRequestDetailsState;
+    controller: PullRequestDetailsControllerApi;
+    handleFetchUsers: (input: string, abortSignal?: AbortSignal) => Promise<User[]>;
+}
+
+export const PullRequestMainContent: React.FC<PullRequestMainContentProps> = ({
+    state,
+    controller,
+    handleFetchUsers,
+}) => {
+    return (
+        <Box margin={2}>
+            <Grid container spacing={3} direction="column" justify="center">
+                <ErrorDisplay />
+
+                <Grid item>
+                    <SummaryPanel
+                        rawSummary={state.pr.data.rawSummary}
+                        htmlSummary={state.pr.data.htmlSummary}
+                        fetchUsers={handleFetchUsers}
+                        isLoading={state.loadState.basicData}
+                        summaryChange={controller.updateSummary}
+                    />
+                </Grid>
+                {state.relatedJiraIssues.length > 0 && (
+                    <Grid item>
+                        <BasicPanel
+                            title={'Related Jira Issues'}
+                            subtitle={`${state.relatedJiraIssues.length} issues`}
+                            isLoading={state.loadState.relatedJiraIssues}
+                            hidden={state.relatedJiraIssues.length === 0}
+                        >
+                            <RelatedJiraIssues
+                                relatedIssues={state.relatedJiraIssues}
+                                openJiraIssue={controller.openJiraIssue}
+                            />
+                        </BasicPanel>
+                    </Grid>
+                )}
+                {state.relatedBitbucketIssues.length > 0 && (
+                    <Grid item>
+                        <BasicPanel
+                            title={'Related Bitbucket Issues'}
+                            subtitle={`${state.relatedBitbucketIssues.length} issues`}
+                            isLoading={state.loadState.relatedBitbucketIssues}
+                            hidden={state.relatedBitbucketIssues.length === 0}
+                        >
+                            <RelatedBitbucketIssues
+                                relatedIssues={state.relatedBitbucketIssues}
+                                openBitbucketIssue={controller.openBitbucketIssue}
+                            />
+                        </BasicPanel>
+                    </Grid>
+                )}
+                <Grid item>
+                    <BasicPanel
+                        title={'Commits'}
+                        subtitle={`${state.commits.length} commits`}
+                        isDefaultExpanded
+                        isLoading={state.loadState.commits}
+                    >
+                        <Commits commits={state.commits} />
+                    </BasicPanel>
+                </Grid>
+                <Grid item>
+                    <BasicPanel
+                        title={'Files Changed'}
+                        subtitle={'Click on file names to open diff in editor'}
+                        isDefaultExpanded
+                        isLoading={state.loadState.diffs}
+                    >
+                        <DiffList
+                            fileDiffs={state.fileDiffs}
+                            openDiffHandler={controller.openDiff}
+                            conflictedFiles={state.conflictedFiles}
+                        />
+                    </BasicPanel>
+                </Grid>
+                <Grid item>
+                    <BasicPanel title={'Comments'} isDefaultExpanded isLoading={state.loadState.comments}>
+                        <Grid container spacing={2} direction="column">
+                            <Grid item>
+                                <NestedCommentList
+                                    comments={state.comments}
+                                    currentUser={state.currentUser}
+                                    fetchUsers={handleFetchUsers}
+                                    onDelete={controller.deleteComment}
+                                />
+                            </Grid>
+                            <Grid item>
+                                <CommentForm
+                                    currentUser={state.currentUser}
+                                    fetchUsers={handleFetchUsers}
+                                    onSave={controller.postComment}
+                                />
+                            </Grid>
+                        </Grid>
+                    </BasicPanel>
+                </Grid>
+            </Grid>
+        </Box>
+    );
+};

--- a/src/react/atlascode/pullrequest/PullRequestSideBar.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestSideBar.tsx
@@ -1,0 +1,118 @@
+import { Avatar, Box, CircularProgress, Grid, Tooltip, Typography } from '@material-ui/core';
+import React, { useMemo } from 'react';
+
+import { BasicPanel } from '../common/BasicPanel';
+import { formatDate } from './bitbucketDateFormatter';
+import { PageTaskList } from './PageTaskList';
+import { PRBuildStatus } from './PRBuildStatus';
+import { PullRequestDetailsControllerApi, PullRequestDetailsState } from './pullRequestDetailsController';
+import { Reviewers } from './Reviewers';
+
+interface PullRequestSidebarProps {
+    state: PullRequestDetailsState;
+    controller: PullRequestDetailsControllerApi;
+}
+
+export const PullRequestSidebar: React.FC<PullRequestSidebarProps> = ({ state, controller }) => {
+    const taskTitle = useMemo(() => {
+        const numTasks = state.tasks.length;
+        const numCompletedTasks = state.tasks.filter((task) => task.isComplete).length;
+        return numTasks === 0 ? '0 tasks' : `${numCompletedTasks} of ${numTasks} complete`;
+    }, [state.tasks]);
+
+    return (
+        <Box margin={2}>
+            <Grid container spacing={1} direction={'column'}>
+                <Grid item>
+                    <Typography variant="h6">
+                        <strong>Author</strong>
+                    </Typography>
+                    <Box hidden={state.loadState.basicData}>
+                        <Grid container spacing={1} direction="row" alignItems="center">
+                            <Grid item>
+                                {' '}
+                                <Tooltip title={state.pr.data.author.displayName}>
+                                    <Avatar
+                                        alt={state.pr.data.author.displayName}
+                                        src={state.pr.data.author.avatarUrl}
+                                    />
+                                </Tooltip>
+                            </Grid>
+
+                            <Grid item>
+                                <Typography>{state.pr.data.author.displayName}</Typography>
+                            </Grid>
+                        </Grid>
+                    </Box>
+                    <Box hidden={!state.loadState.basicData}>
+                        <CircularProgress />
+                    </Box>
+                </Grid>
+                <Grid item>
+                    <BasicPanel
+                        isLoading={state.loadState.basicData}
+                        isDefaultExpanded
+                        hidden={false}
+                        title={`Reviewers`}
+                    >
+                        <Reviewers
+                            site={state.pr.site}
+                            participants={state.pr.data.participants}
+                            onUpdateReviewers={controller.updateReviewers}
+                            isLoading={state.loadState.basicData}
+                        />
+                    </BasicPanel>
+                </Grid>
+
+                <Grid item>
+                    <Typography variant="h6">
+                        <strong>Created</strong>
+                    </Typography>
+                    <Tooltip title={state.pr.data.ts || 'unknown'}>
+                        <Typography>{formatDate(state.pr.data.ts)}</Typography>
+                    </Tooltip>
+                </Grid>
+
+                <Grid item>
+                    <Typography variant="h6">
+                        <strong>Updated</strong>
+                    </Typography>
+                    <Tooltip title={state.pr.data.updatedTs || 'unknown'}>
+                        <Typography>{formatDate(state.pr.data.updatedTs)}</Typography>
+                    </Tooltip>
+                </Grid>
+
+                <Grid item>
+                    <BasicPanel
+                        isLoading={state.loadState.buildStatuses}
+                        isDefaultExpanded
+                        hidden={state.buildStatuses.length === 0}
+                        title={`${
+                            state.buildStatuses.filter((status) => status.state === 'SUCCESSFUL').length
+                        } of ${state.buildStatuses.length} build${state.buildStatuses.length > 0 ? 's' : ''} passed`}
+                    >
+                        <PRBuildStatus
+                            buildStatuses={state.buildStatuses}
+                            openBuildStatus={controller.openBuildStatus}
+                        />
+                    </BasicPanel>
+                </Grid>
+
+                <Grid item>
+                    <BasicPanel
+                        title={'Tasks'}
+                        subtitle={taskTitle}
+                        isDefaultExpanded
+                        isLoading={state.loadState.tasks}
+                    >
+                        <PageTaskList
+                            tasks={state.tasks}
+                            onEdit={controller.editTask}
+                            onDelete={controller.deleteTask}
+                        />
+                    </BasicPanel>
+                </Grid>
+            </Grid>
+        </Box>
+    );
+};


### PR DESCRIPTION
### What Is This Change?

This PR moves around the components so that not everything is within the PR Details page:

1. It creates new child component files.
2. Moves derived state into the child files instead of creating and passing everything from the top of the page.
3. Adds a new boolean variable in the PR model `draft`: which is not used anywhere yet.

This PR acts as an intermediary PR to avoid big monolith PRs.

### How Has This Been Tested?

- [x] Loom was created earlier but not for this rebased PR. Yet to create.

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change