### PR TITLE
Remove the p-any package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,6 @@
                 "merge-anything": "^3.0.3",
                 "mustache": "^4.0.1",
                 "node-ipc": "^9.2.1",
-                "p-any": "^2.1.0",
                 "p-cancelable": "^2.0.0",
                 "p-queue": "^6.3.0",
                 "p-retry": "^4.2.0",
@@ -11038,6 +11037,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
             "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "clean-stack": "^2.0.0",
@@ -12931,6 +12931,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -19312,6 +19313,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -24969,20 +24971,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/p-any": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-any/-/p-any-2.1.0.tgz",
-            "integrity": "sha512-JAERcaMBLYKMq+voYw36+x5Dgh47+/o7yuv2oQYuSSUml4YeqJEFznBrY2UeEkoSHqBua6hz518n/PsowTYLLg==",
-            "license": "MIT",
-            "dependencies": {
-                "p-cancelable": "^2.0.0",
-                "p-some": "^4.0.0",
-                "type-fest": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/p-cancelable": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
@@ -25083,19 +25071,6 @@
             "dependencies": {
                 "p-limit": "^2.2.0",
                 "p-reflect": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/p-some": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-some/-/p-some-4.1.0.tgz",
-            "integrity": "sha512-MF/HIbq6GeBqTrTIl5OJubzkGU+qfFhAFi0gnTAK6rgEIJIknEiABHOTtQu4e6JiXjIwuMPMUFQzyHh5QjCl1g==",
-            "license": "MIT",
-            "dependencies": {
-                "aggregate-error": "^3.0.0",
-                "p-cancelable": "^2.0.0"
             },
             "engines": {
                 "node": ">=8"
@@ -30092,15 +30067,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-            "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -1534,7 +1534,6 @@
         "merge-anything": "^3.0.3",
         "mustache": "^4.0.1",
         "node-ipc": "^9.2.1",
-        "p-any": "^2.1.0",
         "p-cancelable": "^2.0.0",
         "p-queue": "^6.3.0",
         "p-retry": "^4.2.0",

--- a/src/jira/issueForKey.ts
+++ b/src/jira/issueForKey.ts
@@ -1,5 +1,4 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
-import pAny from 'p-any';
 import pTimeout from 'p-timeout';
 
 import { DetailedSiteInfo, ProductJira } from '../atlclients/authInfo';
@@ -17,7 +16,7 @@ export async function issueForKey(issueKey: string): Promise<MinimalIssue<Detail
             })(),
         );
     });
-    const promise = pAny(emptyPromises);
+    const promise = Promise.any(emptyPromises);
 
     const foundSite = await pTimeout(promise, 1 * Time.MINUTES).catch(() => undefined);
     return foundSite ? foundSite : Promise.reject(`no issue found with key ${issueKey}`);

--- a/src/util/online.ts
+++ b/src/util/online.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosInstance } from 'axios';
-import pAny from 'p-any';
 import pRetry from 'p-retry';
 import { ConfigurationChangeEvent, Disposable, Event, EventEmitter } from 'vscode';
 
@@ -80,7 +79,7 @@ export class OnlineDetector extends Disposable {
     private async runOnlineChecks(): Promise<boolean> {
         const urlList = Container.config.onlineCheckerUrls.slice();
         const promise = async () =>
-            await pAny(
+            await Promise.any(
                 urlList.map((url) => {
                     return (async () => {
                         Logger.debug(`Online check attempting to connect to ${url}`);

--- a/src/views/gitContentProvider.ts
+++ b/src/views/gitContentProvider.ts
@@ -1,4 +1,3 @@
-import pAny from 'p-any';
 import pathlib from 'path';
 import vscode from 'vscode';
 
@@ -30,7 +29,7 @@ export class GitContentProvider implements vscode.TextDocumentContentProvider {
             //Attempt to get the file content locally with a source-control manager and also try to fetch from Bitbucket
             //pAny returns the first successful result, so it will return the local one if you have this commit on your computer,
             //otherwise it will get it from the Bitbucket API (which takes longer)
-            content = await pAny([
+            content = await Promise.any([
                 (async () => {
                     const u: vscode.Uri = vscode.Uri.parse(repoUri);
                     const wsRepo = this.bbContext.getRepository(u);


### PR DESCRIPTION
### What Is This Change?

The [p-any package](https://www.npmjs.com/package/p-any) was used to retrieve the first promise that resolves from an array of promises.
We don't need a package for that, the native [Promise.any](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any) does exactly that.