### PR TITLE
AXON-319: add option to explicitly fire exposure event

### DIFF
--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -136,7 +136,7 @@ export abstract class FeatureFlagClient {
         let gateValue = false;
         if (FeatureGates.initializeCompleted()) {
             // FeatureGates.checkGate returns false if any errors
-            gateValue = FeatureGates.checkGate(gate);
+            gateValue = FeatureGates.checkGate(gate, { fireGateExposure: true });
         }
 
         Logger.debug(`FeatureGates ${gate} -> ${gateValue}`);
@@ -160,6 +160,7 @@ export abstract class FeatureFlagClient {
                 experiment,
                 experimentGate.parameter,
                 experimentGate.defaultValue,
+                { fireExperimentExposure: true },
             );
         }
 
@@ -179,7 +180,7 @@ export abstract class FeatureFlagClient {
         let gateValue = false;
         if (FeatureGates.initializeCompleted()) {
             // FeatureGates.checkGate returns false if any errors
-            gateValue = FeatureGates.checkGate(gate);
+            gateValue = FeatureGates.checkGate(gate, { fireGateExposure: true });
             featureGateExposureBoolEvent(gate, true, gateValue, 0).then((e) => {
                 this.analyticsClient.sendTrackEvent(e);
             });
@@ -217,6 +218,7 @@ export abstract class FeatureFlagClient {
                 experiment,
                 experimentGate.parameter,
                 experimentGate.defaultValue,
+                { fireExperimentExposure: true },
             );
 
             if (gateValue === experimentGate.defaultValue) {

--- a/src/util/featureFlags/client.ts
+++ b/src/util/featureFlags/client.ts
@@ -7,7 +7,6 @@ import {
 } from '../../analytics';
 import { AnalyticsClient } from '../../analytics-node-client/src/client.min';
 import { Logger } from '../../logger';
-import { AnalyticsClientMapper } from './analytics';
 import { ExperimentGates, ExperimentGateValues, Experiments, FeatureGateValues, Features } from './features';
 
 export type FeatureFlagClientOptions = {
@@ -52,8 +51,6 @@ export abstract class FeatureFlagClient {
 
         Logger.debug(`FeatureGates: initializing, target: ${targetApp}, environment: ${environment}`);
 
-        const analyticsClientMapper = new AnalyticsClientMapper(options.analyticsClient, options.identifiers);
-
         try {
             await FeatureGates.initialize(
                 {
@@ -61,7 +58,6 @@ export abstract class FeatureFlagClient {
                     environment,
                     targetApp,
                     fetchTimeoutMs: Number.parseInt(timeout),
-                    analyticsWebClient: Promise.resolve(analyticsClientMapper),
                 },
                 options.identifiers,
             );


### PR DESCRIPTION
### What Is This Change?
Problem: Our Statsig client is unable to send exposure events to Statsig even though we are connected

Possible solution:

Add option to explicitly fire exposure/check event through Statsig client. Safe to do so in this context as there is no possibility of false exposure for AA exp

### How Has This Been Tested?

Unfortunately, Statsig does not get our staging events/exposures so need to release to production to see impact.

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change