### PR TITLE
chore: make file diffs appear clickable

### DIFF
--- a/src/react/atlascode/pullrequest/DiffList.tsx
+++ b/src/react/atlascode/pullrequest/DiffList.tsx
@@ -159,7 +159,7 @@ export const DiffList: React.FunctionComponent<{
                                 {ConflictChip(row, props.conflictedFiles)}
                             </TableCell>
                             <TableCell className={classes.tableCell}>
-                                <Link onClick={() => props.openDiffHandler(row)}>
+                                <Link component="button" onClick={() => props.openDiffHandler(row)}>
                                     <Typography>{row.file}</Typography>
                                 </Link>
                             </TableCell>


### PR DESCRIPTION
Very small change which changes the cursor from `Edit` to `pointer`.

I used component = button instead of changing the style because, we were using `onClick` and it was more semantical approach to use button instead of a plain link.

## From This
![IMG_5074](https://github.com/user-attachments/assets/16e17616-117e-4279-95d0-e242cceaf998)

## To this ( check the cursor )
![IMG_5073](https://github.com/user-attachments/assets/ea8e5d46-2bc3-49a4-98ac-e73814bc045f)
