### PR TITLE
AXON-327: fix pull requests field in issue view sidebar

### DIFF
--- a/src/webviews/components/issue/PullRequests.tsx
+++ b/src/webviews/components/issue/PullRequests.tsx
@@ -1,6 +1,7 @@
-import Avatar from '@atlaskit/avatar';
+// import Avatar from '@atlaskit/avatar';
 import Button from '@atlaskit/button';
 import Lozenge from '@atlaskit/lozenge';
+import Tooltip from '@atlaskit/tooltip';
 import React from 'react';
 
 import { PullRequestData } from '../../../bitbucket/model';
@@ -12,14 +13,6 @@ export default class PullRequests extends React.Component<
     },
     {}
 > {
-    private avatar(pr: PullRequestData): any {
-        const url = pr.author.avatarUrl;
-        if (url) {
-            return <Avatar src={url} size="small" />;
-        }
-        return <div />;
-    }
-
     private prState(pr: any): any {
         switch (pr.state) {
             case 'MERGED':
@@ -37,14 +30,19 @@ export default class PullRequests extends React.Component<
 
     render() {
         return this.props.pullRequests.map((pr: PullRequestData) => {
+            const title = `${pr.destination!.repo!.displayName} - Pull request #${pr.id}`;
             return (
-                <div key={pr.url} style={{ display: 'flex', alignItems: 'center' }}>
-                    {this.avatar(pr)}
-                    <Button appearance="link" onClick={() => this.props.onClick(pr)}>{`${
-                        pr.destination!.repo!.displayName
-                    } - Pull request #${pr.id}`}</Button>
-                    {this.prState(pr)}
-                </div>
+                <Tooltip content={`${pr.author.displayName}: ${title}`}>
+                    <div key={pr.url} style={{ display: 'flex', alignItems: 'center' }}>
+                        {/* {this.avatar(pr)} */}
+                        <div style={{ maxLines: 1, textOverflow: 'ellipsis', overflow: 'auto' }}>
+                            <Button appearance="link" onClick={() => this.props.onClick(pr)}>
+                                {title}
+                            </Button>
+                        </div>
+                        <div style={{ overflow: 'visible' }}>{this.prState(pr)}</div>
+                    </div>
+                </Tooltip>
             );
         });
     }

--- a/src/webviews/components/issue/PullRequests.tsx
+++ b/src/webviews/components/issue/PullRequests.tsx
@@ -33,7 +33,6 @@ export default class PullRequests extends React.Component<
             return (
                 <Tooltip content={`${pr.author.displayName}: ${title}`}>
                     <div key={pr.url} style={{ display: 'flex', alignItems: 'center' }}>
-                        {/* {this.avatar(pr)} */}
                         <div style={{ maxLines: 1, textOverflow: 'ellipsis', overflow: 'auto' }}>
                             <Button appearance="link" onClick={() => this.props.onClick(pr)}>
                                 {title}

--- a/src/webviews/components/issue/PullRequests.tsx
+++ b/src/webviews/components/issue/PullRequests.tsx
@@ -1,4 +1,3 @@
-// import Avatar from '@atlaskit/avatar';
 import Button from '@atlaskit/button';
 import Lozenge from '@atlaskit/lozenge';
 import Tooltip from '@atlaskit/tooltip';

--- a/src/webviews/components/issue/view-issue-screen/sidebar/IssueSidebarCollapsible.tsx
+++ b/src/webviews/components/issue/view-issue-screen/sidebar/IssueSidebarCollapsible.tsx
@@ -110,7 +110,7 @@ export const IssueSidebarCollapsible: React.FC<Props> = ({ label, items, default
                             >
                                 {item.itemLabel}
                             </div>
-                            <Box style={{ width: '100%' }}>{item.itemComponent}</Box>
+                            <Box style={{ width: '100%', overflow: 'hidden' }}>{item.itemComponent}</Box>
                         </Box>
                     ))}
                 </Box>


### PR DESCRIPTION
### What Is This Change?

Fix overflow styling for Recent Pull Requests field in Issue Screen sidebar group

Before: 
<img width="476" alt="Screenshot 2025-04-10 at 8 35 41 AM" src="https://github.com/user-attachments/assets/8a4c1eef-bc99-4af9-8461-e529ea50ab79" />


After: 
<img width="408" alt="Screenshot 2025-04-10 at 9 24 29 AM" src="https://github.com/user-attachments/assets/3f2f533f-ed45-4b3b-9e17-f24b9f2ccce8" />


### How Has This Been Tested?

Manual testing

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change