### PR TITLE
[AXON-329] Fix error telemetry to include only atlascode errors

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -80,11 +80,15 @@ export async function loggedOutEvent(site: DetailedSiteInfo): Promise<TrackEvent
 
 // Error/diagnostics events
 
+function sanitizeStackTrace(stack?: string): string | undefined {
+    return stack ? stack.replace(/\/Users\/[^/]+\//g, '/Users/<user>/') : stack;
+}
+
 export async function errorEvent(error: Error | string): Promise<TrackEvent> {
-    const attributes =
+    const attributes: { name: string; message: string; stack?: string } =
         typeof error === 'string'
             ? { name: 'Error', message: error }
-            : { name: error.name || 'Error', message: error.message, stack: error.stack! };
+            : { name: error.name || 'Error', message: error.message, stack: sanitizeStackTrace(error.stack) };
 
     return trackEvent('errorEvent', 'atlascode', { attributes });
 }


### PR DESCRIPTION
### What Is This Change?

The error telemetry is capturing errors originating from outside of the extension.
For instance, the most frequent errors are coming from the extension `mohamedbenhida.laravel-intellisense-0.2.0`.

Added a filter that filters out Errors not originating from our extension simply analyzing the stack trace. 

Additionally, added a sanitization of the stack trace to remove the os's user name from it.

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change