### PR TITLE
Removes pull request ID from sidebar listing

### DIFF
--- a/src/views/pullrequest/pullRequestNode.ts
+++ b/src/views/pullrequest/pullRequestNode.ts
@@ -51,10 +51,7 @@ export class PullRequestTitlesNode extends AbstractBaseNode {
             .map((approver) => `Approved-by: ${approver.displayName}`)
             .join('\n');
 
-        const item = new vscode.TreeItem(
-            `#${this.pr.data.id!} ${this.pr.data.title!}`,
-            vscode.TreeItemCollapsibleState.Collapsed,
-        );
+        const item = new vscode.TreeItem(`${this.pr.data.title!}`, vscode.TreeItemCollapsibleState.Collapsed);
         item.tooltip = `#${this.pr.data.id!} ${this.pr.data.title!}${
             approvalText.length > 0 ? `\n\n${approvalText}` : ''
         }`;


### PR DESCRIPTION
Removes the PR ID prefix added to each PR in the pull request listings view. 

1. This is already a very tight space, and a user cares about the pull request title more than the ID, jira ticket number in the PR
2. The PR ID is not really very useful and can be very long in active repos
3. If needed, it is still available on hover and PR open

### Before
<img width="423" alt="Screenshot 2025-04-14 at 3 46 44 PM" src="https://github.com/user-attachments/assets/d765e63f-e26a-4463-a055-02ff00616e10" />

### After
<img width="343" alt="Screenshot 2025-04-14 at 3 51 15 PM" src="https://github.com/user-attachments/assets/8fb6d304-fe4a-40c7-b080-13d981e01a5e" />
