### PR TITLE
Rename telemetry error event

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -90,7 +90,7 @@ export async function errorEvent(error: Error | string): Promise<TrackEvent> {
             ? { name: 'Error', message: error }
             : { name: error.name || 'Error', message: error.message, stack: sanitizeStackTrace(error.stack) };
 
-    return trackEvent('errorEvent', 'atlascode', { attributes });
+    return trackEvent('errorEvent_v2', 'atlascode', { attributes });
 }
 
 // Feature Flag Events


### PR DESCRIPTION
### What Is This Change?

The old error event is being flooded by telemetry events from v3.4.24, and we had to shut it down immediately to reduce the cost for those unnecessary events.

The telemetry fix is already in place since v3.4.25, but we now want to have a new event name so we only process the ones we need.