### PR TITLE
Fail the build on npm audit failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,9 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: |
+          npm install --no-audit
+          npm audit
 
       - name: Run linter
         run: npm run lint


### PR DESCRIPTION
### What Is This Change?

This change introduces an explicit `npm audit` in the build pipeline that fails if npm detects packages with vulnerabilites.

This works, but a cleaner way would be adding a GitHub action that runs only on PRs, and fails the PR if the change contains a vulnerabilities.
I'll explore that in the near future.