### PR TITLE
AXON-344: add window object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
                 "prosemirror-state": "^1.3.3",
                 "prosemirror-view": "^1.15.2",
                 "react": "^16.13.1",
-                "react-async-hook": "^3.6.1",
+                "react-async-hook": "^4.0.0",
                 "react-dom": "^16.13.1",
                 "react-dropzone": "^10.2.1",
                 "react-editext": "3.6.1",
@@ -168,7 +168,7 @@
                 "npm-run-all": "^4.1.5",
                 "nyc": "^17.1.0",
                 "ovsx": "^0.10.1",
-                "patch-package": "^6.2.2",
+                "patch-package": "^8.0.0",
                 "postcss-flexbugs-fixes": "^5.0.2",
                 "postcss-loader": "^8.1.1",
                 "postcss-preset-env": "^10.0.5",
@@ -4527,6 +4527,18 @@
                 "@material-ui/lab": "^4.0.0-alpha.52",
                 "react": "^16.13.1",
                 "react-dom": "^16.13.1"
+            }
+        },
+        "node_modules/@atlassianlabs/guipi-jira-components/node_modules/react-async-hook": {
+            "version": "3.6.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-async-hook/-/react-async-hook-3.6.2.tgz",
+            "integrity": "sha512-RkwHCJ8V7I6umKZLHneapuTRWf+eO4LOj0qUwUDsSn27jrAOcW6ClbV3x22Z4hVxH9bA0zb7y+ozDJDJ8PnZoA==",
+            "engines": {
+                "node": ">=8",
+                "npm": ">=5"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
             }
         },
         "node_modules/@atlassianlabs/jira-metaui-client": {
@@ -22122,11 +22134,36 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-stable-stringify": {
+            "version": "1.2.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz",
+            "integrity": "sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "isarray": "^2.0.5",
+                "jsonify": "^0.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "license": "MIT"
+        },
+        "node_modules/json-stable-stringify/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -22158,6 +22195,15 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonify": {
+            "version": "0.0.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jsonify/-/jsonify-0.0.1.tgz",
+            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/jsonwebtoken": {
@@ -24737,32 +24783,32 @@
             "license": "0BSD"
         },
         "node_modules/patch-package": {
-            "version": "6.5.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/patch-package/-/patch-package-6.5.1.tgz",
-            "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+            "version": "8.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/patch-package/-/patch-package-8.0.0.tgz",
+            "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@yarnpkg/lockfile": "^1.1.0",
                 "chalk": "^4.1.2",
-                "cross-spawn": "^6.0.5",
+                "ci-info": "^3.7.0",
+                "cross-spawn": "^7.0.3",
                 "find-yarn-workspace-root": "^2.0.0",
                 "fs-extra": "^9.0.0",
-                "is-ci": "^2.0.0",
+                "json-stable-stringify": "^1.0.2",
                 "klaw-sync": "^6.0.0",
                 "minimist": "^1.2.6",
                 "open": "^7.4.2",
                 "rimraf": "^2.6.3",
-                "semver": "^5.6.0",
+                "semver": "^7.5.3",
                 "slash": "^2.0.0",
                 "tmp": "^0.0.33",
-                "yaml": "^1.10.2"
+                "yaml": "^2.2.2"
             },
             "bin": {
                 "patch-package": "index.js"
             },
             "engines": {
-                "node": ">=10",
+                "node": ">=14",
                 "npm": ">5"
             }
         },
@@ -24799,6 +24845,21 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/patch-package/node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/patch-package/node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/color-convert/-/color-convert-2.0.1.tgz",
@@ -24818,6 +24879,20 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/patch-package/node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/patch-package/node_modules/fs-extra": {
             "version": "9.1.0",
@@ -24845,14 +24920,34 @@
                 "node": ">=8"
             }
         },
-        "node_modules/patch-package/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+        "node_modules/patch-package/node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/patch-package/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/patch-package/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/patch-package/node_modules/slash": {
@@ -24876,6 +24971,33 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/patch-package/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/patch-package/node_modules/yaml": {
+            "version": "2.7.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yaml/-/yaml-2.7.1.tgz",
+            "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+            "dev": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/path-browserify": {
@@ -26681,10 +26803,9 @@
             }
         },
         "node_modules/react-async-hook": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/react-async-hook/-/react-async-hook-3.6.1.tgz",
-            "integrity": "sha512-YWBB2feVQF79t5u2raMPHlZ8975Jds+guCvkWVC4kRLDlSCouLsYpQm4DGSqPeHvoHYVVcDfqNayLZAXQmnxnw==",
-            "license": "MIT",
+            "version": "4.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-async-hook/-/react-async-hook-4.0.0.tgz",
+            "integrity": "sha512-97lgjFkOcHCTYSrsKBpsXg3iVWM0LnzedB749iP76sb3/8Ouu4nHIkCLEOrQWHVYqrYxjF05NN6GHoXWFkB3Kw==",
             "engines": {
                 "node": ">=8",
                 "npm": ">=5"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,10 +27,12 @@ import { GitExtension } from './typings/git';
 import { FeatureFlagClient } from './util/featureFlags';
 
 const AnalyticDelay = 5000;
+
 export async function activate(context: ExtensionContext) {
     const start = process.hrtime();
 
     registerErrorReporting();
+
     const atlascode = extensions.getExtension('atlassian.atlascode')!;
     const atlascodeVersion = atlascode.packageJSON.version;
     const previousVersion = context.globalState.get<string>(GlobalStateVersionKey);
@@ -93,12 +95,14 @@ export async function activate(context: ExtensionContext) {
     // icon to appear in the activity bar
     activateBitbucketFeatures();
     activateYamlFeatures(context);
+
     Logger.info(
         `Atlassian for VS Code (v${atlascodeVersion}) activated in ${
             duration[0] * 1000 + Math.floor(duration[1] / 1000000)
         } ms`,
     );
 }
+
 async function activateBitbucketFeatures() {
     let gitExt: GitExtension;
     try {
@@ -114,6 +118,7 @@ async function activateBitbucketFeatures() {
         );
         return;
     }
+
     try {
         const gitApi = gitExt.getAPI(1);
         const bbContext = new BitbucketContext(gitApi);
@@ -134,6 +139,7 @@ async function activateYamlFeatures(context: ExtensionContext) {
     await addPipelinesSchemaToYamlConfig();
     await activateYamlExtension();
 }
+
 async function showWelcomePage(version: string, previousVersion: string | undefined) {
     if (
         (previousVersion === undefined || semver.gt(version, previousVersion)) &&
@@ -160,6 +166,7 @@ async function sendAnalytics(version: string, globalState: Memento) {
         });
         return;
     }
+
     if (semver.gt(version, previousVersion)) {
         Logger.info(`Atlassian for VS Code upgraded from v${previousVersion} to v${version}`);
         upgradedEvent(version, previousVersion).then((e) => {


### PR DESCRIPTION
### What Is This Change?

Based on [this thread](https://atlassian.slack.com/archives/C04PR2YE4UC/p1742429892425979), it was discoved that the exposure events were being blocked because the Statsig client was recognizing our extension as a server environment rather than a client. This check is shown in this [code here](https://github.com/statsig-io/js-client-monorepo/blob/05021e3b0ed79e7ae09ded914dff6089561853ec/packages/client-core/src/SafeJs.ts#L13-L25)

As a work around, I defined a window object so the Stastig client can declare us as a client side app and let us send exposure events back to statsig

Test exposures on `atlascode-noop` flag: https://console.statsig.com/LqivKg6ADZZaGczRfBKfX/gates/atlascode-noop/diagnostics

Test exposures in `atlascode_aa_experiment`: https://console.statsig.com/LqivKg6ADZZaGczRfBKfX/experiments/atlascode_aa_experiment/diagnostics

I have opened this issue [here](https://github.com/statsig-io/js-client-monorepo/issues/23) so Statsig is aware of this issue for vscode developers
 
### How Has This Been Tested?

Test exposures for AA experiment and FG

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change