### PR TITLE
AXON-346: fix pr reviewers spacing

### DIFF
--- a/src/react/atlascode/pullrequest/Reviewers.tsx
+++ b/src/react/atlascode/pullrequest/Reviewers.tsx
@@ -90,7 +90,7 @@ export const Reviewers: React.FunctionComponent<ReviewersProps> = ({
                 </Grid>
             )}
 
-            <Grid item>
+            <Grid style={{ width: '100%' }} item>
                 <AddReviewers site={site} reviewers={activeParticipants} updateReviewers={handleUpdateReviewers} />
             </Grid>
         </Grid>


### PR DESCRIPTION
### What Is This Change?

Fix squashed reviewer drop down in PR details page

Issue: https://github.com/atlassian/atlascode/issues/324

Before 
![image](https://github.com/user-attachments/assets/5a40ad9f-e5fb-4c0e-ab92-1e394342dcb1)

After
<img width="364" alt="Screenshot 2025-04-14 at 3 04 28 PM" src="https://github.com/user-attachments/assets/d0162d53-cf9b-4b08-b511-5184e8527169" />

### How Has This Been Tested?

manual testing PR functionality

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change