### PR TITLE
AXON-120: epic/parent link clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues/new/choose)
 
------
+---
 
 ## What's new in 3.5.0
 
 ### Deprecations
 
--   Following the official deprecation of Bitbucket issues, and their very low usage in our extension, we have removed the Bitbucket issues functionality from Atlascode. 
+-   Following the official deprecation of Bitbucket issues, and their very low usage in our extension, we have removed the Bitbucket issues functionality from Atlascode.
 
     Users who still need to use the Bitbucket issues functionality can manually install the latest version supporting it: v3.4.25.
+
+### Bug fixes
+
+-   Fixed bug where Epic/Parent links on Jira Issue Screen Navigation are not clickable
 
 ## What's new in 3.4.25
 
@@ -18,7 +22,7 @@
 
 ### Bug fixes
 
--   Some Jira issues weren't loading due to poor handling of missing fields. 
+-   Some Jira issues weren't loading due to poor handling of missing fields.
 
 ## What's new in 3.4.24
 
@@ -29,7 +33,7 @@
 
 ### Bug fixes:
 
-- Fixed bug in Bitbucket DC for PRs with comments where the PR Details would not display. 
+-   Fixed bug in Bitbucket DC for PRs with comments where the PR Details would not display.
 
 ## What's new in 3.4.23
 

--- a/src/webviews/components/issue/create-issue-screen/Panel.tsx
+++ b/src/webviews/components/issue/create-issue-screen/Panel.tsx
@@ -44,6 +44,7 @@ export const Panel: React.FC<PanelProps> = ({ isDefaultExpanded, header, childre
                     alignItems: 'center',
                     padding: '2px 0 2px 24px',
                     width: '100%',
+                    cursor: 'pointer',
                 }}
             >
                 <span style={{ position: 'absolute', top: 0, left: 0 }}>

--- a/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
+++ b/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
@@ -462,7 +462,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                                     onItemClick={() =>
                                         this.handleOpenIssue({
                                             siteDetails: this.state.siteDetails,
-                                            key: this.state.fieldValues['parent'],
+                                            key: this.state.fieldValues['parent'].key,
                                         })
                                     }
                                 />


### PR DESCRIPTION
### What Is This Change?

Made the epic/parent link in issue view nav clickable

### How Has This Been Tested?

Loom: https://www.loom.com/share/85b58288400e4a2ea7ea1dc3ac97ed20?sid=d9a3ddeb-f413-4283-ac2a-66998032d4c3

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change