### PR TITLE
Remove JQL initialization on Jira site add

### DIFF
--- a/src/jira/jqlManager.test.ts
+++ b/src/jira/jqlManager.test.ts
@@ -3,7 +3,6 @@ import { it } from '@jest/globals';
 
 import { expansionCastTo } from '../../testsutil';
 import { DetailedSiteInfo, ProductJira } from '../atlclients/authInfo';
-import { configuration } from '../config/configuration';
 import { JQLEntry } from '../config/model';
 import { Container } from '../container';
 import { JQLManager } from './jqlManager';
@@ -168,13 +167,6 @@ describe('JQLManager', () => {
         expect(entries[1].id).toEqual('siteDetailsId2');
     });
 
-    it('getCustomJQLEntries retrieves the list of customized and enabled JQL entries', () => {
-        const entries = jqlManager.getCustomJQLEntries();
-
-        expect(entries).toHaveLength(3);
-        expect(entries).toEqual([mockedJqlEntries[2], mockedJqlEntries[3], mockedJqlEntries[4]]);
-    });
-
     it.each([
         ['resolution', true],
         ['anotherField', false],
@@ -202,33 +194,4 @@ describe('JQLManager', () => {
             expect(mockSite.hasResolutionField).toBe(expectedHasResolutionField);
         },
     );
-
-    it('initializeJQL should initialize JQL entries for new sites', async () => {
-        const mockSite = expansionCastTo<DetailedSiteInfo>({
-            id: 'site1',
-            name: 'Site 1',
-            hasResolutionField: undefined,
-        });
-
-        let actualValue: JQLEntry[] = [];
-
-        jest.spyOn(configuration, 'update').mockImplementation((section, value, target) => {
-            actualValue = value;
-            return Promise.resolve();
-        });
-
-        Container.config.jira.jqlList = [];
-        await jqlManager.initializeJQL([mockSite]);
-
-        expect(configuration.update).toHaveBeenCalledWith(
-            'jira.jqlList',
-            expect.anything(),
-            1 /*vscode.ConfigurationTarget.Global*/,
-        );
-        expect(actualValue).toHaveLength(1);
-
-        expect(actualValue[0].siteId).toBe('site1');
-        expect(actualValue[0].id).toBeDefined();
-        expect(actualValue[0].id).not.toEqual(actualValue[0].siteId);
-    });
 });

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -56,7 +56,7 @@ export class CustomJQLViewProvider extends Disposable implements TreeDataProvide
             treeView,
         );
 
-        const jqlEntries = Container.jqlManager.getCustomJQLEntries();
+        const jqlEntries = Container.jqlManager.enabledJQLEntries();
         if (jqlEntries.length) {
             setCommandContext(CommandContext.CustomJQLExplorer, Container.config.jira.explorer.enabled);
         }
@@ -79,8 +79,8 @@ export class CustomJQLViewProvider extends Disposable implements TreeDataProvide
             configuration.changed(e, 'jira.explorer') ||
             configuration.changed(e, 'jira.explorer.enabled')
         ) {
-            const jqlEntries = Container.jqlManager.getCustomJQLEntries();
-            if (jqlEntries.length > 0) {
+            const jqlEntries = Container.jqlManager.enabledJQLEntries();
+            if (jqlEntries.length) {
                 setCommandContext(CommandContext.CustomJQLExplorer, Container.config.jira.explorer.enabled);
             } else {
                 setCommandContext(CommandContext.CustomJQLExplorer, false);
@@ -91,9 +91,6 @@ export class CustomJQLViewProvider extends Disposable implements TreeDataProvide
 
     private async onSitesDidChange(e: SitesAvailableUpdateEvent) {
         if (e.product.key === ProductJira.key) {
-            if (e.newSites) {
-                Container.jqlManager.initializeJQL(e.newSites);
-            }
             this.refresh();
         }
     }
@@ -119,7 +116,7 @@ export class CustomJQLViewProvider extends Disposable implements TreeDataProvide
         } else {
             SearchJiraHelper.clearIssues(CustomJQLViewProviderId);
 
-            const jqlEntries = Container.jqlManager.getCustomJQLEntries();
+            const jqlEntries = Container.jqlManager.enabledJQLEntries();
             return jqlEntries.length
                 ? jqlEntries.map((jqlEntry) => new JiraIssueQueryNode(jqlEntry))
                 : [CustomJQLViewProvider._treeItemConfigureJqlMessage];


### PR DESCRIPTION
### What Is This Change?

With the new Jira panels, we don't need the JQL initialization for every site anymore.

The default query is built ad-hoc for the assigned jira work items panel, and we only need custom JQLs manually configured by the user.

Side effect: users who are upgrading from previous versions will see the default queries appearing in the Custom JQL panel, and they have to delete them manually.
Unfortunately, I think there aren't safest alternatives to this.

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change