### PR TITLE
[AXON-348] Bitbucket PR creation terminal integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
     Users who still need to use the Bitbucket issues functionality can manually install the latest version supporting it: v3.4.25.
 
+### Features
+
+-   Added informational panel when user clicks on create PR link in terminal which asks whether to create PR in extension or continue to browser
+
 ### Bug fixes
 
 -   Fixed bug where Epic/Parent links on Jira Issue Screen Navigation are not clickable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ---
 
+## What's new in 3.6.1
+
+### Features
+
+-   Added informational panel when user clicks on create PR link in terminal which asks whether to create PR in extension or continue to browser
+
 ## What's new in 3.6.0
 
 ### Deprecations
@@ -9,10 +15,6 @@
 -   Following the official deprecation of Bitbucket issues, and their very low usage in our extension, we have removed the Bitbucket issues functionality from Atlascode.
 
     Users who still need to use the Bitbucket issues functionality can manually install the latest version supporting it: v3.4.25.
-
-### Features
-
--   Added informational panel when user clicks on create PR link in terminal which asks whether to create PR in extension or continue to browser
 
 ### Bug fixes
 

--- a/package.json
+++ b/package.json
@@ -1363,7 +1363,7 @@
                 "atlascode.bitbucket.showTerminalLinkPanel": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Asks whether to create pull request in bitbucket or browser",
+                    "description": "Asks whether to create pull request in extension or browser",
                     "scope": "window"
                 },
                 "atlascode.helpExplorerEnabled": {

--- a/package.json
+++ b/package.json
@@ -1363,7 +1363,7 @@
                 "atlascode.bitbucket.showTerminalLinkPanel": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Shows the terminal link panel when create PR link is clicked in terminal",
+                    "description": "Asks whether to create pull request in bitbucket or browser",
                     "scope": "window"
                 },
                 "atlascode.helpExplorerEnabled": {

--- a/package.json
+++ b/package.json
@@ -1363,7 +1363,7 @@
                 "atlascode.bitbucket.showTerminalLinkPanel": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Asks whether to create pull request in extension or browser",
+                    "description": "Asks whether to create pull requests in extension or browser",
                     "scope": "window"
                 },
                 "atlascode.helpExplorerEnabled": {

--- a/package.json
+++ b/package.json
@@ -1360,6 +1360,12 @@
                     "description": "Shows a login button in the status bar",
                     "scope": "window"
                 },
+                "atlascode.bitbucket.showTerminalLinkPanel": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows the terminal link panel when create PR link is clicked in terminal",
+                    "scope": "window"
+                },
                 "atlascode.helpExplorerEnabled": {
                     "type": "boolean",
                     "default": true,

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -191,9 +191,9 @@ export async function searchIssuesEvent(product: Product): Promise<TrackEvent> {
 
 // PR events
 
-export async function createPrTerminalLinkDetectedEvent(isEnabled: boolean): Promise<TrackEvent> {
+export async function createPrTerminalLinkDetectedEvent(isNotifEnabled: boolean): Promise<TrackEvent> {
     return trackEvent('createPrTerminalLink', 'detected', {
-        attributes: { isEnabled: isEnabled },
+        attributes: { isNotificationEnabled: isNotifEnabled },
     });
 }
 
@@ -624,7 +624,7 @@ export async function openActiveIssueEvent(): Promise<UIEvent> {
     return anyUserOrAnonymous<UIEvent>(e);
 }
 
-export async function createPrTerminalLinkPanelButtonCLickedEvent(
+export async function createPrTerminalLinkPanelButtonClickedEvent(
     source: string,
     type: CreatePrTerminalSelection,
 ): Promise<UIEvent> {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,5 +1,5 @@
 import { ScreenEvent, TrackEvent, UIEvent } from './analytics-node-client/src/types';
-import { UIErrorInfo } from './analyticsTypes';
+import { CreatePrTerminalSelection, UIErrorInfo } from './analyticsTypes';
 import { DetailedSiteInfo, isEmptySiteInfo, Product, ProductJira, SiteInfo } from './atlclients/authInfo';
 import { BitbucketIssuesTreeViewId, PullRequestTreeViewId } from './constants';
 import { Container } from './container';
@@ -190,6 +190,12 @@ export async function searchIssuesEvent(product: Product): Promise<TrackEvent> {
 }
 
 // PR events
+
+export async function createPrTerminalLinkDetectedEvent(isEnabled: boolean): Promise<TrackEvent> {
+    return trackEvent('createPrTerminalLink', 'detected', {
+        attributes: { isEnabled: isEnabled },
+    });
+}
 
 export async function prCreatedEvent(site: DetailedSiteInfo): Promise<TrackEvent> {
     return instanceTrackEvent(site, 'created', 'pullRequest');
@@ -618,6 +624,27 @@ export async function openActiveIssueEvent(): Promise<UIEvent> {
     return anyUserOrAnonymous<UIEvent>(e);
 }
 
+export async function createPrTerminalLinkPanelButtonCLickedEvent(
+    source: string,
+    type: CreatePrTerminalSelection,
+): Promise<UIEvent> {
+    const e = {
+        tenantIdType: null,
+        uiEvent: {
+            origin: 'desktop',
+            platform: AnalyticsPlatform.for(process.platform),
+            action: 'clicked',
+            actionSubject: 'button',
+            actionSubjectId: 'createPrTerminalLinkPanel',
+            source: source,
+            attributes: {
+                buttonType: type,
+            },
+        },
+    };
+
+    return anyUserOrAnonymous<UIEvent>(e);
+}
 // Helper methods
 
 async function instanceTrackEvent(

--- a/src/analyticsTypes.ts
+++ b/src/analyticsTypes.ts
@@ -55,3 +55,9 @@ export type UIErrorInfo = UIAnalyticsContext & {
     errorMessage: string;
     errorCause: string;
 };
+
+export enum CreatePrTerminalSelection {
+    Yes = 'yes',
+    Ignore = 'ignore',
+    Disable = 'disable',
+}

--- a/src/bitbucket/terminal-link/createPrLinkProvider.test.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.test.ts
@@ -18,6 +18,10 @@ jest.mock('../../container', () => ({
                 showTerminalLinkPanel: true,
             },
         },
+        analyticsClient: {
+            sendTrackEvent: jest.fn(),
+            sendUIEvent: jest.fn(),
+        },
     },
 }));
 
@@ -25,7 +29,7 @@ import { commands, env, TerminalLinkContext, Uri, window } from 'vscode';
 
 import { configuration } from '../../config/configuration';
 import { Container } from '../../container';
-import { BitbucketPullRequestLinkProvider } from './createPrLinkProvider';
+import { BitbucketCloudPullRequestLinkProvider } from './createPrLinkProvider';
 
 beforeEach(() => {
     env.openExternal = jest.fn().mockResolvedValue(true);
@@ -38,7 +42,7 @@ afterEach(() => {
 describe('BitbucketPullRequestLinkProvider', () => {
     describe('provideTerminalLinks', () => {
         it('should return empty array if no bb link is found', async () => {
-            const provider = new BitbucketPullRequestLinkProvider();
+            const provider = new BitbucketCloudPullRequestLinkProvider();
             const context: TerminalLinkContext = {
                 line: 'This is a test line without a link',
                 terminal: {} as any,
@@ -49,7 +53,7 @@ describe('BitbucketPullRequestLinkProvider', () => {
         });
 
         it('should return empty array if link is not a create pull request link', async () => {
-            const provider = new BitbucketPullRequestLinkProvider();
+            const provider = new BitbucketCloudPullRequestLinkProvider();
             const context: TerminalLinkContext = {
                 line: 'https://bitbucket.org/workspace/repo/pull-requests/1',
                 terminal: {} as any,
@@ -60,7 +64,7 @@ describe('BitbucketPullRequestLinkProvider', () => {
         });
 
         it('should return a link if a create pull request link is found', async () => {
-            const provider = new BitbucketPullRequestLinkProvider();
+            const provider = new BitbucketCloudPullRequestLinkProvider();
             const context: TerminalLinkContext = {
                 line: 'https://bitbucket.org/workspace/repo/pull-requests/new?source=branch',
                 terminal: {} as any,
@@ -76,7 +80,7 @@ describe('BitbucketPullRequestLinkProvider', () => {
         it('should not display a message if disabled in config', async () => {
             Container.config.bitbucket.showTerminalLinkPanel = false;
             jest.spyOn(window, 'showInformationMessage');
-            const provider = new BitbucketPullRequestLinkProvider();
+            const provider = new BitbucketCloudPullRequestLinkProvider();
 
             await provider.handleTerminalLink(mockLink);
 
@@ -86,7 +90,7 @@ describe('BitbucketPullRequestLinkProvider', () => {
         it('should display a message if enabled in config', async () => {
             Container.config.bitbucket.showTerminalLinkPanel = true;
             jest.spyOn(window, 'showInformationMessage');
-            const provider = new BitbucketPullRequestLinkProvider();
+            const provider = new BitbucketCloudPullRequestLinkProvider();
 
             await provider.handleTerminalLink(mockLink);
 
@@ -100,7 +104,7 @@ describe('BitbucketPullRequestLinkProvider', () => {
 
         it('should open create pull request view if user selects "Yes"', async () => {
             Container.config.bitbucket.showTerminalLinkPanel = true;
-            const provider = new BitbucketPullRequestLinkProvider();
+            const provider = new BitbucketCloudPullRequestLinkProvider();
             jest.spyOn(window, 'showInformationMessage');
             const executeCommandSpy = jest.spyOn(commands, 'executeCommand');
 
@@ -113,7 +117,7 @@ describe('BitbucketPullRequestLinkProvider', () => {
         it('should open the URL if user selects "No, continue to Bitbucket"', async () => {
             const mockUri = Uri.parse(mockLink.url);
             Container.config.bitbucket.showTerminalLinkPanel = true;
-            const provider = new BitbucketPullRequestLinkProvider();
+            const provider = new BitbucketCloudPullRequestLinkProvider();
             const executeCommandSpy = jest.spyOn(commands, 'executeCommand');
 
             (window.showInformationMessage as jest.Mock).mockResolvedValue('No, continue to Bitbucket');
@@ -126,7 +130,7 @@ describe('BitbucketPullRequestLinkProvider', () => {
         it('should open the URL and disable the terminal link if user selects "Don\'t show again"', async () => {
             const mockUri = Uri.parse(mockLink.url);
             Container.config.bitbucket.showTerminalLinkPanel = true;
-            const provider = new BitbucketPullRequestLinkProvider();
+            const provider = new BitbucketCloudPullRequestLinkProvider();
             const executeCommandSpy = jest.spyOn(commands, 'executeCommand');
             const configSpy = jest.spyOn(configuration, 'update');
 
@@ -135,7 +139,7 @@ describe('BitbucketPullRequestLinkProvider', () => {
             await provider.handleTerminalLink(mockLink);
             expect(executeCommandSpy).not.toHaveBeenCalledWith('bitbucket.createPullRequest');
             expect(env.openExternal).toHaveBeenCalledWith(mockUri);
-            expect(configSpy).toHaveBeenCalledWith('bitbucket.showTerminalLinkPanel', false, 1);
+            expect(configSpy).toHaveBeenCalledWith('bitbucket.showTerminalLinkPanel', false, 2);
         });
     });
 });

--- a/src/bitbucket/terminal-link/createPrLinkProvider.test.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.test.ts
@@ -1,0 +1,141 @@
+const mockLink = {
+    startIndex: 0,
+    length: 0,
+    tooltip: 'Create pull request',
+    url: 'https://bitbucket.org/workspace/repo/pull-requests/new?source=branch',
+};
+
+jest.mock('../../commands', () => ({
+    Commands: {
+        CreatePullRequest: 'bitbucket.createPullRequest',
+    },
+}));
+
+jest.mock('../../container', () => ({
+    Container: {
+        config: {
+            bitbucket: {
+                showTerminalLinkPanel: true,
+            },
+        },
+    },
+}));
+
+import { commands, env, TerminalLinkContext, Uri, window } from 'vscode';
+
+import { configuration } from '../../config/configuration';
+import { Container } from '../../container';
+import { BitbucketPullRequestLinkProvider } from './createPrLinkProvider';
+
+beforeEach(() => {
+    env.openExternal = jest.fn().mockResolvedValue(true);
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('BitbucketPullRequestLinkProvider', () => {
+    describe('provideTerminalLinks', () => {
+        it('should return empty array if no bb link is found', async () => {
+            const provider = new BitbucketPullRequestLinkProvider();
+            const context: TerminalLinkContext = {
+                line: 'This is a test line without a link',
+                terminal: {} as any,
+            };
+            const result = await provider.provideTerminalLinks(context, {} as any);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array if link is not a create pull request link', async () => {
+            const provider = new BitbucketPullRequestLinkProvider();
+            const context: TerminalLinkContext = {
+                line: 'https://bitbucket.org/workspace/repo/pull-requests/1',
+                terminal: {} as any,
+            };
+            const result = await provider.provideTerminalLinks(context, {} as any);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should return a link if a create pull request link is found', async () => {
+            const provider = new BitbucketPullRequestLinkProvider();
+            const context: TerminalLinkContext = {
+                line: 'https://bitbucket.org/workspace/repo/pull-requests/new?source=branch',
+                terminal: {} as any,
+            };
+            const result = await provider.provideTerminalLinks(context, {} as any);
+
+            expect(result).toHaveLength(1);
+            expect(result?.[0].url).toBe('https://bitbucket.org/workspace/repo/pull-requests/new?source=branch');
+        });
+    });
+
+    describe('handleTerminalLink', () => {
+        it('should not display a message if disabled in config', async () => {
+            Container.config.bitbucket.showTerminalLinkPanel = false;
+            jest.spyOn(window, 'showInformationMessage');
+            const provider = new BitbucketPullRequestLinkProvider();
+
+            await provider.handleTerminalLink(mockLink);
+
+            expect(window.showInformationMessage).not.toHaveBeenCalled();
+        });
+
+        it('should display a message if enabled in config', async () => {
+            Container.config.bitbucket.showTerminalLinkPanel = true;
+            jest.spyOn(window, 'showInformationMessage');
+            const provider = new BitbucketPullRequestLinkProvider();
+
+            await provider.handleTerminalLink(mockLink);
+
+            expect(window.showInformationMessage).toHaveBeenCalledWith(
+                'Do you want to create a pull request using the Jira and Bitbucket extension?',
+                'Yes',
+                'No, continue to Bitbucket',
+                "Don't show again",
+            );
+        });
+
+        it('should open create pull request view if user selects "Yes"', async () => {
+            Container.config.bitbucket.showTerminalLinkPanel = true;
+            const provider = new BitbucketPullRequestLinkProvider();
+            jest.spyOn(window, 'showInformationMessage');
+            const executeCommandSpy = jest.spyOn(commands, 'executeCommand');
+
+            (window.showInformationMessage as jest.Mock).mockResolvedValue('Yes');
+
+            await provider.handleTerminalLink(mockLink);
+            expect(executeCommandSpy).toHaveBeenCalledWith('bitbucket.createPullRequest');
+        });
+
+        it('should open the URL if user selects "No, continue to Bitbucket"', async () => {
+            const mockUri = Uri.parse(mockLink.url);
+            Container.config.bitbucket.showTerminalLinkPanel = true;
+            const provider = new BitbucketPullRequestLinkProvider();
+            const executeCommandSpy = jest.spyOn(commands, 'executeCommand');
+
+            (window.showInformationMessage as jest.Mock).mockResolvedValue('No, continue to Bitbucket');
+
+            await provider.handleTerminalLink(mockLink);
+            expect(executeCommandSpy).not.toHaveBeenCalledWith('bitbucket.createPullRequest');
+            expect(env.openExternal).toHaveBeenCalledWith(mockUri);
+        });
+
+        it('should open the URL and disable the terminal link if user selects "Don\'t show again"', async () => {
+            const mockUri = Uri.parse(mockLink.url);
+            Container.config.bitbucket.showTerminalLinkPanel = true;
+            const provider = new BitbucketPullRequestLinkProvider();
+            const executeCommandSpy = jest.spyOn(commands, 'executeCommand');
+            const configSpy = jest.spyOn(configuration, 'update');
+
+            (window.showInformationMessage as jest.Mock).mockResolvedValue("Don't show again");
+
+            await provider.handleTerminalLink(mockLink);
+            expect(executeCommandSpy).not.toHaveBeenCalledWith('bitbucket.createPullRequest');
+            expect(env.openExternal).toHaveBeenCalledWith(mockUri);
+            expect(configSpy).toHaveBeenCalledWith('bitbucket.showTerminalLinkPanel', false, 1);
+        });
+    });
+});

--- a/src/bitbucket/terminal-link/createPrLinkProvider.test.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.test.ts
@@ -17,7 +17,6 @@ jest.mock('../../container', () => ({
         config: {
             bitbucket: {
                 showTerminalLinkPanel: true,
-                enabled: true,
             },
         },
         analyticsClient: {
@@ -45,7 +44,6 @@ import { BitbucketCloudPullRequestLinkProvider } from './createPrLinkProvider';
 
 beforeEach(() => {
     env.openExternal = jest.fn().mockResolvedValue(true);
-    Container.config.bitbucket.enabled = true;
     Container.config.bitbucket.showTerminalLinkPanel = true;
 });
 
@@ -94,18 +92,6 @@ describe('BitbucketPullRequestLinkProvider', () => {
         it('should not display a message if disabled in config', async () => {
             Container.config.bitbucket.showTerminalLinkPanel = false;
             jest.spyOn(window, 'showInformationMessage');
-            const provider = new BitbucketCloudPullRequestLinkProvider();
-
-            await provider.handleTerminalLink(mockLink);
-
-            expect(window.showInformationMessage).not.toHaveBeenCalled();
-        });
-
-        it('should not display a message if Bitbucket is disabled', async () => {
-            Container.config.bitbucket.enabled = false;
-            Container.config.bitbucket.showTerminalLinkPanel = true;
-            jest.spyOn(window, 'showInformationMessage');
-
             const provider = new BitbucketCloudPullRequestLinkProvider();
 
             await provider.handleTerminalLink(mockLink);

--- a/src/bitbucket/terminal-link/createPrLinkProvider.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.ts
@@ -12,7 +12,7 @@ import {
     window,
 } from 'vscode';
 
-import { createPrTerminalLinkDetectedEvent, createPrTerminalLinkPanelButtonCLickedEvent } from '../../analytics';
+import { createPrTerminalLinkDetectedEvent, createPrTerminalLinkPanelButtonClickedEvent } from '../../analytics';
 import { AnalyticsClient } from '../../analytics-node-client/src/client.min.js';
 import { CreatePrTerminalSelection } from '../../analyticsTypes';
 import { Commands } from '../../commands';
@@ -25,13 +25,16 @@ interface BitbucketTerminalLink extends TerminalLink {
 const PanelId = 'atlascode.bitbucket.createPullRequestTerminalLinkPanel';
 
 const BBCloudPullRequestLinkRegex = new RegExp(/https:\/\/bitbucket\.org\/(.*)\/(.*)\/pull-requests\/new\?source=(.*)/);
+
 export class BitbucketCloudPullRequestLinkProvider extends Disposable implements TerminalLinkProvider {
     private _analyticsClient: AnalyticsClient;
+
     constructor() {
         super(() => this.dispose());
         this._analyticsClient = Container.analyticsClient;
         window.registerTerminalLinkProvider(this);
     }
+
     provideTerminalLinks(
         context: TerminalLinkContext,
         token: CancellationToken,
@@ -98,7 +101,7 @@ export class BitbucketCloudPullRequestLinkProvider extends Disposable implements
                         break;
                 }
 
-                createPrTerminalLinkPanelButtonCLickedEvent(PanelId, type).then((event) => {
+                createPrTerminalLinkPanelButtonClickedEvent(PanelId, type).then((event) => {
                     this._analyticsClient.sendUIEvent(event);
                 });
             });

--- a/src/bitbucket/terminal-link/createPrLinkProvider.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.ts
@@ -68,28 +68,30 @@ export class BitbucketCloudPullRequestLinkProvider extends Disposable implements
 
         // check if url is proper create pull request url
         // https://bitbucket.org/<workspace>/<repo>/pull-requests/new?source=<branch>
-        if (result) {
-            let response: BitbucketTerminalLink[] = [];
+        if (!result) {
+            return [];
+        }
 
-            if (this._isNotificationEnabled) {
-                const link: BitbucketTerminalLink = {
-                    startIndex,
-                    length: context.line.length - startIndex,
-                    tooltip: `Create pull request`,
-                    url,
-                };
+        if (this._isNotificationEnabled) {
+            const link: BitbucketTerminalLink = {
+                startIndex,
+                length: context.line.length - startIndex,
+                tooltip: `Create pull request`,
+                url,
+            };
 
-                response = [link];
-            }
-
-            // send event for link detected
-            createPrTerminalLinkDetectedEvent(this._isNotificationEnabled).then((event) => {
+            createPrTerminalLinkDetectedEvent(true).then((event) => {
                 this._analyticsClient.sendTrackEvent(event);
             });
 
-            return response;
+            return [link];
+        } else {
+            createPrTerminalLinkDetectedEvent(false).then((event) => {
+                this._analyticsClient.sendTrackEvent(event);
+            });
+
+            return [];
         }
-        return [];
     }
 
     handleTerminalLink(link: BitbucketTerminalLink): ProviderResult<void> {

--- a/src/bitbucket/terminal-link/createPrLinkProvider.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.ts
@@ -1,6 +1,3 @@
-import { Commands } from 'src/commands';
-import { configuration } from 'src/config/configuration';
-import { Container } from 'src/container';
 import {
     CancellationToken,
     commands,
@@ -14,6 +11,10 @@ import {
     Uri,
     window,
 } from 'vscode';
+
+import { Commands } from '../../commands';
+import { configuration } from '../../config/configuration';
+import { Container } from '../../container';
 
 interface BitbucketTerminalLink extends TerminalLink {
     url: string;

--- a/src/bitbucket/terminal-link/createPrLinkProvider.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.ts
@@ -36,20 +36,15 @@ export class BitbucketCloudPullRequestLinkProvider extends Disposable implements
     constructor() {
         super(() => this.dispose());
         this._analyticsClient = Container.analyticsClient;
-        this._isNotificationEnabled =
-            Container.config.bitbucket.showTerminalLinkPanel && Container.config.bitbucket.enabled;
+        this._isNotificationEnabled = Container.config.bitbucket.showTerminalLinkPanel;
 
         Container.context.subscriptions.push(configuration.onDidChange(this.onDidChangeConfiguration, this));
         window.registerTerminalLinkProvider(this);
     }
 
     onDidChangeConfiguration(e: ConfigurationChangeEvent) {
-        if (
-            configuration.changed(e, 'bitbucket.showTerminalLinkPanel') ||
-            configuration.changed(e, 'bitbucket.enabled')
-        ) {
-            this._isNotificationEnabled =
-                Container.config.bitbucket.showTerminalLinkPanel && Container.config.bitbucket.enabled;
+        if (configuration.changed(e, 'bitbucket.showTerminalLinkPanel')) {
+            this._isNotificationEnabled = Container.config.bitbucket.showTerminalLinkPanel;
         }
     }
 

--- a/src/bitbucket/terminal-link/createPrLinkProvider.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.ts
@@ -1,0 +1,97 @@
+import { Commands } from 'src/commands';
+import { configuration } from 'src/config/configuration';
+import { Container } from 'src/container';
+import {
+    CancellationToken,
+    commands,
+    ConfigurationTarget,
+    Disposable,
+    env,
+    ProviderResult,
+    TerminalLink,
+    TerminalLinkContext,
+    TerminalLinkProvider,
+    Uri,
+    window,
+} from 'vscode';
+
+interface BitbucketTerminalLink extends TerminalLink {
+    url: string;
+}
+
+export class BitbucketPullRequestLinkProvider extends Disposable implements TerminalLinkProvider {
+    private readonly bbPullRequestLinkRegex = new RegExp(
+        /https:\/\/bitbucket\.org\/(.*)\/(.*)\/pull-requests\/new\?source=(.*)&?.*/,
+    );
+    constructor() {
+        super(() => this.dispose());
+
+        window.registerTerminalLinkProvider(this);
+    }
+    provideTerminalLinks(
+        context: TerminalLinkContext,
+        token: CancellationToken,
+    ): ProviderResult<BitbucketTerminalLink[]> {
+        const startIndex = context.line.indexOf('https://bitbucket.org/');
+        if (startIndex === -1) {
+            return [];
+        }
+
+        const url = context.line.substring(startIndex);
+
+        const result = url.match(this.bbPullRequestLinkRegex);
+
+        // check if url is proper create pull request url
+        // https://bitbucket.org/<workspace>/<repo>/pull-requests/new?source=<branch>
+        if (result && result.length === 4) {
+            const link: BitbucketTerminalLink = {
+                startIndex,
+                length: context.line.length - startIndex,
+                tooltip: `Create pull request`,
+                url,
+            };
+
+            return [link];
+        }
+        return [];
+    }
+
+    handleTerminalLink(link: BitbucketTerminalLink): ProviderResult<void> {
+        const enabled = Container.config.bitbucket.showTerminalLinkPanel;
+
+        if (!enabled) {
+            this.openUrl(link.url);
+            return;
+        }
+        const yes = 'Yes';
+        const neverShow = "Don't show again";
+
+        window
+            .showInformationMessage(
+                'Do you want to create a pull request using the Jira and Bitbucket extension?',
+                yes,
+                'No, continue to Bitbucket',
+                neverShow,
+            )
+            .then((selection) => {
+                switch (selection) {
+                    case yes:
+                        commands.executeCommand(Commands.CreatePullRequest);
+                        break;
+                    case neverShow:
+                        this.disable();
+                        this.openUrl(link.url);
+                        break;
+                    default:
+                        this.openUrl(link.url);
+                        break;
+                }
+            });
+    }
+
+    private openUrl(url: string) {
+        return env.openExternal(Uri.parse(url));
+    }
+
+    private disable = () => configuration.update('bitbucket.showTerminalLinkPanel', false, ConfigurationTarget.Global);
+}

--- a/src/bitbucket/terminal-link/createPrLinkProvider.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.ts
@@ -52,6 +52,7 @@ export class BitbucketCloudPullRequestLinkProvider extends Disposable implements
                 Container.config.bitbucket.showTerminalLinkPanel && Container.config.bitbucket.enabled;
         }
     }
+
     provideTerminalLinks(
         context: TerminalLinkContext,
         token: CancellationToken,
@@ -137,6 +138,7 @@ export class BitbucketCloudPullRequestLinkProvider extends Disposable implements
             commands.executeCommand(Commands.CreatePullRequest);
         }
     }
+
     private openUrl(url: string) {
         return env.openExternal(Uri.parse(url));
     }

--- a/src/config/model.ts
+++ b/src/config/model.ts
@@ -118,6 +118,7 @@ export interface BitbucketConfig {
     pipelines: BitbucketPipelinesConfig;
     issues: BitbucketIssuesConfig;
     preferredRemotes: string[];
+    showTerminalLinkPanel: boolean;
 }
 
 export interface BitbucketPipelinesConfig {
@@ -286,6 +287,7 @@ const emptyBitbucketConfig: BitbucketConfig = {
     pipelines: emptyPipelinesConfig,
     issues: emptyIssuesConfig,
     preferredRemotes: ['upstream', 'origin'],
+    showTerminalLinkPanel: true,
 };
 
 export const emptyConfig: IConfig = {

--- a/src/container.ts
+++ b/src/container.ts
@@ -10,7 +10,7 @@ import { BitbucketContext } from './bitbucket/bbContext';
 import { BitbucketCheckoutHelper } from './bitbucket/checkoutHelper';
 import { CheckoutHelper } from './bitbucket/interfaces';
 import { PullRequest, WorkspaceRepo } from './bitbucket/model';
-import { BitbucketPullRequestLinkProvider } from './bitbucket/terminal-link/createPrLinkProvider';
+import { BitbucketCloudPullRequestLinkProvider } from './bitbucket/terminal-link/createPrLinkProvider';
 import { openPullRequest } from './commands/bitbucket/pullRequest';
 import { configuration, IConfig } from './config/configuration';
 import { ATLASCODE_TEST_HOST, ATLASCODE_TEST_USER_EMAIL } from './constants';
@@ -242,7 +242,7 @@ export class Container {
                 this._analyticsApi,
             )),
         );
-        this._context.subscriptions.push(new BitbucketPullRequestLinkProvider());
+        this._context.subscriptions.push(new BitbucketCloudPullRequestLinkProvider());
         // It seems to take a bit of time for VS Code to initialize git, if we try and find repos before that completes
         // we'll fail. Wait a few seconds before trying to check out a branch.
         setTimeout(() => {

--- a/src/container.ts
+++ b/src/container.ts
@@ -170,7 +170,6 @@ export class Container {
 
         this._loginManager = new LoginManager(this._credentialManager, this._siteManager, this._analyticsClient);
         this._bitbucketHelper = new BitbucketCheckoutHelper(context.globalState);
-        context.subscriptions.push(new BitbucketPullRequestLinkProvider());
         context.subscriptions.push(new HelpExplorer());
 
         try {

--- a/src/container.ts
+++ b/src/container.ts
@@ -242,6 +242,8 @@ export class Container {
                 this._analyticsApi,
             )),
         );
+        this._context.subscriptions.push((this._jiraActiveIssueStatusBar = new JiraActiveIssueStatusBar(bbCtx)));
+
         this._context.subscriptions.push(new BitbucketCloudPullRequestLinkProvider());
         // It seems to take a bit of time for VS Code to initialize git, if we try and find repos before that completes
         // we'll fail. Wait a few seconds before trying to check out a branch.

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,4 +1,4 @@
-import { ConfigurationChangeEvent, env, ExtensionContext, UIKind, window, workspace } from 'vscode';
+import { env, ExtensionContext, UIKind, window, workspace } from 'vscode';
 
 import { featureFlagClientInitializedEvent } from './analytics';
 import { AnalyticsClient, analyticsClient } from './analytics-node-client/src/client.min.js';
@@ -243,16 +243,7 @@ export class Container {
                 this._analyticsApi,
             )),
         );
-        if (this.config.bitbucket.showTerminalLinkPanel) {
-            this._context.subscriptions.push(new BitbucketPullRequestLinkProvider());
-        } else {
-            configuration.onDidChange(
-                (e: ConfigurationChangeEvent) =>
-                    configuration.changed(e, 'bitbucket.showTerminalLinkPanel') &&
-                    this._context.subscriptions.push(new BitbucketPullRequestLinkProvider()),
-                this,
-            );
-        }
+        this._context.subscriptions.push(new BitbucketPullRequestLinkProvider());
         // It seems to take a bit of time for VS Code to initialize git, if we try and find repos before that completes
         // we'll fail. Wait a few seconds before trying to check out a branch.
         setTimeout(() => {


### PR DESCRIPTION
### What Is This Change?

Adds terminal link panel to show when creating pr from terminal that asks whether to create pr in extension or browser

***Only cloud BB***
### How Has This Been Tested?

Added UT + manual testing

Loom: https://www.loom.com/share/6f3224d0bf2942bca271ab651749d979?sid=5f7af610-8c9b-47cf-961c-4a028b38656c
Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change