### PR TITLE
Enrich launched event

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -51,19 +51,19 @@ export async function upgradedEvent(version: string, previousVersion: string): P
 
 export async function launchedEvent(
     location: string,
-    isJiraCloudAuthenticated: boolean,
-    isJiraServerAuthenticated: boolean,
-    isBitbucketCloudAuthenticated: boolean,
-    isBitbucketServerAuthenticated: boolean,
+    numJiraCloudAuthed: number,
+    numJiraDcAuthed: number,
+    numBitbucketCloudAuthed: number,
+    numBitbucketDcAuthed: number,
 ): Promise<TrackEvent> {
     return trackEvent('launched', 'atlascode', {
         attributes: {
             machineId: Container.machineId,
             extensionLocation: location,
-            jiraCloudAuthenticated: isJiraCloudAuthenticated,
-            jiraServerAuthenticated: isJiraServerAuthenticated,
-            bitbucketCloudAuthenticated: isBitbucketCloudAuthenticated,
-            bitbucketServerAuthenticated: isBitbucketServerAuthenticated,
+            numJiraCloudAuthed: numJiraCloudAuthed,
+            numJiraDcAuthed: numJiraDcAuthed,
+            numBitbucketCloudAuthed: numBitbucketCloudAuthed,
+            numBitbucketDcAuthed: numBitbucketDcAuthed,
         },
     });
 }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -51,15 +51,19 @@ export async function upgradedEvent(version: string, previousVersion: string): P
 
 export async function launchedEvent(
     location: string,
-    isJiraAuthenticated: boolean,
-    isBitbucketAuthenticated: boolean,
+    isJiraCloudAuthenticated: boolean,
+    isJiraServerAuthenticated: boolean,
+    isBitbucketCloudAuthenticated: boolean,
+    isBitbucketServerAuthenticated: boolean,
 ): Promise<TrackEvent> {
     return trackEvent('launched', 'atlascode', {
         attributes: {
             machineId: Container.machineId,
             extensionLocation: location,
-            jiraAuthenticated: isJiraAuthenticated,
-            bitbucketAuthenticated: isBitbucketAuthenticated,
+            jiraCloudAuthenticated: isJiraCloudAuthenticated,
+            jiraServerAuthenticated: isJiraServerAuthenticated,
+            bitbucketCloudAuthenticated: isBitbucketCloudAuthenticated,
+            bitbucketServerAuthenticated: isBitbucketServerAuthenticated,
         },
     });
 }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -49,9 +49,18 @@ export async function upgradedEvent(version: string, previousVersion: string): P
     });
 }
 
-export async function launchedEvent(location: string): Promise<TrackEvent> {
+export async function launchedEvent(
+    location: string,
+    isJiraAuthenticated: boolean,
+    isBitbucketAuthenticated: boolean,
+): Promise<TrackEvent> {
     return trackEvent('launched', 'atlascode', {
-        attributes: { machineId: Container.machineId, extensionLocation: location },
+        attributes: {
+            machineId: Container.machineId,
+            extensionLocation: location,
+            jiraAuthenticated: isJiraAuthenticated,
+            bitbucketAuthenticated: isBitbucketAuthenticated,
+        },
     });
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,8 +184,10 @@ async function sendAnalytics(version: string, globalState: Memento) {
 
     launchedEvent(
         env.remoteName ? env.remoteName : 'local',
-        Container.siteManager.productHasAtLeastOneSite(ProductJira),
-        Container.siteManager.productHasAtLeastOneSite(ProductBitbucket),
+        Container.siteManager.productHasAtLeastOneSite(ProductJira, true),
+        Container.siteManager.productHasAtLeastOneSite(ProductJira, false),
+        Container.siteManager.productHasAtLeastOneSite(ProductBitbucket, true),
+        Container.siteManager.productHasAtLeastOneSite(ProductBitbucket, false),
     ).then((e) => {
         Container.analyticsClient.sendTrackEvent(e);
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,7 +182,11 @@ async function sendAnalytics(version: string, globalState: Memento) {
         });
     }
 
-    launchedEvent(env.remoteName ? env.remoteName : 'local').then((e) => {
+    launchedEvent(
+        env.remoteName ? env.remoteName : 'local',
+        Container.siteManager.productHasAtLeastOneSite(ProductJira),
+        Container.siteManager.productHasAtLeastOneSite(ProductBitbucket),
+    ).then((e) => {
         Container.analyticsClient.sendTrackEvent(e);
     });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,10 +184,10 @@ async function sendAnalytics(version: string, globalState: Memento) {
 
     launchedEvent(
         env.remoteName ? env.remoteName : 'local',
-        Container.siteManager.productHasAtLeastOneSite(ProductJira, true),
-        Container.siteManager.productHasAtLeastOneSite(ProductJira, false),
-        Container.siteManager.productHasAtLeastOneSite(ProductBitbucket, true),
-        Container.siteManager.productHasAtLeastOneSite(ProductBitbucket, false),
+        Container.siteManager.numberOfSites(ProductJira, true),
+        Container.siteManager.numberOfSites(ProductJira, false),
+        Container.siteManager.numberOfSites(ProductBitbucket, true),
+        Container.siteManager.numberOfSites(ProductBitbucket, false),
     ).then((e) => {
         Container.analyticsClient.sendTrackEvent(e);
     });

--- a/src/lib/analyticsApi.ts
+++ b/src/lib/analyticsApi.ts
@@ -7,10 +7,10 @@ export interface AnalyticsApi {
     fireUpgradedEvent(version: string, previousVersion: string): Promise<void>;
     fireLaunchedEvent(
         location: string,
-        isJiraCloudAuthenticated: boolean,
-        isJiraServerAuthenticated: boolean,
-        isBitbucketCloudAuthenticated: boolean,
-        isBitbucketServerAuthenticated: boolean,
+        numJiraCloudAuthed: number,
+        numJiraDcAuthed: number,
+        numBitbucketCloudAuthed: number,
+        numBitbucketDcAuthed: number,
     ): Promise<void>;
     fireFeatureChangeEvent(featureId: string, enabled: boolean): Promise<void>;
     fireAuthenticatedEvent(site: DetailedSiteInfo): Promise<void>;

--- a/src/lib/analyticsApi.ts
+++ b/src/lib/analyticsApi.ts
@@ -5,7 +5,13 @@ import { DetailedSiteInfo, Product, SiteInfo } from '../atlclients/authInfo';
 export interface AnalyticsApi {
     fireInstalledEvent(version: string): Promise<void>;
     fireUpgradedEvent(version: string, previousVersion: string): Promise<void>;
-    fireLaunchedEvent(location: string, isJiraAuthenticated: boolean, isBitbucketAuthenticated: boolean): Promise<void>;
+    fireLaunchedEvent(
+        location: string,
+        isJiraCloudAuthenticated: boolean,
+        isJiraServerAuthenticated: boolean,
+        isBitbucketCloudAuthenticated: boolean,
+        isBitbucketServerAuthenticated: boolean,
+    ): Promise<void>;
     fireFeatureChangeEvent(featureId: string, enabled: boolean): Promise<void>;
     fireAuthenticatedEvent(site: DetailedSiteInfo): Promise<void>;
     fireLoggedOutEvent(site: DetailedSiteInfo): Promise<void>;

--- a/src/lib/analyticsApi.ts
+++ b/src/lib/analyticsApi.ts
@@ -5,7 +5,7 @@ import { DetailedSiteInfo, Product, SiteInfo } from '../atlclients/authInfo';
 export interface AnalyticsApi {
     fireInstalledEvent(version: string): Promise<void>;
     fireUpgradedEvent(version: string, previousVersion: string): Promise<void>;
-    fireLaunchedEvent(location: string): Promise<void>;
+    fireLaunchedEvent(location: string, isJiraAuthenticated: boolean, isBitbucketAuthenticated: boolean): Promise<void>;
     fireFeatureChangeEvent(featureId: string, enabled: boolean): Promise<void>;
     fireAuthenticatedEvent(site: DetailedSiteInfo): Promise<void>;
     fireLoggedOutEvent(site: DetailedSiteInfo): Promise<void>;

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -193,12 +193,12 @@ export class SiteManager extends Disposable {
         return undefined;
     }
 
-    public productHasAtLeastOneSite(product: Product, isCloud: boolean | undefined = undefined): boolean {
-        if (isCloud !== undefined) {
-            return this.getSitesAvailable(product).some((site) => site.isCloud === isCloud);
-        }
-
+    public productHasAtLeastOneSite(product: Product): boolean {
         return this.getSitesAvailable(product).length > 0;
+    }
+
+    public numberOfSites(product: Product, isCloud: boolean): number {
+        return this.getSitesAvailable(product).filter((site) => site.isCloud === isCloud).length;
     }
 
     public getSiteForHostname(product: Product, hostname: string): DetailedSiteInfo | undefined {

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -193,7 +193,11 @@ export class SiteManager extends Disposable {
         return undefined;
     }
 
-    public productHasAtLeastOneSite(product: Product): boolean {
+    public productHasAtLeastOneSite(product: Product, isCloud: boolean | undefined = undefined): boolean {
+        if (isCloud !== undefined) {
+            return this.getSitesAvailable(product).some((site) => site.isCloud === isCloud);
+        }
+
         return this.getSitesAvailable(product).length > 0;
     }
 

--- a/src/vscAnalyticsApi.ts
+++ b/src/vscAnalyticsApi.ts
@@ -74,17 +74,17 @@ export class VSCAnalyticsApi implements AnalyticsApi {
 
     public async fireLaunchedEvent(
         location: string,
-        isJiraCloudAuthenticated: boolean,
-        isJiraServerAuthenticated: boolean,
-        isBitbucketCloudAuthenticated: boolean,
-        isBitbucketServerAuthenticated: boolean,
+        numJiraCloudAuthed: number,
+        numJiraDcAuthed: number,
+        numBitbucketCloudAuthed: number,
+        numBitbucketDcAuthed: number,
     ): Promise<void> {
         return launchedEvent(
             location,
-            isJiraCloudAuthenticated,
-            isJiraServerAuthenticated,
-            isBitbucketCloudAuthenticated,
-            isBitbucketServerAuthenticated,
+            numJiraCloudAuthed,
+            numJiraDcAuthed,
+            numBitbucketCloudAuthed,
+            numBitbucketDcAuthed,
         ).then((e) => {
             this._analyticsClient.sendTrackEvent(e);
         });

--- a/src/vscAnalyticsApi.ts
+++ b/src/vscAnalyticsApi.ts
@@ -74,10 +74,18 @@ export class VSCAnalyticsApi implements AnalyticsApi {
 
     public async fireLaunchedEvent(
         location: string,
-        isJiraAuthenticated: boolean,
-        isBitbucketAuthenticated: boolean,
+        isJiraCloudAuthenticated: boolean,
+        isJiraServerAuthenticated: boolean,
+        isBitbucketCloudAuthenticated: boolean,
+        isBitbucketServerAuthenticated: boolean,
     ): Promise<void> {
-        return launchedEvent(location, isJiraAuthenticated, isBitbucketAuthenticated).then((e) => {
+        return launchedEvent(
+            location,
+            isJiraCloudAuthenticated,
+            isJiraServerAuthenticated,
+            isBitbucketCloudAuthenticated,
+            isBitbucketServerAuthenticated,
+        ).then((e) => {
             this._analyticsClient.sendTrackEvent(e);
         });
     }

--- a/src/vscAnalyticsApi.ts
+++ b/src/vscAnalyticsApi.ts
@@ -72,8 +72,12 @@ export class VSCAnalyticsApi implements AnalyticsApi {
         });
     }
 
-    public async fireLaunchedEvent(location: string): Promise<void> {
-        return launchedEvent(location).then((e) => {
+    public async fireLaunchedEvent(
+        location: string,
+        isJiraAuthenticated: boolean,
+        isBitbucketAuthenticated: boolean,
+    ): Promise<void> {
+        return launchedEvent(location, isJiraAuthenticated, isBitbucketAuthenticated).then((e) => {
             this._analyticsClient.sendTrackEvent(e);
         });
     }


### PR DESCRIPTION
### What Is This Change?

The current launched event doesn't track Authentication State. So, adding it in. 

Why is the necessary? 

We need to approximate the number of calls we will make to the notification service. Without knowing the number of auth'ed users who are launching VSCode in a given day, this is hard. 

Added in dataPortal: 
https://data-portal.internal.atlassian.com/analytics/registry/18825?tabIndex=Attributes

### How Has This Been Tested?
Manual debug to confirm that the is<Product>Authenticate works as expected. 


Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change