### PR TITLE
[AXON-362] Fixed already registered id error when showing PR related issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues/new/choose)
-
 ---
+
+## What's new in 3.6.4
+
+### Bug fixes
+
+- Fixed "already registered id" error when rendering PR related issues in the Bitbucket Pull Requests side panel.
+
 ## What's new in 3.6.3
 
 - Internal changes only 

--- a/src/views/jira/treeViews/customJqlViewProvider.test.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.test.ts
@@ -34,7 +34,7 @@ const mockedIssue1 = forceCastTo<TreeViewIssue>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockJqlEntries[0],
+    source: mockJqlEntries[0],
     children: [],
 });
 
@@ -47,7 +47,7 @@ const mockedIssue2 = forceCastTo<TreeViewIssue>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockJqlEntries[0],
+    source: mockJqlEntries[0],
     children: [],
 });
 
@@ -60,7 +60,7 @@ const mockedIssue3 = forceCastTo<TreeViewIssue>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockJqlEntries[0],
+    source: mockJqlEntries[0],
     children: [],
 });
 

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -205,7 +205,7 @@ class JiraIssueQueryNode extends TreeItem {
         return await Promise.all(
             keys.map(async (issueKey) => {
                 const parent = (await fetchMinimalIssue(issueKey, site)) as TreeViewIssue;
-                parent.jqlSource = this.jqlEntry;
+                parent.source = this.jqlEntry;
                 parent.children = [];
                 return parent;
             }),

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -26,7 +26,7 @@ const mockedIssue1 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockedJqlEntry,
+    source: mockedJqlEntry,
     children: [],
 });
 
@@ -39,7 +39,7 @@ const mockedIssue2 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockedJqlEntry,
+    source: mockedJqlEntry,
     children: [],
 });
 
@@ -52,7 +52,7 @@ const mockedIssue3 = forceCastTo<MinimalIssue<DetailedSiteInfo>>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails/' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockedJqlEntry,
+    source: mockedJqlEntry,
     children: [],
 });
 

--- a/src/views/jira/treeViews/utils.test.ts
+++ b/src/views/jira/treeViews/utils.test.ts
@@ -41,7 +41,7 @@ const mockedIssue1 = forceCastTo<TreeViewIssue>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockedJqlEntry,
+    source: mockedJqlEntry,
     children: [],
 });
 
@@ -54,7 +54,7 @@ const mockedIssue2 = forceCastTo<TreeViewIssue>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockedJqlEntry,
+    source: mockedJqlEntry,
     children: [mockedIssue1],
 });
 
@@ -67,7 +67,7 @@ const mockedIssue3 = forceCastTo<TreeViewIssue>({
     siteDetails: { id: 'siteDetailsId', baseLinkUrl: '/siteDetails' },
     issuetype: { iconUrl: '/issueType/' },
     subtasks: [],
-    jqlSource: mockedJqlEntry,
+    source: mockedJqlEntry,
     children: [],
 });
 
@@ -105,16 +105,14 @@ describe('utils', () => {
 
         it('JiraIssueNode id is unique for the same Jira issue across different JQL entries', () => {
             const _mockedIssue1 = cloneDeep(mockedIssue1);
-            _mockedIssue1.jqlSource = expansionCastTo<JQLEntry>({
+            _mockedIssue1.source = {
                 id: 'jqlId1',
-                siteId: 'siteDetailsId',
-            });
+            };
 
             const _mockedIssue2 = cloneDeep(mockedIssue1);
-            _mockedIssue2.jqlSource = expansionCastTo<JQLEntry>({
+            _mockedIssue2.source = {
                 id: 'jqlId2',
-                siteId: 'siteDetailsId',
-            });
+            };
 
             const jiraIssueNode1 = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, _mockedIssue1);
             const jiraIssueNode2 = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, _mockedIssue2);

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -16,7 +16,7 @@ export function createLabelItem(label: string, command?: Command): TreeItem {
 }
 
 export interface TreeViewIssue extends MinimalIssue<DetailedSiteInfo> {
-    jqlSource: JQLEntry;
+    source: { id: string };
     children: TreeViewIssue[];
 }
 
@@ -29,7 +29,7 @@ export async function executeJqlQuery(jqlEntry: JQLEntry): Promise<TreeViewIssue
                 const issues = (await issuesForJQL(jqlEntry.query, jqlSite)) as TreeViewIssue[];
 
                 issues.forEach((i) => {
-                    i.jqlSource = jqlEntry;
+                    i.source = jqlEntry;
                     i.children = [];
                 });
 
@@ -63,7 +63,7 @@ export class JiraIssueNode extends TreeItem implements AbstractBaseNode {
 
         // this id is constructed to ensure unique values for the same jira issue across multiple jql queries.
         // therefore, multiple jql entries must have a unique id for the same site.
-        this.id = `${issue.key}_${issue.siteDetails.id}_${issue.jqlSource.id}`;
+        this.id = `${issue.key}_${issue.siteDetails.id}_${issue.source.id}`;
 
         this.description = isMinimalIssue(issue) && issue.isEpic ? issue.epicName : issue.summary;
         this.command = { command: Commands.ShowIssue, title: 'Show Issue', arguments: [issue] };

--- a/src/views/nodes/relatedIssuesNode.ts
+++ b/src/views/nodes/relatedIssuesNode.ts
@@ -10,7 +10,7 @@ import { SimpleNode } from './simpleNode';
 export class RelatedIssuesNode extends TreeItem implements AbstractBaseNode {
     private readonly childrenPromises: Promise<JiraIssueNode[]>;
 
-    constructor(jiraKeys: string[], label: string) {
+    constructor(prId: string, jiraKeys: string[], label: string) {
         const collapsibleState = jiraKeys.length ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.None;
         super(label, collapsibleState);
 
@@ -20,14 +20,7 @@ export class RelatedIssuesNode extends TreeItem implements AbstractBaseNode {
             jiraKeys.map((key) =>
                 issueForKey(key).then((issue) => {
                     (issue as TreeViewIssue).children = [];
-                    (issue as TreeViewIssue).jqlSource = {
-                        id: 'relatedJiras',
-                        name: '',
-                        query: '',
-                        siteId: '',
-                        enabled: false,
-                        monitor: false,
-                    };
+                    (issue as TreeViewIssue).source = { id: prId };
                     return new JiraIssueNode(
                         JiraIssueNode.NodeType.RelatedJiraIssueInBitbucketPR,
                         issue as TreeViewIssue,

--- a/src/views/pullrequest/pullRequestNode.ts
+++ b/src/views/pullrequest/pullRequestNode.ts
@@ -202,7 +202,7 @@ export class PullRequestTitlesNode extends AbstractBaseNode {
         }
 
         const issueKeys = await extractIssueKeys(this.pr, commits, allComments.data);
-        return issueKeys.length ? [new RelatedIssuesNode(issueKeys, 'Related Jira issues')] : [];
+        return issueKeys.length ? [new RelatedIssuesNode(this.pr.data.id, issueKeys, 'Related Jira issues')] : [];
     }
 }
 


### PR DESCRIPTION
### What Is This Change?

Fixes #372.
Similar issue and fix to #261.

Related Jira issues in Pull Requests need to have unique IDs for different PRs so the same item can show up multiple times for different pull requests.

### How Has This Been Tested?

Basic checks:

- [X] manual tests
- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change