### PR TITLE
[AXON-374] chore: add format-on-save to the workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 node_modules
 .vscode-test/
 .vscode/*
+!.vscode/settings.json
 launch.json
 !.vscode/launch.json.example
 *.vsix

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+}


### PR DESCRIPTION
### What Is This Change?

Small ways-of-working improvement - we now format file automatically on save after editing. Returning from the other project, this was bugging me quite a bit ;D

The configuration for this is added to workspace settings, which are now no longer `.gitignore`-d

### How Has This Been Tested?

Edited some files, then saved them ;) Observed the expected behavior

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] ~If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)~ N/A

Recommendations:
- [x] ~Update the CHANGELOG if making a user facing change~ N/A