### PR TITLE
Refined error telemetry data

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -95,7 +95,6 @@ export async function loggedOutEvent(site: DetailedSiteInfo): Promise<TrackEvent
 
 function sanitazeErrorMessage(message?: string): string | undefined {
     if (message) {
-        message = message.replace(/^(Failed to execute default JQL query for site ")([^"]+)(": .*)/, '$1<site>$3');
         message = message.replace(/^(connect \w+ )(\d+\.\d+\.\d+\.\d+)(.*)/, '$1<ip>$3');
         message = message.replace(/^(getaddrinfo \w+ )(.*)/, '$1<domain>');
     }
@@ -109,12 +108,24 @@ function sanitizeStackTrace(stack?: string): string | undefined {
     return stack || undefined;
 }
 
-export async function errorEvent(errorMessage: string, error?: Error, capturedBy?: string): Promise<TrackEvent> {
-    const attributes: { name: string; message?: string; capturedBy?: string; stack?: string } = {
+export async function errorEvent(
+    errorMessage: string,
+    error?: Error,
+    capturedBy?: string,
+    additionalParams?: string,
+): Promise<TrackEvent> {
+    const attributes: {
+        name: string;
+        message?: string;
+        capturedBy?: string;
+        stack?: string;
+        additionalParams?: string;
+    } = {
         message: sanitazeErrorMessage(errorMessage),
         name: error?.name || 'Error',
         capturedBy,
         stack: error?.stack ? sanitizeStackTrace(error.stack) : undefined,
+        additionalParams,
     };
 
     return trackEvent('errorEvent_v2', 'atlascode', { attributes });

--- a/src/atlclients/clientManager.ts
+++ b/src/atlclients/clientManager.ts
@@ -188,7 +188,7 @@ export class ClientManager implements Disposable {
                 });
             });
         } catch (e) {
-            Logger.error(e, `${tag}: Failed to refresh tokens`);
+            Logger.error(e, `Failed to refresh tokens`);
             throw e;
         }
         return newClient!;

--- a/src/bitbucket/httpClient.ts
+++ b/src/bitbucket/httpClient.ts
@@ -68,7 +68,7 @@ export class HTTPClient {
             });
             return { data: res.data, headers: res.headers };
         } catch (e) {
-            Logger.error(e, `Error getting URL: ${url}`);
+            Logger.error(e, 'Error getting URL', url);
             if (e.response) {
                 return Promise.reject(await this.errorHandler(e.response));
             } else {

--- a/src/errorReporting.test.ts
+++ b/src/errorReporting.test.ts
@@ -5,11 +5,18 @@ import * as analytics from './analytics';
 import { AnalyticsClient } from './analytics-node-client/src/client.min';
 import { TrackEvent } from './analytics-node-client/src/types';
 import { registerAnalyticsClient, registerErrorReporting, unregisterErrorReporting } from './errorReporting';
-import { Logger } from './logger';
+import { ErrorEvent, Logger } from './logger';
 
 const mockAnalyticsClient = expansionCastTo<AnalyticsClient>({
     sendTrackEvent: () => Promise.reject(),
 });
+
+const createError = (message: string, stack?: string) => {
+    const error = new Error();
+    error.message = message;
+    error.stack = stack || '@';
+    return error;
+};
 
 jest.mock('./analytics', () => ({
     errorEvent: () => Promise.resolve({ userId: 'id', anonymousId: 'anonId' }),
@@ -24,6 +31,7 @@ describe('errorReporting', () => {
 
     afterEach(() => {
         unregisterErrorReporting();
+        jest.clearAllMocks();
         jest.restoreAllMocks();
     });
 
@@ -65,7 +73,36 @@ describe('errorReporting', () => {
         it('should register the analytics client and process queued events', async () => {
             const mockEvent = expansionCastTo<TrackEvent>({ userId: 'id', anonymousId: 'anonId' });
 
-            let errorlistener: Function;
+            jest.spyOn(analytics, 'errorEvent').mockResolvedValue(mockEvent);
+            jest.spyOn(mockAnalyticsClient, 'sendTrackEvent').mockImplementation(jest.fn());
+
+            let errorlistener: (data: ErrorEvent) => void;
+            (Logger.onError as jest.Mock).mockImplementation((listener) => {
+                errorlistener = listener;
+            });
+
+            registerErrorReporting();
+
+            expect(errorlistener!).toBeDefined();
+            errorlistener!({ error: createError('Error1') });
+
+            expect(analytics.errorEvent).toHaveBeenCalled();
+            expect(mockAnalyticsClient.sendTrackEvent).not.toHaveBeenCalled();
+
+            await registerAnalyticsClient(mockAnalyticsClient);
+
+            expect(mockAnalyticsClient.sendTrackEvent).toHaveBeenCalledWith(mockEvent);
+        });
+    });
+
+    describe('errorEvent arguments', () => {
+        let errorlistener: (data: ErrorEvent) => void;
+        let uncaughtExceptionListener: Function;
+        let uncaughtExceptionMonitorListener: Function;
+        let unhandledRejectionListener: Function;
+
+        beforeEach(() => {
+            const mockEvent = expansionCastTo<TrackEvent>({ userId: 'id', anonymousId: 'anonId' });
 
             jest.spyOn(analytics, 'errorEvent').mockResolvedValue(mockEvent);
             jest.spyOn(mockAnalyticsClient, 'sendTrackEvent').mockImplementation(jest.fn());
@@ -74,17 +111,141 @@ describe('errorReporting', () => {
                 errorlistener = listener;
             });
 
+            (process.addListener as jest.Mock).mockImplementation((name, listener) => {
+                switch (name) {
+                    case 'uncaughtException':
+                        uncaughtExceptionListener = listener;
+                        break;
+                    case 'uncaughtExceptionMonitor':
+                        uncaughtExceptionMonitorListener = listener;
+                        break;
+                    case 'unhandledRejection':
+                        unhandledRejectionListener = listener;
+                        break;
+                }
+            });
+
             registerErrorReporting();
+        });
 
-            expect(errorlistener!).toBeDefined();
-            errorlistener!({ error: expansionCastTo<Error>({ message: 'Error1', stack: '@' }) });
+        describe('when error is of type Error', () => {
+            it('no extra params', () => {
+                const error = createError('Error1');
+                errorlistener!({ error });
 
-            expect(analytics.errorEvent).toHaveBeenCalled();
-            expect(mockAnalyticsClient.sendTrackEvent).not.toHaveBeenCalled();
+                expect(analytics.errorEvent).toHaveBeenCalledWith(error.message, error, undefined, undefined);
+            });
 
-            await registerAnalyticsClient(mockAnalyticsClient);
+            it('with capturedBy', () => {
+                const error = createError('Error1');
+                errorlistener!({ error, capturedBy: 'foo' });
 
-            expect(mockAnalyticsClient.sendTrackEvent).toHaveBeenCalledWith(mockEvent);
+                expect(analytics.errorEvent).toHaveBeenCalledWith(error.message, error, 'foo', undefined);
+            });
+
+            it('with a custom message', () => {
+                const error = createError('Error1');
+                errorlistener!({ error, errorMessage: "what's this" });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith("what's this", error, undefined, undefined);
+            });
+
+            it('with a custom message and capturedBy', () => {
+                const error = createError('Error1');
+                errorlistener!({ error, errorMessage: "what's this", capturedBy: 'fii' });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith("what's this", error, 'fii', undefined);
+            });
+
+            it('with a single param', () => {
+                const error = createError('Error1');
+                const params = ['single param'];
+                errorlistener!({ error, params });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith(error.message, error, undefined, 'single param');
+            });
+
+            it('with multiple params', () => {
+                const error = createError('Error1');
+                const params = ['param one', 'param two'];
+                errorlistener!({ error, params });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    error.message,
+                    error,
+                    undefined,
+                    JSON.stringify(params),
+                );
+            });
+
+            it('with empty params', () => {
+                const error = createError('Error1');
+                const params = [] as string[];
+                errorlistener!({ error, params });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith(error.message, error, undefined, undefined);
+            });
+
+            it('captured by uncaughtException', () => {
+                const error = createError('Error1', '/.vscode/extensions/atlassian.atlascode-');
+                uncaughtExceptionListener(error);
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    error.message,
+                    error,
+                    'NodeJS.uncaughtException',
+                    undefined,
+                );
+            });
+
+            it('captured by uncaughtExceptionMonitor', () => {
+                const error = createError('Error1', '/.vscode/extensions/atlassian.atlascode-');
+                uncaughtExceptionMonitorListener(error);
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    error.message,
+                    error,
+                    'NodeJS.uncaughtExceptionMonitor',
+                    undefined,
+                );
+            });
+
+            it('captured by unhandledRejection', () => {
+                const error = createError('Error1', '/.vscode/extensions/atlassian.atlascode-');
+                unhandledRejectionListener(error);
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    error.message,
+                    error,
+                    'NodeJS.unhandledRejection',
+                    undefined,
+                );
+            });
+        });
+
+        describe('when error is of string type', () => {
+            it('no extra params', () => {
+                errorlistener!({ error: 'Error1' as any });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith('Error1', undefined, undefined, undefined);
+            });
+
+            it('with capturedBy', () => {
+                errorlistener!({ error: 'Error1' as any, capturedBy: 'foo' });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith('Error1', undefined, 'foo', undefined);
+            });
+
+            it('with a custom message', () => {
+                errorlistener!({ error: 'Seg fault' as any, errorMessage: 'Error reading stream buffer' });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    'Error reading stream buffer: Seg fault',
+                    undefined,
+                    undefined,
+                    undefined,
+                );
+            });
         });
     });
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,6 +11,7 @@ export type ErrorEvent = {
     error: Error;
     errorMessage?: string;
     capturedBy?: string;
+    params?: string[];
 };
 
 /** This function must be called from the VERY FIRST FUNCTION that the called invoked from Logger.
@@ -109,29 +110,29 @@ export class Logger {
         }
     }
 
-    public static error(ex: Error, errorMessage?: string): void {
+    public static error(ex: Error, errorMessage?: string, ...params: string[]): void {
         const callerName = retrieveCallerName();
-        this.Instance.errorInternal(ex, callerName, errorMessage);
+        this.Instance.errorInternal(ex, callerName, errorMessage, ...params);
     }
 
-    public error(ex: Error, errorMessage?: string): void {
+    public error(ex: Error, errorMessage?: string, ...params: string[]): void {
         const callerName = retrieveCallerName();
-        this.errorInternal(ex, callerName, errorMessage);
+        this.errorInternal(ex, callerName, errorMessage, ...params);
     }
 
-    private errorInternal(ex: Error, capturedBy?: string, errorMessage?: string): void {
-        Logger._onError.fire({ error: ex, errorMessage, capturedBy });
+    private errorInternal(ex: Error, capturedBy?: string, errorMessage?: string, ...params: string[]): void {
+        Logger._onError.fire({ error: ex, errorMessage, capturedBy, params });
 
         if (this.level === OutputLevel.Silent) {
             return;
         }
 
         if (Container.isDebugging) {
-            console.error(this.timestamp, ConsolePrefix, errorMessage, ex);
+            console.error(this.timestamp, ConsolePrefix, errorMessage, ...params, ex);
         }
 
         if (this.output !== undefined) {
-            this.output.appendLine([this.timestamp, errorMessage, ex].join(' '));
+            this.output.appendLine([this.timestamp, errorMessage, ex, ...params].join(' '));
         }
     }
 

--- a/src/views/jira/treeViews/utils.test.ts
+++ b/src/views/jira/treeViews/utils.test.ts
@@ -91,7 +91,7 @@ describe('utils', () => {
         });
 
         it('returns an empty collection of issues for no corresponding site', async () => {
-            const jqlEntry = expansionCastTo<JQLEntry>({ id: 'id1', query: 'query1' });
+            const jqlEntry = expansionCastTo<JQLEntry>({ id: 'id1', query: 'query1', siteId: 'site-id-guid' });
             jest.spyOn(Container.siteManager, 'getSiteForId').mockReturnValue(undefined);
 
             const issues = await executeJqlQuery(jqlEntry);
@@ -100,7 +100,7 @@ describe('utils', () => {
         });
 
         it('initializes the `source` and the `children` fields', async () => {
-            const jqlEntry = expansionCastTo<JQLEntry>({ id: 'id1', query: 'query1' });
+            const jqlEntry = expansionCastTo<JQLEntry>({ id: 'id1', query: 'query1', siteId: 'site-id-guid' });
             const mockedMinimalIssues = [
                 expansionCastTo<MinimalIssue<DetailedSiteInfo>>({ key: 'AXON-1' }),
                 expansionCastTo<MinimalIssue<DetailedSiteInfo>>({ key: 'AXON-2' }),
@@ -122,12 +122,16 @@ describe('utils', () => {
 
         it('logs an error in case of failure, and returns an empty collection of issues', async () => {
             const error = new Error('this is a failure');
-            const jqlEntry = expansionCastTo<JQLEntry>({ id: 'id1', query: 'query1' });
+            const jqlEntry = expansionCastTo<JQLEntry>({ id: 'id1', query: 'query1', siteId: 'site-id-guid' });
             jest.spyOn(issuesForJQL, 'issuesForJQL').mockRejectedValue(error);
 
             const issues = await executeJqlQuery(jqlEntry);
             expect(issues).toHaveLength(0);
-            expect(Logger.error).toHaveBeenCalledWith(error, expect.any(String));
+            expect(Logger.error).toHaveBeenCalledWith(
+                error,
+                'Failed to execute default JQL query for site',
+                'site-id-guid',
+            );
         });
     });
 

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -37,7 +37,7 @@ export async function executeJqlQuery(jqlEntry: JQLEntry): Promise<TreeViewIssue
             }
         }
     } catch (e) {
-        Logger.error(e, `Failed to execute default JQL query for site "${jqlEntry.siteId}"`);
+        Logger.error(e, 'Failed to execute default JQL query for site', jqlEntry.siteId);
     }
 
     return [];

--- a/testsutil/miscFunctions.ts
+++ b/testsutil/miscFunctions.ts
@@ -15,8 +15,8 @@ export function forceCastTo<T>(obj: any): T {
 }
 
 /** Returns a Promise-like object that resolves synchronously */
-export function resolvePromiseSync<T>(value: T): Thenable<T> {
-    return forceCastTo<Thenable<T>>({
+export function resolvePromiseSync<T>(value: T): Promise<T> {
+    return forceCastTo<Promise<T>>({
         then: (onfulfilled: (val: T) => void) => onfulfilled(value),
     });
 }


### PR DESCRIPTION
### What Is This Change?

This PR:
- fixes a couple of error messages to not include variable parameters
- adds a new field in the error event to carry extra params
- other minor fixes

### How Has This Been Tested?

- [X] manual tests
- [X] `npm run lint`
- [X] `npm run test`