### PR TITLE
Add notif change event for any time banner appears

### DIFF
--- a/src/bitbucket/terminal-link/createPrLinkProvider.test.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.test.ts
@@ -35,7 +35,9 @@ jest.mock('../../container', () => ({
 jest.mock('../../analytics', () => ({
     createPrTerminalLinkDetectedEvent: jest.fn().mockResolvedValue({}),
     createPrTerminalLinkPanelButtonClickedEvent: jest.fn().mockResolvedValue({}),
+    notificationChangeEvent: jest.fn().mockResolvedValue({}),
 }));
+
 import { commands, env, TerminalLinkContext, Uri, window } from 'vscode';
 
 import { configuration } from '../../config/configuration';

--- a/src/bitbucket/terminal-link/createPrLinkProvider.ts
+++ b/src/bitbucket/terminal-link/createPrLinkProvider.ts
@@ -13,13 +13,18 @@ import {
     window,
 } from 'vscode';
 
-import { createPrTerminalLinkDetectedEvent, createPrTerminalLinkPanelButtonClickedEvent } from '../../analytics';
+import {
+    createPrTerminalLinkDetectedEvent,
+    createPrTerminalLinkPanelButtonClickedEvent,
+    notificationChangeEvent,
+} from '../../analytics';
 import { AnalyticsClient } from '../../analytics-node-client/src/client.min.js';
 import { CreatePrTerminalSelection } from '../../analyticsTypes';
 import { ProductBitbucket } from '../../atlclients/authInfo';
 import { Commands } from '../../commands';
 import { configuration } from '../../config/configuration';
 import { Container } from '../../container';
+import { NotificationSurface } from '../../views/notifications/notificationManager';
 
 interface BitbucketTerminalLink extends TerminalLink {
     url: string;
@@ -96,6 +101,10 @@ export class BitbucketCloudPullRequestLinkProvider extends Disposable implements
         }
         const yes = 'Yes';
         const neverShow = "Don't show again";
+
+        notificationChangeEvent(Uri.parse(PanelId), NotificationSurface.Banner, 1).then((event) => {
+            this._analyticsClient.sendTrackEvent(event);
+        });
 
         window
             .showInformationMessage(


### PR DESCRIPTION
### What Is This Change?

Add `notificationChangeEvent` to the banner notifcation flow to signify that the banner has appeared before the user has taken any action

### How Has This Been Tested?

- [x] `npm run lint`
- [x] `npm run test`
