### PR TITLE
fork-to-main: Add PR Overview Panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -407,6 +407,14 @@
                 "command": "atlascode.disableHelpExplorer",
                 "title": "Disable Help Explorer",
                 "category": "Atlassian"
+            },
+            {
+                "command": "atlascode.bitbucket.pullRequestsOverview.refresh",
+                "title": "Refresh",
+                "icon": {
+                    "light": "resources/light/refresh.svg",
+                    "dark": "resources/dark/refresh.svg"
+                }
             }
         ],
         "viewsContainers": {
@@ -433,7 +441,12 @@
                 {
                     "id": "atlascode.views.bb.pullrequestsTreeView",
                     "name": "Bitbucket pull requests",
-                    "when": "atlascode:bitbucketExplorerEnabled && config.atlascode.bitbucket.enabled"
+                    "when": "atlascode:bitbucketExplorerEnabled && config.atlascode.bitbucket.enabled && config.atlascode.bitbucket.explorer.repositoryBasedPullRequestView.enabled"
+                },
+                {
+                    "id": "atlascode.views.bb.pullRequestsOverviewTreeView",
+                    "name": "Bitbucket pull requests overview",
+                    "when": "atlascode:bitbucketExplorerEnabled && config.atlascode.bitbucket.enabled && config.atlascode.bitbucket.explorer.pullRequestsOverview.enabled"
                 },
                 {
                     "id": "atlascode.views.bb.pipelinesTreeView",
@@ -580,6 +593,11 @@
                 {
                     "command": "atlascode.disableHelpExplorer",
                     "when": "view == atlascode.views.helpTreeView"
+                },
+                {
+                    "command": "atlascode.bitbucket.pullRequestsOverview.refresh",
+                    "when": "view == atlascode.views.bb.pullRequestsOverviewTreeView",
+                    "group": "navigation@1"
                 }
             ],
             "view/item/context": [
@@ -1095,6 +1113,18 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enables the Bitbucket Pull Request Explorer",
+                    "scope": "window"
+                },
+                "atlascode.bitbucket.explorer.repositoryBasedPullRequestView.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable repository based pull requests tree view",
+                    "scope": "window"
+                },
+                "atlascode.bitbucket.explorer.pullRequestsOverview.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable pull requests overview tree view",
                     "scope": "window"
                 },
                 "atlascode.bitbucket.explorer.nestFilesEnabled": {

--- a/src/atlclients/clientManager.ts
+++ b/src/atlclients/clientManager.ts
@@ -6,6 +6,7 @@ import { ConfigurationChangeEvent, Disposable, ExtensionContext } from 'vscode';
 import { commands, window } from 'vscode';
 
 import { CloudPullRequestApi } from '../bitbucket/bitbucket-cloud/pullRequests';
+import { PullRequestsOverviewApi } from '../bitbucket/bitbucket-cloud/pullRequestsOverview';
 import { CloudRepositoriesApi } from '../bitbucket/bitbucket-cloud/repositories';
 import { ServerPullRequestApi } from '../bitbucket/bitbucket-server/pullRequests';
 import { ServerRepositoriesApi } from '../bitbucket/bitbucket-server/repositories';
@@ -124,6 +125,9 @@ export class ClientManager implements Disposable {
                     pullrequests: isOAuthInfo(info)
                         ? new CloudPullRequestApi(this.createOAuthHTTPClient(site, info.access))
                         : undefined!,
+                    pullrequestsOverview: isOAuthInfo(info)
+                        ? new PullRequestsOverviewApi(this.createOAuthHTTPClient(site, info.access))
+                        : undefined!,
                     pipelines: isOAuthInfo(info)
                         ? new PipelineApiImpl(this.createOAuthHTTPClient(site, info.access))
                         : undefined!,
@@ -138,6 +142,8 @@ export class ClientManager implements Disposable {
                         isBasicAuthInfo(info) || isPATAuthInfo(info)
                             ? new ServerPullRequestApi(this.createHTTPClient(site, info))
                             : undefined!,
+                    // Note: For now Internal Pull Requests are not supported for Server
+                    pullrequestsOverview: undefined,
                     pipelines: undefined,
                 };
             }

--- a/src/bitbucket/bbContext.ts
+++ b/src/bitbucket/bbContext.ts
@@ -9,6 +9,7 @@ import { CacheMap } from '../util/cachemap';
 import { Time } from '../util/time';
 import { PullRequestCommentController } from '../views/pullrequest/prCommentController';
 import { PullRequestsExplorer } from '../views/pullrequest/pullRequestsExplorer';
+import { PullRequestsOverviewExplorer } from '../views/pullrequest/PullRequestsOverviewExplorer';
 import { clientForSite, getBitbucketCloudRemotes, getBitbucketRemotes, workspaceRepoFor } from './bbUtils';
 import { BitbucketSite, PullRequest, User, WorkspaceRepo } from './model';
 
@@ -21,6 +22,7 @@ export class BitbucketContext extends Disposable {
     private _gitApi: GitApi;
     private _repoMap: Map<string, WorkspaceRepo> = new Map();
     private _pullRequestsExplorer: PullRequestsExplorer;
+    private _pullRequestsOverviewExplorer: PullRequestsOverviewExplorer;
     private _disposable: Disposable;
     private _currentUsers: CacheMap;
     private _pullRequestCache = new CacheMap();
@@ -31,6 +33,7 @@ export class BitbucketContext extends Disposable {
         super(() => this.dispose());
         this._gitApi = gitApi;
         this._pullRequestsExplorer = new PullRequestsExplorer(this);
+        this._pullRequestsOverviewExplorer = new PullRequestsOverviewExplorer(this);
         this._currentUsers = new CacheMap();
 
         Container.context.subscriptions.push(
@@ -48,6 +51,7 @@ export class BitbucketContext extends Disposable {
             this._gitApi.onDidOpenRepository(() => this.refreshRepos()),
             this._gitApi.onDidCloseRepository(() => this.refreshRepos()),
             this._pullRequestsExplorer,
+            this._pullRequestsOverviewExplorer,
             this.prCommentController,
         );
 

--- a/src/bitbucket/bitbucket-cloud/pullRequestsOverview.ts
+++ b/src/bitbucket/bitbucket-cloud/pullRequestsOverview.ts
@@ -1,0 +1,132 @@
+import { DetailedSiteInfo } from '../../atlclients/authInfo';
+import { toISOString } from '../../react/atlascode/util/date-fns';
+import { HTTPClient } from '../httpClient';
+import { BitbucketSite, PullRequest, WorkspaceRepo } from '../model';
+import { CloudPullRequestApi } from './pullRequests';
+
+export interface OverviewViewState {
+    pullRequests: {
+        authored: PullRequest[];
+        reviewing: PullRequest[];
+        closed: PullRequest[];
+    };
+}
+
+function updatedAfter(minUpdatedTs?: string) {
+    return (pr: PullRequest) => {
+        if (!minUpdatedTs) {
+            return true;
+        }
+
+        const updatedTsIsoString = toISOString(pr.data.updatedTs);
+        if (!updatedTsIsoString) {
+            return true;
+        }
+
+        return updatedTsIsoString > minUpdatedTs;
+    };
+}
+
+export class PullRequestsOverviewApi {
+    constructor(private client: HTTPClient) {}
+
+    private extractSiteFromPRData(prData: any, site: DetailedSiteInfo): BitbucketSite {
+        // Extract site information from the PR data
+        const repoSlug = prData.destination.repository.full_name.split('/')[1];
+        const ownerSlug = prData.destination.repository.workspace.slug;
+
+        // Create a site object
+        return {
+            ownerSlug,
+            repoSlug,
+            details: site,
+        };
+    }
+
+    private createWorkspaceRepoFromPRData(prData: any, site: BitbucketSite): WorkspaceRepo {
+        // Create a minimal WorkspaceRepo object with required fields
+        return {
+            rootUri: prData.destination.repository.full_name,
+            mainSiteRemote: {
+                site: site,
+                remote: {
+                    name: prData.destination.repository.name,
+                    fetchUrl: `https://bitbucket.org/${prData.destination.repository.full_name}.git`,
+                    pushUrl: `https://bitbucket.org/${prData.destination.repository.full_name}.git`,
+                    isReadOnly: true,
+                },
+            },
+            siteRemotes: [],
+        };
+    }
+
+    async getOverviewViewState(
+        ownerSlug: string,
+        site: DetailedSiteInfo,
+        minUpdatedTs: string,
+    ): Promise<OverviewViewState> {
+        const fields = [
+            '+pullRequests.*.author',
+            '+pullRequests.*.closed_on',
+            '+pullRequests.*.comment_count',
+            '+pullRequests.*.created_on',
+            '+pullRequests.*.destination.branch.name',
+            '+pullRequests.*.destination.commit.hash',
+            '+pullRequests.*.destination.repository.workspace',
+            '+pullRequests.*.id',
+            '+pullRequests.*.links.html',
+            '+pullRequests.*.links.self',
+            '+pullRequests.*.participants',
+            '+pullRequests.*.repository.links.avatar',
+            '+pullRequests.*.repository.links.html',
+            '+pullRequests.*.repository.full_name',
+            '+pullRequests.*.repository.name',
+            '+pullRequests.*.source.branch.name',
+            '+pullRequests.*.source.commit.hash',
+            '+pullRequests.*.source.repository.workspace',
+            '+pullRequests.*.state',
+            '+pullRequests.*.task_count',
+            '+pullRequests.*.title',
+            '+pullRequests.*.updated_on',
+        ].join(',');
+
+        const { data } = await this.client.get(
+            `/workspaces/${ownerSlug}/overview-view-state/?fields=${encodeURIComponent(fields)}`,
+        );
+
+        const authored: PullRequest[] = data.pullRequests.authored
+            .map((pr: any) => {
+                const bbSite = this.extractSiteFromPRData(pr, site);
+                const workspaceRepo = this.createWorkspaceRepoFromPRData(pr, bbSite);
+
+                return CloudPullRequestApi.toPullRequestData(pr, bbSite, workspaceRepo);
+            })
+            .filter(updatedAfter(minUpdatedTs));
+
+        const reviewing: PullRequest[] = data.pullRequests.reviewing
+            .map((pr: any) => {
+                const bbSite = this.extractSiteFromPRData(pr, site);
+                const workspaceRepo = this.createWorkspaceRepoFromPRData(pr, bbSite);
+                return CloudPullRequestApi.toPullRequestData(pr, bbSite, workspaceRepo);
+            })
+            .filter(updatedAfter(minUpdatedTs));
+
+        const closed: PullRequest[] = data.pullRequests.closed
+            .map((pr: any) => {
+                const bbSite = this.extractSiteFromPRData(pr, site);
+                const workspaceRepo = this.createWorkspaceRepoFromPRData(pr, bbSite);
+                return CloudPullRequestApi.toPullRequestData(pr, bbSite, workspaceRepo);
+            })
+            .filter(updatedAfter(minUpdatedTs));
+
+        const response: OverviewViewState = {
+            pullRequests: {
+                authored,
+                reviewing,
+                closed,
+            },
+        };
+
+        return response;
+    }
+}

--- a/src/bitbucket/model.ts
+++ b/src/bitbucket/model.ts
@@ -4,6 +4,7 @@ import { DetailedSiteInfo, emptySiteInfo } from '../atlclients/authInfo';
 import { PipelineApiImpl } from '../pipelines/pipelines';
 import { Remote, Repository } from '../typings/git';
 import { FileDiffQueryParams } from '../views/pullrequest/diffViewHelper';
+import { OverviewViewState } from './bitbucket-cloud/pullRequestsOverview';
 
 export type BitbucketSite = {
     details: DetailedSiteInfo;
@@ -369,6 +370,10 @@ export interface PullRequestApi {
     getFileContent(site: BitbucketSite, commitHash: string, path: string): Promise<string>;
 }
 
+export interface PullRequestsOverviewApi {
+    getOverviewViewState(ownerSlug: string, site: DetailedSiteInfo, minUpdatedTs: string): Promise<OverviewViewState>;
+}
+
 export interface RepositoriesApi {
     getMirrorHosts(): Promise<string[]>;
     get(site: BitbucketSite): Promise<Repo>;
@@ -383,6 +388,7 @@ export interface RepositoriesApi {
 export interface BitbucketApi {
     repositories: RepositoriesApi;
     pullrequests: PullRequestApi;
+    pullrequestsOverview?: PullRequestsOverviewApi;
     pipelines?: PipelineApiImpl;
 }
 

--- a/src/commandContext.ts
+++ b/src/commandContext.ts
@@ -11,6 +11,8 @@ export enum CommandContext {
     JiraLoginTree = 'atlascode:jiraLoginTreeEnabled',
     IsJiraAuthenticated = 'atlascode:isJiraAuthenticated',
     IsBBAuthenticated = 'atlascode:isBBAuthenticated',
+    PullRequestOverviewEnabled = 'atlascode:bitbucketPullRequestOverviewEnabled',
+    RepositoryBasedPullRequestViewEnabled = 'atlascode:bitbucketRepositoryBasedPullRequestViewEnabled',
 }
 
 export function setCommandContext(key: CommandContext | string, value: any) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,6 +27,8 @@ import { PipelineNode } from './views/pipelines/PipelinesTree';
 
 export enum Commands {
     BitbucketSelectContainer = 'atlascode.bb.selectContainer',
+    BitbucketPullRequestsOverviewRefresh = 'atlascode.bitbucket.pullRequestsOverview.refresh',
+    BitbucketPullRequestsOverviewFocus = 'atlascode.views.bb.pullRequestsOverviewTreeView.focus',
     BitbucketFetchPullRequests = 'atlascode.bb.fetchPullRequests',
     BitbucketRefreshPullRequests = 'atlascode.bb.refreshPullRequests',
     BitbucketToggleFileNesting = 'atlascode.bb.toggleFileNesting',

--- a/src/config/model.ts
+++ b/src/config/model.ts
@@ -114,6 +114,8 @@ export interface BitbucketExplorer {
     enabled: boolean;
     nestFilesEnabled: boolean;
     refreshInterval: number;
+    repositoryBasedPullRequestView: boolean;
+    pullRequestsOverview: boolean;
     relatedJiraIssues: BitbucketRelatedJiraIssues;
     relatedBitbucketIssues: BitbucketRelatedBitbucketIssues;
     notifications: BitbucketNotifications;
@@ -205,6 +207,8 @@ const emptyBitbucketNotfications: BitbucketNotifications = {
 
 const emptyBitbucketExplorer: BitbucketExplorer = {
     enabled: true,
+    repositoryBasedPullRequestView: true,
+    pullRequestsOverview: true,
     nestFilesEnabled: true,
     refreshInterval: 5,
     relatedJiraIssues: emptyRelatedJiraIssues,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,11 @@ export const JiraEnabledKey = 'jira.enabled';
 export const BitbucketEnabledKey = 'bitbucket.enabled';
 export const JiraHoverProviderConfigurationKey = 'jira.hover.enabled';
 export const AssignedJiraItemsViewId = 'atlascode.views.jira.assignedWorkItemsTreeView';
+export const BitbucketPullRequestsOverviewConfigurationKey = 'bitbucket.explorer.pullRequestsOverview.enabled';
+export const BitbucketRepositoryBasedPullRequestsConfigurationKey =
+    'bitbucket.explorer.repositoryBasedPullRequestView.enabled';
 export const PullRequestTreeViewId = 'atlascode.views.bb.pullrequestsTreeView';
+export const PullRequestsOverviewTreeViewId = 'atlascode.views.bb.pullRequestsOverviewTreeView';
 export const PipelinesTreeViewId = 'atlascode.views.bb.pipelinesTreeView';
 export const BitbucketIssuesTreeViewId = 'atlascode.views.bb.issuesTreeView';
 export const HelpTreeViewId = 'atlascode.views.helpTreeView';

--- a/src/lib/ipc/toUI/pullRequestDetails.ts
+++ b/src/lib/ipc/toUI/pullRequestDetails.ts
@@ -72,7 +72,7 @@ export interface PullRequestDetailsInitMessage {
     pr: PullRequest;
     commits: Commit[];
     currentUser: User;
-    currentBranchName: string;
+    currentBranchName: string | null;
     comments: Comment[];
     tasks: Task[];
     fileDiffs: FileDiff[];
@@ -156,7 +156,7 @@ export const emptyPullRequestDetailsInitMessage: PullRequestDetailsInitMessage =
     pr: emptyPullRequest,
     commits: [],
     currentUser: emptyUser,
-    currentBranchName: '',
+    currentBranchName: null,
     comments: [],
     fileDiffs: [],
     mergeStrategies: [],

--- a/src/lib/webview/controller/pullrequest/pullRequestDetailsActionApi.ts
+++ b/src/lib/webview/controller/pullrequest/pullRequestDetailsActionApi.ts
@@ -25,7 +25,7 @@ export interface PullRequestDetailsActionApi {
     updateReviewers(pr: PullRequest, newReviewers: User[]): Promise<Reviewer[]>;
     updateApprovalStatus(pr: PullRequest, status: ApprovalStatus): Promise<ApprovalStatus>;
     checkout(pr: PullRequest): Promise<string>;
-    getCurrentBranchName(pr: PullRequest): string;
+    getCurrentBranchName(pr: PullRequest): string | null;
     getComments(pr: PullRequest): Promise<Comment[]>;
     postComment(comments: Comment[], pr: PullRequest, rawText: string, parentId?: string): Promise<Comment[]>;
     editComment(comments: Comment[], pr: PullRequest, content: string, commentId: string): Promise<Comment[]>;

--- a/src/react/atlascode/config/bitbucket/BitbucketPanel.tsx
+++ b/src/react/atlascode/config/bitbucket/BitbucketPanel.tsx
@@ -62,6 +62,12 @@ export const BitbucketPanel: React.FunctionComponent<BitbucketPanelProps> = ({
                                 pullRequestCreated={
                                     config[`${ConfigSection.Bitbucket}.explorer.notifications.pullRequestCreated`]
                                 }
+                                pullRequestsEnabled={
+                                    config[`${ConfigSection.Bitbucket}.explorer.repositoryBasedPullRequestView.enabled`]
+                                }
+                                pullRequestsOverviewEnabled={
+                                    config[`${ConfigSection.Bitbucket}.explorer.pullRequestsOverview.enabled`]
+                                }
                                 nestFiles={config[`${ConfigSection.Bitbucket}.explorer.nestFilesEnabled`]}
                                 refreshInterval={config[`${ConfigSection.Bitbucket}.explorer.refreshInterval`]}
                             />

--- a/src/react/atlascode/config/bitbucket/PRExplorer.tsx
+++ b/src/react/atlascode/config/bitbucket/PRExplorer.tsx
@@ -13,6 +13,8 @@ type PRExplorerProps = {
     pullRequestCreated: boolean;
     nestFiles: boolean;
     refreshInterval: number;
+    pullRequestsEnabled: boolean;
+    pullRequestsOverviewEnabled: boolean;
 };
 
 const useStyles = makeStyles(
@@ -25,7 +27,16 @@ const useStyles = makeStyles(
 );
 
 export const PRExplorer: React.FunctionComponent<PRExplorerProps> = memo(
-    ({ enabled, relatedJiraIssues, relatedBitbucketIssues, pullRequestCreated, nestFiles, refreshInterval }) => {
+    ({
+        enabled,
+        relatedJiraIssues,
+        relatedBitbucketIssues,
+        pullRequestCreated,
+        nestFiles,
+        refreshInterval,
+        pullRequestsEnabled,
+        pullRequestsOverviewEnabled,
+    }) => {
         const classes = useStyles();
         const controller = useContext(ConfigControllerContext);
 
@@ -65,6 +76,44 @@ export const PRExplorer: React.FunctionComponent<PRExplorerProps> = memo(
                             />
                         }
                         label="Enable Bitbucket pull requests explorer"
+                        spacing={1}
+                        variant="body1"
+                    />
+                </Grid>
+                <Grid item>
+                    <ToggleWithLabel
+                        control={
+                            <Switch
+                                className={classes.indent}
+                                size="small"
+                                color="primary"
+                                id="bbPullRequestsOverviewEnabled"
+                                value="explorer.pullRequestsOverview.enabled"
+                                checked={!!pullRequestsOverviewEnabled}
+                                disabled={!enabled}
+                                onChange={handleChange}
+                            />
+                        }
+                        label="Enable Bitbucket pull requests overview explorer"
+                        spacing={1}
+                        variant="body1"
+                    />
+                </Grid>
+                <Grid item>
+                    <ToggleWithLabel
+                        control={
+                            <Switch
+                                className={classes.indent}
+                                size="small"
+                                color="primary"
+                                id="bbPullRequestsEnabled"
+                                value="explorer.repositoryBasedPullRequestView.enabled"
+                                checked={!!pullRequestsEnabled}
+                                disabled={!enabled}
+                                onChange={handleChange}
+                            />
+                        }
+                        label="Enable Repository based pull requests explorer"
                         spacing={1}
                         variant="body1"
                     />

--- a/src/react/atlascode/config/bitbucket/subpanels/PRExplorerPanel.tsx
+++ b/src/react/atlascode/config/bitbucket/subpanels/PRExplorerPanel.tsx
@@ -15,6 +15,8 @@ type PRExplorerPanelProps = CommonSubpanelProps & {
     pullRequestCreated: boolean;
     nestFiles: boolean;
     refreshInterval: number;
+    pullRequestsEnabled: boolean;
+    pullRequestsOverviewEnabled: boolean;
 };
 
 export const PRExplorerPanel: React.FunctionComponent<PRExplorerPanelProps> = memo(
@@ -28,6 +30,8 @@ export const PRExplorerPanel: React.FunctionComponent<PRExplorerPanelProps> = me
         pullRequestCreated,
         nestFiles,
         refreshInterval,
+        pullRequestsEnabled,
+        pullRequestsOverviewEnabled,
     }) => {
         const [internalExpanded, setInternalExpanded] = useState(expanded);
 
@@ -66,6 +70,8 @@ export const PRExplorerPanel: React.FunctionComponent<PRExplorerPanelProps> = me
                         pullRequestCreated={pullRequestCreated}
                         nestFiles={nestFiles}
                         refreshInterval={refreshInterval}
+                        pullRequestsEnabled={pullRequestsEnabled}
+                        pullRequestsOverviewEnabled={pullRequestsOverviewEnabled}
                     />
                 </ExpansionPanelDetails>
             </ExpansionPanel>

--- a/src/react/atlascode/util/date-fns.ts
+++ b/src/react/atlascode/util/date-fns.ts
@@ -5,9 +5,9 @@ interface FormatTimeOptions {
     daysPreference?: number;
 }
 
-export function formatTime(dateString: string | number | undefined, options: FormatTimeOptions = {}): string {
+export function toDate(dateString: string | number | undefined): Date | null {
     if (!dateString) {
-        return '';
+        return null;
     }
 
     let date: Date;
@@ -19,6 +19,15 @@ export function formatTime(dateString: string | number | undefined, options: For
     }
 
     if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    return date;
+}
+
+export function formatTime(dateString: string | number | undefined, options: FormatTimeOptions = {}): string {
+    const date = toDate(dateString);
+    if (!date) {
         return '';
     }
 
@@ -30,4 +39,13 @@ export function formatTime(dateString: string | number | undefined, options: For
     }
 
     return `${options.prefix ? `${options.prefix} ` : ''}${formatDistanceToNow(date, { addSuffix: true })}`;
+}
+
+export function toISOString(dateString: string | number | undefined): string | null {
+    const date = toDate(dateString);
+    if (!date) {
+        return null;
+    }
+
+    return date.toISOString();
 }

--- a/src/views/pullRequestOverviewNodeDataProvider.ts
+++ b/src/views/pullRequestOverviewNodeDataProvider.ts
@@ -1,0 +1,127 @@
+import { Disposable, Event, EventEmitter, TreeItem } from 'vscode';
+
+import { viewScreenEvent } from '../analytics';
+import { DetailedSiteInfo, ProductBitbucket } from '../atlclients/authInfo';
+import { Commands } from '../commands';
+import { Container } from '../container';
+import { BaseTreeDataProvider } from './Explorer';
+import { AbstractBaseNode } from './nodes/abstractBaseNode';
+import { SimpleNode } from './nodes/simpleNode';
+import { PullRequestsOverviewSectionNode } from './pullrequest/pullRequestsOverviewSectionNode';
+
+export class PullRequestsOverviewNodeDataProvider extends BaseTreeDataProvider {
+    private _onDidChangeTreeData: EventEmitter<AbstractBaseNode | null> = new EventEmitter<AbstractBaseNode | null>();
+    readonly onDidChangeTreeData: Event<AbstractBaseNode | null> = this._onDidChangeTreeData.event;
+    private _prsTitleSectionMap: Map<string, PullRequestsOverviewSectionNode> = new Map();
+    private _isFetchingPullRequests: boolean = false;
+    private readonly _minUpdatedTs: string;
+
+    private _disposable: Disposable;
+    private _ownerSlug: string = 'atlassian'; // Hardcoded for now as per requirements
+
+    constructor() {
+        super();
+        this._disposable = Disposable.from(this._onDidChangeTreeData);
+
+        this.updateChildren();
+
+        // TODO: Make this configurable
+        this._minUpdatedTs = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+    }
+
+    dispose() {
+        this._disposable.dispose();
+    }
+
+    async refresh() {
+        await this.updateChildren();
+        this._onDidChangeTreeData.fire(null);
+    }
+
+    private async updateChildren(): Promise<void> {
+        // Clear the current map
+        this._prsTitleSectionMap.clear();
+
+        try {
+            if (this.cloudSite) {
+                const internalSite = {
+                    ...this.cloudSite,
+                    baseApiUrl: `https://bitbucket.org/!api/internal`,
+                };
+
+                const bbApi = await Container.clientManager.bbClient(internalSite);
+
+                if (bbApi.pullrequestsOverview) {
+                    this._isFetchingPullRequests = true;
+                    const overviewViewState = await bbApi.pullrequestsOverview.getOverviewViewState(
+                        this._ownerSlug,
+                        internalSite,
+                        this._minUpdatedTs,
+                    );
+
+                    // Create the "PRs to be reviewed" section
+                    const toReviewNode = new PullRequestsOverviewSectionNode(
+                        'Pull requests to review',
+                        overviewViewState.pullRequests.reviewing,
+                    );
+                    this._prsTitleSectionMap.set('reviewing', toReviewNode);
+
+                    // Create the "PRs created by you" section
+                    const authoredNode = new PullRequestsOverviewSectionNode(
+                        'Your pull requests',
+                        overviewViewState.pullRequests.authored,
+                    );
+                    this._prsTitleSectionMap.set('authored', authoredNode);
+                    this._isFetchingPullRequests = false;
+                }
+            }
+        } catch (e) {
+            console.error('Error fetching pull requests:', e);
+            // Make sure to set _isFetchingPullRequests to false when there's an error
+            this._isFetchingPullRequests = false;
+        }
+
+        this._onDidChangeTreeData.fire(null);
+    }
+
+    override async getTreeItem(element: AbstractBaseNode): Promise<TreeItem> {
+        return element.getTreeItem();
+    }
+
+    get cloudSite(): DetailedSiteInfo | null {
+        const sites = Container.siteManager.getSitesAvailable(ProductBitbucket);
+        return sites.find((site) => site.isCloud) ?? null;
+    }
+
+    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+        if (Container.siteManager.getSitesAvailable(ProductBitbucket).length === 0) {
+            viewScreenEvent('pullRequestsOverviewTreeViewUnauthenticatedMessage', undefined, ProductBitbucket).then(
+                (event) => Container.analyticsClient.sendScreenEvent(event),
+            );
+            return [
+                new SimpleNode('Authenticate with Bitbucket to view pull requests', {
+                    command: Commands.ShowBitbucketAuth,
+                    title: 'Open Bitbucket Settings',
+                }),
+            ];
+        }
+
+        if (!this.cloudSite) {
+            return [new SimpleNode('This view is only available on Bitbucket Cloud')];
+        }
+
+        if (element) {
+            return element.getChildren();
+        }
+
+        if (this._isFetchingPullRequests) {
+            return [new SimpleNode('Fetching pull requests...')];
+        }
+
+        if (this._prsTitleSectionMap.size === 0) {
+            return [new SimpleNode('No Pull Requests found')];
+        }
+
+        return Array.from(this._prsTitleSectionMap.values());
+    }
+}

--- a/src/views/pullrequest/PullRequestsOverviewExplorer.ts
+++ b/src/views/pullrequest/PullRequestsOverviewExplorer.ts
@@ -1,0 +1,77 @@
+import { commands, ConfigurationChangeEvent } from 'vscode';
+
+import { BitbucketContext } from '../../bitbucket/bbContext';
+import { CommandContext, setCommandContext } from '../../commandContext';
+import { Commands } from '../../commands';
+import { configuration } from '../../config/configuration';
+import { PullRequestsOverviewTreeViewId } from '../../constants';
+import { Container } from '../../container';
+import { BitbucketActivityMonitor } from '../BitbucketActivityMonitor';
+import { BitbucketExplorer } from '../BitbucketExplorer';
+import { BaseTreeDataProvider } from '../Explorer';
+import { PullRequestsOverviewNodeDataProvider } from '../pullRequestOverviewNodeDataProvider';
+
+export class PullRequestsOverviewExplorer extends BitbucketExplorer {
+    constructor(ctx: BitbucketContext) {
+        super(ctx);
+
+        Container.context.subscriptions.push(
+            Container.siteManager.onDidSitesAvailableChange(this.refresh, this),
+            commands.registerCommand(Commands.BitbucketPullRequestsOverviewRefresh, this.refresh, this),
+            this.ctx.onDidChangeBitbucketContext(() => this.updateExplorerState()),
+        );
+    }
+
+    viewId(): string {
+        return PullRequestsOverviewTreeViewId;
+    }
+
+    explorerEnabledConfiguration(): string {
+        return 'bitbucket.explorer.pullRequestsOverview.enabled';
+    }
+
+    monitorEnabledConfiguration(): string {
+        return 'bitbucket.explorer.pullRequestsOverview.enabled';
+    }
+
+    refreshConfiguration(): string {
+        return 'bitbucket.explorer.pullRequestsOverview.refreshInterval';
+    }
+
+    newTreeDataProvider(): BaseTreeDataProvider {
+        return new PullRequestsOverviewNodeDataProvider();
+    }
+
+    newMonitor(): BitbucketActivityMonitor {
+        return {
+            checkForNewActivity(): void {
+                // No-op for now
+            },
+        };
+    }
+
+    override async refresh(): Promise<void> {
+        if (!Container.onlineDetector.isOnline()) {
+            return;
+        }
+
+        if (this.treeDataProvider) {
+            this.treeDataProvider.refresh();
+        }
+    }
+
+    async onConfigurationChanged(e: ConfigurationChangeEvent) {
+        const initializing = configuration.initializing(e);
+
+        if (initializing || configuration.changed(e, 'bitbucket.explorer.pullRequestsOverview.enabled')) {
+            this.updateExplorerState();
+        }
+    }
+
+    private updateExplorerState() {
+        setCommandContext(
+            CommandContext.PullRequestOverviewEnabled,
+            Container.config.bitbucket.explorer.pullRequestsOverview,
+        );
+    }
+}

--- a/src/views/pullrequest/PullRequestsOverviewExplorer.ts
+++ b/src/views/pullrequest/PullRequestsOverviewExplorer.ts
@@ -51,10 +51,6 @@ export class PullRequestsOverviewExplorer extends BitbucketExplorer {
     }
 
     override async refresh(): Promise<void> {
-        if (!Container.onlineDetector.isOnline()) {
-            return;
-        }
-
         if (this.treeDataProvider) {
             this.treeDataProvider.refresh();
         }

--- a/src/views/pullrequest/pullRequestsOverviewSectionNode.ts
+++ b/src/views/pullrequest/pullRequestsOverviewSectionNode.ts
@@ -30,7 +30,7 @@ export class PullRequestsOverviewSectionNode extends AbstractBaseNode {
     }
 
     private createChildren(): void {
-        this.children = this.pullRequests.map((pr) => new PullRequestTitlesNode(pr, true, this));
+        this.children = this.pullRequests.map((pr) => new PullRequestTitlesNode(pr, true));
     }
 
     getTreeItem(): vscode.TreeItem {

--- a/src/views/pullrequest/pullRequestsOverviewSectionNode.ts
+++ b/src/views/pullrequest/pullRequestsOverviewSectionNode.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+
+import { PullRequest } from '../../bitbucket/model';
+import { AbstractBaseNode } from '../nodes/abstractBaseNode';
+import { SimpleNode } from '../nodes/simpleNode';
+import { PullRequestContextValue, PullRequestTitlesNode } from './pullRequestNode';
+
+export class PullRequestsOverviewSectionNode extends AbstractBaseNode {
+    private treeItem: vscode.TreeItem;
+    private children: PullRequestTitlesNode[] = [];
+
+    constructor(
+        private sectionTitle: string,
+        private pullRequests: PullRequest[],
+    ) {
+        super();
+        this.treeItem = this.createTreeItem();
+        this.createChildren();
+    }
+
+    private createTreeItem(): vscode.TreeItem {
+        const item = new vscode.TreeItem(
+            this.sectionTitle,
+            this.pullRequests.length > 0
+                ? vscode.TreeItemCollapsibleState.Expanded
+                : vscode.TreeItemCollapsibleState.Collapsed,
+        );
+        item.contextValue = PullRequestContextValue;
+        return item;
+    }
+
+    private createChildren(): void {
+        this.children = this.pullRequests.map((pr) => new PullRequestTitlesNode(pr, true, this));
+    }
+
+    getTreeItem(): vscode.TreeItem {
+        return this.treeItem;
+    }
+
+    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+        if (element) {
+            return element.getChildren();
+        }
+
+        if (this.children.length === 0) {
+            return [new SimpleNode('No pull requests found')];
+        }
+
+        return this.children;
+    }
+}

--- a/src/webview/pullrequest/vscPullRequestDetailsActionApi.ts
+++ b/src/webview/pullrequest/vscPullRequestDetailsActionApi.ts
@@ -113,11 +113,13 @@ export class VSCPullRequestDetailsActionApi implements PullRequestDetailsActionA
         return newStatus;
     }
 
-    getCurrentBranchName(pr: PullRequest): string {
-        let currentBranchName = '';
+    getCurrentBranchName(pr: PullRequest): string | null {
+        let currentBranchName = null;
         if (pr.workspaceRepo) {
-            const scm = Container.bitbucketContext.getRepositoryScm(pr.workspaceRepo!.rootUri)!;
-            currentBranchName = scm.state.HEAD ? scm.state.HEAD.name! : '';
+            const scm = Container.bitbucketContext?.getRepositoryScm?.(pr.workspaceRepo.rootUri);
+            if (scm && scm.state && scm.state.HEAD) {
+                currentBranchName = scm.state.HEAD.name || null;
+            }
         }
 
         return currentBranchName;


### PR DESCRIPTION
### What Is This Change?

We are introducing a PR Overview Panel that shows user-relevant PRs only. Details are as follows:

[Loom Video](https://www.loom.com/share/7da5d2c76ef44ea58a19005ba0c7b107)

### How Has This Been Tested?

Installed it locally and checked all the scenarios:
- Login / logout works for the panel.
- PRs show up.
- PR Details show up on clicking.
- Settings are enabled to turn its view on/off.

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change