### PR TITLE
AXON-301: Drop labs from extension title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
 ---
+## What's new in 3.8.2
 
+### Improvement 
+
+- Remove the word "Labs" from the title of the extension
 
 ## What's new in 3.8.1
 

--- a/HOMEPAGE.md
+++ b/HOMEPAGE.md
@@ -6,9 +6,6 @@ This extension combines the power of Jira and Bitbucket to streamline the develo
 
 With Atlassian for VS Code you can create and view issues, start work on issues, create pull requests, do code reviews, start builds, get build statuses and more!
 
-**Note:** 'Atlassian for VS Code' is published as an Atlassian Labs project.
-Although you may find unique and highly useful functionality in the Atlassian Labs apps, Atlassian takes no responsibility for your use of these apps.
-
 ## Getting Started
 
 -   Make sure you have VS Code version 1.40.0 or above

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "atlascode",
-    "displayName": "Jira and Bitbucket (Atlassian Labs)",
+    "displayName": "Atlassian: Jira & Bitbucket",
     "description": "Bringing the power of Jira and Bitbucket to VS Code - With Atlassian for VS Code you can create and view issues, start work on issues, create pull requests, do code reviews, start builds, get build statuses and more!",
     "keywords": [
         "bitbucket",


### PR DESCRIPTION
### What Is This Change?

- Drop the "Labs" from our name
- Move Atlassian from back of title to front of title to match the short name "Atlassian For VS Code" more. 
- TBD: Used & per our Word Engineer Collin
- Approved List: Trevor (HOE), Laurena (PMM)
- [x] Needs Nat's approval

### Visuals 

![image](https://github.com/user-attachments/assets/122d6809-0470-4d55-8e07-5c8ae84f4e3d)

### How Has This Been Tested?

- [x] Local install 


### Is this safe? 

- https://www.reddit.com/r/vscode/comments/16lzht9/comment/k18ne7t/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

### Recommendations:
- [x] Update the CHANGELOG if making a user facing change