### PR TITLE
[AXON-412] Use correct client & metadata for cloud API tokens

### DIFF
--- a/src/atlclients/clientManager.ts
+++ b/src/atlclients/clientManager.ts
@@ -168,6 +168,14 @@ export class ClientManager implements Disposable {
                             jiraTokenAuthProvider(info.access),
                             getAgent,
                         );
+                    } else if (isBasicAuthInfo(info) && site.isCloud) {
+                        Logger.debug(`${tag}: creating cloud client for ${site.baseApiUrl}`);
+                        client = new JiraCloudClient(
+                            site,
+                            basicJiraTransportFactory(site),
+                            jiraBasicAuthProvider(info.username, info.password),
+                            getAgent,
+                        );
                     } else if (isBasicAuthInfo(info)) {
                         client = new JiraServerClient(
                             site,


### PR DESCRIPTION
### What Is This Change?

We have a known issue in #152 where certain actions unassign issues from the user if API token.

This is a small fix for that - less of a comprehensive solution, more of a workaround for our existing auth implementation:
* When saving API key for cloud sites, store the correct user and tenant IDs
* When generating a client, use the correct cloud API

### How Has This Been Tested?

More exhaustive testing is pending, but:
 * Issue is no longer unassigned in `Start Work` transition
 * It's possible to edit fields w/o the issue disappearing
 * No weird 4XX error caused by us using the wrong API

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] ~If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)~ No changes that would affect DC

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change <- TODO