### PR TITLE
AXON-405: Remove FF for badges and banners

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,9 +61,7 @@ export async function activate(context: ExtensionContext) {
             Container.siteManager.productHasAtLeastOneSite(ProductBitbucket),
         );
 
-        if (FeatureFlagClient.checkGate(Features.AuthBadgeNotification)) {
-            NotificationManagerImpl.getInstance().listen();
-        }
+        NotificationManagerImpl.getInstance().listen();
     } catch (e) {
         Logger.error(e, 'Error initializing atlascode!');
     }

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -1,7 +1,6 @@
 export const enum Features {
     NoOpFeature = 'atlascode-noop',
     EnableErrorTelemetry = 'atlascode-send-error-telemetry',
-    AuthBadgeNotification = 'auth_notifications_badge_vscode',
 }
 
 export const enum Experiments {

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -96,14 +96,6 @@ jest.mock('../../../container', () => ({
         },
     },
 }));
-jest.mock('../../../util/featureFlags', () => ({
-    FeatureFlagClient: {
-        checkGate: jest.fn().mockResolvedValue(true),
-    },
-    Features: {
-        AuthBadgeNotification: 'AuthBadgeNotification',
-    },
-}));
 
 type ExtractPublic<T> = { [P in keyof T]: T[P] };
 

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -17,7 +17,6 @@ import { Commands } from '../../../commands';
 import { configuration } from '../../../config/configuration';
 import { Container } from '../../../container';
 import { SitesAvailableUpdateEvent } from '../../../siteManager';
-import { FeatureFlagClient, Features } from '../../../util/featureFlags';
 import { PromiseRacer } from '../../../util/promises';
 import { BadgeDelegate } from '../../notifications/badgeDelegate';
 import { JiraNotifier } from '../../notifications/jiraNotifier';
@@ -47,9 +46,7 @@ export class AssignedWorkItemsViewProvider extends Disposable implements TreeDat
 
         const treeView = window.createTreeView(AssignedWorkItemsViewProviderId, { treeDataProvider: this });
 
-        if (FeatureFlagClient.checkGate(Features.AuthBadgeNotification)) {
-            BadgeDelegate.initialize(treeView);
-        }
+        BadgeDelegate.initialize(treeView);
 
         this._disposable = Disposable.from(
             Container.siteManager.onDidSitesAvailableChange(this.onSitesDidChange, this),

--- a/src/views/notifications/bannerDelegate.ts
+++ b/src/views/notifications/bannerDelegate.ts
@@ -70,11 +70,8 @@ export class BannerDelegate implements NotificationDelegate {
             let count = 0;
             if (event.action === NotificationAction.Added) {
                 event.notifications.forEach((notification) => {
-                    this.showNotification(
-                        notification,
-                        this.makeActionText(notification),
-                        this.makeActionFunction(notification),
-                    );
+                    const { text, action } = this.makeAction(notification);
+                    this.showNotification(notification, text, action);
                     count++;
                 });
             }
@@ -98,31 +95,27 @@ export class BannerDelegate implements NotificationDelegate {
         });
     }
 
-    private makeActionText(notification: AtlasCodeNotification): string {
+    private makeAction(notification: AtlasCodeNotification): { text: string; action: () => void } {
         switch (notification.notificationType) {
             case NotificationType.NewCommentOnJira:
-                return 'Reply';
+                return {
+                    text: 'Reply',
+                    action: () => {},
+                };
             case NotificationType.AssignedToYou:
-                return 'View Assigned Work Item';
+                return {
+                    text: 'View Assigned Work Item',
+                    action: () => {},
+                };
             case NotificationType.LoginNeeded:
-                return 'Log in to Jira';
-            default:
-                throw new Error(`Cannot make action text: Unknown notification type: ${notification.notificationType}`);
-        }
-    }
-
-    private makeActionFunction(notification: AtlasCodeNotification): () => void {
-        switch (notification.notificationType) {
-            case NotificationType.NewCommentOnJira:
-                return () => {};
-            case NotificationType.AssignedToYou:
-                return () => {};
-            case NotificationType.LoginNeeded:
-                return () => {
-                    commands.executeCommand(Commands.ShowJiraAuth);
+                return {
+                    text: 'Log in to Jira',
+                    action: () => {
+                        commands.executeCommand(Commands.ShowJiraAuth);
+                    },
                 };
             default:
-                throw new Error(`Cannot make action text: Unknown notification type: ${notification.notificationType}`);
+                throw new Error(`Cannot make action: Unknown notification type: ${notification.notificationType}`);
         }
     }
 


### PR DESCRIPTION
### What Is This Change?

Badges are out in production now. 

Data indicates that it increases the rate of a no-auth launch -> Authentication by a 2x factor. 

Removing FF so we can accelerate the change faster. 

Note: The FF strategy is enforcing bake times that are too slow. 

### Tests
- [x] Unit tests passed. 
- [x] Manual testing to ensure nothing broke 

