### PR TITLE
Clean-ups after changing the E2E framework

### DIFF
--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -6,27 +6,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug UI Tests",
-            "type": "node",
-            "request": "launch",
-            "program": "${workspaceFolder}/node_modules/.bin/extest",
-            "windows": {
-                "program": "${workspaceFolder}/node_modules/vscode-extension-tester/out/cli.js",
-            },
-            "args": [
-                "run-tests",
-                "${workspaceFolder}/.generated/atlascode/e2e/tests/*.test.js",
-                "--code_settings",
-                "${workspaceFolder}/e2e/test-settings.json",
-                "--extensions_dir",
-                ".test-extensions",
-                "--mocha_config",
-                "${workspaceFolder}/.mocharc.js"
-            ],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
-        },
-        {
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
                 "@jest/globals": "^29.7.0",
                 "@playwright/test": "^1.52.0",
                 "@stylistic/eslint-plugin-js": "^2.8.0",
-                "@types/chai": "^4",
                 "@types/express": "^5.0.1",
                 "@types/filesize": "^4.1.0",
                 "@types/git-url-parse": "^9.0.1",
@@ -127,7 +126,6 @@
                 "@types/lodash.debounce": "^4.0.6",
                 "@types/lodash.orderby": "^4.6.6",
                 "@types/lodash.truncate": "^4.4.6",
-                "@types/mocha": "^10.0.10",
                 "@types/node": "^18.16.19",
                 "@types/node-ipc": "^9.2.0",
                 "@types/prosemirror-state": "^1.2.5",
@@ -146,7 +144,6 @@
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
                 "autoprefixer": "^10.4.20",
-                "chai": "^4",
                 "concurrently": "^9.1.2",
                 "css-loader": "^7.1.2",
                 "css-minimizer-webpack-plugin": "^7.0.0",
@@ -9218,13 +9215,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/chai": {
-            "version": "4.3.20",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/chai/-/chai-4.3.20.tgz",
-            "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/connect/-/connect-3.4.38.tgz",
@@ -9423,13 +9413,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/mocha": {
-            "version": "10.0.10",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/mocha/-/mocha-10.0.10.tgz",
-            "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -10967,16 +10950,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/async": {
             "version": "2.6.4",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/async/-/async-2.6.4.tgz",
@@ -12100,34 +12073,6 @@
                 }
             ]
         },
-        "node_modules/chai": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/chai/-/chai-4.0.0.tgz",
-            "integrity": "sha512-FQdXBx+UlDU1RljcWV3/ha2Mm+ooF9IQApHXZA1Az+XYItNtzYPR7e1Ga6WwjTkhCPrE6WhvaCU6b4ljGKbgoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "assertion-error": "^1.0.1",
-                "check-error": "^1.0.1",
-                "deep-eql": "^2.0.1",
-                "get-func-name": "^2.0.0",
-                "pathval": "^1.0.0",
-                "type-detect": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/chai/node_modules/type-detect": {
-            "version": "4.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/type-detect/-/type-detect-4.1.0.tgz",
-            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -12150,19 +12095,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/check-error": {
-            "version": "1.0.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/check-error/-/check-error-1.0.3.tgz",
-            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.2"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/cheerio": {
@@ -14571,29 +14503,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10"
-            }
-        },
-        "node_modules/deep-eql": {
-            "version": "2.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/deep-eql/-/deep-eql-2.0.2.tgz",
-            "integrity": "sha512-uts3fF4HnV1bcNx8K5c9NMjXXKtLOf1obUMq04uEuMaF8i1m0SfugbpDMd59cYfodQcMqeUISvL4Pmx5NZ7lcw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-detect": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
-        "node_modules/deep-eql/node_modules/type-detect": {
-            "version": "3.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/type-detect/-/type-detect-3.0.0.tgz",
-            "integrity": "sha512-pwZo7l1T0a8wmTMDc4FtXuHseRaqa9nyaUArp4xHaBMUlRzr72PvgF6ouXIIj5rjbVWqo8pZu6vw74jDKg4Dvw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/deep-equal": {
@@ -17602,16 +17511,6 @@
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/get-func-name": {
-            "version": "2.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/get-func-name/-/get-func-name-2.0.2.tgz",
-            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/get-intrinsic": {
@@ -24676,16 +24575,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/pathval": {
-            "version": "1.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/pathval/-/pathval-1.1.1.tgz",
-            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/pend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,7 +180,6 @@
                 "ts-loader": "^8.4.0",
                 "tsconfig-paths-webpack-plugin": "^3.2.0",
                 "typescript": "^5.7.3",
-                "vscode-extension-tester": "^8.10.0",
                 "webpack": "^5",
                 "webpack-cli": "^5.1.4",
                 "webpack-manifest-plugin": "^5.0.0",
@@ -5673,12 +5672,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@bazel/runfiles": {
-            "version": "6.3.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@bazel/runfiles/-/runfiles-6.3.1.tgz",
-            "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
-            "dev": true
-        },
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -8659,16 +8652,6 @@
                 "node": ">=12.4.0"
             }
         },
-        "node_modules/@pkgjs/parseargs": {
-            "version": "0.11.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@pkgr/core": {
             "version": "0.1.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@pkgr/core/-/core-0.1.1.tgz",
@@ -8712,70 +8695,10 @@
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@react-loosely-lazy/manifest/-/manifest-1.2.0.tgz",
             "integrity": "sha512-MbDl+1p0eAQK0FbqSXeleFwiv8UQn534frgNAZ2hRfi7Cp+pZe50AwouPy5NNzRbPyLlu5FD7use0+qOaBQYPQ=="
         },
-        "node_modules/@redhat-developer/locators": {
-            "version": "1.8.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@redhat-developer/locators/-/locators-1.8.0.tgz",
-            "integrity": "sha512-N83s7QTKjT2EEnKA4NiWGhTyrU4gUwsadiO0ueDg4xfXNcfJ2aUMSAzcvJWUDQbOftDMg4xawx9ho7UlI/+jQg==",
-            "dev": true,
-            "peerDependencies": {
-                "@redhat-developer/page-objects": ">=1.0.0",
-                "selenium-webdriver": ">=4.6.1"
-            }
-        },
-        "node_modules/@redhat-developer/page-objects": {
-            "version": "1.8.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@redhat-developer/page-objects/-/page-objects-1.8.0.tgz",
-            "integrity": "sha512-lbB3liUNVBj6yddqJDxejHcTaGg5WA8nlCOtZHzA/mLnotMqkt+wDjJ22z/zAfc4K2zhRZZFXpnjl7SMjO8XAQ==",
-            "dev": true,
-            "dependencies": {
-                "clipboardy": "^4.0.0",
-                "clone-deep": "^4.0.1",
-                "compare-versions": "^6.1.1",
-                "fs-extra": "^11.2.0",
-                "type-fest": "^4.27.0"
-            },
-            "peerDependencies": {
-                "selenium-webdriver": ">=4.6.1",
-                "typescript": ">=4.6.2"
-            }
-        },
-        "node_modules/@redhat-developer/page-objects/node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
-        "node_modules/@redhat-developer/page-objects/node_modules/type-fest": {
-            "version": "4.30.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/type-fest/-/type-fest-4.30.0.tgz",
-            "integrity": "sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@rtsao/scc/-/scc-1.1.0.tgz",
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@sec-ant/readable-stream": {
-            "version": "0.4.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
             "dev": true,
             "license": "MIT"
         },
@@ -8886,19 +8809,6 @@
             "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
             "dev": true
         },
-        "node_modules/@sindresorhus/is": {
-            "version": "7.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sindresorhus/is/-/is-7.0.1.tgz",
-            "integrity": "sha512-QWLl2P+rsCJeofkDNIT3WFmb6NrRud1SUYW8dIhXK/46XFV8Q/g7Bsvib0Askb0reRLe+WYPeeE+l5cH7SlkuQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -8960,19 +8870,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@szmarczak/http-timer": {
-            "version": "5.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "defer-to-connect": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=14.16"
             }
         },
         "node_modules/@testing-library/dom": {
@@ -9301,13 +9198,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/http-cache-semantics": {
-            "version": "4.0.4",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-            "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/http-errors": {
             "version": "2.0.4",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -9585,16 +9475,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/selenium-webdriver": {
-            "version": "4.1.27",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/selenium-webdriver/-/selenium-webdriver-4.1.27.tgz",
-            "integrity": "sha512-ALqsj8D7Swb6MnBQuAQ58J3KC3yh6fLGtAmpBmnZX8j+0kmP7NaLt56CuzBw2W2bXPrvHFTgn8iekOQFUKXEQA==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*",
-                "@types/ws": "*"
-            }
-        },
         "node_modules/@types/semver": {
             "version": "7.5.5",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/semver/-/semver-7.5.5.tgz",
@@ -9660,16 +9540,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.0.tgz",
             "integrity": "sha512-MLr8hDM8y7vvdAdnoDEP5LotRoYJj7wgT6mWzCUQH/gHqzS4qcnOT/K4dhC0WimWIUiA3Arj9QAJGGKNRiRZKA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/ws": {
-            "version": "8.5.12",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/ws/-/ws-8.5.12.tgz",
-            "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10648,16 +10518,6 @@
                 }
             }
         },
-        "node_modules/ansi-colors": {
-            "version": "4.1.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ansi-colors/-/ansi-colors-4.1.3.tgz",
-            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/ansi-escapes": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -11421,12 +11281,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/bluebird": {
-            "version": "3.7.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-            "dev": true
-        },
         "node_modules/body-parser": {
             "version": "1.20.3",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/body-parser/-/body-parser-1.20.3.tgz",
@@ -11489,13 +11343,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/browser-stdout": {
-            "version": "1.3.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true,
-            "peer": true
         },
         "node_modules/browserslist": {
             "version": "4.24.4",
@@ -11561,22 +11408,6 @@
                 "ieee754": "^1.1.4"
             }
         },
-        "node_modules/buffer-alloc": {
-            "version": "1.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-            "dev": true,
-            "dependencies": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
-            }
-        },
-        "node_modules/buffer-alloc-unsafe": {
-            "version": "1.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-            "dev": true
-        },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -11593,12 +11424,6 @@
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "dev": true,
             "license": "BSD-3-Clause"
-        },
-        "node_modules/buffer-fill": {
-            "version": "1.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-            "dev": true
         },
         "node_modules/buffer-from": {
             "version": "1.1.1",
@@ -11626,308 +11451,6 @@
             "license": "MIT",
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/c8": {
-            "version": "10.1.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/c8/-/c8-10.1.3.tgz",
-            "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
-            "dev": true,
-            "dependencies": {
-                "@bcoe/v8-coverage": "^1.0.1",
-                "@istanbuljs/schema": "^0.1.3",
-                "find-up": "^5.0.0",
-                "foreground-child": "^3.1.1",
-                "istanbul-lib-coverage": "^3.2.0",
-                "istanbul-lib-report": "^3.0.1",
-                "istanbul-reports": "^3.1.6",
-                "test-exclude": "^7.0.1",
-                "v8-to-istanbul": "^9.0.0",
-                "yargs": "^17.7.2",
-                "yargs-parser": "^21.1.1"
-            },
-            "bin": {
-                "c8": "bin/c8.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "monocart-coverage-reports": "^2"
-            },
-            "peerDependenciesMeta": {
-                "monocart-coverage-reports": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/c8/node_modules/@bcoe/v8-coverage": {
-            "version": "1.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@bcoe/v8-coverage/-/v8-coverage-1.0.1.tgz",
-            "integrity": "sha512-W+a0/JpU28AqH4IKtwUPcEUnUyXMDLALcn5/JLczGGT9fHE2sIby/xP/oQnx3nxkForzgzPy201RAKcB4xPAFQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/c8/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/c8/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/c8/node_modules/find-up": {
-            "version": "5.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/c8/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/c8/node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dev": true,
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/c8/node_modules/locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/c8/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true
-        },
-        "node_modules/c8/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/c8/node_modules/p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/c8/node_modules/p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/c8/node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/c8/node_modules/test-exclude": {
-            "version": "7.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/test-exclude/-/test-exclude-7.0.1.tgz",
-            "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
-            "dev": true,
-            "dependencies": {
-                "@istanbuljs/schema": "^0.1.2",
-                "glob": "^10.4.1",
-                "minimatch": "^9.0.4"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/c8/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/cacheable-lookup": {
-            "version": "7.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
-        "node_modules/cacheable-request": {
-            "version": "12.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cacheable-request/-/cacheable-request-12.0.1.tgz",
-            "integrity": "sha512-Yo9wGIQUaAfIbk+qY0X4cDQgCosecfBe3V9NSyeY4qPC2SAkbCS4Xj79VP8WOzitpJUZKc/wsRCYF5ariDIwkg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-cache-semantics": "^4.0.4",
-                "get-stream": "^9.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "keyv": "^4.5.4",
-                "mimic-response": "^4.0.0",
-                "normalize-url": "^8.0.1",
-                "responselike": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/get-stream": {
-            "version": "9.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/get-stream/-/get-stream-9.0.1.tgz",
-            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sec-ant/readable-stream": "^0.4.1",
-                "is-stream": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/is-stream": {
-            "version": "4.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-stream/-/is-stream-4.0.1.tgz",
-            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/mimic-response": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mimic-response/-/mimic-response-4.0.0.tgz",
-            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/caching-transform": {
@@ -12392,243 +11915,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/clipboardy": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/clipboardy/-/clipboardy-4.0.0.tgz",
-            "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
-            "dev": true,
-            "dependencies": {
-                "execa": "^8.0.1",
-                "is-wsl": "^3.1.0",
-                "is64bit": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/cross-spawn": {
-            "version": "7.0.6",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cross-spawn/-/cross-spawn-7.0.6.tgz",
-            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/clipboardy/node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/clipboardy/node_modules/get-stream": {
-            "version": "8.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/human-signals": {
-            "version": "5.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=16.17.0"
-            }
-        },
-        "node_modules/clipboardy/node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/is-wsl": {
-            "version": "3.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-wsl/-/is-wsl-3.1.0.tgz",
-            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-            "dev": true,
-            "dependencies": {
-                "is-inside-container": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/npm-run-path": {
-            "version": "5.3.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/path-key": {
-            "version": "3.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/clipboardy/node_modules/shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
-            "dependencies": {
-                "shebang-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/clipboardy/node_modules/shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/clipboardy/node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/clipboardy/node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/clipboardy/node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/cliui": {
-            "version": "7.0.4",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            }
-        },
         "node_modules/clone-deep": {
             "version": "4.0.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -12753,12 +12039,6 @@
             "version": "1.0.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
-        },
-        "node_modules/compare-versions": {
-            "version": "6.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/compare-versions/-/compare-versions-6.1.1.tgz",
-            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-            "dev": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -14476,19 +13756,6 @@
                 "ms": "2.0.0"
             }
         },
-        "node_modules/decamelize": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/decamelize/-/decamelize-4.0.0.tgz",
-            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/decimal.js": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
@@ -14587,16 +13854,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/defer-to-connect": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/define-data-property": {
@@ -14876,15 +14133,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "^2.0.2"
             }
         },
         "node_modules/eastasianwidth": {
@@ -17328,16 +16576,6 @@
                 "node": ">= 0.12"
             }
         },
-        "node_modules/form-data-encoder": {
-            "version": "4.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/form-data-encoder/-/form-data-encoder-4.0.2.tgz",
-            "integrity": "sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 18"
-            }
-        },
         "node_modules/form-data/node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -17705,84 +16943,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/got": {
-            "version": "14.4.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/got/-/got-14.4.5.tgz",
-            "integrity": "sha512-sq+uET8TnNKRNnjEOPJzMcxeI0irT8BBNmf+GtZcJpmhYsQM1DSKmCROUjPWKsXZ5HzwD5Cf5/RV+QD9BSTxJg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/is": "^7.0.1",
-                "@szmarczak/http-timer": "^5.0.1",
-                "cacheable-lookup": "^7.0.0",
-                "cacheable-request": "^12.0.1",
-                "decompress-response": "^6.0.0",
-                "form-data-encoder": "^4.0.2",
-                "http2-wrapper": "^2.2.1",
-                "lowercase-keys": "^3.0.0",
-                "p-cancelable": "^4.0.1",
-                "responselike": "^3.0.0",
-                "type-fest": "^4.26.1"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/got?sponsor=1"
-            }
-        },
-        "node_modules/got/node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/got/node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/got/node_modules/p-cancelable": {
-            "version": "4.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-cancelable/-/p-cancelable-4.0.1.tgz",
-            "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
-        "node_modules/got/node_modules/type-fest": {
-            "version": "4.30.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/type-fest/-/type-fest-4.30.2.tgz",
-            "integrity": "sha512-UJShLPYi1aWqCdq9HycOL/gwsuqda1OISdBO3t8RlXQC4QvtuIz4b5FCfe2dQIWEpmlRExKmcTBfP1r9bhY7ig==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -17954,15 +17114,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/hpagent": {
-            "version": "1.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/hpagent/-/hpagent-1.2.0.tgz",
-            "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
-            "dev": true,
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/html-encoding-sniffer": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -18129,13 +17280,6 @@
                 "entities": "^2.0.0"
             }
         },
-        "node_modules/http-cache-semantics": {
-            "version": "4.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/http-errors/-/http-errors-2.0.0.tgz",
@@ -18213,20 +17357,6 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/http2-wrapper": {
-            "version": "2.2.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "quick-lru": "^5.1.1",
-                "resolve-alpn": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
-            }
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.5",
@@ -18320,13 +17450,6 @@
             "engines": {
                 "node": ">= 4"
             }
-        },
-        "node_modules/immediate": {
-            "version": "3.0.6",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -18715,41 +17838,6 @@
             "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g==",
             "license": "MIT"
         },
-        "node_modules/is-inside-container": {
-            "version": "1.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-inside-container/-/is-inside-container-1.0.0.tgz",
-            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-docker": "^3.0.0"
-            },
-            "bin": {
-                "is-inside-container": "cli.js"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-inside-container/node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-map": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -18793,16 +17881,6 @@
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-            "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -18992,21 +18070,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is64bit": {
-            "version": "2.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is64bit/-/is64bit-2.0.0.tgz",
-            "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
-            "dev": true,
-            "dependencies": {
-                "system-architecture": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/isarray": {
@@ -21949,19 +21012,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/jszip": {
-            "version": "3.10.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jszip/-/jszip-3.10.1.tgz",
-            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-            "dev": true,
-            "license": "(MIT OR GPL-3.0-or-later)",
-            "dependencies": {
-                "lie": "~3.3.0",
-                "pako": "~1.0.2",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "^1.0.5"
-            }
-        },
         "node_modules/jwa": {
             "version": "2.0.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jwa/-/jwa-2.0.0.tgz",
@@ -22059,16 +21109,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/lie": {
-            "version": "3.3.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/lie/-/lie-3.3.0.tgz",
-            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "immediate": "~3.0.5"
             }
         },
         "node_modules/lines-and-columns": {
@@ -22264,112 +21304,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/log-symbols": {
-            "version": "4.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/log-symbols/-/log-symbols-4.1.0.tgz",
-            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "chalk": "^4.1.0",
-                "is-unicode-supported": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-symbols/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/log-symbols/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/log-symbols/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/log-symbols/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/log-symbols/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/log-symbols/node_modules/is-unicode-supported": {
-            "version": "0.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-symbols/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -22398,19 +21332,6 @@
             "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
             "dev": true,
             "license": "0BSD"
-        },
-        "node_modules/lowercase-keys": {
-            "version": "3.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/lru-cache": {
             "version": "11.0.1",
@@ -22787,324 +21708,6 @@
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "license": "MIT"
         },
-        "node_modules/mocha": {
-            "version": "11.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mocha/-/mocha-11.0.1.tgz",
-            "integrity": "sha512-+3GkODfsDG71KSCQhc4IekSW+ItCK/kiez1Z28ksWvYhKXV/syxMlerR/sC7whDp7IyreZ4YxceMLdTs5hQE8A==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "ansi-colors": "^4.1.3",
-                "browser-stdout": "^1.3.1",
-                "chokidar": "^3.5.3",
-                "debug": "^4.3.5",
-                "diff": "^5.2.0",
-                "escape-string-regexp": "^4.0.0",
-                "find-up": "^5.0.0",
-                "glob": "^10.4.5",
-                "he": "^1.2.0",
-                "js-yaml": "^4.1.0",
-                "log-symbols": "^4.1.0",
-                "minimatch": "^5.1.6",
-                "ms": "^2.1.3",
-                "serialize-javascript": "^6.0.2",
-                "strip-json-comments": "^3.1.1",
-                "supports-color": "^8.1.1",
-                "workerpool": "^6.5.1",
-                "yargs": "^16.2.0",
-                "yargs-parser": "^20.2.9",
-                "yargs-unparser": "^2.0.0"
-            },
-            "bin": {
-                "_mocha": "bin/_mocha",
-                "mocha": "bin/mocha.js"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/mocha/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/mocha/node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/mocha/node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/mocha/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/find-up": {
-            "version": "5.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/mocha/node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/mocha/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/mocha/node_modules/locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "p-locate": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/mocha/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "peer": true
-        },
-        "node_modules/mocha/node_modules/p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "p-limit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mocha/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/mocha/node_modules/yargs-parser": {
-            "version": "20.2.9",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/mri": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
@@ -23401,19 +22004,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/normalize-url": {
-            "version": "8.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/normalize-url/-/normalize-url-8.0.1.tgz",
-            "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/npm-run-all": {
@@ -24104,13 +22694,6 @@
             "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
             "dev": true,
             "license": "BlueOak-1.0.0"
-        },
-        "node_modules/pako": {
-            "version": "1.0.11",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-            "dev": true,
-            "license": "(MIT AND Zlib)"
         },
         "node_modules/param-case": {
             "version": "3.0.4",
@@ -26262,19 +24845,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/quick-lru": {
-            "version": "5.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/quick-lru/-/quick-lru-5.1.1.tgz",
-            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/raf-schd": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-2.1.2.tgz",
@@ -26818,13 +25388,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/resolve-alpn": {
-            "version": "1.2.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/resolve-cwd": {
             "version": "3.0.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -26872,22 +25435,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/responselike": {
-            "version": "3.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/responselike/-/responselike-3.0.0.tgz",
-            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lowercase-keys": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/reusify": {
@@ -27039,15 +25586,6 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
         },
-        "node_modules/sanitize-filename": {
-            "version": "1.6.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-            "dev": true,
-            "dependencies": {
-                "truncate-utf8-bytes": "^1.0.0"
-            }
-        },
         "node_modules/sax": {
             "version": "1.4.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/sax/-/sax-1.4.1.tgz",
@@ -27130,40 +25668,6 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/selenium-webdriver": {
-            "version": "4.27.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/selenium-webdriver/-/selenium-webdriver-4.27.0.tgz",
-            "integrity": "sha512-LkTJrNz5socxpPnWPODQ2bQ65eYx9JK+DQMYNihpTjMCqHwgWGYQnQTCAAche2W3ZP87alA+1zYPvgS8tHNzMQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/SeleniumHQ"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/selenium"
-                }
-            ],
-            "dependencies": {
-                "@bazel/runfiles": "^6.3.1",
-                "jszip": "^3.10.1",
-                "tmp": "^0.2.3",
-                "ws": "^8.18.0"
-            },
-            "engines": {
-                "node": ">= 14.21.0"
-            }
-        },
-        "node_modules/selenium-webdriver/node_modules/tmp": {
-            "version": "0.2.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tmp/-/tmp-0.2.3.tgz",
-            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.14"
-            }
         },
         "node_modules/semver": {
             "version": "7.6.3",
@@ -27309,13 +25813,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/setimmediate": {
-            "version": "1.0.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -28163,18 +26660,6 @@
             "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
             "license": "0BSD"
         },
-        "node_modules/system-architecture": {
-            "version": "0.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/system-architecture/-/system-architecture-0.1.0.tgz",
-            "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/tabbable": {
             "version": "1.1.3",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tabbable/-/tabbable-1.1.3.tgz",
@@ -28231,66 +26716,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/targz": {
-            "version": "1.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/targz/-/targz-1.0.1.tgz",
-            "integrity": "sha512-6q4tP9U55mZnRuMTBqnqc3nwYQY3kv+QthCFZuMk+Tn1qYUnMPmL/JZ/mzgXINzFpSqfU+242IFmFU9VPvqaQw==",
-            "dev": true,
-            "dependencies": {
-                "tar-fs": "^1.8.1"
-            }
-        },
-        "node_modules/targz/node_modules/bl": {
-            "version": "1.2.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bl/-/bl-1.2.3.tgz",
-            "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "^2.3.5",
-                "safe-buffer": "^5.1.1"
-            }
-        },
-        "node_modules/targz/node_modules/pump": {
-            "version": "1.0.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/pump/-/pump-1.0.3.tgz",
-            "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-            "dev": true,
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
-        "node_modules/targz/node_modules/tar-fs": {
-            "version": "1.16.4",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.4.tgz",
-            "integrity": "sha512-u3XczWoYAIVXe5GOKK6+VeWaHjtc47W7hyuTo3+4cNakcCcuDmlkYiiHEsECwTkcI3h1VUgtwBQ54+RvY6cM4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chownr": "^1.0.1",
-                "mkdirp": "^0.5.1",
-                "pump": "^1.0.0",
-                "tar-stream": "^1.1.2"
-            }
-        },
-        "node_modules/targz/node_modules/tar-stream": {
-            "version": "1.6.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/tar-stream/-/tar-stream-1.6.2.tgz",
-            "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-            "dev": true,
-            "dependencies": {
-                "bl": "^1.0.0",
-                "buffer-alloc": "^1.2.0",
-                "end-of-stream": "^1.0.0",
-                "fs-constants": "^1.0.0",
-                "readable-stream": "^2.3.0",
-                "to-buffer": "^1.1.1",
-                "xtend": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/terser-webpack-plugin": {
@@ -28438,12 +26863,6 @@
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
-        "node_modules/to-buffer": {
-            "version": "1.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/to-buffer/-/to-buffer-1.1.1.tgz",
-            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-            "dev": true
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -28505,15 +26924,6 @@
             "license": "MIT",
             "bin": {
                 "tree-kill": "cli.js"
-            }
-        },
-        "node_modules/truncate-utf8-bytes": {
-            "version": "1.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-            "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
-            "dev": true,
-            "dependencies": {
-                "utf8-byte-length": "^1.0.1"
             }
         },
         "node_modules/ts-api-utils": {
@@ -28947,18 +27357,6 @@
                 "node": ">=18.17"
             }
         },
-        "node_modules/unicorn-magic": {
-            "version": "0.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/universalify": {
             "version": "2.0.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/universalify/-/universalify-2.0.1.tgz",
@@ -28976,33 +27374,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/unzipper": {
-            "version": "0.12.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/unzipper/-/unzipper-0.12.3.tgz",
-            "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
-            "dev": true,
-            "dependencies": {
-                "bluebird": "~3.7.2",
-                "duplexer2": "~0.1.4",
-                "fs-extra": "^11.2.0",
-                "graceful-fs": "^4.2.2",
-                "node-int64": "^0.4.0"
-            }
-        },
-        "node_modules/unzipper/node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -29143,12 +27514,6 @@
                 "node": ">=6.14.2"
             }
         },
-        "node_modules/utf8-byte-length": {
-            "version": "1.0.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
-            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
-            "dev": true
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -29227,210 +27592,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/vscode-extension-tester": {
-            "version": "8.10.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/vscode-extension-tester/-/vscode-extension-tester-8.10.0.tgz",
-            "integrity": "sha512-Q4Fd1GJ0V1kA5+a6JEzUOkeLE/5zndVr1sBWtYjQuuswp9ef1PxWtqjFtC8kFy7pfZbmD2PpN+EH3uhR5rX76g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@redhat-developer/locators": "^1.8.0",
-                "@redhat-developer/page-objects": "^1.8.0",
-                "@types/selenium-webdriver": "^4.1.27",
-                "@vscode/vsce": "^3.2.1",
-                "c8": "^10.1.2",
-                "commander": "^12.1.0",
-                "compare-versions": "^6.1.1",
-                "find-up": "7.0.0",
-                "fs-extra": "^11.2.0",
-                "glob": "^11.0.0",
-                "got": "^14.4.4",
-                "hpagent": "^1.2.0",
-                "js-yaml": "^4.1.0",
-                "sanitize-filename": "^1.6.3",
-                "selenium-webdriver": "^4.26.0",
-                "targz": "^1.0.1",
-                "unzipper": "^0.12.3"
-            },
-            "bin": {
-                "extest": "out/cli.js"
-            },
-            "peerDependencies": {
-                "mocha": ">=5.2.0",
-                "typescript": ">=4.6.2"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "node_modules/vscode-extension-tester/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/commander": {
-            "version": "12.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/commander/-/commander-12.1.0.tgz",
-            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/find-up": {
-            "version": "7.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/find-up/-/find-up-7.0.0.tgz",
-            "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^7.2.0",
-                "path-exists": "^5.0.0",
-                "unicorn-magic": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/glob": {
-            "version": "11.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-11.0.0.tgz",
-            "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
-            "dev": true,
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^4.0.1",
-                "minimatch": "^10.0.0",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^2.0.0"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/locate-path": {
-            "version": "7.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/locate-path/-/locate-path-7.2.0.tgz",
-            "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^6.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/minimatch": {
-            "version": "10.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-10.0.1.tgz",
-            "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/p-limit": {
-            "version": "4.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-limit/-/p-limit-4.0.0.tgz",
-            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-            "dev": true,
-            "dependencies": {
-                "yocto-queue": "^1.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/p-locate": {
-            "version": "6.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/p-locate/-/p-locate-6.0.0.tgz",
-            "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/path-exists": {
-            "version": "5.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-exists/-/path-exists-5.0.0.tgz",
-            "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
-        "node_modules/vscode-extension-tester/node_modules/yocto-queue": {
-            "version": "1.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yocto-queue/-/yocto-queue-1.1.1.tgz",
-            "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/vscode-uri": {
@@ -29973,13 +28134,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/workerpool": {
-            "version": "6.5.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/workerpool/-/workerpool-6.5.1.tgz",
-            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -30161,15 +28315,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4"
-            }
-        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/y18n/-/y18n-5.0.8.tgz",
@@ -30201,25 +28346,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/yargs": {
-            "version": "16.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs/-/yargs-16.2.0.tgz",
-            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "cliui": "^7.0.2",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -30227,45 +28353,6 @@
             "dev": true,
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/yargs-unparser": {
-            "version": "2.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "camelcase": "^6.0.0",
-                "decamelize": "^4.0.0",
-                "flat": "^5.0.2",
-                "is-plain-obj": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/yargs-unparser/node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yargs/node_modules/yargs-parser": {
-            "version": "20.2.9",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -300,16 +300,6 @@
                 "category": "Atlassian"
             },
             {
-                "command": "atlascode.testLogin",
-                "title": "Test Login",
-                "category": "Atlassian"
-            },
-            {
-                "command": "atlascode.testLogout",
-                "title": "Test Logout",
-                "category": "Atlassian"
-            },
-            {
                 "command": "atlascode.bb.openInBitbucket",
                 "title": "Open in Bitbucket",
                 "category": "Atlassian"
@@ -1343,7 +1333,6 @@
         "@jest/globals": "^29.7.0",
         "@playwright/test": "^1.52.0",
         "@stylistic/eslint-plugin-js": "^2.8.0",
-        "@types/chai": "^4",
         "@types/express": "^5.0.1",
         "@types/filesize": "^4.1.0",
         "@types/git-url-parse": "^9.0.1",
@@ -1351,7 +1340,6 @@
         "@types/lodash.debounce": "^4.0.6",
         "@types/lodash.orderby": "^4.6.6",
         "@types/lodash.truncate": "^4.4.6",
-        "@types/mocha": "^10.0.10",
         "@types/node": "^18.16.19",
         "@types/node-ipc": "^9.2.0",
         "@types/prosemirror-state": "^1.2.5",
@@ -1370,7 +1358,6 @@
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.4.20",
-        "chai": "^4",
         "concurrently": "^9.1.2",
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1394,7 +1394,6 @@
         "ts-loader": "^8.4.0",
         "tsconfig-paths-webpack-plugin": "^3.2.0",
         "typescript": "^5.7.3",
-        "vscode-extension-tester": "^8.10.0",
         "webpack": "^5",
         "webpack-cli": "^5.1.4",
         "webpack-manifest-plugin": "^5.0.0",

--- a/src/atlclients/authInfo.ts
+++ b/src/atlclients/authInfo.ts
@@ -1,5 +1,3 @@
-import { ATLASCODE_TEST_HOST } from '../../src/constants';
-
 export enum AuthChangeType {
     Update = 'update',
     Remove = 'remove',
@@ -225,11 +223,6 @@ export function getSecretForAuthInfo(info: any): string {
 
 export function oauthProviderForSite(site: SiteInfo): OAuthProvider | undefined {
     const hostname = site.host.split(':')[0];
-
-    // Added to allow for testing flow of AXON-32
-    if (hostname.endsWith(ATLASCODE_TEST_HOST)) {
-        return undefined;
-    }
 
     if (hostname.endsWith('atlassian.net') || hostname.endsWith('jira.com')) {
         return OAuthProvider.JiraCloud;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -69,8 +69,6 @@ export enum Commands {
     ShowJiraAuth = 'atlascode.showJiraAuth',
     ShowBitbucketAuth = 'atlascode.showBitbucketAuth',
     ShowOnboardingPage = 'atlascode.showOnboardingPage',
-    TestLogin = 'atlascode.testLogin',
-    TestLogout = 'atlascode.testLogout',
     ShowPullRequestDetailsPage = 'atlascode.showPullRequestDetailsPage',
     AssignIssueToMe = 'atlascode.jira.assignIssueToMe',
     StartWorkOnIssue = 'atlascode.jira.startWorkOnIssue',
@@ -160,8 +158,6 @@ export function registerCommands(vscodeContext: ExtensionContext) {
             });
         }),
         commands.registerCommand(Commands.ShowOnboardingPage, () => Container.onboardingWebviewFactory.createOrShow()),
-        commands.registerCommand(Commands.TestLogin, () => Container.testLogin()),
-        commands.registerCommand(Commands.TestLogout, () => Container.testLogout()),
         commands.registerCommand(
             Commands.ViewInWebBrowser,
             async (prNode: AbstractBaseNode, source?: string, linkId?: string) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,3 @@ export const AxiosUserAgent = 'atlascode/2.x axios/0.19.2';
 
 export const bbAPIConnectivityError = new Error('cannot connect to bitbucket api');
 export const cannotGetClientFor = 'cannot get client for';
-
-export const ATLASCODE_TEST_USER_EMAIL = 'axontest2025@gmail.com';
-export const ATLASCODE_TEST_HOST = 'axontest2025.atlassian.net';

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,8 +1,7 @@
-import { env, ExtensionContext, UIKind, window, workspace } from 'vscode';
+import { env, ExtensionContext, UIKind, workspace } from 'vscode';
 
 import { featureFlagClientInitializedEvent } from './analytics';
 import { AnalyticsClient, analyticsClient } from './analytics-node-client/src/client.min.js';
-import { ProductJira } from './atlclients/authInfo';
 import { CredentialManager } from './atlclients/authStore';
 import { ClientManager } from './atlclients/clientManager';
 import { LoginManager } from './atlclients/loginManager';
@@ -13,7 +12,6 @@ import { PullRequest, WorkspaceRepo } from './bitbucket/model';
 import { BitbucketCloudPullRequestLinkProvider } from './bitbucket/terminal-link/createPrLinkProvider';
 import { openPullRequest } from './commands/bitbucket/pullRequest';
 import { configuration, IConfig } from './config/configuration';
-import { ATLASCODE_TEST_HOST, ATLASCODE_TEST_USER_EMAIL } from './constants';
 import { PmfStats } from './feedback/pmfStats';
 import { JQLManager } from './jira/jqlManager';
 import { JiraProjectManager } from './jira/projectManager';
@@ -267,43 +265,6 @@ export class Container {
 
     public static set configTarget(target: ConfigTarget) {
         this._context.globalState.update(ConfigTargetKey, target);
-    }
-
-    public static async testLogout() {
-        Container.siteManager.getSitesAvailable(ProductJira).forEach(async (site) => {
-            await Container.clientManager.removeClient(site);
-            Container.siteManager.removeSite(site);
-        });
-    }
-
-    public static async testLogin() {
-        if (!process.env.ATLASCODE_TEST_USER_API_TOKEN) {
-            // vscode notify user that this is for testing only
-            window.showInformationMessage(
-                'This is for testing only. Please set the ATLASCODE_TEST_USER_API_TOKEN environment variable to run this test',
-            );
-            return;
-        }
-        const authInfo = {
-            username: ATLASCODE_TEST_USER_EMAIL,
-            password: process.env.ATLASCODE_TEST_USER_API_TOKEN,
-            user: {
-                id: '',
-                displayName: '',
-                email: '',
-                avatarUrl: '',
-            },
-            state: 0,
-        };
-        const site = {
-            host: ATLASCODE_TEST_HOST,
-            protocol: 'https:',
-            product: {
-                name: 'Jira',
-                key: 'jira',
-            },
-        };
-        await Container.loginManager.userInitiatedServerLogin(site, authInfo);
     }
 
     private static _version: string;

--- a/webpack.extension.dev.js
+++ b/webpack.extension.dev.js
@@ -77,7 +77,6 @@ module.exports = [
                 'process.env.ATLASCODE_FX3_ENVIRONMENT': JSON.stringify(process.env.ATLASCODE_FX3_ENVIRONMENT),
                 'process.env.ATLASCODE_FX3_TARGET_APP': JSON.stringify(process.env.ATLASCODE_FX3_TARGET_APP),
                 'process.env.ATLASCODE_FX3_TIMEOUT': JSON.stringify(process.env.ATLASCODE_FX3_TIMEOUT),
-                'process.env.ATLASCODE_TEST_USER_API_TOKEN': JSON.stringify(process.env.ATLASCODE_TEST_USER_API_TOKEN),
                 'process.env.ATLASCODE_FF_OVERRIDES': JSON.stringify(process.env.ATLASCODE_FF_OVERRIDES),
                 'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
                 'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_STRING),

--- a/webpack.extension.prod.js
+++ b/webpack.extension.prod.js
@@ -102,7 +102,6 @@ module.exports = [
                 'process.env.ATLASCODE_FX3_ENVIRONMENT': JSON.stringify(process.env.ATLASCODE_FX3_ENVIRONMENT),
                 'process.env.ATLASCODE_FX3_TARGET_APP': JSON.stringify(process.env.ATLASCODE_FX3_TARGET_APP),
                 'process.env.ATLASCODE_FX3_TIMEOUT': JSON.stringify(process.env.ATLASCODE_FX3_TIMEOUT),
-                'process.env.ATLASCODE_TEST_USER_API_TOKEN': JSON.stringify(process.env.ATLASCODE_TEST_USER_API_TOKEN),
                 'process.env.ATLASCODE_FF_OVERRIDES': JSON.stringify(process.env.ATLASCODE_FF_OVERRIDES),
                 'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
                 'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_STRING),

--- a/webpack.react.dev.js
+++ b/webpack.react.dev.js
@@ -60,7 +60,6 @@ module.exports = {
             'process.env.ATLASCODE_FX3_ENVIRONMENT': JSON.stringify(process.env.ATLASCODE_FX3_ENVIRONMENT),
             'process.env.ATLASCODE_FX3_TARGET_APP': JSON.stringify(process.env.ATLASCODE_FX3_TARGET_APP),
             'process.env.ATLASCODE_FX3_TIMEOUT': JSON.stringify(process.env.ATLASCODE_FX3_TIMEOUT),
-            'process.env.ATLASCODE_TEST_USER_API_TOKEN': JSON.stringify(process.env.ATLASCODE_TEST_USER_API_TOKEN),
             'process.env.ATLASCODE_FF_OVERRIDES': JSON.stringify(process.env.ATLASCODE_FF_OVERRIDES),
             'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
             'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_STRING),

--- a/webpack.react.prod.js
+++ b/webpack.react.prod.js
@@ -94,7 +94,6 @@ module.exports = {
             'process.env.ATLASCODE_FX3_ENVIRONMENT': JSON.stringify(process.env.ATLASCODE_FX3_ENVIRONMENT),
             'process.env.ATLASCODE_FX3_TARGET_APP': JSON.stringify(process.env.ATLASCODE_FX3_TARGET_APP),
             'process.env.ATLASCODE_FX3_TIMEOUT': JSON.stringify(process.env.ATLASCODE_FX3_TIMEOUT),
-            'process.env.ATLASCODE_TEST_USER_API_TOKEN': JSON.stringify(process.env.ATLASCODE_TEST_USER_API_TOKEN),
             'process.env.ATLASCODE_FF_OVERRIDES': JSON.stringify(process.env.ATLASCODE_FF_OVERRIDES),
             'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
             'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_STRING),


### PR DESCRIPTION
### What Is This Change?

This cleans up leftovers from the old E2E infrastructures:
- `chai` and `vscode-extension-tester` packages
- `test login` and `test logout` commands
- usage of `ATLASCODE_TEST_USER_API_TOKEN`
- unused code

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`