### PR TITLE
[AXON-293] update fg client and add new init options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@atlaskit/comment": "^10.3.0",
                 "@atlaskit/datetime-picker": "^11.1.1",
                 "@atlaskit/dropdown-menu": "^12.26.5",
-                "@atlaskit/feature-gate-js-client": "^5.3.0",
+                "@atlaskit/feature-gate-js-client": "^5.3.1",
                 "@atlaskit/form": "^11.2.0",
                 "@atlaskit/icon": "^21.12.8",
                 "@atlaskit/icon-lab": "^2.8.0",
@@ -1704,14 +1704,14 @@
             }
         },
         "node_modules/@atlaskit/feature-gate-js-client": {
-            "version": "5.3.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/feature-gate-js-client/-/feature-gate-js-client-5.3.0.tgz",
-            "integrity": "sha512-eSW3ZwAIvpSfLnch7+zuxyMvIPFVrfEAX0PNj7Zg70Epm3RJ4Dl62szAhmZrp5xxx5eeVj3BnlIk5Fq7rWY6WQ==",
+            "version": "5.3.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/feature-gate-js-client/-/feature-gate-js-client-5.3.1.tgz",
+            "integrity": "sha512-2ZsxZ3r2+J22fT341JzR/vad1N95OK5hHybJC5iVQ961+x0q6pjRikaqOtRjGfcH6tOmV4br4wb14DeHH1YcbQ==",
             "dependencies": {
                 "@atlaskit/atlassian-context": "^0.2.0",
                 "@babel/runtime": "^7.0.0",
-                "@statsig/client-core": "^3.10.0",
-                "@statsig/js-client": "^3.10.0",
+                "@statsig/client-core": "^3.16.0",
+                "@statsig/js-client": "^3.16.0",
                 "eventemitter2": "^4.1.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -1232,7 +1232,7 @@
         "@atlaskit/comment": "^10.3.0",
         "@atlaskit/datetime-picker": "^11.1.1",
         "@atlaskit/dropdown-menu": "^12.26.5",
-        "@atlaskit/feature-gate-js-client": "^5.3.0",
+        "@atlaskit/feature-gate-js-client": "^5.3.1",
         "@atlaskit/form": "^11.2.0",
         "@atlaskit/icon": "^21.12.8",
         "@atlaskit/icon-lab": "^2.8.0",


### PR DESCRIPTION
### What Is This Change?

Update `@atlaskit/feature-gate-js-client` package after statsig client version bump
> This update includes the statsig exposures override for non-window environments

#### Snapshot of exposure event sent through `xp.atlassian.com`: 
<img width="826" alt="Screenshot 2025-05-21 at 2 04 29 AM" src="https://github.com/user-attachments/assets/36424334-d9b8-4edc-b0cc-f67c7ef801e4" />

#### User info for exposure event in statsig: 
<img width="767" alt="Screenshot 2025-05-21 at 2 06 10 AM" src="https://github.com/user-attachments/assets/ddc85269-2160-4a34-84b2-6458abe4522d" />

- [x] `npm run lint`
- [x] `npm run test`