### PR TITLE
Fixed E2E tests in nightly build

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -31,7 +31,7 @@ update-ca-certificates
 echo "installing dependencies for atlascode extension"
 code-server --install-extension ../redhat.vscode-yaml-1.18.0.vsix --force
 echo "installing atlascode"
-code-server --install-extension atlascode-0.0.0.vsix --force
+code-server --install-extension atlascode-*.vsix --force
 
 echo "starting code-server"
 code-server --auth none --bind-addr localhost:9988 &


### PR DESCRIPTION
### What Is This Change?

In the nightly release build, we package the code with the correct version (and not 0.0.0), so the Dockerfile command needs to account for that.