### PR TITLE
Use npm ci in pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install --no-audit
+          npm ci --no-audit
           npm audit
 
       - name: Build and package the extension

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -43,7 +43,7 @@ jobs:
           npm -no-git-tag-version --allow-same-version -f version $PACKAGE_VERSION
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --no-audit
 
       - name: Build and package the extension for pre-release
         run: npm run extension:package:prerelease

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
         run: npm -no-git-tag-version --allow-same-version -f version $PACKAGE_VERSION
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --no-audit
 
       - name: Build and package the extension
         run: npm run extension:package


### PR DESCRIPTION
### What Is This Change?

`npm ci` is generally faster than `npm install` because it installs packages directly from the `package-lock.json` file without checking for updates or modifying it. This makes `npm ci` particularly efficient for clean installations in automated environments.