### PR TITLE
[AXON-385] chore: fix jest config to work with src/ paths

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,8 +17,9 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
     roots: ['<rootDir>'],
 
     moduleNameMapper: {
-        "^testsutil(/.+)?": "<rootDir>/testsutil$1"
-    },    
+        '^src(.*)$': '<rootDir>/src$1',
+        '^testsutil(/.+)?': '<rootDir>/testsutil$1',
+    },
 
     testMatch: [`**/*.test.${testExtension}`],
     testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
@@ -27,7 +28,7 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
         '^.+\\.(js|ts|tsx)$': [
             'ts-jest',
             {
-                tsconfig: project === 'react' ? ({ esModuleInterop: true, isolatedModules: true }) : false,
+                tsconfig: project === 'react' ? { esModuleInterop: true, isolatedModules: true } : false,
             },
         ],
         '^.+\\.(css|styl|less|sass|scss)$': 'jest-css-modules-transform',
@@ -55,17 +56,20 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
     coverageReporters: ['json', 'lcov', 'text-summary', 'clover', 'html'],
 
     coverageThreshold: {
-        global: testExtension === 'ts' ? {
-            statements: 40,
-            branches: 27,
-            functions: 34,
-            lines: 40,
-        } : /* tsx */{
-            statements: 7,
-            branches: 5,
-            functions: 5,
-            lines: 7,
-        },
+        global:
+            testExtension === 'ts'
+                ? {
+                      statements: 40,
+                      branches: 27,
+                      functions: 34,
+                      lines: 40,
+                  }
+                : /* tsx */ {
+                      statements: 7,
+                      branches: 5,
+                      functions: 5,
+                      lines: 7,
+                  },
     },
 });
 

--- a/src/siteManager.test.ts
+++ b/src/siteManager.test.ts
@@ -1,3 +1,4 @@
+import { SiteManager } from 'src/siteManager';
 import { expansionCastTo } from 'testsutil';
 import { EventEmitter, Memento } from 'vscode';
 
@@ -14,7 +15,6 @@ import {
 import { CredentialManager } from './atlclients/authStore';
 import { configuration } from './config/configuration';
 import { Container } from './container';
-import { SiteManager } from './siteManager';
 
 describe('SiteManager', () => {
     let siteManager: SiteManager;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,17 +24,9 @@
         "strictPropertyInitialization": true,
         "typeRoots": ["node_modules/@types", "src/typings/"],
         "paths": {
-            "testsutil/*": ["testsutil/*"],
+            "testsutil/*": ["testsutil/*"]
         }
     },
     "include": ["**/src/**/*", "webpack.*.js", "e2e/**/*"],
-    "exclude": [
-        "out",
-        "node_modules",
-        "build",
-        "scripts",
-        "webpack",
-        "jest",
-        ".vscode-test",
-    ]
+    "exclude": ["out", "node_modules", "build", "scripts", "webpack", "jest", ".vscode-test"]
 }


### PR DESCRIPTION
### What Is This Change?

For a while now, we've been using relative paths in our modules to avoid errors in tests along the lines of this:
![image](https://github.com/user-attachments/assets/d942f1e0-6d65-467c-b82c-47030fa4e731)

This PR slightly changes jest config to where it now accepts `src/` paths

### How Has This Been Tested?

A bunch of tiresome trial and error ;)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change