### PR TITLE
fix copy to be more concise

### DIFF
--- a/src/onboarding/onboardingQuickPickManager.test.ts
+++ b/src/onboarding/onboardingQuickPickManager.test.ts
@@ -70,16 +70,14 @@ describe('OnboardingQuickPickManager', () => {
         const manager = new OnboardingQuickPickManager(items, ProductJira, onAccept, onBack);
         manager.show();
 
-        expect(quickPickMock.title).toBe('Setup Jira & Bitbucket');
+        expect(quickPickMock.title).toBe('Sign in to Jira');
         expect(quickPickMock.ignoreFocusOut).toBe(true);
         expect(quickPickMock.items).toBe(items);
         expect(quickPickMock.totalSteps).toBe(2);
         expect(quickPickMock.activeItems).toEqual([items[0]]);
         expect(quickPickMock.step).toBe(OnboardingStep.Jira);
         expect(quickPickMock.buttons).toEqual([OnboardingButtons.settings]);
-        expect(quickPickMock.placeholder).toBe(
-            'Select your Jira site type. For more advanced options, click on the gear button.',
-        );
+        expect(quickPickMock.placeholder).toBe('Type to search. Select settings for advanced options.');
         expect(quickPickMock.show).toHaveBeenCalled();
     });
 
@@ -89,9 +87,7 @@ describe('OnboardingQuickPickManager', () => {
 
         expect(quickPickMock.step).toBe(OnboardingStep.Bitbucket);
         expect(quickPickMock.buttons).toEqual([QuickInputButtons.Back, OnboardingButtons.settings]);
-        expect(quickPickMock.placeholder).toBe(
-            'Select your Bitbucket site type. For more advanced options, click on the gear button.',
-        );
+        expect(quickPickMock.placeholder).toBe('Type to search. Select settings for advanced options.');
         expect(quickPickMock.show).toHaveBeenCalled();
     });
 

--- a/src/onboarding/onboardingQuickPickManager.ts
+++ b/src/onboarding/onboardingQuickPickManager.ts
@@ -40,25 +40,23 @@ class OnboardingQuickPickManager {
     }
 
     private _resetItems() {
-        this._quickPick.title = 'Setup Jira & Bitbucket';
         this._quickPick.ignoreFocusOut = true;
         this._quickPick.items = this._items;
         this._quickPick.totalSteps = 2;
         this._quickPick.activeItems = [this._items[0]];
-
+        this._quickPick.placeholder = 'Type to search. Select settings for advanced options.';
         switch (this.product) {
             case ProductJira: {
+                this._quickPick.title = 'Sign in to Jira';
                 this._quickPick.step = OnboardingStep.Jira;
                 this._quickPick.buttons = [OnboardingButtons.settings];
-                this._quickPick.placeholder =
-                    'Select your Jira site type. For more advanced options, click on the gear button.';
+
                 break;
             }
             case ProductBitbucket: {
+                this._quickPick.title = 'Sign in to Bitbucket';
                 this._quickPick.step = OnboardingStep.Bitbucket;
                 this._quickPick.buttons = [QuickInputButtons.Back, OnboardingButtons.settings];
-                this._quickPick.placeholder =
-                    'Select your Bitbucket site type. For more advanced options, click on the gear button.';
                 break;
             }
         }

--- a/src/onboarding/utils.ts
+++ b/src/onboarding/utils.ts
@@ -7,22 +7,18 @@ export const onboardingQuickPickItems = (product: Product) => {
         {
             iconPath: new ThemeIcon('cloud'),
             label: `Sign in to ${product.name} Cloud`,
-            description: 'For most of our users.',
-            detail: 'The URL for accessing your site will typically be in the format mysite.atlassian.net.',
+            detail: 'For most users - site usually ends in .atlassian.net.',
             onboardingId: 'onboarding:cloud',
         },
         {
             iconPath: new ThemeIcon('server'),
             label: `Sign in to ${product.name} Server`,
-            description: 'For users with a custom site.',
-            detail: 'The URL is usually a custom domain or IP address set up by your organization.',
+            detail: 'For users with a custom site.',
             onboardingId: 'onboarding:server',
         },
         {
-            iconPath: new ThemeIcon('debug-step-over'),
+            iconPath: new ThemeIcon('live-share'),
             label: `I don't have ${product.name}`,
-            description: 'Skip this step',
-            detail: `You can always set up a new ${product.name} account later.`,
             onboardingId: 'onboarding:skip',
         },
     ];
@@ -52,7 +48,7 @@ export interface OnboardingQuickPickItem extends QuickPickItem {
 export const OnboardingButtons: Record<string, QuickInputButton> = {
     settings: {
         iconPath: new ThemeIcon('gear'),
-        tooltip: 'Configure in settings',
+        tooltip: 'Settings',
     },
     createApiToken: {
         iconPath: new ThemeIcon('key'),


### PR DESCRIPTION
### What Is This Change?
Changed the onboarding modal text/copy to be more concise and have better readability

Modal: 
![Screenshot 2025-06-02 at 7 38 23 PM](https://github.com/user-attachments/assets/01bc4f3a-748c-426a-a7fd-593321ad9117)

### How Has This Been Tested?


Basic checks:

- [x] `npm run lint`
- [x] `npm run test`