### PR TITLE
Remove double dashing in branch names when name uses square brackets

### DIFF
--- a/src/react/atlascode/startwork/StartWorkPage.test.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.test.tsx
@@ -1,50 +1,15 @@
-// buildBranchName logic for testing
-function buildBranchName(branchType: { prefix: string }, state: { issue: { key: string; summary: string } }) {
-    return {
-        prefix: branchType.prefix.replace(/ /g, '-').toLowerCase(),
-        Prefix: branchType.prefix.replace(/ /g, '-'),
-        PREFIX: branchType.prefix.replace(/ /g, '-').toUpperCase(),
-        issueKey: state.issue.key,
-        issuekey: state.issue.key.toLowerCase(),
-        summary: state.issue.summary
-            .substring(0, 50)
-            .trim()
-            .toLowerCase()
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '')
-            .replace(/\W+/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, ''),
-        Summary: state.issue.summary
-            .substring(0, 50)
-            .trim()
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '')
-            .replace(/\W+/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, ''),
-        SUMMARY: state.issue.summary
-            .substring(0, 50)
-            .trim()
-            .toUpperCase()
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '')
-            .replace(/\W+/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, ''),
-    };
-}
+import { buildBranchName } from './branchNameUtils';
 
 describe('buildBranchName', () => {
-    it('should format branch name parts correctly', () => {
-        const branchType = { prefix: 'feature branch' };
-        const state = {
+    it('should normalize and format branch name parts correctly', () => {
+        const input = {
+            branchType: { prefix: 'feature branch' },
             issue: {
                 key: 'ABC-123',
                 summary: 'Fix: naïve façade—remove bugs! (v2.0)   ',
             },
         };
-        const view = buildBranchName(branchType, state);
+        const view = buildBranchName(input);
         expect(view.prefix).toBe('feature-branch');
         expect(view.Prefix).toBe('feature-branch');
         expect(view.PREFIX).toBe('FEATURE-BRANCH');
@@ -56,26 +21,26 @@ describe('buildBranchName', () => {
     });
 
     it('should handle accented and special characters', () => {
-        const branchType = { prefix: 'hot fix' };
-        const state = {
+        const input = {
+            branchType: { prefix: 'hot fix' },
             issue: {
                 key: 'ABC-124',
                 summary: 'Crème brûlée: déjà vu!',
             },
         };
-        const view = buildBranchName(branchType, state);
+        const view = buildBranchName(input);
         expect(view.summary).toBe('creme-brulee-deja-vu');
     });
 
     it('should trim and collapse dashes', () => {
-        const branchType = { prefix: 'bug' };
-        const state = {
+        const input = {
+            branchType: { prefix: 'bug' },
             issue: {
                 key: 'ABC-125',
                 summary: '--- [More dashes are here]   ---Multiple---dashes--- ',
             },
         };
-        const view = buildBranchName(branchType, state);
+        const view = buildBranchName(input);
         expect(view.summary).toBe('more-dashes-are-here-multiple-dashes');
     });
 });

--- a/src/react/atlascode/startwork/StartWorkPage.test.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.test.tsx
@@ -1,0 +1,81 @@
+// buildBranchName logic for testing
+function buildBranchName(branchType: { prefix: string }, state: { issue: { key: string; summary: string } }) {
+    return {
+        prefix: branchType.prefix.replace(/ /g, '-').toLowerCase(),
+        Prefix: branchType.prefix.replace(/ /g, '-'),
+        PREFIX: branchType.prefix.replace(/ /g, '-').toUpperCase(),
+        issueKey: state.issue.key,
+        issuekey: state.issue.key.toLowerCase(),
+        summary: state.issue.summary
+            .substring(0, 50)
+            .trim()
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+        Summary: state.issue.summary
+            .substring(0, 50)
+            .trim()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+        SUMMARY: state.issue.summary
+            .substring(0, 50)
+            .trim()
+            .toUpperCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+    };
+}
+
+describe('buildBranchName', () => {
+    it('should format branch name parts correctly', () => {
+        const branchType = { prefix: 'feature branch' };
+        const state = {
+            issue: {
+                key: 'ABC-123',
+                summary: 'Fix: naïve façade—remove bugs! (v2.0)   ',
+            },
+        };
+        const view = buildBranchName(branchType, state);
+        expect(view.prefix).toBe('feature-branch');
+        expect(view.Prefix).toBe('feature-branch');
+        expect(view.PREFIX).toBe('FEATURE-BRANCH');
+        expect(view.issueKey).toBe('ABC-123');
+        expect(view.issuekey).toBe('abc-123');
+        expect(view.summary).toBe('fix-naive-facade-remove-bugs-v2-0');
+        expect(view.Summary).toBe('Fix-naive-facade-remove-bugs-v2-0');
+        expect(view.SUMMARY).toBe('FIX-NAIVE-FACADE-REMOVE-BUGS-V2-0');
+    });
+
+    it('should handle accented and special characters', () => {
+        const branchType = { prefix: 'hot fix' };
+        const state = {
+            issue: {
+                key: 'ABC-124',
+                summary: 'Crème brûlée: déjà vu!',
+            },
+        };
+        const view = buildBranchName(branchType, state);
+        expect(view.summary).toBe('creme-brulee-deja-vu');
+    });
+
+    it('should trim and collapse dashes', () => {
+        const branchType = { prefix: 'bug' };
+        const state = {
+            issue: {
+                key: 'ABC-125',
+                summary: '--- [More dashes are here]   ---Multiple---dashes--- ',
+            },
+        };
+        const view = buildBranchName(branchType, state);
+        expect(view.summary).toBe('more-dashes-are-here-multiple-dashes');
+    });
+});

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -51,6 +51,7 @@ import { ErrorDisplay } from '../common/ErrorDisplay';
 import Lozenge from '../common/Lozenge';
 import { PMFDisplay } from '../common/pmf/PMFDisplay';
 import { PrepareCommitTip } from '../common/PrepareCommitTip';
+import { buildBranchName } from './branchNameUtils';
 import { StartWorkControllerContext, useStartWorkController } from './startWorkController';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -199,40 +200,11 @@ const StartWorkPage: React.FunctionComponent = () => {
         [setUpstream],
     );
 
-    const buildBranchName = useCallback(() => {
-        const view = {
-            prefix: branchType.prefix.replace(/ /g, '-').toLowerCase(),
-            Prefix: branchType.prefix.replace(/ /g, '-'),
-            PREFIX: branchType.prefix.replace(/ /g, '-').toUpperCase(),
-            issueKey: state.issue.key,
-            issuekey: state.issue.key.toLowerCase(),
-            summary: state.issue.summary
-                .substring(0, 50)
-                .trim()
-                .toLowerCase()
-                .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
-                .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-')
-                .replace(/-+/g, '-') // Collapse multiple dashes to one
-                .replace(/^-|-$/g, ''), // Trim leading/trailing dash
-            Summary: state.issue.summary
-                .substring(0, 50)
-                .trim()
-                .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
-                .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-')
-                .replace(/-+/g, '-') // Collapse multiple dashes to one
-                .replace(/^-|-$/g, ''), // Trim leading/trailing dash
-            SUMMARY: state.issue.summary
-                .substring(0, 50)
-                .trim()
-                .toUpperCase()
-                .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
-                .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-')
-                .replace(/-+/g, '-') // Collapse multiple dashes to one
-                .replace(/^-|-$/g, ''), // Trim leading/trailing dash
-        };
+    const buildBranchNameView = useCallback(() => {
+        const view = buildBranchName({
+            branchType,
+            issue: state.issue,
+        });
 
         try {
             const generatedBranchTitle = Mustache.render(state.customTemplate, view);
@@ -240,11 +212,11 @@ const StartWorkPage: React.FunctionComponent = () => {
         } catch {
             setLocalBranch('Invalid template: please follow the format described above');
         }
-    }, [state.issue.key, state.issue.summary, branchType.prefix, state.customTemplate]);
+    }, [branchType, state.issue, state.customTemplate]);
 
     useEffect(() => {
-        buildBranchName();
-    }, [branchType, buildBranchName]);
+        buildBranchNameView();
+    }, [branchType, buildBranchNameView]);
     const handleSuccessSnackbarClose = useCallback(() => setSuccessSnackbarOpen(false), [setSuccessSnackbarOpen]);
 
     const handleStartWorkSubmit = useCallback(async () => {

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -212,20 +212,26 @@ const StartWorkPage: React.FunctionComponent = () => {
                 .toLowerCase()
                 .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
                 .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-'),
+                .replace(/\W+/g, '-')
+                .replace(/-+/g, '-') // Collapse multiple dashes to one
+                .replace(/^-|-$/g, ''), // Trim leading/trailing dash
             Summary: state.issue.summary
                 .substring(0, 50)
                 .trim()
                 .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
                 .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-'),
+                .replace(/\W+/g, '-')
+                .replace(/-+/g, '-') // Collapse multiple dashes to one
+                .replace(/^-|-$/g, ''), // Trim leading/trailing dash
             SUMMARY: state.issue.summary
                 .substring(0, 50)
                 .trim()
                 .toUpperCase()
                 .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
                 .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-'),
+                .replace(/\W+/g, '-')
+                .replace(/-+/g, '-') // Collapse multiple dashes to one
+                .replace(/^-|-$/g, ''), // Trim leading/trailing dash
         };
 
         try {

--- a/src/react/atlascode/startwork/branchNameUtils.ts
+++ b/src/react/atlascode/startwork/branchNameUtils.ts
@@ -1,0 +1,40 @@
+export interface BranchNameInput {
+    branchType: { prefix: string };
+    issue: { key: string; summary: string };
+}
+
+export function buildBranchName({ branchType, issue }: BranchNameInput) {
+    return {
+        prefix: branchType.prefix.replace(/ /g, '-').toLowerCase(),
+        Prefix: branchType.prefix.replace(/ /g, '-'),
+        PREFIX: branchType.prefix.replace(/ /g, '-').toUpperCase(),
+        issueKey: issue.key,
+        issuekey: issue.key.toLowerCase(),
+        summary: issue.summary
+            .substring(0, 50)
+            .trim()
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+        Summary: issue.summary
+            .substring(0, 50)
+            .trim()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+        SUMMARY: issue.summary
+            .substring(0, 50)
+            .trim()
+            .toUpperCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+    };
+}


### PR DESCRIPTION
### What Is This Change?

This is the change that fixes the following issue:
During starting of a task, which will lead me to create and checkout branch, the branch name will always have double dash if my task make use of square bracket:

task name: [module] create function xxx
generated branch name module--create-function-xxx

the fix will change for the name to be module-create-function-xxx

### How Has This Been Tested?

There is a test written for that in the PR

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change