### PR TITLE
[AXON-163] Remove dashing duplicates and trailing dashes

### DIFF
--- a/src/react/atlascode/startwork/StartWorkPage.test.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.test.tsx
@@ -1,0 +1,46 @@
+import { buildBranchName } from './branchNameUtils';
+
+describe('buildBranchName', () => {
+    it('should normalize and format branch name parts correctly', () => {
+        const input = {
+            branchType: { prefix: 'feature branch' },
+            issue: {
+                key: 'ABC-123',
+                summary: 'Fix: naïve façade—remove bugs! (v2.0)   ',
+            },
+        };
+        const view = buildBranchName(input);
+        expect(view.prefix).toBe('feature-branch');
+        expect(view.Prefix).toBe('feature-branch');
+        expect(view.PREFIX).toBe('FEATURE-BRANCH');
+        expect(view.issueKey).toBe('ABC-123');
+        expect(view.issuekey).toBe('abc-123');
+        expect(view.summary).toBe('fix-naive-facade-remove-bugs-v2-0');
+        expect(view.Summary).toBe('Fix-naive-facade-remove-bugs-v2-0');
+        expect(view.SUMMARY).toBe('FIX-NAIVE-FACADE-REMOVE-BUGS-V2-0');
+    });
+
+    it('should handle accented and special characters', () => {
+        const input = {
+            branchType: { prefix: 'hot fix' },
+            issue: {
+                key: 'ABC-124',
+                summary: 'Crème brûlée: déjà vu!',
+            },
+        };
+        const view = buildBranchName(input);
+        expect(view.summary).toBe('creme-brulee-deja-vu');
+    });
+
+    it('should trim and collapse dashes', () => {
+        const input = {
+            branchType: { prefix: 'bug' },
+            issue: {
+                key: 'ABC-125',
+                summary: '--- [More dashes are here]   ---Multiple---dashes--- ',
+            },
+        };
+        const view = buildBranchName(input);
+        expect(view.summary).toBe('more-dashes-are-here-multiple-dashes');
+    });
+});

--- a/src/react/atlascode/startwork/StartWorkPage.test.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.test.tsx
@@ -1,5 +1,21 @@
 import { buildBranchName } from './branchNameUtils';
 
+const mockRepoData = {
+    workspaceRepo: {
+        rootUri: 'test-uri',
+        mainSiteRemote: {
+            remote: {
+                name: 'origin',
+            },
+        },
+        siteRemotes: [],
+    },
+    localBranches: [],
+    remoteBranches: [],
+    branchTypes: [],
+    developmentBranch: 'main',
+};
+
 describe('buildBranchName', () => {
     it('should normalize and format branch name parts correctly', () => {
         const input = {
@@ -42,5 +58,44 @@ describe('buildBranchName', () => {
         };
         const view = buildBranchName(input);
         expect(view.summary).toBe('more-dashes-are-here-multiple-dashes');
+    });
+
+    it('should build branch name with username when userEmail is available', () => {
+        const mockRepo = {
+            ...mockRepoData,
+            userEmail: 'user.name@example.com',
+        };
+        const mockBranchType = { kind: 'feature', prefix: 'feature' };
+        const mockIssue = {
+            key: 'TEST-123',
+            summary: 'Test Issue',
+        };
+
+        const view = buildBranchName({
+            branchType: mockBranchType,
+            issue: mockIssue,
+            userEmail: mockRepo.userEmail,
+        });
+
+        expect(view.username).toBe('user.name');
+        expect(view.UserName).toBe('user.name');
+        expect(view.USERNAME).toBe('USER.NAME');
+    });
+
+    it('should use default username when userEmail is not available', () => {
+        const mockBranchType = { kind: 'feature', prefix: 'feature' };
+        const mockIssue = {
+            key: 'TEST-123',
+            summary: 'Test Issue',
+        };
+
+        const view = buildBranchName({
+            branchType: mockBranchType,
+            issue: mockIssue,
+        });
+
+        expect(view.username).toBe('username');
+        expect(view.UserName).toBe('username');
+        expect(view.USERNAME).toBe('USERNAME');
     });
 });

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -136,6 +136,7 @@ const StartWorkPage: React.FunctionComponent = () => {
         const view = buildBranchName({
             branchType,
             issue: state.issue,
+            userEmail: repository.userEmail,
         });
 
         try {
@@ -144,7 +145,7 @@ const StartWorkPage: React.FunctionComponent = () => {
         } catch {
             setLocalBranch('Invalid template: please follow the format described above');
         }
-    }, [branchType, state.issue, state.customTemplate]);
+    }, [branchType, state.issue, state.customTemplate, repository.userEmail]);
 
     const handleRepositoryChange = useCallback(
         (event: React.ChangeEvent<{ name?: string | undefined; value: any }>) => {

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -51,6 +51,7 @@ import { ErrorDisplay } from '../common/ErrorDisplay';
 import Lozenge from '../common/Lozenge';
 import { PMFDisplay } from '../common/pmf/PMFDisplay';
 import { PrepareCommitTip } from '../common/PrepareCommitTip';
+import { buildBranchName } from './branchNameUtils';
 import { StartWorkControllerContext, useStartWorkController } from './startWorkController';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -199,34 +200,11 @@ const StartWorkPage: React.FunctionComponent = () => {
         [setUpstream],
     );
 
-    const buildBranchName = useCallback(() => {
-        const view = {
-            prefix: branchType.prefix.replace(/ /g, '-').toLowerCase(),
-            Prefix: branchType.prefix.replace(/ /g, '-'),
-            PREFIX: branchType.prefix.replace(/ /g, '-').toUpperCase(),
-            issueKey: state.issue.key,
-            issuekey: state.issue.key.toLowerCase(),
-            summary: state.issue.summary
-                .substring(0, 50)
-                .trim()
-                .toLowerCase()
-                .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
-                .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-'),
-            Summary: state.issue.summary
-                .substring(0, 50)
-                .trim()
-                .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
-                .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-'),
-            SUMMARY: state.issue.summary
-                .substring(0, 50)
-                .trim()
-                .toUpperCase()
-                .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
-                .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
-                .replace(/\W+/g, '-'),
-        };
+    const buildBranchNameView = useCallback(() => {
+        const view = buildBranchName({
+            branchType,
+            issue: state.issue,
+        });
 
         try {
             const generatedBranchTitle = Mustache.render(state.customTemplate, view);
@@ -234,11 +212,11 @@ const StartWorkPage: React.FunctionComponent = () => {
         } catch {
             setLocalBranch('Invalid template: please follow the format described above');
         }
-    }, [state.issue.key, state.issue.summary, branchType.prefix, state.customTemplate]);
+    }, [branchType, state.issue, state.customTemplate]);
 
     useEffect(() => {
-        buildBranchName();
-    }, [branchType, buildBranchName]);
+        buildBranchNameView();
+    }, [branchType, buildBranchNameView]);
     const handleSuccessSnackbarClose = useCallback(() => setSuccessSnackbarOpen(false), [setSuccessSnackbarOpen]);
 
     const handleStartWorkSubmit = useCallback(async () => {

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -146,10 +146,6 @@ const StartWorkPage: React.FunctionComponent = () => {
         }
     }, [branchType, state.issue, state.customTemplate]);
 
-    useEffect(() => {
-        buildBranchNameView();
-    }, [branchType, buildBranchNameView]);
-
     const handleRepositoryChange = useCallback(
         (event: React.ChangeEvent<{ name?: string | undefined; value: any }>) => {
             setRepository(event.target.value);
@@ -258,11 +254,19 @@ const StartWorkPage: React.FunctionComponent = () => {
     }, [controller]);
 
     useEffect(() => {
+        console.log(`JS-1324 selected repo ${repository.workspaceRepo.rootUri}`);
         if (repository.workspaceRepo.rootUri === '' && state.repoData.length > 0) {
             setRepository(state.repoData?.[0]);
-            buildBranchNameView();
+            // Only build branch name if we have both branchType and issue
+            if (branchType && state.issue) {
+                buildBranchNameView();
+            }
         }
-    }, [repository, buildBranchNameView, state.repoData]);
+    }, [repository, branchType, setRepository, state.repoData, state.issue, state.customTemplate, buildBranchNameView]);
+
+    useEffect(() => {
+        console.log(`JS-1324 repos: ${JSON.stringify(state.repoData.map((r) => r.workspaceRepo.rootUri))}`);
+    }, [state.repoData]);
 
     useEffect(() => {
         const newBranchType = repository.branchTypes?.[0] || emptyPrefix;

--- a/src/react/atlascode/startwork/branchNameUtils.ts
+++ b/src/react/atlascode/startwork/branchNameUtils.ts
@@ -1,0 +1,40 @@
+export interface BranchNameInput {
+    branchType: { prefix: string };
+    issue: { key: string; summary: string };
+}
+
+export function buildBranchName({ branchType, issue }: BranchNameInput) {
+    return {
+        prefix: branchType.prefix.replace(/ /g, '-').toLowerCase(),
+        Prefix: branchType.prefix.replace(/ /g, '-'),
+        PREFIX: branchType.prefix.replace(/ /g, '-').toUpperCase(),
+        issueKey: issue.key,
+        issuekey: issue.key.toLowerCase(),
+        summary: issue.summary
+            .substring(0, 50)
+            .trim()
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+        Summary: issue.summary
+            .substring(0, 50)
+            .trim()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+        SUMMARY: issue.summary
+            .substring(0, 50)
+            .trim()
+            .toUpperCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\W+/g, '-')
+            .replace(/-+/g, '-')
+            .replace(/^-|-$/g, ''),
+    };
+}

--- a/src/react/atlascode/startwork/branchNameUtils.ts
+++ b/src/react/atlascode/startwork/branchNameUtils.ts
@@ -1,40 +1,40 @@
 export interface BranchNameInput {
     branchType: { prefix: string };
     issue: { key: string; summary: string };
+    userEmail?: string;
 }
 
-export function buildBranchName({ branchType, issue }: BranchNameInput) {
+export function buildBranchName({ branchType, issue, userEmail }: BranchNameInput) {
+    const usernameBase = userEmail
+        ? userEmail
+              .split('@')[0]
+              .normalize('NFD')
+              .replace(/[\u0300-\u036f]/g, '')
+        : 'username';
+
+    const prefixBase = branchType.prefix.replace(/ /g, '-');
+    const summaryBase = issue.summary
+        .substring(0, 50)
+        .trim()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/\W+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+
     return {
-        prefix: branchType.prefix.replace(/ /g, '-').toLowerCase(),
-        Prefix: branchType.prefix.replace(/ /g, '-'),
-        PREFIX: branchType.prefix.replace(/ /g, '-').toUpperCase(),
+        username: usernameBase.toLowerCase(),
+        UserName: usernameBase,
+        USERNAME: usernameBase.toUpperCase(),
+        prefix: prefixBase.toLowerCase(),
+        Prefix: prefixBase,
+        PREFIX: prefixBase.toUpperCase(),
         issueKey: issue.key,
         issuekey: issue.key.toLowerCase(),
-        summary: issue.summary
-            .substring(0, 50)
-            .trim()
-            .toLowerCase()
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '')
-            .replace(/\W+/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, ''),
-        Summary: issue.summary
-            .substring(0, 50)
-            .trim()
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '')
-            .replace(/\W+/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, ''),
-        SUMMARY: issue.summary
-            .substring(0, 50)
-            .trim()
-            .toUpperCase()
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '')
-            .replace(/\W+/g, '-')
-            .replace(/-+/g, '-')
-            .replace(/^-|-$/g, ''),
+        IssueKey: issue.key,
+        ISSUEKEY: issue.key.toUpperCase(),
+        summary: summaryBase.toLowerCase(),
+        Summary: summaryBase,
+        SUMMARY: summaryBase.toUpperCase(),
     };
 }


### PR DESCRIPTION

### What Is This Change?

This is the change that fixes the following issue:
During starting of a task, which will lead me to create and checkout branch, the branch name will always have double dash if my task make use of square bracket:

task name: [module] create function xxx
generated branch name module--create-function-xxx

the fix will change for the name to be module-create-function-xxx

### How Has This Been Tested?

There is a test written for that in the PR

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change