### PR TITLE
Fixed the E2E docker build for playwright

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -3,7 +3,7 @@ FROM node:23-slim
 # Install dependencies and xvfb
 RUN apt-get update \
     && apt-get install -y wget gpg xauth curl git \ 
-    && npm install --global playwright \
+    && npm install --global playwright@1.53.0 \
     && npx playwright install --with-deps chromium
 
 # install code-server 

--- a/e2e/tests/playwright.spec.ts
+++ b/e2e/tests/playwright.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test("Onboarding flow's navigation among pages works", async ({ page }) => {
-    await page.goto('http://[::1]:9988/');
+    await page.goto('http://localhost:9988/');
 
     await page.getByRole('tab', { name: 'Atlassian' }).click();
     await page.waitForTimeout(250);
@@ -57,7 +57,7 @@ test("Onboarding flow's navigation among pages works", async ({ page }) => {
 });
 
 test('Authenticating with Jira works, and assigned items are displayed', async ({ page }) => {
-    await page.goto('http://[::1]:9988/');
+    await page.goto('http://localhost:9988/');
 
     await page.getByRole('tab', { name: 'Atlassian' }).click();
     await page.waitForTimeout(250);

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
             },
             "devDependencies": {
                 "@jest/globals": "^30.0.0-beta.3",
-                "@playwright/test": "^1.52.0",
+                "@playwright/test": "1.53.0",
                 "@testing-library/react": "^12.1.5",
                 "@types/express": "^5.0.2",
                 "@types/git-url-parse": "^9.0.1",
@@ -158,7 +158,7 @@
                 "nyc": "^17.1.0",
                 "ovsx": "^0.10.1",
                 "path-browserify": "^1.0.1",
-                "playwright": "^1.52.0",
+                "playwright": "1.53.0",
                 "postcss-flexbugs-fixes": "^5.0.2",
                 "postcss-loader": "^8.1.1",
                 "postcss-preset-env": "^10.2.0",
@@ -9107,12 +9107,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.52.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@playwright/test/-/test-1.52.0.tgz",
-            "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+            "version": "1.53.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@playwright/test/-/test-1.53.0.tgz",
+            "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
             "dev": true,
             "dependencies": {
-                "playwright": "1.52.0"
+                "playwright": "1.53.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -20418,12 +20418,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.52.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/playwright/-/playwright-1.52.0.tgz",
-            "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+            "version": "1.53.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/playwright/-/playwright-1.53.0.tgz",
+            "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
             "dev": true,
             "dependencies": {
-                "playwright-core": "1.52.0"
+                "playwright-core": "1.53.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -20436,9 +20436,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.52.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/playwright-core/-/playwright-core-1.52.0.tgz",
-            "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+            "version": "1.53.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/playwright-core/-/playwright-core-1.53.0.tgz",
+            "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
             "dev": true,
             "bin": {
                 "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -1345,7 +1345,7 @@
     },
     "devDependencies": {
         "@jest/globals": "^30.0.0-beta.3",
-        "@playwright/test": "^1.52.0",
+        "@playwright/test": "1.53.0",
         "@testing-library/react": "^12.1.5",
         "@types/express": "^5.0.2",
         "@types/git-url-parse": "^9.0.1",
@@ -1390,7 +1390,7 @@
         "nyc": "^17.1.0",
         "ovsx": "^0.10.1",
         "path-browserify": "^1.0.1",
-        "playwright": "^1.52.0",
+        "playwright": "1.53.0",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^8.1.1",
         "postcss-preset-env": "^10.2.0",


### PR DESCRIPTION
### What Is This Change?

Thanks so much @sdzh-atlassian for basically doing all this change yourself 😆 

This changes is fixing the E2E docker image build to prevent docker & local host from having two different playwright versions, which will prevent the tests to run successfully (because of playwright deps).

1. Pin the playwright in package.json
2. Pin the same playwright version from package.json in Dockerfile when installing playwright
3. Fixed another issue regarding code-server sometimes listening to ipv4 instead of ipv6, changing from `[::1]` to `localhost` in the playwright test file.