### PR TITLE
FIX: fix issue when commit url is undefined

### DIFF
--- a/src/bitbucket/bitbucket-server/pullRequests.ts
+++ b/src/bitbucket/bitbucket-server/pullRequests.ts
@@ -545,7 +545,7 @@ export class ServerPullRequestApi implements PullRequestApi {
             ts: commit.authorTimestamp,
             hash: commit.id,
             message: commit.message,
-            url: '',
+            url: `${pr.site.details.baseLinkUrl}/projects/${ownerSlug}/repos/${repoSlug}/pull-requests/${pr.data.id}/commits/${commit.id}`,
             htmlSummary: '',
             rawSummary: '',
         }));


### PR DESCRIPTION
### What Is This Change?
Fix of the issue when hyperlink for commit fails to open. The issue is related to Server Bitbucket. We don’t pass the url for commit. That’s why when  the url is undefined or malformed VS Code's webview tries to interpret this as a local resource path.
I’ve reproduced the issue by hardcoding the url to be undefined for Bitbucket Cloud. 

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change