### PR TITLE
FIX: getAllRepositories cannot read properties of undefined

### DIFF
--- a/src/commands/jira/createIssue.ts
+++ b/src/commands/jira/createIssue.ts
@@ -59,7 +59,7 @@ function annotateComment(data: CommentData) {
 function descriptionForUri(uri: Uri) {
     const linesText = getLineRange();
 
-    const wsRepos = Container.bitbucketContext.getAllRepositories();
+    const wsRepos = Container.bitbucketContext?.getAllRepositories() || [];
 
     const urls = wsRepos
         .map((wsRepo) => bitbucketUrlsInRepo(wsRepo, uri, linesText))


### PR DESCRIPTION
### What Is This Change?
Fix of the issue https://github.com/atlassian/atlascode/issues/465

There are cases when bitbucketContext can be undefined. Added handling for such cases to avoid the `cannot read properties of undefined` error

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change