### PR TITLE
AXON-512: add e2e test for add description flow

### DIFF
--- a/e2e/helpers/updateIssueFields.ts
+++ b/e2e/helpers/updateIssueFields.ts
@@ -1,0 +1,14 @@
+export function updateIssueField(issueJson: any, updates: Record<string, any>) {
+    const parsedBody = JSON.parse(issueJson.response.body);
+
+    const updated = structuredClone(parsedBody);
+
+    for (const [key, value] of Object.entries(updates)) {
+        if (key === 'description') {
+            updated.renderedFields.description = `<p>${value}</p>`;
+            updated.fields.description = value;
+        }
+    }
+
+    return updated;
+}

--- a/e2e/tests/playwright.spec.ts
+++ b/e2e/tests/playwright.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from '@playwright/test';
+import { expect, request, test } from '@playwright/test';
+import { updateIssueField } from 'e2e/helpers/updateIssueFields';
+import fs from 'fs';
 
 test("Onboarding flow's navigation among pages works", async ({ page }) => {
     await page.goto('http://localhost:9988/');
@@ -118,4 +120,84 @@ test('Authenticating with Jira works, and assigned items are displayed', async (
     await expect(page.getByRole('treeitem', { name: 'BTS-6 - Fix Button Alignment Issue' })).toBeVisible();
 
     //await expect(page).toHaveScreenshot();
+});
+
+test('Update description flow', async ({ page }) => {
+    const oldDescription = 'Track and resolve bugs related to the user interface.';
+    const newDescription = 'Add e2e test for this functionality';
+
+    await page.goto('http://localhost:9988/');
+
+    await page.getByRole('tab', { name: 'Atlassian' }).click();
+
+    await page.getByRole('tab', { name: 'Getting Started' }).getByLabel(/close/i).click();
+
+    await page.getByRole('treeitem', { name: 'Please login to Jira' }).click();
+
+    await page.getByRole('tab', { name: 'Atlassian Settings' }).click();
+
+    const settingsFrame = page.frameLocator('iframe.webview').frameLocator('iframe[title="Atlassian Settings"]');
+
+    settingsFrame.getByRole('button', { name: 'Login to Jira' }).click();
+
+    await settingsFrame.getByRole('textbox', { name: 'Base URL' }).fill('https://mockedteams.atlassian.net');
+
+    await settingsFrame.getByRole('textbox', { name: 'Username' }).fill('mock@atlassian.code');
+
+    await settingsFrame.getByRole('textbox', { name: 'Password (API token)' }).fill('12345');
+
+    await settingsFrame.getByRole('button', { name: 'Save Site' }).click();
+    await page.waitForTimeout(2000);
+
+    await page.getByRole('treeitem', { name: 'BTS-1 - User Interface Bugs' }).click();
+    await page.waitForTimeout(250);
+
+    await page.getByRole('tab', { name: 'Atlassian Settings' }).getByLabel(/close/i).click();
+    await page.waitForTimeout(2000);
+
+    const issueFrame = page.frameLocator('iframe.webview.ready').frameLocator('iframe[title="Jira Issue"]');
+
+    // Check the existing description
+    await expect(issueFrame.getByText(oldDescription)).toBeVisible();
+
+    // Click on the description element to enter edit mode
+    await issueFrame.getByText(oldDescription).click();
+    const textarea = issueFrame.locator('textarea');
+    await expect(textarea).toBeVisible();
+
+    // Clear the existing description and enter new one
+    await textarea.clear();
+    await textarea.fill(newDescription);
+    await page.waitForTimeout(500);
+
+    // Add the updated mock
+    const api = await request.newContext({
+        baseURL: 'http://wiremock-mockedteams:8080',
+        ignoreHTTPSErrors: true,
+    });
+    const issueJSON = JSON.parse(fs.readFileSync('e2e/wiremock-mappings/mockedteams/BTS-1/bts1.json', 'utf-8'));
+    const updatedIssue = updateIssueField(issueJSON, {
+        description: newDescription,
+    });
+    await api.post('/__admin/mappings', {
+        data: {
+            request: {
+                method: 'GET',
+                urlPath: '/rest/api/2/issue/BTS-1',
+            },
+            response: {
+                status: 200,
+                body: JSON.stringify(updatedIssue),
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            },
+        },
+    });
+
+    await issueFrame.getByRole('button', { name: 'Save' }).click();
+    await page.waitForTimeout(2000);
+
+    await expect(issueFrame.getByText(oldDescription)).not.toBeVisible();
+    await expect(issueFrame.getByText(newDescription)).toBeVisible();
 });

--- a/e2e/wiremock-mappings/mockedteams/BTS-1/bts1.json
+++ b/e2e/wiremock-mappings/mockedteams/BTS-1/bts1.json
@@ -1,13 +1,10 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": " /rest/api/2/issue/BTS-1",
+    "urlPath": "/rest/api/2/issue/BTS-1",
     "queryParameters": {
       "expand": {
-        "equalTo": "transitions%2CrenderedFields%2Ceditmeta%2Ctransitions.fields"
-      },
-      "fields": {
-        "equalTo": "*all"
+        "contains": "transitions"
       }
     }
   },

--- a/e2e/wiremock-mappings/mockedteams/updateIssue.json
+++ b/e2e/wiremock-mappings/mockedteams/updateIssue.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "method": "PUT",
+    "urlPath": "/rest/api/2/issue/BTS-1",
+    "headers": {
+      "Content-Type": {
+        "contains": "application/json"
+      }
+    },
+    "bodyPatterns": [
+      {
+        "matchesJsonPath": "$.fields.description",
+        "contains": "Add e2e test for this functionality"
+      }
+    ]
+  },
+  "response": {
+    "status": 204,
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+} 


### PR DESCRIPTION
### What Is This Change?
Flow covered in added test:
✅ setup and authentication
✅ navigation to issue
✅ initial state verification ( check the existing description )
✅ description editing 

Added dynamic API mocking to update the issue mock. Created separate `helpers` folder for functions related to mock updates.


[video.webm](https://github.com/user-attachments/assets/e0caeb47-2625-4ed9-9342-57125e017805)

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change