### PR TITLE
AXON-455: add e2e test for comment on jira flow

### DIFF
--- a/e2e/helpers/updateIssueFields.ts
+++ b/e2e/helpers/updateIssueFields.ts
@@ -7,6 +7,61 @@ export function updateIssueField(issueJson: any, updates: Record<string, any>) {
         if (key === 'description') {
             updated.renderedFields.description = `<p>${value}</p>`;
             updated.fields.description = value;
+        } else if (key === 'comment') {
+            const comment = {
+                id: '10001',
+                self: 'https://mockedteams.atlassian.net/rest/api/2/issue/10001/comment/10001',
+                author: {
+                    self: 'https://mockedteams.atlassian.net/rest/api/2/user?accountId=712020%3A13354d79-beaa-49d6-a55f-b9510892e3f4',
+                    accountId: '712020:13354d79-beaa-49d6-a55f-b9510892e3f4',
+                    emailAddress: 'mock@atlassian.code',
+                    avatarUrls: {
+                        '48x48':
+                            'https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png',
+                        '24x24':
+                            'https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png',
+                        '16x16':
+                            'https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png',
+                        '32x32':
+                            'https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png',
+                    },
+                    displayName: 'Mocked McMock',
+                    active: true,
+                    timeZone: 'America/Los_Angeles',
+                    accountType: 'atlassian',
+                },
+                body: value,
+                updateAuthor: {
+                    self: 'https://mockedteams.atlassian.net/rest/api/2/user?accountId=712020%3A13354d79-beaa-49d6-a55f-b9510892e3f4',
+                    accountId: '712020:13354d79-beaa-49d6-a55f-b9510892e3f4',
+                    emailAddress: 'mock@atlassian.code',
+                    avatarUrls: {
+                        '48x48':
+                            'https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png',
+                        '24x24':
+                            'https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png',
+                        '16x16':
+                            'https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png',
+                        '32x32':
+                            'https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png',
+                    },
+                    displayName: 'Mocked McMock',
+                    active: true,
+                    timeZone: 'America/Los_Angeles',
+                    accountType: 'atlassian',
+                },
+                created: '2025-01-10T12:00:00.000-0800',
+                updated: '2025-01-10T12:00:00.000-0800',
+                visibility: {
+                    type: 'role',
+                    value: 'Administrators',
+                },
+            };
+
+            updated.renderedFields.comment.comments.push(comment);
+            updated.renderedFields.comment.total = 1;
+            updated.renderedFields.comment.maxResults = 1;
+            updated.renderedFields.comment.startAt = 0;
         }
     }
 

--- a/e2e/tests/playwright.spec.ts
+++ b/e2e/tests/playwright.spec.ts
@@ -168,12 +168,9 @@ test('Update description flow', async ({ page, request }) => {
     if (!issueFrame) {
         throw new Error('iframe element not found');
     }
-    await issueFrame.waitForLoadState('domcontentloaded');
-
-    await expect(issueFrame.locator('body')).toBeVisible({ timeout: 15000 });
 
     // Check the existing description
-    await expect(issueFrame.getByText(oldDescription)).toBeVisible({ timeout: 50000 });
+    await expect(issueFrame.getByText(oldDescription)).toBeVisible();
 
     // Click on the description element to enter edit mode
     await issueFrame.getByText(oldDescription).click();
@@ -239,7 +236,7 @@ test('Add comment flow', async ({ page, request }) => {
     await settingsFrame.getByRole('textbox', { name: 'Password (API token)' }).fill('12345');
 
     await settingsFrame.getByRole('button', { name: 'Save Site' }).click();
-    await page.waitForTimeout(3000);
+    await page.waitForTimeout(2000);
 
     await page.getByRole('treeitem', { name: 'BTS-1 - User Interface Bugs' }).click();
     await page.waitForTimeout(1000);
@@ -256,12 +253,9 @@ test('Add comment flow', async ({ page, request }) => {
     if (!issueFrame) {
         throw new Error('iframe element not found');
     }
-    await issueFrame.waitForLoadState('domcontentloaded');
-
-    await expect(issueFrame.locator('body')).toBeVisible({ timeout: 15000 });
 
     // Wait for the iframe to be ready and the comment textarea to be visible
-    await expect(issueFrame.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 10000 });
+    await expect(issueFrame.getByPlaceholder('Add a comment...')).toBeVisible();
 
     // Find and click the "Add comment" button
     const commentTextarea = issueFrame.getByPlaceholder('Add a comment...');
@@ -299,7 +293,7 @@ test('Add comment flow', async ({ page, request }) => {
     await expect(addCommentButton).toBeVisible();
     await addCommentButton.click();
 
-    await page.waitForTimeout(3000);
+    await page.waitForTimeout(2000);
 
     await expect(issueFrame.getByText(commentText)).toBeVisible();
 

--- a/e2e/tests/playwright.spec.ts
+++ b/e2e/tests/playwright.spec.ts
@@ -247,11 +247,12 @@ test('Add comment flow', async ({ page }) => {
     await page.getByRole('tab', { name: 'Atlassian Settings' }).getByLabel(/close/i).click();
 
     const issueFrame = page.frameLocator('iframe.webview.ready').frameLocator('iframe[title="Jira Issue"]');
-    await page.waitForTimeout(2000);
+
+    // Wait for the iframe to be ready and the comment textarea to be visible
+    await expect(issueFrame.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 10000 });
 
     // Find and click the "Add comment" button
     const commentTextarea = issueFrame.getByPlaceholder('Add a comment...');
-    await expect(commentTextarea).toBeVisible();
     await commentTextarea.click();
 
     const textarea = issueFrame.locator('textarea').first();

--- a/e2e/tests/playwright.spec.ts
+++ b/e2e/tests/playwright.spec.ts
@@ -239,13 +239,12 @@ test('Add comment flow', async ({ page }) => {
     await settingsFrame.getByRole('textbox', { name: 'Password (API token)' }).fill('12345');
 
     await settingsFrame.getByRole('button', { name: 'Save Site' }).click();
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(3000);
 
     await page.getByRole('treeitem', { name: 'BTS-1 - User Interface Bugs' }).click();
-    await page.waitForTimeout(250);
+    await page.waitForTimeout(1000);
 
     await page.getByRole('tab', { name: 'Atlassian Settings' }).getByLabel(/close/i).click();
-    await page.waitForTimeout(250);
 
     const issueFrame = page.frameLocator('iframe.webview.ready').frameLocator('iframe[title="Jira Issue"]');
     await page.waitForTimeout(2000);
@@ -258,7 +257,7 @@ test('Add comment flow', async ({ page }) => {
     const textarea = issueFrame.locator('textarea').first();
     await expect(textarea).toBeVisible();
     await textarea.fill(commentText);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(1000);
 
     // Set up WireMock API for comment creation
     const api = await request.newContext({
@@ -292,7 +291,7 @@ test('Add comment flow', async ({ page }) => {
     await expect(addCommentButton).toBeVisible();
     await addCommentButton.click();
 
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(3000);
 
     await expect(issueFrame.getByText(commentText)).toBeVisible();
 

--- a/e2e/wiremock-mappings/mockedteams/addComment.json
+++ b/e2e/wiremock-mappings/mockedteams/addComment.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/rest/api/2/issue/BTS-1/comment"
+  },
+  "response": {
+    "status": 201,
+    "body": "{\"id\":\"10001\",\"self\":\"https://mockedteams.atlassian.net/rest/api/2/issue/10001/comment/10001\",\"author\":{\"self\":\"https://mockedteams.atlassian.net/rest/api/2/user?accountId=712020%3A13354d79-beaa-49d6-a55f-b9510892e3f4\",\"accountId\":\"712020:13354d79-beaa-49d6-a55f-b9510892e3f4\",\"emailAddress\":\"mock@atlassian.code\",\"avatarUrls\":{\"48x48\":\"https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png\",\"24x24\":\"https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png\",\"16x16\":\"https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png\",\"32x32\":\"https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png\"},\"displayName\":\"Mocked McMock\",\"active\":true,\"timeZone\":\"America/Los_Angeles\",\"accountType\":\"atlassian\"},\"body\":\"This is a test comment added via e2e test\",\"updateAuthor\":{\"self\":\"https://mockedteams.atlassian.net/rest/api/2/user?accountId=712020%3A13354d79-beaa-49d6-a55f-b9510892e3f4\",\"accountId\":\"712020:13354d79-beaa-49d6-a55f-b9510892e3f4\",\"emailAddress\":\"mock@atlassian.code\",\"avatarUrls\":{\"48x48\":\"https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png\",\"24x24\":\"https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png\",\"16x16\":\"https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png\",\"32x32\":\"https://secure.gravatar.com/avatar/3c1286d428ff8f7167844ee661f0aef0?d=https%3A%2F%2Favatar-management--avatars.us-west-2.staging.public.atl-paas.net%2Finitials%2FMM-3.png\"},\"displayName\":\"Mocked McMock\",\"active\":true,\"timeZone\":\"America/Los_Angeles\",\"accountType\":\"atlassian\"},\"created\":\"2025-01-10T12:00:00.000-0800\",\"updated\":\"2025-01-10T12:00:00.000-0800\",\"visibility\":{\"type\":\"role\",\"value\":\"Administrators\"}}",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
### What Is This Change?
Added the e2e test that covers adding the comment flow. The author of the comment is checked as well

[video.webm](https://github.com/user-attachments/assets/0e4395e2-99b0-4fa6-b758-51210ecf0aeb)


<!--
Thanks for considering making a PR to this repository!👋


Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change