### PR TITLE
Fixed it

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,6 +403,14 @@
                 "category": "Atlassian"
             },
             {
+                "command": "atlascode.startWork",
+                "title": "Start Work on Issue"
+            },
+            {
+             "command": "atlascode.finishWork",
+             "title": "Finish Work on Issue"
+            },
+            {
                 "command": "atlascode.showOnboardingFlow",
                 "title": "Show Onboarding Flow",
                 "category": "Atlassian"
@@ -705,6 +713,14 @@
                     "command": "atlascode.bb.refreshPipelines",
                     "when": "false"
                 },
+                {
+                    "command": "atlascode.startWork",
+                    "when": "true"
+                },
+                {
+                    "command": "atlascode.finishWork",
+                    "when": "true"
+                 },
                 {
                     "command": "atlascode.bb.openInBitbucket",
                     "when": "false"

--- a/src/lib/ipc/toUI/startWork.ts
+++ b/src/lib/ipc/toUI/startWork.ts
@@ -8,10 +8,12 @@ import { Branch } from '../../../typings/git';
 export enum StartWorkMessageType {
     Init = 'init',
     StartWorkResponse = 'startWorkResponse',
+    FinishWork = 'finishWork',
 }
 
 export type StartWorkMessage = ReducerAction<StartWorkMessageType.Init, StartWorkInitMessage>;
 export type StartWorkResponse = ReducerAction<StartWorkMessageType.StartWorkResponse, StartWorkResponseMessage>;
+export type FinishWorkMessage = ReducerAction<StartWorkMessageType.FinishWork, FinishWorkRequestMessage>;
 
 export interface StartWorkIssueMessage {
     issue: MinimalIssue<DetailedSiteInfo>;
@@ -28,6 +30,10 @@ export interface StartWorkResponseMessage {
     transistionStatus?: string;
     branch?: string;
     upstream?: string;
+}
+
+export interface FinishWorkRequestMessage {
+    clearIssue: boolean;
 }
 
 export interface BranchType {
@@ -50,13 +56,15 @@ export interface RepoData {
     isCloud: boolean;
 }
 
-export const emptyStartWorkIssueMessage = {
+export const emptyStartWorkIssueMessage: StartWorkIssueMessage = {
     issue: createEmptyMinimalIssue(emptySiteInfo),
 };
 
-export const emptyStartWorkInitMessage = {
+export const emptyStartWorkInitMessage: StartWorkInitMessage = {
     issue: createEmptyMinimalIssue(emptySiteInfo),
     repoData: [],
+    customTemplate: '',
+    customPrefixes: [],
 };
 
 export const emptyRepoData: RepoData = {


### PR DESCRIPTION
This PR introduces two new commands to improve the developer workflow integration with Jira issues in VS Code:

🏁 atlascode.startWork: Marks a Jira issue as "in progress" and displays it in the status bar.

✅ atlascode.finishWork: Clears the active issue, removing it from the status bar.

Key Changes
New commands registered: atlascode.startWork and atlascode.finishWork in extension.ts.

Status Bar Integration: A persistent status bar item shows the current active issue, with a quick action to "Finish Work".

Updated package.json: Commands are added to the extension’s contribution points for visibility in the Command Palette.

Code cleanup and state management: The extension maintains the currently active issue in memory and updates the status bar dynamically.