### PR TITLE
AXON-525: fix issue with prefix dropdown

### DIFF
--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -272,7 +272,10 @@ const StartWorkPage: React.FunctionComponent = () => {
     useEffect(() => {
         const newBranchType = repository.branchTypes?.[0] || emptyPrefix;
         setUpstream(repository.workspaceRepo.mainSiteRemote.remote.name);
-        setBranchType(newBranchType);
+        // Only set branch type if it's still the empty prefix (initial state)
+        if (branchType.kind === '' && branchType.prefix === '') {
+            setBranchType(newBranchType);
+        }
         setSourceBranch(
             repository.localBranches?.find(
                 (b) => repository.developmentBranch && b.name === repository.developmentBranch,
@@ -289,7 +292,7 @@ const StartWorkPage: React.FunctionComponent = () => {
                 ),
         ]);
         buildBranchNameView();
-    }, [repository, state.issue, buildBranchNameView]);
+    }, [repository, state.issue, buildBranchNameView, branchType.kind, branchType.prefix]);
 
     useEffect(() => {
         setSubmitState('initial');


### PR DESCRIPTION
### What Is This Change?
✅ Fixed the issue with branch prefix always set to the first one in list ( default one ).  
❓ The reason of the issue: in `handleBranchTypeChange` we set up the branch type and call the `buildBranchNameView` func.  `buildBranchNameView` is in deps list in useEffect, where we again rewrite branch type and set it up to the first value in the list ( initial setup ).

Screenrecord with fixed behaviour: 

https://github.com/user-attachments/assets/2fbf1c72-7613-499c-831a-51c63bfa8299



<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change