### PR TITLE
[Rovo Dev] Auto-adjust code highlighting on changed theme

### DIFF
--- a/resources/html/reactWebview.html
+++ b/resources/html/reactWebview.html
@@ -8,7 +8,6 @@
         <meta id="reactView" name="reactView" content="{{view}}" />
         <title>Atlassian Webview</title>
         <link rel="stylesheet" type="text/css" href="{{styleUri}}" />
-        <link rel="stylesheet" type="text/css" href="{{syntaxStyles}}" />
         <meta
             http-equiv="Content-Security-Policy"
             content="default-src https://api.atlassian.com ; img-src data: {{cspSource}} http: https: blob:; object-src data:; script-src {{cspSource}}; style-src {{cspSource}} 'unsafe-inline' blob: http: https: data:; font-src {{cspSource}} blob: http: https: data:;"

--- a/src/react/atlascode/rovo-dev/RovoDevCodeHighlighting.css
+++ b/src/react/atlascode/rovo-dev/RovoDevCodeHighlighting.css
@@ -1,0 +1,162 @@
+/* Copied from `node_modules/@speed-highlight/core/dist/themes/visual-studio-dark.css` and
+ * modified to work correctly with vscode theming
+ */
+
+[class*=shj-lang-] {
+    white-space: pre;
+    color: #112;
+    text-shadow: none;
+    box-sizing: border-box;
+    background: #fff;
+    border-radius: 10px;
+    max-width: min(100%, 100vw);
+    margin: 10px 0;
+    padding: 30px 20px;
+    font: 18px/24px Consolas, Courier New, Monaco, Andale Mono, Ubuntu Mono, monospace;
+    box-shadow: 0 0 5px #0001;
+}
+
+.shj-inline {
+    border-radius: 5px;
+    margin: 0;
+    padding: 2px 5px;
+    display: inline-block;
+}
+
+[class*=shj-lang-]::selection {
+    background: #bdf5;
+}
+
+[class*=shj-lang-] ::selection {
+    background: #bdf5;
+}
+
+[class*=shj-lang-] > div {
+    display: flex;
+    overflow: auto;
+}
+
+[class*=shj-lang-] > div :last-child {
+    outline: none;
+    flex: 1;
+}
+
+.shj-numbers {
+    counter-reset: line;
+    padding-left: 5px;
+}
+
+.shj-numbers div {
+    padding-right: 5px;
+}
+
+.shj-numbers div:before {
+    color: #999;
+    content: counter(line);
+    opacity: .5;
+    text-align: right;
+    counter-increment: line;
+    margin-right: 5px;
+    display: block;
+}
+
+.shj-syn-cmnt {
+    font-style: italic;
+}
+
+.shj-syn-err,
+.shj-syn-kwd {
+    color: #e16;
+}
+
+.shj-syn-num,
+.shj-syn-class {
+    color: #f60;
+}
+
+.shj-syn-insert,
+.shj-syn-str {
+    color: #7d8;
+}
+
+.shj-syn-type,
+.shj-syn-oper {
+    color: #5af;
+}
+
+.shj-syn-section,
+.shj-syn-func {
+    color: #84f;
+}
+
+.shj-syn-deleted,
+.shj-syn-var {
+    color: #f44;
+}
+
+.shj-oneline {
+    padding: 12px 10px;
+}
+
+.shj-lang-http.shj-oneline .shj-syn-kwd {
+    color: #fff;
+    background: #25f;
+    border-radius: 5px;
+    padding: 5px 7px;
+}
+
+/* DARK MODE */
+
+.vscode-dark {
+    
+    [class*=shj-lang-] {
+        color: #d4d4d4;
+        background: #1e1e1e;
+    }
+
+    [class*=shj-lang-]:before {
+        color: #6f9aff;
+    }
+
+    .shj-syn-insert {
+        color: #98c379;
+    }
+
+    .shj-syn-var {
+        color: #9cdcfe;
+    }
+
+    .shj-syn-oper {
+        color: #d4d4d4;
+    }
+
+    .shj-syn-num,
+    .shj-syn-kwd {
+        color: #569cd6;
+    }
+
+    .shj-syn-section,
+    .shj-syn-type,
+    .shj-syn-class {
+        color: #4fc1ff;
+    }
+
+    .shj-numbers,
+    .shj-syn-cmnt {
+        color: #6a9955;
+    }
+
+    .shj-syn-bool {
+        color: #b5cea8;
+    }
+
+    .shj-syn-deleted,
+    .shj-syn-err,
+    .shj-syn-str {
+        color: #ce9178;
+    }
+
+    .shj-syn-func {
+        color: #dcdcaa;
+    }
+}

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -1,3 +1,5 @@
+import './RovoDevCodeHighlighting.css';
+
 import LoadingButton from '@atlaskit/button/loading-button';
 import SendIcon from '@atlaskit/icon/glyph/send';
 import PauseIcon from '@atlaskit/icon/glyph/vid-pause';

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import { setTimeout } from 'timers/promises';
 import {
     CancellationToken,
-    ColorThemeKind,
     commands,
     Disposable,
     Event,
@@ -108,27 +107,11 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             localResourceRoots: [
                 Uri.file(path.join(this._extensionPath, 'build')),
                 Uri.file(path.join(this._extensionPath, 'node_modules', '@vscode', 'codicons', 'dist')),
-                Uri.file(path.join(this._extensionPath, 'node_modules', '@speed-highlight', 'core', 'dist')),
             ],
         };
 
-        const isDarkTheme =
-            window.activeColorTheme.kind === ColorThemeKind.HighContrast ||
-            window.activeColorTheme.kind === ColorThemeKind.Dark;
-
         const codiconsUri = webview.asWebviewUri(
             Uri.joinPath(this._extensionUri, 'node_modules', '@vscode', 'codicons', 'dist', 'codicon.css'),
-        );
-        const syntaxStylesUri = webview.asWebviewUri(
-            Uri.joinPath(
-                this._extensionUri,
-                'node_modules',
-                '@speed-highlight',
-                'core',
-                'dist',
-                'themes',
-                isDarkTheme ? 'dark.css' : 'default.css',
-            ),
         );
 
         webview.html = getHtmlForView(
@@ -137,7 +120,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             webview.cspSource,
             this.viewType,
             codiconsUri,
-            syntaxStylesUri,
         );
 
         webview.onDidReceiveMessage(async (e) => {

--- a/src/webview/common/getHtmlForView.ts
+++ b/src/webview/common/getHtmlForView.ts
@@ -11,7 +11,6 @@ export function getHtmlForView(
     cspSource: string,
     viewId: string,
     styles?: Uri,
-    syntaxStyles?: Uri,
 ): string {
     const manifest = JSON.parse(readFileSync(pathJoin(extensionPath, 'build', 'asset-manifest.json')).toString());
     const mainScript = manifest[`mui.js`];
@@ -25,7 +24,6 @@ export function getHtmlForView(
             baseUri: baseUri,
             cspSource: cspSource,
             styleUri: styles || '',
-            syntaxStyles: syntaxStyles || '',
         });
     } else {
         return Mustache.render(Resources.htmlNotFound, { resource: 'reactWebviewHtml' });

--- a/webpack.react.prod.js
+++ b/webpack.react.prod.js
@@ -50,7 +50,13 @@ module.exports = {
             cacheGroups: {
                 styles: {
                     name: 'main',
-                    test: /\.css$/,
+                    test: /^\.\/src\/webviews\.css$/,
+                    chunks: 'all',
+                    enforce: true,
+                },
+                styles2: {
+                    name: 'mui',
+                    test: /^\.\/src\/react\.css$/,
                     chunks: 'all',
                     enforce: true,
                 },


### PR DESCRIPTION
### What Is This Change?

This PR defines the css styling for code highlighting with the `.vscode-dark` directive to automatically adjust it to a change of light and dark themes.

It doesn't follow the same theme's color, but it simply sets two different set of colors for light and dark.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] manual testing