### PR TITLE
AXON-528: add trailing slash to custom prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ---
 
+## What's new in 3.8.7
+
+### Bug Fixes
+
+- Fixed a bug when slash is missing after custom branch prefix in branch naming
+
 ## What's new in 3.8.6
 
 ### Features
@@ -33,7 +39,7 @@
 ### Features
 
 - It is now possible to transition Jira work items to a different status from the sidebar, via `Transition Issue...` context menu option
-- Notifications for unseen & recent comments on Jira and Bitbucket are now supported 
+- Notifications for unseen & recent comments on Jira and Bitbucket are now supported
 
 ## What's new in 3.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ---
 
-## What's new in 3.8.7
-
-### Bug Fixes
-
-- Fixed a bug when slash is missing after custom branch prefix in branch naming
-
 ## What's new in 3.8.6
 
 ### Features
@@ -18,6 +12,7 @@
 
 - Fixed a regression in the source branch dropdrown of the Start work page
 - Fixed sometimes the 'Assigned Jira work items' and 'Custom JQL filters' panels don't retrieve recently edited items
+- Fixed a bug when slash is missing after custom branch prefix in branch naming
 
 ## What's new in 3.8.5
 

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -91,7 +91,8 @@ const StartWorkPage: React.FunctionComponent = () => {
     const classes = useStyles(vscStyles);
     const [state, controller] = useStartWorkController();
     const convertedCustomPrefixes = state.customPrefixes.map((prefix) => {
-        return { prefix: prefix, kind: prefix };
+        const normalizedCustomPrefix = prefix.endsWith('/') ? prefix : prefix + '/';
+        return { prefix: normalizedCustomPrefix, kind: prefix };
     });
 
     const [transitionIssueEnabled, setTransitionIssueEnabled] = useState(true);


### PR DESCRIPTION
### What Is This Change?
Added trailing slash to custom prefix 

**Expected behaviour** -> trailing slash is added to custom prefix as  described on Settings page
<img width="413" alt="Screenshot 2025-06-30 at 16 02 03" src="https://github.com/user-attachments/assets/fc24b037-3fba-4130-bc09-015265f54af1" />

Current behaviour: 

https://github.com/user-attachments/assets/a89d698e-c324-4bc9-b17f-37f6f528d662

Behaviour with fix:

https://github.com/user-attachments/assets/ce88d077-682f-4ed2-9b5a-01135467b865



<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change