### PR TITLE
AXON-452: add e2e test for create an issue flow

### DIFF
--- a/e2e/tests/jira/createIssue.spec.ts
+++ b/e2e/tests/jira/createIssue.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+import { authenticateWithJira } from 'e2e/helpers';
+
+test('Create an issue via side pannel flow', async ({ page }) => {
+    const newIssueSummary = 'Test Issue Created via E2E Test';
+    const newIssueKey = 'BTS-7';
+
+    await authenticateWithJira(page);
+
+    await page.getByRole('button', { name: 'Create Jira issue' }).click();
+
+    await page.getByRole('tab', { name: 'Atlassian Settings' }).getByLabel(/close/i).click();
+
+    const createIssueFrame = page.frameLocator('iframe.webview').frameLocator('iframe[title="Create Jira Issue"]');
+
+    await expect(createIssueFrame.getByRole('heading', { name: 'Create work item' })).toBeVisible();
+
+    await createIssueFrame.getByLabel('Summary').click();
+    await createIssueFrame.getByLabel('Summary').fill(newIssueSummary);
+
+    await createIssueFrame.getByRole('button', { name: 'Create' }).scrollIntoViewIfNeeded();
+    await page.waitForTimeout(500);
+
+    await createIssueFrame.getByRole('button', { name: 'Create' }).click();
+
+    await createIssueFrame.getByText('Issue Created').scrollIntoViewIfNeeded();
+    await page.waitForTimeout(500);
+
+    await expect(createIssueFrame.getByText('Issue Created')).toBeVisible();
+    await expect(createIssueFrame.getByText(newIssueKey)).toBeVisible();
+});

--- a/e2e/wiremock-mappings/mockedteams/createIssue.json
+++ b/e2e/wiremock-mappings/mockedteams/createIssue.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/rest/api/2/issue"
+  },
+  "response": {
+    "status": 201,
+    "body": "{\"id\":\"10007\",\"key\":\"BTS-7\",\"self\":\"https://mockedteams.atlassian.net/rest/api/2/issue/BTS-7\",\"fields\":{\"summary\":\"Test Issue Created via E2E Test\",\"description\":\"This is a test issue created during end-to-end testing.\",\"issuetype\":{\"id\":\"10003\",\"name\":\"Task\",\"description\":\"Tasks track small, distinct pieces of work.\",\"iconUrl\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium\",\"subtask\":false,\"hierarchyLevel\":0},\"project\":{\"id\":\"10000\",\"key\":\"BTS\",\"name\":\"KANBAN\",\"projectTypeKey\":\"software\",\"simplified\":true},\"status\":{\"id\":\"10000\",\"name\":\"To Do\",\"description\":\"\",\"iconUrl\":\"https://mockedteams.atlassian.net/images/icons/statuses/generic.png\",\"statusCategory\":{\"id\":2,\"key\":\"new\",\"colorName\":\"blue-gray\",\"name\":\"To Do\"}},\"reporter\":{\"accountId\":\"700002:00000000-0000-0000-0000-000000000001\",\"displayName\":\"Mocked McMock\",\"emailAddress\":\"mock@atlassian.code\",\"active\":true,\"timeZone\":\"America/Los_Angeles\",\"accountType\":\"atlassian\"},\"assignee\":null,\"created\":\"2025-01-10T12:00:00.000-0800\",\"updated\":\"2025-01-10T12:00:00.000-0800\",\"priority\":{\"id\":\"3\",\"name\":\"Medium\",\"iconUrl\":\"https://mockedteams.atlassian.net/images/icons/priorities/medium_new.svg\"},\"labels\":[],\"components\":[],\"fixVersions\":[],\"resolution\":null,\"resolutiondate\":null,\"duedate\":null,\"watches\":{\"watchCount\":0,\"isWatching\":false},\"attachment\":[],\"comment\":{\"comments\":[],\"maxResults\":0,\"total\":0,\"startAt\":0},\"worklog\":{\"startAt\":0,\"maxResults\":20,\"total\":0,\"worklogs\":[]}}}",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+} 

--- a/e2e/wiremock-mappings/mockedteams/project.json
+++ b/e2e/wiremock-mappings/mockedteams/project.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/api/2/project/BTS"
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"self\":\"https://mockedteams.atlassian.net/rest/api/2/project/10000\",\"id\":\"10000\",\"key\":\"BTS\",\"name\":\"MMOCK\",\"projectTypeKey\":\"software\",\"simplified\":true,\"avatarUrls\":{\"48x48\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10417\",\"24x24\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10417?size=small\",\"16x16\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10417?size=xsmall\",\"32x32\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10417?size=medium\"}}",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+} 

--- a/e2e/wiremock-mappings/mockedteams/search-project.json
+++ b/e2e/wiremock-mappings/mockedteams/search-project.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/api/2/project/search",
+    "queryParameters": {
+      "orderBy": {
+        "equalTo": "key"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"self\":\"https://mockedteams.atlassian.net/rest/api/2/project/search?orderBy=key\",\"maxResults\":50,\"startAt\":0,\"total\":1,\"isLast\":true,\"values\":[{\"self\":\"https://mockedteams.atlassian.net/rest/api/2/project/10000\",\"id\":\"10000\",\"key\":\"BTS\",\"name\":\"KANBAN\",\"projectTypeKey\":\"software\",\"simplified\":true,\"avatarUrls\":{\"48x48\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10417\",\"24x24\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10417?size=small\",\"16x16\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10417?size=xsmall\",\"32x32\":\"https://mockedteams.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10417?size=medium\"}}]}",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
### What Is This Change?
Added e2e test for create an issue via side pannel flow:

✅  Authenticate with Jira using the existing helper function
✅ Click the "Create Jira issue" button in the side panel
✅ Check that create issue form is loaded with the heading "Create work item"
✅ Click and fill in the summary field with "Test Issue Created via E2E Test"
✅ Scroll the Create button into view to ensure it's visible
✅ Click the Create button to submit the form
✅ Scroll the success message into view
✅ Verify that "Issue Created" text appears and new issue key "BTS-7" is displayed

[CreateIssue.webm](https://github.com/user-attachments/assets/c81660c7-e20d-4ca6-8e4b-066504574a32)



<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change