### PR TITLE
[AXON-521] Add PR creation functionality to rovodev view

### DIFF
--- a/src/react/atlascode/rovo-dev/common.tsx
+++ b/src/react/atlascode/rovo-dev/common.tsx
@@ -3,6 +3,7 @@ import CheckIcon from '@atlaskit/icon/glyph/check';
 import CrossIcon from '@atlaskit/icon/glyph/cross';
 import { Marked } from '@ts-stack/markdown';
 import React, { useCallback } from 'react';
+import { RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
 import {
     agentMessageStyles,
@@ -211,10 +212,18 @@ export const UpdatedFilesComponent: React.FC<{
     modifiedFiles: ToolReturnParseResult[];
     onUndo: (filePath: string[]) => void;
     onAccept: (filePath: string[]) => void;
+    onCreatePR: () => void;
     openDiff: OpenFileFunc;
-}> = ({ modifiedFiles, onUndo, onAccept, openDiff }) => {
+}> = ({ modifiedFiles, onUndo, onAccept, openDiff, onCreatePR }) => {
     const [isUndoHovered, setIsUndoHovered] = React.useState(false);
     const [isAcceptHovered, setIsAcceptHovered] = React.useState(false);
+    const [isPullRequestLoading, setIsPullRequestLoading] = React.useState(false);
+
+    window.addEventListener('message', (event) => {
+        if (event.data.type === RovoDevProviderMessageType.CreatePRComplete) {
+            setIsPullRequestLoading(false);
+        }
+    });
 
     const handleAcceptAll = useCallback(() => {
         const filePaths = modifiedFiles.map((msg) => msg.filePath).filter((path) => path !== undefined);
@@ -285,6 +294,25 @@ export const UpdatedFilesComponent: React.FC<{
                         onMouseLeave={() => setIsAcceptHovered(false)}
                     >
                         Keep
+                    </button>
+                    <button
+                        style={{
+                            color: 'var(--vscode-button-secondaryForeground)',
+                            backgroundColor: 'var(--vscode-button-background)',
+                            border: '1px solid var(--vscode-button-secondaryBorder)',
+                            ...undoAcceptButtonStyles,
+                        }}
+                        onClick={() => {
+                            setIsPullRequestLoading(true);
+                            onCreatePR();
+                        }}
+                        title="Create Pull Request"
+                    >
+                        {!isPullRequestLoading ? (
+                            <i className="codicon codicon-git-pull-request-create" />
+                        ) : (
+                            <i className="codicon codicon-loading codicon-modifier-spin" />
+                        )}
                     </button>
                 </div>
             </div>

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -347,6 +347,11 @@ const RovoDevView: React.FC = () => {
                     onUndo={undoFiles}
                     onAccept={acceptFiles}
                     openDiff={openFile}
+                    onCreatePR={() => {
+                        postMessage({
+                            type: RovoDevViewResponseType.CreatePR,
+                        });
+                    }}
                 />
                 <div style={styles.rovoDevPromptContainerStyles}>
                     <div

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -6,6 +6,7 @@ export const enum RovoDevViewResponseType {
     OpenFile = 'openFile',
     UndoFiles = 'undoFiles',
     AcceptFiles = 'acceptFiles',
+    CreatePR = 'createPR',
 }
 
 export type RovoDevViewResponse =
@@ -13,4 +14,5 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.CancelResponse>
     | ReducerAction<RovoDevViewResponseType.OpenFile, { filePath: string; tryShowDiff: boolean; range?: number[] }>
     | ReducerAction<RovoDevViewResponseType.UndoFiles, { filePaths: string[] }>
-    | ReducerAction<RovoDevViewResponseType.AcceptFiles, { filePaths: string[] }>;
+    | ReducerAction<RovoDevViewResponseType.AcceptFiles, { filePaths: string[] }>
+    | ReducerAction<RovoDevViewResponseType.CreatePR>;

--- a/src/rovo-dev/rovoDevPullRequestHandler.test.ts
+++ b/src/rovo-dev/rovoDevPullRequestHandler.test.ts
@@ -1,0 +1,44 @@
+import { RovoDevPullRequestHandler } from './rovoDevPullRequestHandler';
+
+describe('RovoDevPullRequestHandler', () => {
+    let handler: RovoDevPullRequestHandler;
+
+    beforeEach(() => {
+        handler = new RovoDevPullRequestHandler();
+    });
+
+    describe('findPRLink', () => {
+        it('Should match the link in GitHub push output', () => {
+            const link = handler.findPRLink(`
+remote:      https://github.com/my-org/my-repo/pull/new/my-branch
+remote:`);
+            expect(link).toBe('https://github.com/my-org/my-repo/pull/new/my-branch');
+        });
+
+        it('Should match the link in Bitbucket push output', () => {
+            const link = handler.findPRLink(`
+remote:      https://bitbucket.org/my-org/my-repo/pull-requests/new?source=my-branch
+remote:`);
+            expect(link).toBe('https://bitbucket.org/my-org/my-repo/pull-requests/new?source=my-branch');
+        });
+
+        it('Should match the link in generic push output', () => {
+            const link = handler.findPRLink(`
+                remote:      https://example.com/my-org/my-repo/pull/new/my-branch
+remote:`);
+            expect(link).toBe('https://example.com/my-org/my-repo/pull/new/my-branch');
+        });
+
+        it('Should return undefined for empty output', () => {
+            const link = handler.findPRLink('');
+            expect(link).toBeUndefined();
+        });
+
+        it('Should not match anything to odd links', () => {
+            const link = handler.findPRLink(`
+                remote:      https://example.com/my-org/my-repo/not-a-pr-link
+remote:`);
+            expect(link).toBeUndefined();
+        });
+    });
+});

--- a/src/rovo-dev/rovoDevPullRequestHandler.ts
+++ b/src/rovo-dev/rovoDevPullRequestHandler.ts
@@ -1,0 +1,107 @@
+import { exec } from 'child_process';
+import { Logger } from 'src/logger';
+import { GitExtension, Repository } from 'src/typings/git';
+import { promisify } from 'util';
+import { env, extensions, Uri, window } from 'vscode';
+
+export class RovoDevPullRequestHandler {
+    private async getGitExtension(): Promise<GitExtension> {
+        try {
+            const gitExtension = extensions.getExtension<GitExtension>('vscode.git');
+            if (!gitExtension) {
+                throw new Error('vscode.git extension not found');
+            }
+            return await gitExtension.activate();
+        } catch (e) {
+            window.showErrorMessage(
+                'Git extension not found or failed to activate. Please ensure Git is installed and the extension is enabled.',
+            );
+            console.error('Error activating git extension:', e);
+            throw e;
+        }
+    }
+
+    private async getGitRepository(gitExt: GitExtension): Promise<Repository> {
+        const gitApi = gitExt.getAPI(1);
+
+        if (gitApi.repositories.length === 0) {
+            window.showErrorMessage('No Git repositories found in the workspace.');
+            throw new Error('No Git repositories found');
+        }
+
+        // TODO: what do we want to do in case of multiple repositories?
+        return gitApi.repositories[0];
+    }
+
+    private async getBranchAndCommitInfo(repo: Repository): Promise<{ branchName: string; commitMessage: string }> {
+        const branchName = await window.showInputBox({
+            prompt: 'Enter a branch name for the PR',
+            value: 'my-branch',
+        });
+
+        const commitMessage = await window.showInputBox({
+            prompt: 'Enter a commit message for the PR',
+            value: 'My awesome work!',
+        });
+
+        if (!branchName || !commitMessage) {
+            throw new Error('Branch name and commit message are required');
+        }
+
+        return { branchName, commitMessage };
+    }
+
+    public findPRLink(output: string): string | undefined {
+        if (!output) {
+            return undefined;
+        }
+
+        // TODO: This turned out to be a whole can of worms.
+        // Using rather specific regexes for now; we should consider trade-offs between specificity and flexibility.
+        const linkMatchers = [
+            // Github: https://github.com/my-org/my-repo/pull/new/my-branch
+            /https:\/\/github\.com\/[^\s]+\/pull\/new\/[^\s]+/g,
+            // Bitbucket: https://bitbucket.org/my-org/my-repo/pull-requests/new?source=my-branch
+            /https:\/\/bitbucket\.org\/[^\s]+\/pull-requests\/new\?[^\s]+/g,
+            // Generic
+            /https:\/\/[^\s]+\/pull[^\s]*\/new\/[^\s]+/g,
+        ];
+
+        for (const matcher of linkMatchers) {
+            const match = output.match(matcher);
+            if (match && match[0]) {
+                Logger.info(`Create PR: ${match[0]}`);
+                return match[0];
+            }
+        }
+
+        Logger.info(`Could not find PR link in push output.`);
+        Logger.info(`Push warnings: ${output}`);
+        return undefined;
+    }
+
+    // This is the happy path for single small repository
+    // There would probably need to be a lot of logic in monorepos/multiple repos etc.
+    public async createPR(): Promise<void> {
+        const gitExt = await this.getGitExtension();
+        const repo = await this.getGitRepository(gitExt);
+        const { branchName, commitMessage } = await this.getBranchAndCommitInfo(repo);
+
+        await repo.fetch();
+        await repo.createBranch(branchName, true);
+        await repo.commit(commitMessage, {
+            all: true,
+        });
+
+        const execAsync = promisify(exec);
+
+        const { stderr } = await execAsync(`git push origin ${branchName}`, {
+            cwd: repo.rootUri.fsPath,
+        });
+
+        const prLink = this.findPRLink(stderr);
+        if (prLink) {
+            env.openExternal(Uri.parse(prLink));
+        }
+    }
+}

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -23,6 +23,7 @@ import { RovoDevViewResponse, RovoDevViewResponseType } from '../react/atlascode
 import { getHtmlForView } from '../webview/common/getHtmlForView';
 import { RovoDevResponse, RovoDevResponseParser } from './responseParser';
 import { RovoDevApiClient } from './rovoDevApiClient';
+import { RovoDevPullRequestHandler } from './rovoDevPullRequestHandler';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from './rovoDevWebviewProviderMessages';
 
 interface TypedWebview<MessageOut, MessageIn> extends Webview {
@@ -32,6 +33,7 @@ interface TypedWebview<MessageOut, MessageIn> extends Webview {
 
 export class RovoDevWebviewProvider extends Disposable implements WebviewViewProvider {
     private readonly viewType = 'atlascodeRovoDev';
+    private _prHandler = new RovoDevPullRequestHandler();
     private _webView?: TypedWebview<RovoDevProviderMessage, RovoDevViewResponse>;
     private _rovoDevApiClient?: RovoDevApiClient;
     private _initialized = false;
@@ -150,6 +152,10 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
                 case RovoDevViewResponseType.AcceptFiles:
                     await this.executeAcceptFiles(e.filePaths);
+                    break;
+
+                case RovoDevViewResponseType.CreatePR:
+                    await this.createPR();
                     break;
             }
         });
@@ -410,6 +416,20 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         });
 
         await Promise.all(promises);
+    }
+
+    private async createPR() {
+        try {
+            await this._prHandler.createPR();
+        } catch (e) {
+            console.error('Error creating PR:', e);
+            await this.processError(e as Error);
+        } finally {
+            const webview = this._webView!;
+            await webview.postMessage({
+                type: RovoDevProviderMessageType.CreatePRComplete,
+            });
+        }
     }
 
     private async executeApiWithErrorHandling<T>(

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -14,6 +14,7 @@ export const enum RovoDevProviderMessageType {
     NewSession = 'newSession',
     Initialized = 'initialized',
     CancelFailed = 'cancelFailed',
+    CreatePRComplete = 'createPRComplete',
 }
 
 export interface RovoDevObjectResponse {
@@ -30,4 +31,5 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.ErrorMessage, { message: ErrorMessage }>
     | ReducerAction<RovoDevProviderMessageType.NewSession>
     | ReducerAction<RovoDevProviderMessageType.Initialized>
-    | ReducerAction<RovoDevProviderMessageType.CancelFailed>;
+    | ReducerAction<RovoDevProviderMessageType.CancelFailed>
+    | ReducerAction<RovoDevProviderMessageType.CreatePRComplete>;


### PR DESCRIPTION
### What Is This Change?

This change adds a working bit of logic to create PRs right from the rovodev changeset:
![image](https://github.com/user-attachments/assets/1e385e05-2b46-4989-909f-8abb07686836)

I've iterated on the PR logic and the look and feel of this since the PoC, but this is still somewhat happy-path oriented

### How Has This Been Tested?

Manually, against bitbucket and github! :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] ~If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)~ N/A

Recommendations:
- [X] ~Update the CHANGELOG if making a user facing change~ N/A