### PR TITLE
AXON-314 - Fixed visibility of message about successful Jira issue cr…

### DIFF
--- a/e2e/tests/jira/createIssue.spec.ts
+++ b/e2e/tests/jira/createIssue.spec.ts
@@ -23,9 +23,7 @@ test('Create an issue via side pannel flow', async ({ page }) => {
 
     await createIssueFrame.getByRole('button', { name: 'Create' }).click();
 
-    await createIssueFrame.getByText('Issue Created').scrollIntoViewIfNeeded();
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(2000);
 
-    await expect(createIssueFrame.getByText('Issue Created')).toBeVisible();
-    await expect(createIssueFrame.getByText(newIssueKey)).toBeVisible();
+    await expect(page.getByRole('dialog', { name: new RegExp(`Issue ${newIssueKey} has been created`) })).toBeVisible();
 });

--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
@@ -2,7 +2,6 @@ import Button from '@atlaskit/button';
 import LoadingButton from '@atlaskit/button/loading-button';
 import Form, { Field, FormFooter, FormHeader, RequiredAsterisk } from '@atlaskit/form';
 import Page from '@atlaskit/page';
-import SectionMessage from '@atlaskit/section-message';
 import Select, { components } from '@atlaskit/select';
 import Spinner from '@atlaskit/spinner';
 import { IssueKeyAndSite } from '@atlassianlabs/jira-pi-common-models';
@@ -32,14 +31,12 @@ import { Panel } from './Panel';
 type Emit = CommonEditorPageEmit;
 type Accept = CommonEditorPageAccept | CreateIssueData;
 interface ViewState extends CommonEditorViewState, CreateIssueData {
-    isCreateBannerOpen: boolean;
     createdIssue: IssueKeyAndSite<DetailedSiteInfo>;
 }
 
 const emptyState: ViewState = {
     ...emptyCommonEditorState,
     ...emptyCreateIssueData,
-    isCreateBannerOpen: false,
     createdIssue: { key: '', siteDetails: emptySiteInfo },
 };
 
@@ -106,7 +103,6 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
                             errorDetails: undefined,
                             isSomethingLoading: false,
                             loadingField: '',
-                            isCreateBannerOpen: true,
                             createdIssue: e.issueData,
                             fieldValues: {
                                 ...this.state.fieldValues,
@@ -175,7 +171,6 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
         this.setState({
             isSomethingLoading: true,
             loadingField: 'submitButton',
-            isCreateBannerOpen: false,
         });
         this.postMessage({
             action: 'createIssue',
@@ -339,26 +334,6 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
                                         onPMFNever={() => this.onPMFNever()}
                                         onPMFSubmit={(data: LegacyPMFData) => this.onPMFSubmit(data)}
                                     />
-                                )}
-                                {this.state.isCreateBannerOpen && (
-                                    <div className="fade-in">
-                                        <SectionMessage appearance="success" title="Issue Created">
-                                            <p>
-                                                Issue{' '}
-                                                <Button
-                                                    className="ac-banner-link-button"
-                                                    appearance="link"
-                                                    spacing="none"
-                                                    onClick={() => {
-                                                        this.handleOpenIssue(this.state.createdIssue);
-                                                    }}
-                                                >
-                                                    {this.state.createdIssue.key}
-                                                </Button>{' '}
-                                                has been created.
-                                            </p>
-                                        </SectionMessage>
-                                    </div>
                                 )}
                                 {this.state.isErrorBannerOpen && (
                                     <ErrorBanner

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -3,10 +3,11 @@ import { CreateMetaTransformerResult, FieldValues, IssueTypeUI, ValueType } from
 import { decode } from 'base64-arraybuffer-es6';
 import { format } from 'date-fns';
 import FormData from 'form-data';
-import { commands, Position, Uri, ViewColumn } from 'vscode';
+import { commands, Position, Uri, ViewColumn, window } from 'vscode';
 
 import { issueCreatedEvent } from '../analytics';
 import { DetailedSiteInfo, emptySiteInfo, Product, ProductJira } from '../atlclients/authInfo';
+import { showIssue } from '../commands/jira/showIssue';
 import { configuration } from '../config/configuration';
 import { Commands } from '../constants';
 import { Container } from '../container';
@@ -465,6 +466,14 @@ export class CreateIssueWebview
                             });
 
                             this.fireCallback(resp.key, payload.summary);
+
+                            window
+                                .showInformationMessage(`Issue ${resp.key} has been created`, 'Open Issue')
+                                .then((selection) => {
+                                    if (selection === 'Open Issue') {
+                                        showIssue({ key: resp.key, siteDetails: msg.site });
+                                    }
+                                });
                         } catch (e) {
                             Logger.error(e, 'Error creating issue');
                             this.postMessage({


### PR DESCRIPTION

### What Is This Change?

**Problem**:
After creating an issue, a success message is displayed at the top of the page, but the user does not see it immediately.

**Solution**:
Replace the message block at the top with the VS Code's native notification.

**NOTE**: This is not the only possible solution, I have described some others in the comments to the ticket, please take a look

**Screenshot**:
<img width="1218" alt="Screenshot 2025-07-07 at 11 22 29" src="https://github.com/user-attachments/assets/dd281fd6-218d-4848-924a-aa712ba83ffc" />


**Recordings**:
https://www.loom.com/share/6d0ecbf6ada543699a1e21db2dca1c2b

As a bonus, the SR announcement was also fixed (which didn't work before):
https://www.loom.com/share/b9b9467ea7b5470ea44abeabe22a3167

### How Has This Been Tested?

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change