### PR TITLE
AXON-18 Creating a JIRA issue should default to the most relevant site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## What's new in 3.8.7
 
+### Features
+- Update logic of selecting the default project and site to the most relevant one for the user on the Creating a JIRA issue page
+
 ### Bug Fixes
 
 - Fixed a bug when transitioning Jira issues from 'Start work', which doesn't refresh the issues panels

--- a/src/views/jira/searchJiraHelper.test.ts
+++ b/src/views/jira/searchJiraHelper.test.ts
@@ -11,8 +11,17 @@ jest.mock('../../commands');
 jest.mock('../../container');
 jest.mock('../../atlclients/authInfo');
 
-const issue1 = forceCastTo<MinimalORIssueLink<DetailedSiteInfo>>({ key: 'ISSUE-1', summary: 'Test Issue' });
-const issue2 = forceCastTo<MinimalORIssueLink<DetailedSiteInfo>>({ key: 'ISSUE-2', summary: 'Another Issue' });
+const issue1 = forceCastTo<MinimalORIssueLink<DetailedSiteInfo>>({
+    key: 'ISSUE-1',
+    summary: 'Test Issue',
+    siteDetails: { id: 'site1' },
+});
+
+const issue2 = forceCastTo<MinimalORIssueLink<DetailedSiteInfo>>({
+    key: 'ISSUE-2',
+    summary: 'Another Issue',
+    siteDetails: { id: 'site2' },
+});
 
 describe('SearchJiraHelper', () => {
     beforeEach(() => {
@@ -50,6 +59,15 @@ describe('SearchJiraHelper', () => {
         expect(SearchJiraHelper.findIssue(issue2.key)).toBeUndefined();
     });
 
+    it('clearIssues clears all the issues for provider1', () => {
+        SearchJiraHelper.setIssues([issue1], 'provider1');
+        SearchJiraHelper.setIssues([issue2], 'provider2');
+        SearchJiraHelper.clearIssues('provider1');
+
+        expect(SearchJiraHelper.findIssue(issue1.key)).toBeUndefined();
+        expect(SearchJiraHelper.findIssue(issue2.key)).toBe(issue2);
+    });
+
     it("setIssues replaces the provider's issues", () => {
         SearchJiraHelper.setIssues([issue1], 'provider1');
         SearchJiraHelper.setIssues([issue2], 'provider1');
@@ -79,5 +97,13 @@ describe('SearchJiraHelper', () => {
 
         expect(SearchJiraHelper.findIssue(issue1.key)).toBe(issue1);
         expect(SearchJiraHelper.findIssue(issue2.key)).toBe(issue2);
+    });
+
+    it('returns issues for provided siteId', () => {
+        SearchJiraHelper.setIssues([issue1], 'provider1');
+        SearchJiraHelper.setIssues([issue2], 'provider2');
+
+        expect(SearchJiraHelper.getIssuesPerSite('site1')).toStrictEqual([issue1]);
+        expect(SearchJiraHelper.getIssuesPerSite('site2')).toStrictEqual([issue2]);
     });
 });

--- a/src/views/jira/searchJiraHelper.test.ts
+++ b/src/views/jira/searchJiraHelper.test.ts
@@ -1,5 +1,6 @@
 import { MinimalORIssueLink } from '@atlassianlabs/jira-pi-common-models';
 import { DetailedSiteInfo } from 'src/atlclients/authInfo';
+import { AssignedJiraItemsViewId } from 'src/constants';
 import { forceCastTo } from 'testsutil';
 import * as vscode from 'vscode';
 
@@ -100,10 +101,9 @@ describe('SearchJiraHelper', () => {
     });
 
     it('returns issues for provided siteId', () => {
-        SearchJiraHelper.setIssues([issue1], 'provider1');
-        SearchJiraHelper.setIssues([issue2], 'provider2');
+        SearchJiraHelper.setIssues([issue1, issue2], AssignedJiraItemsViewId);
 
-        expect(SearchJiraHelper.getAssignedIssuesPerSite('site1', 'provider1')).toStrictEqual([issue1]);
-        expect(SearchJiraHelper.getAssignedIssuesPerSite('site2', 'provider2')).toStrictEqual([issue2]);
+        expect(SearchJiraHelper.getAssignedIssuesPerSite('site1')).toStrictEqual([issue1]);
+        expect(SearchJiraHelper.getAssignedIssuesPerSite('site2')).toStrictEqual([issue2]);
     });
 });

--- a/src/views/jira/searchJiraHelper.test.ts
+++ b/src/views/jira/searchJiraHelper.test.ts
@@ -103,7 +103,7 @@ describe('SearchJiraHelper', () => {
         SearchJiraHelper.setIssues([issue1], 'provider1');
         SearchJiraHelper.setIssues([issue2], 'provider2');
 
-        expect(SearchJiraHelper.getIssuesPerSite('site1')).toStrictEqual([issue1]);
-        expect(SearchJiraHelper.getIssuesPerSite('site2')).toStrictEqual([issue2]);
+        expect(SearchJiraHelper.getAssignedIssuesPerSite('site1', 'provider1')).toStrictEqual([issue1]);
+        expect(SearchJiraHelper.getAssignedIssuesPerSite('site2', 'provider2')).toStrictEqual([issue2]);
     });
 });

--- a/src/views/jira/searchJiraHelper.ts
+++ b/src/views/jira/searchJiraHelper.ts
@@ -64,6 +64,11 @@ export class SearchJiraHelper {
         return undefined;
     }
 
+    static getIssuesPerSite(siteId: string): MinimalORIssueLink<DetailedSiteInfo>[] | undefined {
+        const issues = Object.values(this._searchableIssueMap).flat();
+        return issues.filter((issue) => issue.siteDetails.id === siteId);
+    }
+
     // This method is called when the user clicks on the "Search Jira" button in the Jira Tree View
     private static createIssueQuickPick() {
         searchIssuesEvent(ProductJira).then((e) => {

--- a/src/views/jira/searchJiraHelper.ts
+++ b/src/views/jira/searchJiraHelper.ts
@@ -3,7 +3,7 @@ import { commands, QuickPickItem, window } from 'vscode';
 
 import { searchIssuesEvent } from '../../analytics';
 import { DetailedSiteInfo, ProductJira } from '../../atlclients/authInfo';
-import { Commands } from '../../constants';
+import { AssignedJiraItemsViewId, Commands } from '../../constants';
 import { Container } from '../../container';
 
 interface QuickPickIssue extends QuickPickItem {
@@ -64,8 +64,8 @@ export class SearchJiraHelper {
         return undefined;
     }
 
-    static getAssignedIssuesPerSite(siteId: string, dataProviderId: string): MinimalORIssueLink<DetailedSiteInfo>[] {
-        const assignedIssues = this._searchableIssueMap[dataProviderId] || [];
+    static getAssignedIssuesPerSite(siteId: string): MinimalORIssueLink<DetailedSiteInfo>[] {
+        const assignedIssues = this._searchableIssueMap[AssignedJiraItemsViewId] || [];
         const assignedIssuesForSite = assignedIssues.filter((issue) => issue.siteDetails.id === siteId);
         return assignedIssuesForSite;
     }

--- a/src/views/jira/searchJiraHelper.ts
+++ b/src/views/jira/searchJiraHelper.ts
@@ -64,9 +64,10 @@ export class SearchJiraHelper {
         return undefined;
     }
 
-    static getIssuesPerSite(siteId: string): MinimalORIssueLink<DetailedSiteInfo>[] | undefined {
-        const issues = Object.values(this._searchableIssueMap).flat();
-        return issues.filter((issue) => issue.siteDetails.id === siteId);
+    static getAssignedIssuesPerSite(siteId: string, dataProviderId: string): MinimalORIssueLink<DetailedSiteInfo>[] {
+        const assignedIssues = this._searchableIssueMap[dataProviderId] || [];
+        const assignedIssuesForSite = assignedIssues.filter((issue) => issue.siteDetails.id === siteId);
+        return assignedIssuesForSite;
     }
 
     // This method is called when the user clicks on the "Search Jira" button in the Jira Tree View

--- a/src/webviews/createIssueWebview.test.ts
+++ b/src/webviews/createIssueWebview.test.ts
@@ -893,5 +893,4 @@ describe('CreateIssueWebview', () => {
             });
         });
     });
-
 });

--- a/src/webviews/createIssueWebview.test.ts
+++ b/src/webviews/createIssueWebview.test.ts
@@ -1,4 +1,4 @@
-import { IssueType, Project } from '@atlassianlabs/jira-pi-common-models';
+import { IssueType, MinimalORIssueLink, Project } from '@atlassianlabs/jira-pi-common-models';
 import { CreateMetaTransformerResult, FieldUI, IssueTypeUI, ValueType } from '@atlassianlabs/jira-pi-meta-models';
 import { expansionCastTo } from 'testsutil';
 import { Position, Uri, window } from 'vscode';
@@ -9,6 +9,7 @@ import { Container } from '../container';
 import * as fetchIssue from '../jira/fetchIssue';
 import { WebViewID } from '../lib/ipc/models/common';
 import { Logger } from '../logger';
+import { SearchJiraHelper } from '../views/jira/searchJiraHelper';
 import { CreateIssueWebview, PartialIssue } from './createIssueWebview';
 
 jest.mock('../container', () => ({
@@ -79,8 +80,13 @@ jest.mock('../commands/jira/showIssue', () => ({
     showIssue: jest.fn(),
 }));
 
-const mockWindow = window as jest.Mocked<typeof window>;
+jest.mock('../views/jira/searchJiraHelper', () => ({
+    SearchJiraHelper: {
+        getIssuesPerSite: jest.fn().mockReturnValue([]),
+    },
+}));
 
+const mockWindow = window as jest.Mocked<typeof window>;
 describe('CreateIssueWebview', () => {
     // Mock data
     const extensionPath = '/path/to/extension';
@@ -762,4 +768,130 @@ describe('CreateIssueWebview', () => {
             });
         });
     });
+
+    describe('Should correctly set site and project (updateSiteAndProject)', () => {
+        beforeEach(() => {
+            Container.config.jira.lastCreateSiteAndProject = {
+                siteId: '',
+                projectKey: '',
+            };
+            jest.spyOn(SearchJiraHelper, 'getIssuesPerSite').mockReturnValue([]);
+        });
+
+        it('should set site and project from last used values', async () => {
+            const lastUsedSiteId = 'last-used-site';
+            const lastUsedProjectKey = 'last-used-project';
+
+            Container.config.jira.lastCreateSiteAndProject = {
+                siteId: lastUsedSiteId,
+                projectKey: lastUsedProjectKey,
+            };
+
+            Container.siteManager.getSiteForId = jest.fn().mockReturnValue({
+                ...mockSiteDetails,
+                id: lastUsedSiteId,
+            });
+            Container.jiraProjectManager.getProjectForKey = jest.fn().mockReturnValue({
+                ...mockProject,
+                key: lastUsedProjectKey,
+            });
+
+            await webview.initialize();
+            expect(configuration.setLastCreateSiteAndProject).toHaveBeenCalledWith({
+                siteId: lastUsedSiteId,
+                projectKey: lastUsedProjectKey,
+            });
+        });
+
+        it('should set site and project with maximum issues', async () => {
+            Container.siteManager.getSiteForId = jest.fn().mockReturnValueOnce(undefined);
+
+            const maxIssuesSite = {
+                ...mockSiteDetails,
+                id: 'max-issues-site',
+            };
+            const maxIssuesProject = {
+                ...mockProject,
+                key: 'max-issues-project',
+            };
+
+            Container.jiraProjectManager.getProjectForKey = jest
+                .fn()
+                .mockReturnValueOnce(undefined)
+                .mockReturnValueOnce(maxIssuesProject);
+
+            Container.siteManager.getSitesAvailable = jest.fn().mockReturnValueOnce([maxIssuesSite]);
+
+            jest.spyOn(SearchJiraHelper, 'getIssuesPerSite').mockReturnValue([
+                { id: 'mock', key: 'TST-1' } as MinimalORIssueLink<DetailedSiteInfo>,
+                { id: 'mock', key: 'TST-2' } as MinimalORIssueLink<DetailedSiteInfo>,
+                { id: 'mock', key: 'TSR-1' } as MinimalORIssueLink<DetailedSiteInfo>,
+            ]);
+
+            await webview.initialize();
+            expect(configuration.setLastCreateSiteAndProject).toHaveBeenCalledWith({
+                siteId: maxIssuesSite.id,
+                projectKey: maxIssuesProject.key,
+            });
+        });
+
+        it('should set site and project from first available site and project', async () => {
+            Container.siteManager.getSiteForId = jest.fn().mockReturnValueOnce(undefined);
+            Container.jiraProjectManager.getProjectForKey = jest.fn().mockReturnValueOnce(undefined);
+
+            Container.siteManager.getFirstSite = jest.fn().mockReturnValue({ ...mockSiteDetails, id: 'first-site' });
+            Container.jiraProjectManager.getFirstProject = jest
+                .fn()
+                .mockResolvedValue({ ...mockProject, key: 'first-project' });
+
+            await webview.initialize();
+            expect(configuration.setLastCreateSiteAndProject).toHaveBeenCalledWith({
+                siteId: 'first-site',
+                projectKey: 'first-project',
+            });
+        });
+
+        it('should use provided project if available', async () => {
+            const inputProject: Project = {
+                ...mockProject,
+                key: 'input-project',
+            };
+
+            await webview.initialize();
+            expect(configuration.setLastCreateSiteAndProject).toHaveBeenCalled();
+
+            const action = {
+                action: 'getScreensForProject',
+                project: inputProject,
+            };
+            await webview['onMessageReceived'](action);
+
+            expect(configuration.setLastCreateSiteAndProject).toHaveBeenLastCalledWith({
+                projectKey: inputProject.key,
+                siteId: 'site-1',
+            });
+        });
+
+        it('should use provided site if available', async () => {
+            const inputSite: DetailedSiteInfo = {
+                ...mockSiteDetails,
+                id: 'input-site',
+            };
+
+            await webview.initialize();
+            expect(configuration.setLastCreateSiteAndProject).toHaveBeenCalled();
+
+            const action = {
+                action: 'getScreensForSite',
+                site: { id: inputSite.id },
+            };
+            await webview['onMessageReceived'](action);
+
+            expect(configuration.setLastCreateSiteAndProject).toHaveBeenLastCalledWith({
+                siteId: inputSite.id,
+                projectKey: 'TEST',
+            });
+        });
+    });
+
 });

--- a/src/webviews/createIssueWebview.test.ts
+++ b/src/webviews/createIssueWebview.test.ts
@@ -82,7 +82,7 @@ jest.mock('../commands/jira/showIssue', () => ({
 
 jest.mock('../views/jira/searchJiraHelper', () => ({
     SearchJiraHelper: {
-        getIssuesPerSite: jest.fn().mockReturnValue([]),
+        getAssignedIssuesPerSite: jest.fn().mockReturnValue([]),
     },
 }));
 
@@ -775,7 +775,7 @@ describe('CreateIssueWebview', () => {
                 siteId: '',
                 projectKey: '',
             };
-            jest.spyOn(SearchJiraHelper, 'getIssuesPerSite').mockReturnValue([]);
+            jest.spyOn(SearchJiraHelper, 'getAssignedIssuesPerSite').mockReturnValue([]);
         });
 
         it('should set site and project from last used values', async () => {
@@ -822,7 +822,7 @@ describe('CreateIssueWebview', () => {
 
             Container.siteManager.getSitesAvailable = jest.fn().mockReturnValueOnce([maxIssuesSite]);
 
-            jest.spyOn(SearchJiraHelper, 'getIssuesPerSite').mockReturnValue([
+            jest.spyOn(SearchJiraHelper, 'getAssignedIssuesPerSite').mockReturnValue([
                 { id: 'mock', key: 'TST-1' } as MinimalORIssueLink<DetailedSiteInfo>,
                 { id: 'mock', key: 'TST-2' } as MinimalORIssueLink<DetailedSiteInfo>,
                 { id: 'mock', key: 'TSR-1' } as MinimalORIssueLink<DetailedSiteInfo>,

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -9,7 +9,7 @@ import { issueCreatedEvent } from '../analytics';
 import { DetailedSiteInfo, emptySiteInfo, Product, ProductJira } from '../atlclients/authInfo';
 import { showIssue } from '../commands/jira/showIssue';
 import { configuration } from '../config/configuration';
-import { AssignedJiraItemsViewId, Commands } from '../constants';
+import { Commands } from '../constants';
 import { Container } from '../container';
 import {
     CreateIssueAction,
@@ -118,7 +118,7 @@ export class CreateIssueWebview
         const availableSites = Container.siteManager.getSitesAvailable(ProductJira);
         const { siteWithMaxIssues } = availableSites.reduce(
             (prev: { numIssues: number; siteWithMaxIssues: DetailedSiteInfo | null }, curr) => {
-                const siteIssues = SearchJiraHelper.getAssignedIssuesPerSite(curr.id, AssignedJiraItemsViewId);
+                const siteIssues = SearchJiraHelper.getAssignedIssuesPerSite(curr.id);
                 if (siteIssues && siteIssues.length > 0 && siteIssues.length > prev.numIssues) {
                     prev.numIssues = siteIssues.length;
                     prev.siteWithMaxIssues = curr;
@@ -134,7 +134,7 @@ export class CreateIssueWebview
     }
 
     private getProjectKeyWithMaxIssues(siteId: string): string | undefined {
-        const siteIssues = SearchJiraHelper.getAssignedIssuesPerSite(siteId, AssignedJiraItemsViewId);
+        const siteIssues = SearchJiraHelper.getAssignedIssuesPerSite(siteId);
         if (siteIssues && siteIssues.length > 0) {
             const issuesNumberPerProjectKey = siteIssues.reduce((prev: Record<string, number>, issue) => {
                 const projectKey = issue.key?.split('-')[0];

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -23,6 +23,7 @@ import { Action } from '../ipc/messaging';
 import { fetchCreateIssueUI } from '../jira/fetchIssue';
 import { WebViewID } from '../lib/ipc/models/common';
 import { Logger } from '../logger';
+import { SearchJiraHelper } from '../views/jira/searchJiraHelper';
 import { AbstractIssueEditorWebview } from './abstractIssueEditorWebview';
 import { InitializingWebview } from './abstractWebview';
 
@@ -113,6 +114,48 @@ export class CreateIssueWebview
         this.invalidate();
     }
 
+    private getSiteWithMaxIssues(): DetailedSiteInfo | undefined {
+        const availableSites = Container.siteManager.getSitesAvailable(ProductJira);
+        const { siteWithMaxIssues } = availableSites.reduce(
+            (prev: { numIssues: number; siteWithMaxIssues: DetailedSiteInfo | null }, curr) => {
+                const siteIssues = SearchJiraHelper.getIssuesPerSite(curr.id);
+                if (siteIssues && siteIssues.length > 0 && siteIssues.length > prev.numIssues) {
+                    prev.numIssues = siteIssues.length;
+                    prev.siteWithMaxIssues = curr;
+                }
+                return prev;
+            },
+            { numIssues: 0, siteWithMaxIssues: null },
+        );
+        if (siteWithMaxIssues) {
+            return siteWithMaxIssues;
+        }
+        return undefined;
+    }
+
+    private getProjectKeyWithMaxIssues(siteId: string): string | undefined {
+        const siteIssues = SearchJiraHelper.getIssuesPerSite(siteId);
+        if (siteIssues && siteIssues.length > 0) {
+            const issuesNumberPerProjectKey = siteIssues.reduce((prev: Record<string, number>, issue) => {
+                const projectKey = issue.key.split('-')[0];
+                if (!prev[projectKey]) {
+                    prev[projectKey] = 1;
+                    return prev;
+                }
+                prev[projectKey]++;
+                return prev;
+            }, {});
+            const projectKeyWithMaxIssues = Object.keys(issuesNumberPerProjectKey).reduce(
+                (prev: string, curr: string) =>
+                    issuesNumberPerProjectKey[curr] > issuesNumberPerProjectKey[prev] ? curr : prev,
+            );
+            if (projectKeyWithMaxIssues) {
+                return projectKeyWithMaxIssues;
+            }
+        }
+        return undefined;
+    }
+
     private async updateSiteAndProject(inputSite?: DetailedSiteInfo, inputProject?: Project) {
         if (inputSite) {
             this._siteDetails = inputSite;
@@ -125,7 +168,12 @@ export class CreateIssueWebview
             if (configSite) {
                 this._siteDetails = configSite;
             } else {
-                this._siteDetails = Container.siteManager.getFirstSite(ProductJira.key);
+                const siteWithMaxIssues = this.getSiteWithMaxIssues();
+                if (siteWithMaxIssues) {
+                    this._siteDetails = siteWithMaxIssues;
+                } else {
+                    this._siteDetails = Container.siteManager.getFirstSite(ProductJira.key);
+                }
             }
         }
 
@@ -142,7 +190,15 @@ export class CreateIssueWebview
             if (configProject) {
                 this._currentProject = configProject;
             } else {
-                this._currentProject = await Container.jiraProjectManager.getFirstProject(this._siteDetails);
+                const projectKeyWithMaxIssues = this.getProjectKeyWithMaxIssues(this._siteDetails.id);
+                if (projectKeyWithMaxIssues) {
+                    this._currentProject = await Container.jiraProjectManager.getProjectForKey(
+                        this._siteDetails,
+                        projectKeyWithMaxIssues,
+                    );
+                } else {
+                    this._currentProject = await Container.jiraProjectManager.getFirstProject(this._siteDetails);
+                }
             }
         }
 
@@ -232,9 +288,9 @@ export class CreateIssueWebview
             this._screenData.issueTypeUIs[this._selectedIssueTypeId].selectFieldOptions['project'] = availableProjects;
 
             /*
-            partial issue is used for prepopulating summary and description. 
+            partial issue is used for prepopulating summary and description.
             fieldValues get sent when you change the project in the project dropdown so we can preserve any previously set values.
-            e.g. you type some stuff, then you change the project... 
+            e.g. you type some stuff, then you change the project...
             at this point the new project may or may not have the same (or some of the same) fields.
             we fill them in with the previous user values.
             */

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -137,7 +137,7 @@ export class CreateIssueWebview
         const siteIssues = SearchJiraHelper.getIssuesPerSite(siteId);
         if (siteIssues && siteIssues.length > 0) {
             const issuesNumberPerProjectKey = siteIssues.reduce((prev: Record<string, number>, issue) => {
-                const projectKey = issue.key.split('-')[0];
+                const projectKey = issue.key?.split('-')[0];
                 if (!prev[projectKey]) {
                     prev[projectKey] = 1;
                     return prev;

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -9,7 +9,7 @@ import { issueCreatedEvent } from '../analytics';
 import { DetailedSiteInfo, emptySiteInfo, Product, ProductJira } from '../atlclients/authInfo';
 import { showIssue } from '../commands/jira/showIssue';
 import { configuration } from '../config/configuration';
-import { Commands } from '../constants';
+import { AssignedJiraItemsViewId, Commands } from '../constants';
 import { Container } from '../container';
 import {
     CreateIssueAction,
@@ -118,7 +118,7 @@ export class CreateIssueWebview
         const availableSites = Container.siteManager.getSitesAvailable(ProductJira);
         const { siteWithMaxIssues } = availableSites.reduce(
             (prev: { numIssues: number; siteWithMaxIssues: DetailedSiteInfo | null }, curr) => {
-                const siteIssues = SearchJiraHelper.getIssuesPerSite(curr.id);
+                const siteIssues = SearchJiraHelper.getAssignedIssuesPerSite(curr.id, AssignedJiraItemsViewId);
                 if (siteIssues && siteIssues.length > 0 && siteIssues.length > prev.numIssues) {
                     prev.numIssues = siteIssues.length;
                     prev.siteWithMaxIssues = curr;
@@ -134,7 +134,7 @@ export class CreateIssueWebview
     }
 
     private getProjectKeyWithMaxIssues(siteId: string): string | undefined {
-        const siteIssues = SearchJiraHelper.getIssuesPerSite(siteId);
+        const siteIssues = SearchJiraHelper.getAssignedIssuesPerSite(siteId, AssignedJiraItemsViewId);
         if (siteIssues && siteIssues.length > 0) {
             const issuesNumberPerProjectKey = siteIssues.reduce((prev: Record<string, number>, issue) => {
                 const projectKey = issue.key?.split('-')[0];


### PR DESCRIPTION
### What Is This Change?
This PR slightly changes the logic of filling in the site and project fields on the create issue page.
After this change, the site or project where most of the assigned Jira issues originate will be set as the default if the user opens the page for the first time.
<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change