### PR TITLE
AXON-536: add e2e tests for bb DC and Cloud auth flow

### DIFF
--- a/e2e/compose.yml
+++ b/e2e/compose.yml
@@ -18,6 +18,24 @@ services:
         expose:
             - 443
 
+    wiremock-bitbucket:
+        image: wiremock/wiremock
+        command: >
+            --https-port 443
+            --verbose
+            --https-keystore /home/wiremock_ssl_certs/wiremock-bitbucket.p12
+        volumes:
+            - ./wiremock-mappings/bitbucket:/home/wiremock/mappings
+            - ./sslcerts:/home/wiremock_ssl_certs
+        networks:
+            e2e:
+                aliases:
+                    - bitbucket.mockeddomain.com
+                    - bitbucket.org
+                    - api.bitbucket.org
+        expose:
+            - 443
+
     atlascode-e2e:
         image: atlascode-e2e
         volumes:
@@ -26,6 +44,7 @@ services:
             - NODE_TLS_REJECT_UNAUTHORIZED=0
         depends_on:
             - wiremock-mockedteams
+            - wiremock-bitbucket
         networks:
             - e2e
         ports:

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import type { APIRequestContext, Page } from '@playwright/test';
+import type { APIRequestContext, BrowserContext, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 /**
@@ -75,6 +75,23 @@ export function updateIssueField(issueJson: any, updates: Record<string, any>) {
 }
 
 /**
+ * Helper function to open atlassian settings with provided credentials
+ */
+export const openAtlassianSettings = async (page: Page, itemName: string) => {
+    await page.goto('http://localhost:9988/');
+
+    await page.getByRole('tab', { name: 'Atlassian' }).click();
+    await page.waitForTimeout(250);
+
+    await page.getByRole('tab', { name: 'Getting Started' }).getByLabel(/close/i).click();
+
+    await page.getByRole('treeitem', { name: itemName }).click();
+    await page.waitForTimeout(250);
+
+    return page.frameLocator('iframe.webview').frameLocator('iframe[title="Atlassian Settings"]');
+};
+
+/**
  * Helper function to authenticate with Jira using the provided credentials
  */
 export const authenticateWithJira = async (
@@ -83,21 +100,7 @@ export const authenticateWithJira = async (
     username: string = 'mock@atlassian.code',
     password: string = '12345',
 ) => {
-    await page.goto('http://localhost:9988/');
-
-    await page.getByRole('tab', { name: 'Atlassian' }).click();
-    await page.waitForTimeout(250);
-
-    // Close the onboarding view
-    await page.getByRole('tab', { name: 'Getting Started' }).getByLabel(/close/i).click();
-
-    await page.getByRole('treeitem', { name: 'Please login to Jira' }).click();
-    await page.waitForTimeout(250);
-
-    await page.getByRole('tab', { name: 'Atlassian Settings' }).click();
-    await page.waitForTimeout(250);
-
-    const settingsFrame = page.frameLocator('iframe.webview').frameLocator('iframe[title="Atlassian Settings"]');
+    const settingsFrame = await openAtlassianSettings(page, 'Please login to Jira');
 
     await expect(settingsFrame.getByRole('button', { name: 'Authentication authenticate' })).toBeVisible();
     await expect(settingsFrame.getByRole('button', { name: 'Login to Jira' })).toBeVisible();
@@ -128,6 +131,95 @@ export const authenticateWithJira = async (
 
     // Wait for authentication to complete and tree items to be visible
     await expect(page.getByRole('treeitem', { name: 'BTS-1 - User Interface Bugs' })).toBeVisible();
+};
+
+/**
+ * Helper function to authenticate with Bitbucket DC using the provided credentials
+ */
+export const authenticateWithBitbucketDC = async (
+    page: Page,
+    baseUrl: string = 'https://bitbucket.mockeddomain.com',
+    username: string = 'mockedUser',
+    password: string = '12345',
+) => {
+    const settingsFrame = await openAtlassianSettings(page, 'Connect Bitbucket to view pull requests');
+
+    await expect(settingsFrame.getByRole('button', { name: 'Authentication authenticate' })).toBeVisible();
+    await expect(settingsFrame.getByRole('button', { name: 'Login to Bitbucket' })).toBeVisible();
+
+    await settingsFrame.getByRole('button', { name: 'Login to Bitbucket' }).click();
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('textbox', { name: 'Base URL' }).click();
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('textbox', { name: 'Base URL' }).fill(baseUrl);
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('textbox', { name: 'Username' }).click();
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('textbox', { name: 'Username' }).fill(username);
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('textbox', { name: 'Password' }).click();
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('textbox', { name: 'Password' }).fill(password);
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('button', { name: 'Save Site' }).click();
+    await page.waitForTimeout(1000);
+
+    await expect(settingsFrame.getByText('bitbucket.mockeddomain.com')).toBeVisible();
+    await expect(settingsFrame.getByText('No sites found')).not.toBeVisible();
+};
+
+/**
+ * Helper function to authenticate with Bitbucket Cloud using OAuth
+ */
+export const authenticateWithBitbucketCloud = async (
+    page: Page,
+    context: BrowserContext,
+    baseUrl: string = 'https://bitbucket.org',
+) => {
+    await context.route('https://bitbucket.org/site/oauth2/authorize*', async (route) => {
+        const reqUrl = new URL(route.request().url());
+        const state = reqUrl.searchParams.get('state');
+        const callbackUrl = `http://localhost:31415/bbcloud?code=mocked-code&state=${state}`;
+
+        await context.request.get(callbackUrl);
+
+        route.abort();
+    });
+
+    const settingsFrame = await openAtlassianSettings(page, 'Connect Bitbucket to view pull requests');
+
+    await expect(settingsFrame.getByRole('button', { name: 'Authentication authenticate' })).toBeVisible();
+    await expect(settingsFrame.getByRole('button', { name: 'Login to Bitbucket' })).toBeVisible();
+
+    await settingsFrame.getByRole('button', { name: 'Login to Bitbucket' }).click();
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('textbox', { name: 'Base URL' }).click();
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('textbox', { name: 'Base URL' }).fill(baseUrl);
+    await page.waitForTimeout(250);
+
+    await settingsFrame.getByRole('button', { name: 'Save Site' }).click();
+    await page.waitForTimeout(250);
+
+    const externalPrompt = page
+        .getByRole('dialog')
+        .filter({ hasText: 'Do you want code-server to open the external website' });
+
+    if (await externalPrompt.isVisible()) {
+        await externalPrompt.getByRole('button', { name: 'Open' }).click();
+        await page.waitForTimeout(1000);
+    }
+
+    await expect(settingsFrame.getByText('Bitbucket Cloud')).toBeVisible();
 };
 
 /**

--- a/e2e/sslcerts/generate-certs.sh
+++ b/e2e/sslcerts/generate-certs.sh
@@ -82,5 +82,8 @@ openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 3650 -out rootCA.crt
 # Generates a certificate for mockedteams.atlassian.net
 generate_service_cert "wiremock-mockedteams" "mockedteams.atlassian.net"
 
+# # Generates a certificate for bitbucket.mockeddomain.com
+generate_service_cert "wiremock-bitbucket" "bitbucket.mockeddomain.com"
+
 rm rootCA.key
 rm rootCA.srl

--- a/e2e/tests/bitbucket/authFlowCloud.spec.ts
+++ b/e2e/tests/bitbucket/authFlowCloud.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+import { authenticateWithBitbucketCloud } from 'e2e/helpers';
+
+test('Authenticating with Bitbucket Cloud works', async ({ page, context }) => {
+    await authenticateWithBitbucketCloud(page, context);
+
+    await expect(page.getByRole('treeitem', { name: 'Add a repository to this workspace' })).toBeVisible();
+    await expect(page.getByRole('treeitem', { name: 'Clone a repository from Bitbucket' })).toBeVisible();
+    await expect(
+        page.getByRole('treeitem', { name: 'No Bitbucket repositories found in this workspace' }),
+    ).toBeVisible();
+    await expect(page.getByRole('treeitem', { name: 'Switch workspace' })).toBeVisible();
+});

--- a/e2e/tests/bitbucket/authFlowDC.spec.ts
+++ b/e2e/tests/bitbucket/authFlowDC.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test';
+import { authenticateWithBitbucketDC } from 'e2e/helpers';
+
+test('Authenticating with Bitbucket DC works', async ({ page }) => {
+    await authenticateWithBitbucketDC(page);
+
+    await expect(page.getByRole('treeitem', { name: 'Add a repository' })).toBeVisible();
+    await expect(page.getByRole('treeitem', { name: 'Clone a repository' })).toBeVisible();
+    await expect(page.getByRole('treeitem', { name: 'No Bitbucket repositories found' })).toBeVisible();
+    await expect(page.getByRole('treeitem', { name: 'Switch workspace' })).toBeVisible();
+});

--- a/e2e/wiremock-mappings/bitbucket/access-token-bb-cloud.json
+++ b/e2e/wiremock-mappings/bitbucket/access-token-bb-cloud.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPathPattern": "/site/oauth2/access_token"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+        "access_token": "mocked_token",
+        "token_type": "bearer",
+        "expires_in": 3600
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/e2e/wiremock-mappings/bitbucket/build-capabilities-bb-dc.json
+++ b/e2e/wiremock-mappings/bitbucket/build-capabilities-bb-dc.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/api/latest/build/capabilities"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "capabilities": {
+        "build": {
+          "enabled": true
+        }
+      }
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "x-ausername": "mockedUser"
+    }
+  }
+}

--- a/e2e/wiremock-mappings/bitbucket/get-user-bb-cloud.json
+++ b/e2e/wiremock-mappings/bitbucket/get-user-bb-cloud.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/2.0/user"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+                "username": "mockuser",
+                "display_name": "Mock User",
+                "uuid": "{mock-uuid}",
+                "links": {
+                    "avatar": {
+                        "href": "https://example.com/avatar.png"
+                    }
+                }
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/e2e/wiremock-mappings/bitbucket/get-user-bb-dc.json
+++ b/e2e/wiremock-mappings/bitbucket/get-user-bb-dc.json
@@ -1,0 +1,29 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/rest/api/1.0/users/mockedUser"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "name": "mockedUser",
+      "emailAddress": "mock@atlassian.code",
+      "active": true,
+      "displayName": "Mock User",
+      "id": 1,
+      "slug": "mockuser",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://bitbucket.mockeddomain.com/users/mockedUser"
+          }
+        ]
+      },
+      "avatarUrl": "https://bitbucket.mockeddomain.com/users/mockedUser/avatar.png"
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
### What Is This Change?
- added new WireMock service for Bitbucket testing ( `wiremock-bitbucket` )
- added certificate generation for wiremock-bitbucket service
- added mocked API responses related to auth flow
- extracted duplicated logic into `openAtlassianSettings()` method
- added e2e tests for auth flow in Bitbucket Cloud and Bitbucket DC

Screenrecord for Bitbucket Cloud auth flow:

[cloud.webm](https://github.com/user-attachments/assets/e76444be-a441-4707-958a-fc12fe1c866e)




Screenrecord for Bitbucket DC auth flow: 

[dc.webm](https://github.com/user-attachments/assets/54ff3d32-ff37-462a-98be-8e89984d1055)


<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change