### PR TITLE
AXON-543 added functionality to refresh Jira issue view in active tab…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed a regression in the source branch dropdrown of the Start work page
 - Fixed sometimes the 'Assigned Jira work items' and 'Custom JQL filters' panels don't retrieve recently edited items
 - Fixed a bug when slash is missing after custom branch prefix in branch naming
+- Fixed bug when Jira issue view in active tab doesn't refresh itself after VS Code get focus
 
 ## What's new in 3.8.5
 

--- a/src/webviews/abstractWebview.ts
+++ b/src/webviews/abstractWebview.ts
@@ -10,6 +10,7 @@ import {
     WebviewPanel,
     WebviewPanelOnDidChangeViewStateEvent,
     window,
+    WindowState,
 } from 'vscode';
 
 import { pmfClosed, pmfSnoozed, pmfSubmitted, viewScreenEvent } from '../analytics';
@@ -119,6 +120,7 @@ export abstract class AbstractReactWebview implements ReactWebview {
                 this._panel,
                 this._panel.onDidDispose(this.onPanelDisposed, this),
                 this._panel.onDidChangeViewState(this.onViewStateChanged, this),
+                window.onDidChangeWindowState(this.onWindowReceiveFocus, this),
                 this._panel.webview.onDidReceiveMessage(this.onMessageReceived, this),
                 this.ws,
             );
@@ -177,6 +179,12 @@ export abstract class AbstractReactWebview implements ReactWebview {
                     });
                 }
             });
+        }
+    }
+
+    private onWindowReceiveFocus(windowState: WindowState) {
+        if (windowState.focused && this.visible) {
+            this.invalidate();
         }
     }
 


### PR DESCRIPTION
### What Is This Change?

Added functionality to refresh Jira issue view in active tab when user moves from VS Code somewhere else and then returns to VS Code so it gets focus.

### How Has This Been Tested?

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change