### PR TITLE
[AXON-587] Inform Rovo Dev of reverted files

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -356,6 +356,9 @@ ${message}`;
         const webview = this._webView!;
         await this.executeApiWithErrorHandling(async (client) => {
             await client.reset();
+
+            this._revertedChanges = [];
+
             await webview.postMessage({
                 type: RovoDevProviderMessageType.NewSession,
             });

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -308,6 +308,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private addUndoContextToPrompt(message: string): string {
         if (this._revertedChanges.length) {
             const files = this._revertedChanges.join('\n');
+            this._revertedChanges = [];
             return `<context>
     The following files have been reverted:
     ${files}


### PR DESCRIPTION
### What Is This Change?

When the user undoes one or more files, we should inform Rovo Dev about the reverts within the next prompt.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] manual tests