### PR TITLE
[Rovo Dev] Changes the Stop button from a 'Pause' icon to a 'Cross' icon

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -2,8 +2,8 @@ import './RovoDev.css';
 import './RovoDevCodeHighlighting.css';
 
 import LoadingButton from '@atlaskit/button/loading-button';
+import CrossIcon from '@atlaskit/icon/glyph/cross';
 import SendIcon from '@atlaskit/icon/glyph/send';
-import PauseIcon from '@atlaskit/icon/glyph/vid-pause';
 import { highlightElement } from '@speed-highlight/core';
 import { detectLanguage } from '@speed-highlight/core/detect';
 import { useCallback, useState } from 'react';
@@ -425,7 +425,7 @@ const RovoDevView: React.FC = () => {
                                         backgroundColor: 'var(--vscode-input-background) !important',
                                     }}
                                     label="Stop button"
-                                    iconBefore={<PauseIcon size="small" label="Stop" />}
+                                    iconBefore={<CrossIcon size="small" label="Stop" />}
                                     isDisabled={currentState === State.CancellingResponse}
                                     onClick={() => cancelResponse()}
                                 />


### PR DESCRIPTION
### What Is This Change?

Changes the Stop button from a 'Pause' icon to a 'Cross' icon, to avoid confusion.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`