### PR TITLE
Axon-351 jira item to in progress via start work still to do in the panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed sometimes the 'Assigned Jira work items' and 'Custom JQL filters' panels don't retrieve recently edited items
 - Fixed a bug when slash is missing after custom branch prefix in branch naming
 - Fixed bug when Jira issue view in active tab doesn't refresh itself after VS Code get focus
+- Fixed a bug when transitioning Jira issues from 'Start work', which doesn't refresh the issues panels
 
 ## What's new in 3.8.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+- Fixed a bug when transitioning Jira issues from 'Start work', which doesn't refresh the issues panels
 - Added sorting for status transitions based on their workflow order
 
 ## What's new in 3.8.6
@@ -20,7 +21,6 @@
 - Fixed sometimes the 'Assigned Jira work items' and 'Custom JQL filters' panels don't retrieve recently edited items
 - Fixed a bug when slash is missing after custom branch prefix in branch naming
 - Fixed bug when Jira issue view in active tab doesn't refresh itself after VS Code get focus
-- Fixed a bug when transitioning Jira issues from 'Start work', which doesn't refresh the issues panels
 
 ## What's new in 3.8.5
 

--- a/src/lib/ipc/fromUI/startWork.ts
+++ b/src/lib/ipc/fromUI/startWork.ts
@@ -11,6 +11,7 @@ export enum StartWorkActionType {
     StartRequest = 'startRequest',
     OpenSettings = 'openSettings',
     GetImage = 'getImage',
+    RefreshTreeViews = 'refreshTreeViews',
 }
 
 export type StartWorkAction =
@@ -18,6 +19,7 @@ export type StartWorkAction =
     | ReducerAction<StartWorkActionType.StartRequest, StartRequestAction>
     | ReducerAction<StartWorkActionType.OpenSettings, OpenSettingsAction>
     | ReducerAction<StartWorkActionType.GetImage, GetImageAction>
+    | ReducerAction<StartWorkActionType.RefreshTreeViews, {}>
     | CommonAction;
 
 export interface StartRequestAction {

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -2,6 +2,7 @@ import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import { BitbucketBranchingModel } from '../../../../bitbucket/model';
+import { Commands } from '../../../../constants';
 import { Container } from '../../../../container';
 import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
@@ -207,6 +208,19 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                         imgData: '',
                         nonce: msg.nonce,
                     } as any);
+                }
+                break;
+            }
+            case StartWorkActionType.RefreshTreeViews: {
+                try {
+                    // Add delay to allow Jira's indexes to update before refreshing
+                    await new Promise((resolve) => setTimeout(resolve, 4000));
+                    const vscode = await import('vscode');
+                    vscode.commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
+                    vscode.commands.executeCommand(Commands.RefreshCustomJqlExplorer);
+                    this.logger.debug('Tree views refreshed after start work');
+                } catch (e) {
+                    this.logger.error(e, 'Error refreshing tree views');
                 }
                 break;
             }

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -5,10 +5,12 @@ import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import { BitbucketBranchingModel } from '../../../../bitbucket/model';
 import { Commands } from '../../../../constants';
 import { Container } from '../../../../container';
+import { OnJiraEditedRefreshDelay } from '../../../../util/time';
 import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
 import { StartWorkAction, StartWorkActionType } from '../../../ipc/fromUI/startWork';
 import { WebViewID } from '../../../ipc/models/common';
+import { CommonMessage, CommonMessageType } from '../../../ipc/toUI/common';
 import {
     BranchType,
     emptyStartWorkIssueMessage,

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -1,4 +1,5 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
+import * as vscode from 'vscode';
 
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import { BitbucketBranchingModel } from '../../../../bitbucket/model';
@@ -8,7 +9,6 @@ import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
 import { StartWorkAction, StartWorkActionType } from '../../../ipc/fromUI/startWork';
 import { WebViewID } from '../../../ipc/models/common';
-import { CommonMessage, CommonMessageType } from '../../../ipc/toUI/common';
 import {
     BranchType,
     emptyStartWorkIssueMessage,
@@ -212,16 +212,12 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                 break;
             }
             case StartWorkActionType.RefreshTreeViews: {
-                try {
-                    // Add delay to allow Jira's indexes to update before refreshing
-                    await new Promise((resolve) => setTimeout(resolve, 4000));
-                    const vscode = await import('vscode');
-                    vscode.commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
-                    vscode.commands.executeCommand(Commands.RefreshCustomJqlExplorer);
-                    this.logger.debug('Tree views refreshed after start work');
-                } catch (e) {
-                    this.logger.error(e, 'Error refreshing tree views');
-                }
+                // Pass delay to allow Jira's indexes to update before refreshing
+                await vscode.commands.executeCommand(
+                    Commands.RefreshAssignedWorkItemsExplorer,
+                    OnJiraEditedRefreshDelay,
+                );
+                await vscode.commands.executeCommand(Commands.RefreshCustomJqlExplorer, OnJiraEditedRefreshDelay);
                 break;
             }
             case CommonActionType.Refresh: {

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -261,6 +261,10 @@ const StartWorkPage: React.FunctionComponent = () => {
                 upstream,
                 pushBranchEnabled,
             );
+            // Send message to refresh tree views after successful start work
+            controller.postMessage({
+                type: StartWorkActionType.RefreshTreeViews,
+            });
             setSubmitState('submit-success');
             setSubmitResponse(response);
             setSuccessSnackbarOpen(true);
@@ -453,6 +457,7 @@ const StartWorkPage: React.FunctionComponent = () => {
                                                 <Grid item>
                                                     <Typography variant="h4">
                                                         <Box fontWeight="fontWeightBold">Transition issue</Box>
+                                                        {console.log('Start work page 456')}
                                                     </Typography>
                                                 </Grid>
                                             </Grid>

--- a/src/react/atlascode/startwork/StartWorkPage.tsx
+++ b/src/react/atlascode/startwork/StartWorkPage.tsx
@@ -457,7 +457,6 @@ const StartWorkPage: React.FunctionComponent = () => {
                                                 <Grid item>
                                                     <Typography variant="h4">
                                                         <Box fontWeight="fontWeightBold">Transition issue</Box>
-                                                        {console.log('Start work page 456')}
                                                     </Typography>
                                                 </Grid>
                                             </Grid>

--- a/src/webview/startwork/vscStartWorkActionApi.ts
+++ b/src/webview/startwork/vscStartWorkActionApi.ts
@@ -4,7 +4,6 @@ import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { clientForSite } from '../../bitbucket/bbUtils';
 import { emptyRepo, Repo, WorkspaceRepo } from '../../bitbucket/model';
 import { StartWorkBranchTemplate } from '../../config/model';
-import { Commands } from '../../constants';
 import { Container } from '../../container';
 import { ConfigSection, ConfigSubSection } from '../../lib/ipc/models/config';
 import { StartWorkActionApi } from '../../lib/webview/controller/startwork/startWorkActionApi';
@@ -51,13 +50,6 @@ export class VSCStartWorkActionApi implements StartWorkActionApi {
         if (transition !== undefined && issue.status.id !== transition.to.id) {
             await client.transitionIssue(issue.key, transition.id);
         }
-        // Add delay to allow Jira's indexes to update before refreshing
-        await new Promise((resolve) => setTimeout(resolve, 4000));
-        // Refresh the tree views to show updated status
-        const vscode = await import('vscode');
-        vscode.commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
-        vscode.commands.executeCommand(Commands.RefreshCustomJqlExplorer);
-        console.log('[VSCStartWorkActionApi] Refresh commands executed');
     }
 
     async createOrCheckoutBranch(

--- a/src/webview/startwork/vscStartWorkActionApi.ts
+++ b/src/webview/startwork/vscStartWorkActionApi.ts
@@ -4,6 +4,7 @@ import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { clientForSite } from '../../bitbucket/bbUtils';
 import { emptyRepo, Repo, WorkspaceRepo } from '../../bitbucket/model';
 import { StartWorkBranchTemplate } from '../../config/model';
+import { Commands } from '../../constants';
 import { Container } from '../../container';
 import { ConfigSection, ConfigSubSection } from '../../lib/ipc/models/config';
 import { StartWorkActionApi } from '../../lib/webview/controller/startwork/startWorkActionApi';
@@ -50,6 +51,13 @@ export class VSCStartWorkActionApi implements StartWorkActionApi {
         if (transition !== undefined && issue.status.id !== transition.to.id) {
             await client.transitionIssue(issue.key, transition.id);
         }
+        // Add delay to allow Jira's indexes to update before refreshing
+        await new Promise((resolve) => setTimeout(resolve, 4000));
+        // Refresh the tree views to show updated status
+        const vscode = await import('vscode');
+        vscode.commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
+        vscode.commands.executeCommand(Commands.RefreshCustomJqlExplorer);
+        console.log('[VSCStartWorkActionApi] Refresh commands executed');
     }
 
     async createOrCheckoutBranch(


### PR DESCRIPTION
### What Is This Change?

✅  Fixed a bug when transitioning Jira issues from 'Start work', which doesn't refresh the issues panels
- After the user has started working on the ticket, its status changes to the corresponding one in the sidebar.

![Screenshot 2025-07-09 at 14 13 08](https://github.com/user-attachments/assets/2c73321d-a054-41ad-a9df-b153e02f5b3f)

After fix:
https://www.loom.com/share/2d0b780d02fd4980a0530385b6e7e577?sid=381fc860-4108-46fd-bff5-0017deb8907b

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Recommendations:
- [x] Update the CHANGELOG if making a user facing change