### PR TITLE
[AXON-594] Make rovodev host configurable from environment

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,6 +94,7 @@ export const rovodevInfo = {
     mappingKey: 'workspacePortMapping',
     envVars: {
         port: 'ROVODEV_PORT',
+        host: 'ROVODEV_HOST',
     },
     portRange: {
         start: 40000,

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -57,8 +57,9 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private get rovoDevApiClient() {
         if (!this._rovoDevApiClient) {
             const rovoDevPort = this.getWorkspacePort();
+            const rovoDevHost = process.env[rovodevInfo.envVars.host] || 'localhost';
             if (rovoDevPort) {
-                this._rovoDevApiClient = new RovoDevApiClient('localhost', rovoDevPort);
+                this._rovoDevApiClient = new RovoDevApiClient(rovoDevHost, rovoDevPort);
             }
         }
 


### PR DESCRIPTION
### What Is This Change?

We can configure the port, but not the host for rovodev at the moment. For some launch configurations, we need that to be different too (e.g. when running in docker). This change allows for that to be done via environment

### How Has This Been Tested?

Manually, ran the extension with a bunch of different values in `ROVODEV_HOST` :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] ~If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)~ N/A

Recommendations:
- [x] ~Update the CHANGELOG if making a user facing change~ N/A