### PR TITLE
AXON-592: cleaned up containers used during e2e test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "test:unit": "jest -c jest.unit.config.ts",
         "test:react": "jest -c jest.react.config.ts",
         "test:e2e:sslcerts": "cd e2e/sslcerts && ./generate-certs.sh",
-        "test:e2e:docker": "cd e2e && docker compose run atlascode-e2e; status=$?; docker compose down; exit $status",
+        "test:e2e:docker": "cd e2e && docker compose run --rm atlascode-e2e; status=$?; docker compose down; exit $status",
         "test:e2e:docker:build": "docker build --tag atlascode-e2e - <e2e/Dockerfile",
         "devcompile": "npm run clean && npm run devcompile:react && npm run devcompile:extension",
         "devcompile:react": "webpack --mode development --config webpack.react.dev.js --fail-on-warnings",


### PR DESCRIPTION
### What Is This Change?

Currently, Docker containers used during e2e test runs are not automatically removed after the tests complete. This leads to an accumulation of unused containers over time 
Goal is to ensure that containers are properly cleaned up to prevent resource leakage & maintain a clean local env


#### Before:

![image](https://github.com/user-attachments/assets/0b87adb6-1fa0-490a-a071-0a4fe48a5bb0)

#### After:

![Screenshot 2025-07-09 at 20 51 28](https://github.com/user-attachments/assets/6e0a3815-104d-4640-9379-c5c0caed85e9)

### How Has This Been Tested

Basic checks:

- [ ] `npm run test:e2e:docker`