### PR TITLE
[AXON-606] [Rovo Dev] Removed currentResponse state and simplified rendering

### DIFF
--- a/src/react/atlascode/rovo-dev/common.tsx
+++ b/src/react/atlascode/rovo-dev/common.tsx
@@ -155,7 +155,7 @@ const ToolReturnParsedItem: React.FC<{
     );
 };
 
-export const ChatMessageItem: React.FC<{
+const ChatMessageItem: React.FC<{
     msg: DefaultMessage;
     index?: number;
     openFile: OpenFileFunc;

--- a/src/react/atlascode/rovo-dev/rovoDevViewStyles.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewStyles.tsx
@@ -87,10 +87,6 @@ export const agentMessageStyles: React.CSSProperties = {
     borderBottomLeftRadius: '0px',
 };
 
-export const streamingMessageStyles: React.CSSProperties = {
-    border: '1px dashed var(--vscode-activityBarBadge-background)',
-};
-
 export const messageHeaderStyles: React.CSSProperties = {
     display: 'flex',
     justifyContent: 'space-between',


### PR DESCRIPTION
### What Is This Change?

Messages were buffered in a `currentResponse` state before being finalized and added to the `chatHistory` state.
This indirection isn't really necessary, and we can write directly into the chatHistory, removing extra state, dom elements, and logic.

### How Has This Been Tested?

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`