### PR TITLE
AXON-366 - added sorting for status transitions by status category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ---
 
+## What's new in 3.8.7
+
+### Bug Fixes
+
+- Added sorting for status transitions based on their workflow order
+
 ## What's new in 3.8.6
 
 ### Features

--- a/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
+++ b/src/webviews/components/issue/view-issue-screen/sidebar/StatusTransitionMenu.tsx
@@ -8,6 +8,23 @@ import React from 'react';
 
 import { colorToLozengeAppearanceMap } from '../../../colors';
 
+const statusCategoryOrder: Record<string, number> = {
+    new: 1,
+    indeterminate: 2,
+    done: 3,
+};
+
+// Sort transitions by status category (new → indeterminate → done)
+const sortTransitionsByStatusCategory = (transitions: Transition[]): Transition[] =>
+    [...transitions].sort((a, b) => {
+        const aOrder = statusCategoryOrder[a.to.statusCategory.key] ?? transitions.length;
+        const bOrder = statusCategoryOrder[b.to.statusCategory.key] ?? transitions.length;
+        if (aOrder !== bOrder) {
+            return aOrder - bOrder;
+        }
+        return parseInt(a.to.id) - parseInt(b.to.id);
+    });
+
 const StatusOption = (data: Transition) => (
     <Box>
         <Lozenge appearance={colorToLozengeAppearanceMap[data.to.statusCategory.colorName]}>{data.to.name}</Lozenge>
@@ -33,7 +50,9 @@ export const StatusTransitionMenu: React.FC<Props> = (props) => {
     const [isOpen, setIsOpen] = React.useState(false);
 
     const { border, background } = getDynamicStyles(props.currentStatus.statusCategory.colorName);
+    const transitionsSortedByCategory = sortTransitionsByStatusCategory(props.transitions);
     const shouldShowTransitionName = props.transitions.some((t) => t.name !== t.to.name);
+
     return (
         <Box
             style={{
@@ -79,7 +98,7 @@ export const StatusTransitionMenu: React.FC<Props> = (props) => {
                         border: '1px solid var(--vscode-list-focusOutline)',
                     }}
                 >
-                    {props.transitions.map((t) => (
+                    {transitionsSortedByCategory.map((t) => (
                         <DropdownItem
                             key={t.id}
                             css={{


### PR DESCRIPTION
### What Is This Change?

**Issue**:
The problem was that status transitions received from the API were not always in the correct sequence. 
Custom statuses/columns were ordered by their date of addition, with the most recent appearing first, followed by default statuses in the correct order.

**Solution**:
Added sorting for statuses based on their workflow order. 
After considering a couple of options (as detailed in the ticket), settled on this approach, which seems optimal: sorting first by status category (`statusCategory.key`). 
There are three global categories: `new` ("To Do"), `indeterminate` ("In Progress"), and `done` ("Done") that appear consistent across different boards and workflows. 
Within each category, statuses are further sorted by their `id`.

**Screenshots**:
_Before_:
<img width="408" height="444" alt="Screenshot 2025-07-14 at 11 30 27" src="https://github.com/user-attachments/assets/8a5f9b06-e828-418e-ae34-8f76d3739b2b" />
<img width="401" height="474" alt="Screenshot 2025-07-14 at 11 31 24" src="https://github.com/user-attachments/assets/c57eeb1c-19a7-4385-b9d3-86a469567409" />

_After_:
<img width="399" height="437" alt="Screenshot 2025-07-13 at 23 17 59" src="https://github.com/user-attachments/assets/402e7653-956c-43d4-abe7-d592f1cd717e" />
<img width="422" height="438" alt="Screenshot 2025-07-13 at 23 17 19" src="https://github.com/user-attachments/assets/3e8af862-c423-489c-b6c8-0596f0e101d4" />


### How Has This Been Tested?

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change