### PR TITLE
AXON-298: x button for priority is useless

### DIFF
--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -201,6 +201,11 @@ export abstract class AbstractIssueEditorPage<
     }
 
     protected isClearableSelect = (field: SelectFieldUI): boolean => {
+        // AXON-298 Never allow clearing priority field
+        if (field.key === 'priority') {
+            return false;
+        }
+
         if (!field.required) {
             return true;
         }


### PR DESCRIPTION
### What Is This Change?
Click the "X" button for priority is useless and causes an error. This button does not exist in the cloud version. We can only change the priority, not remove it.

### Before
<img width="389" height="469" alt="axon-298-before" src="https://github.com/user-attachments/assets/92f596a0-9ee9-4b58-8141-9add60e91715" />

### After
<img width="392" height="475" alt="axon-298-after" src="https://github.com/user-attachments/assets/da7d216e-193e-4f9f-b0e2-06c647cb8339" />


### How Has This Been Tested?

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change