### PR TITLE
[AXON-574][Rovo Dev] Detect error mid-response and provide a 'Try again' button

### DIFF
--- a/src/react/atlascode/rovo-dev/common.tsx
+++ b/src/react/atlascode/rovo-dev/common.tsx
@@ -14,6 +14,7 @@ import { RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderM
 import {
     agentMessageStyles,
     chatMessageStyles,
+    errorMessageStyles,
     inlineMofidyButtonStyles,
     messageContentStyles,
     toolCallArgsStyles,
@@ -25,6 +26,7 @@ import {
     ChatMessage,
     CodeSnippetToChange,
     DefaultMessage,
+    ErrorMessage,
     parseToolReturnMessage,
     TechnicalPlan,
     TechnicalPlanFileToChange,
@@ -157,44 +159,17 @@ const ToolReturnParsedItem: React.FC<{
 
 const ChatMessageItem: React.FC<{
     msg: DefaultMessage;
-    index?: number;
-    openFile: OpenFileFunc;
-}> = ({ msg, index, openFile }) => {
-    const messageTypeStyles = msg.author.toLowerCase() === 'user' ? userMessageStyles : agentMessageStyles;
+    index: number;
+}> = ({ msg, index }) => {
+    const messageTypeStyles = msg.source === 'User' ? userMessageStyles : agentMessageStyles;
 
-    const text = msg.text || '';
-
-    const parts = text.trim().split(/(<TOOL_RETURN>.*<\/TOOL_RETURN>)/g);
-    const content = parts.flatMap((part) => {
-        try {
-            if (part.match(/^<TOOL_RETURN>.*<\/TOOL_RETURN>$/)) {
-                const toolReturnContent = part
-                    .replace(/^<TOOL_RETURN>/, '')
-                    .replace(/<\/TOOL_RETURN>$/, '')
-                    .trim();
-
-                const toolReturnMessage: ToolReturnGenericMessage = JSON.parse(toolReturnContent);
-                console.log('Parsed Tool Return Message:', toolReturnMessage);
-                const parsedMessages = parseToolReturnMessage(toolReturnMessage);
-                return parsedMessages.map((message, idx) => (
-                    <ToolReturnParsedItem key={idx} msg={message} openFile={openFile} />
-                ));
-            } else {
-                const htmlContent = md.render(part);
-
-                return (
-                    <div
-                        style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
-                        key="parsed-content"
-                        dangerouslySetInnerHTML={{ __html: htmlContent }}
-                    />
-                );
-            }
-        } catch (error) {
-            console.error('Error parsing message content:', error);
-            return <div key="error-content">Error parsing content</div>;
-        }
-    });
+    const content = (
+        <div
+            style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
+            key="parsed-content"
+            dangerouslySetInnerHTML={{ __html: md.render(msg.text || '') }}
+        />
+    );
 
     return (
         <div key={index} style={{ ...chatMessageStyles, ...messageTypeStyles }}>
@@ -203,13 +178,55 @@ const ChatMessageItem: React.FC<{
     );
 };
 
+const ErrorMessageItem: React.FC<{
+    msg: ErrorMessage;
+    index: number;
+    isRetryAfterErrorButtonEnabled: (uid: string) => boolean;
+    retryAfterError: () => void;
+}> = ({ msg, index, isRetryAfterErrorButtonEnabled, retryAfterError }) => {
+    const content = (
+        <div
+            style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
+            key="parsed-content"
+            dangerouslySetInnerHTML={{ __html: md.render(msg.text || '') }}
+        />
+    );
+
+    return (
+        <div key={index} style={{ ...chatMessageStyles, ...errorMessageStyles }}>
+            <div style={messageContentStyles}>{content}</div>
+            {msg.retriable && (
+                <RetryPromptButton
+                    enabled={isRetryAfterErrorButtonEnabled(msg.uid)}
+                    retryAfterError={retryAfterError}
+                />
+            )}
+        </div>
+    );
+};
+
+const RetryPromptButton: React.FC<{
+    enabled: boolean;
+    retryAfterError: () => void;
+}> = ({ enabled, retryAfterError }) => {
+    return (
+        <div style={{ marginTop: '12px' }}>
+            <button disabled={!enabled} onClick={retryAfterError}>
+                Try again
+            </button>
+        </div>
+    );
+};
+
 export const renderChatHistory = (
     msg: ChatMessage,
     index: number,
     openFile: OpenFileFunc,
+    isRetryAfterErrorButtonEnabled: (uid: string) => boolean,
+    retryAfterError: () => void,
     getText: (fp: string, lr?: number[]) => Promise<string>,
 ) => {
-    switch (msg.author) {
+    switch (msg.source) {
         case 'ToolReturn':
             const parsedMessages = parseToolReturnMessage(msg);
             return parsedMessages.map((message) => {
@@ -225,9 +242,18 @@ export const renderChatHistory = (
                 }
                 return <ToolReturnParsedItem key={index} msg={message} openFile={openFile} />;
             });
+        case 'RovoDevError':
+            return (
+                <ErrorMessageItem
+                    index={index}
+                    msg={msg}
+                    isRetryAfterErrorButtonEnabled={isRetryAfterErrorButtonEnabled}
+                    retryAfterError={retryAfterError}
+                />
+            );
         case 'RovoDev':
         case 'User':
-            return <ChatMessageItem index={index} msg={msg} openFile={openFile} />;
+            return <ChatMessageItem index={index} msg={msg} />;
         default:
             return <div key={index}>Unknown message type</div>;
     }

--- a/src/react/atlascode/rovo-dev/common.tsx
+++ b/src/react/atlascode/rovo-dev/common.tsx
@@ -195,7 +195,7 @@ const ErrorMessageItem: React.FC<{
     return (
         <div key={index} style={{ ...chatMessageStyles, ...errorMessageStyles }}>
             <div style={messageContentStyles}>{content}</div>
-            {msg.retriable && (
+            {msg.isRetriable && (
                 <RetryPromptButton
                     enabled={isRetryAfterErrorButtonEnabled(msg.uid)}
                     retryAfterError={retryAfterError}

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -8,6 +8,7 @@ import { highlightElement } from '@speed-highlight/core';
 import { detectLanguage } from '@speed-highlight/core/detect';
 import { useCallback, useState } from 'react';
 import * as React from 'react';
+import { v4 } from 'uuid';
 
 import { RovoDevResponse } from '../../../rovo-dev/responseParser';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from '../../../rovo-dev/rovoDevWebviewProviderMessages';
@@ -17,6 +18,7 @@ import { RovoDevViewResponse, RovoDevViewResponseType } from './rovoDevViewMessa
 import * as styles from './rovoDevViewStyles';
 import {
     ChatMessage,
+    ErrorMessage,
     isCodeChangeTool,
     parseToolReturnMessage,
     ToolCallMessage,
@@ -44,8 +46,7 @@ const RovoDevView: React.FC = () => {
     const [promptText, setPromptText] = useState('');
     const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
     const [pendingToolCall, setPendingToolCall] = useState<ToolCallMessage | null>(null);
-
-    // const [currentTools, setCurrentTools] = useState<ToolReturnGenericMessage[]>([]);
+    const [retryAfterErrorEnabled, setRetryAfterErrorEnabled] = useState('');
     const [totalModifiedFiles, setTotalModifiedFiles] = useState<ToolReturnParseResult[]>([]);
 
     const chatEndRef = React.useRef<HTMLDivElement>(null);
@@ -61,17 +62,18 @@ const RovoDevView: React.FC = () => {
     const appendCurrentResponse = useCallback(
         (text: string) => {
             if (text) {
+                setRetryAfterErrorEnabled('');
                 setChatHistory((prev) => {
                     let message = prev.pop();
 
-                    if (!message || message.author !== 'RovoDev') {
+                    if (!message || message.source !== 'RovoDev') {
                         if (message) {
                             prev.push(message);
                         }
 
                         message = {
                             text,
-                            author: 'RovoDev',
+                            source: 'RovoDev',
                         };
                     } else if (message.text === '...') {
                         message.text = text;
@@ -83,21 +85,48 @@ const RovoDevView: React.FC = () => {
                 });
             }
         },
-        [setChatHistory],
+        [setChatHistory, setRetryAfterErrorEnabled],
     );
 
     const handleAppendChatHistory = useCallback(
         (msg: ChatMessage) => {
             setChatHistory((prev) => {
+                if (msg.source === 'RovoDevError' && msg.retriable) {
+                    setRetryAfterErrorEnabled(msg.uid);
+                } else {
+                    setRetryAfterErrorEnabled('');
+                }
+
                 const last = prev[prev.length - 1];
-                if (last?.author === 'RovoDev' && last.text === '...') {
+                if (last?.source === 'RovoDev' && last.text === '...') {
                     prev.pop();
                 }
                 return [...prev, msg];
             });
         },
-        [setChatHistory],
+        [setChatHistory, setRetryAfterErrorEnabled],
     );
+
+    const validateResponseFinalized = useCallback(() => {
+        // setChatHistory here is used to ensure we are accessing the most up-to-date state
+        // if we use setHistory, we would not
+        setChatHistory((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.source === 'RovoDev' && last.text === '...') {
+                const msg: ErrorMessage = {
+                    source: 'RovoDevError',
+                    text: 'Error: something went wrong while processing the prompt',
+                    retriable: true,
+                    uid: v4(),
+                };
+                setRetryAfterErrorEnabled(msg.uid);
+                prev.pop();
+                return [...prev, msg];
+            } else {
+                return prev;
+            }
+        });
+    }, [setChatHistory, setRetryAfterErrorEnabled]);
 
     const clearChatHistory = useCallback(() => setChatHistory([]), [setChatHistory]);
 
@@ -133,7 +162,7 @@ const RovoDevView: React.FC = () => {
 
                 case 'tool-call':
                     const callMessage: ToolCallMessage = {
-                        author: 'ToolCall',
+                        source: 'ToolCall',
                         tool_name: data.tool_name,
                         args: data.args,
                         tool_call_id: data.tool_call_id, // Optional ID for tracking
@@ -146,7 +175,7 @@ const RovoDevView: React.FC = () => {
                         data.tool_call_id === pendingToolCall?.tool_call_id ? pendingToolCall?.args : undefined;
 
                     const returnMessage: ToolReturnGenericMessage = {
-                        author: 'ToolReturn',
+                        source: 'ToolReturn',
                         tool_name: data.tool_name,
                         content: data.content || '',
                         tool_call_id: data.tool_call_id, // Optional ID for tracking
@@ -187,6 +216,7 @@ const RovoDevView: React.FC = () => {
                     setSendButtonDisabled(false);
                     setCurrentState(State.WaitingForPrompt);
                     setPendingToolCall(null);
+                    validateResponseFinalized();
                     break;
 
                 case RovoDevProviderMessageType.ToolCall:
@@ -221,19 +251,22 @@ const RovoDevView: React.FC = () => {
 
                 default:
                     handleAppendChatHistory({
-                        author: 'RovoDev',
+                        source: 'RovoDevError',
                         text: `Unknown message type: ${event.type}`,
+                        retriable: false,
+                        uid: v4(),
                     });
                     break;
             }
         },
         [
+            currentState,
             handleResponse,
             handleAppendChatHistory,
-            currentState,
             setCurrentState,
             appendCurrentResponse,
             clearChatHistory,
+            validateResponseFinalized,
         ],
     );
 
@@ -262,6 +295,16 @@ const RovoDevView: React.FC = () => {
         },
         [postMessage, sendButtonDisabled, setSendButtonDisabled, currentState, setCurrentState],
     );
+
+    const retryPromptAfterError = useCallback((): void => {
+        // Disable the send button, and enable the pause button
+        setSendButtonDisabled(true);
+        setCurrentState(State.GeneratingResponse);
+
+        postMessage({
+            type: RovoDevViewResponseType.RetryPromptAfterError,
+        });
+    }, [postMessage]);
 
     const cancelResponse = useCallback((): void => {
         if (currentState === State.CancellingResponse) {
@@ -341,10 +384,24 @@ const RovoDevView: React.FC = () => {
         [postMessageWithReturn],
     );
 
+    const isRetryAfterErrorButtonEnabled = useCallback(
+        (uid: string) => retryAfterErrorEnabled === uid,
+        [retryAfterErrorEnabled],
+    );
+
     return (
         <div className="rovoDevChat" style={styles.rovoDevContainerStyles}>
             <div style={styles.chatMessagesContainerStyles}>
-                {chatHistory.map((msg, index) => renderChatHistory(msg, index, openFile, getOriginalText))}
+                {chatHistory.map((msg, index) =>
+                    renderChatHistory(
+                        msg,
+                        index,
+                        openFile,
+                        isRetryAfterErrorButtonEnabled,
+                        retryPromptAfterError,
+                        getOriginalText,
+                    ),
+                )}
                 {pendingToolCall && <ToolCallItem msg={pendingToolCall} />}
                 <div ref={chatEndRef} />
             </div>

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -91,7 +91,7 @@ const RovoDevView: React.FC = () => {
     const handleAppendChatHistory = useCallback(
         (msg: ChatMessage) => {
             setChatHistory((prev) => {
-                if (msg.source === 'RovoDevError' && msg.retriable) {
+                if (msg.source === 'RovoDevError' && msg.isRetriable) {
                     setRetryAfterErrorEnabled(msg.uid);
                 } else {
                     setRetryAfterErrorEnabled('');
@@ -116,7 +116,7 @@ const RovoDevView: React.FC = () => {
                 const msg: ErrorMessage = {
                     source: 'RovoDevError',
                     text: 'Error: something went wrong while processing the prompt',
-                    retriable: true,
+                    isRetriable: true,
                     uid: v4(),
                 };
                 setRetryAfterErrorEnabled(msg.uid);
@@ -253,7 +253,7 @@ const RovoDevView: React.FC = () => {
                     handleAppendChatHistory({
                         source: 'RovoDevError',
                         text: `Unknown message type: ${event.type}`,
-                        retriable: false,
+                        isRetriable: false,
                         uid: v4(),
                     });
                     break;

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -8,6 +8,7 @@ export const enum RovoDevViewResponseType {
     KeepFileChanges = 'keepFileChanges',
     GetOriginalText = 'getOriginalText',
     CreatePR = 'createPR',
+    RetryPromptAfterError = 'retryPromptAfterError',
 }
 
 export type RovoDevViewResponse =
@@ -17,4 +18,5 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.UndoFileChanges, { filePaths: string[] }>
     | ReducerAction<RovoDevViewResponseType.KeepFileChanges, { filePaths: string[] }>
     | ReducerAction<RovoDevViewResponseType.GetOriginalText, { filePath: string; range?: number[]; requestId: string }>
+    | ReducerAction<RovoDevViewResponseType.RetryPromptAfterError>
     | ReducerAction<RovoDevViewResponseType.CreatePR>;

--- a/src/react/atlascode/rovo-dev/rovoDevViewStyles.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewStyles.tsx
@@ -87,6 +87,14 @@ export const agentMessageStyles: React.CSSProperties = {
     borderBottomLeftRadius: '0px',
 };
 
+export const errorMessageStyles: React.CSSProperties = {
+    backgroundColor: 'var(--vscode-sideBar-background)',
+    alignSelf: 'flex-start',
+    width: '100%',
+    border: 'red solid 1px',
+    borderBottomLeftRadius: '8px',
+};
+
 export const messageHeaderStyles: React.CSSProperties = {
     display: 'flex',
     justifyContent: 'space-between',

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -1,22 +1,33 @@
 export type ToolReturnMessage = ToolReturnFileMessage | ToolReturnBashMessage | ToolReturnTechnicalPlanMessage;
-export type ChatMessage = DefaultMessage | ToolCallMessage | ToolReturnGenericMessage | ToolReturnGroupedMessage;
-export type ErrorMessage = DefaultMessage;
+export type ChatMessage =
+    | DefaultMessage
+    | ErrorMessage
+    | ToolCallMessage
+    | ToolReturnGenericMessage
+    | ToolReturnGroupedMessage;
 
 export interface DefaultMessage {
     text: string;
-    author: 'User' | 'RovoDev';
+    source: 'User' | 'RovoDev';
+}
+
+export interface ErrorMessage {
+    text: string;
+    source: 'RovoDevError';
+    retriable: boolean;
+    uid: string;
 }
 
 export interface ToolCallMessage {
     tool_name: string;
-    author: 'ToolCall';
+    source: 'ToolCall';
     args: string;
     tool_call_id: string; // Optional ID for tracking tool calls
 }
 
 export interface ToolReturnFileMessage {
     tool_name: 'expand_code_chunks' | 'find_and_replace_code' | 'open_files' | 'create_file' | 'delete_file';
-    author: 'ToolReturn';
+    source: 'ToolReturn';
     content: string;
     tool_call_id: string;
     args?: string;
@@ -24,14 +35,14 @@ export interface ToolReturnFileMessage {
 
 export interface ToolReturnBashMessage {
     tool_name: 'bash';
-    author: 'ToolReturn';
+    source: 'ToolReturn';
     tool_call_id: string;
     args?: string;
 }
 
 export interface ToolReturnTechnicalPlanMessage {
     tool_name: 'create_technical_plan';
-    author: 'ToolReturn';
+    source: 'ToolReturn';
     content: string; // JSON string representing the technical plan
     tool_call_id: string;
     args?: string;
@@ -39,14 +50,14 @@ export interface ToolReturnTechnicalPlanMessage {
 
 export interface ToolReturnGenericMessage {
     tool_name: string;
-    author: 'ToolReturn' | 'ModifiedFile';
+    source: 'ToolReturn' | 'ModifiedFile';
     content?: any;
     tool_call_id: string;
     args?: string;
 }
 
 export interface ToolReturnGroupedMessage {
-    author: 'ReturnGroup';
+    source: 'ReturnGroup';
     tool_returns: ToolReturnGenericMessage[];
 }
 

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -14,7 +14,7 @@ export interface DefaultMessage {
 export interface ErrorMessage {
     text: string;
     source: 'RovoDevError';
-    retriable: boolean;
+    isRetriable: boolean;
     uid: string;
 }
 

--- a/src/rovo-dev/rovoDevApiClient.test.ts
+++ b/src/rovo-dev/rovoDevApiClient.test.ts
@@ -107,9 +107,10 @@ describe('RovoDevApiClient', () => {
 
     describe('cancel method', () => {
         it('should return true when cancellation is successful', async () => {
+            const mockResponseObject = { message: 'message', cancelled: true };
             const mockResponse = {
                 status: 200,
-                json: jest.fn().mockResolvedValue({ cancelled: true }),
+                json: jest.fn().mockResolvedValue(mockResponseObject),
             } as unknown as Response;
 
             mockFetch.mockResolvedValue(mockResponse);
@@ -124,20 +125,22 @@ describe('RovoDevApiClient', () => {
                 },
                 body: undefined,
             });
-            expect(result).toBe(true);
+
+            expect(result).toEqual(mockResponseObject);
         });
 
         it('should return false when cancellation fails', async () => {
+            const mockResponseObject = { message: 'failure message', cancelled: false };
             const mockResponse = {
                 status: 200,
-                json: jest.fn().mockResolvedValue({ cancelled: false }),
+                json: jest.fn().mockResolvedValue(mockResponseObject),
             } as unknown as Response;
 
             mockFetch.mockResolvedValue(mockResponse);
 
             const result = await client.cancel();
 
-            expect(result).toBe(false);
+            expect(result).toEqual(mockResponseObject);
         });
 
         it('should throw error when API call fails', async () => {

--- a/src/rovo-dev/rovoDevApiClient.ts
+++ b/src/rovo-dev/rovoDevApiClient.ts
@@ -17,6 +17,11 @@ export interface RovoDevHealthcheckResponse {
     version: string;
 }
 
+export interface RovoDevCancelResponse {
+    message: string;
+    cancelled: boolean;
+}
+
 /** Implements the http client for the RovoDev CLI server */
 export class RovoDevApiClient {
     private readonly _baseApiUrl: string;
@@ -57,12 +62,11 @@ export class RovoDevApiClient {
     }
 
     /** Invokes the POST /v2/cancel rest API
-     * @returns A value indicating if the cancellation request was processed correctly.
+     * @returns An object representing the API response
      */
-    public async cancel(): Promise<boolean> {
+    public async cancel(): Promise<RovoDevCancelResponse> {
         const response = await this.fetchApi('/v2/cancel', 'POST');
-        const data = await response.json();
-        return data.cancelled;
+        return await response.json();
     }
 
     /** Invokes the POST /v2/reset rest API */
@@ -129,7 +133,7 @@ export class RovoDevApiClient {
     }
 
     /** Invokes the GET /healthcheck rest API
-     * @returns A value indicating if the service is healthy.
+     * @returns A value indicating if the service is healthy
      */
     public async healthcheck(): Promise<boolean> {
         try {

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -256,14 +256,14 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         });
     }
 
-    private processError(error: Error, retriable: boolean) {
+    private processError(error: Error, isRetriable: boolean) {
         const webview = this._webView!;
         return webview.postMessage({
             type: RovoDevProviderMessageType.ErrorMessage,
             message: {
                 text: `Error: ${error.message}`,
                 source: 'RovoDevError',
-                retriable,
+                isRetriable,
                 uid: v4(),
             },
         });

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import path from 'path';
 import { gte as semver_gte } from 'semver';
 import { setTimeout } from 'timers/promises';
+import { v4 } from 'uuid';
 import {
     CancellationToken,
     commands,
@@ -41,6 +42,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private _rovoDevApiClient?: RovoDevApiClient;
     private _initialized = false;
 
+    private _previousPrompt: string | undefined;
     private _pendingPrompt: string | undefined;
     private _pendingCancellation = false;
 
@@ -173,6 +175,11 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                 case RovoDevViewResponseType.CreatePR:
                     await this.createPR();
                     break;
+
+                case RovoDevViewResponseType.RetryPromptAfterError:
+                    this._pendingCancellation = false;
+                    await this.executeRetryPromptAfterError();
+                    break;
             }
         });
 
@@ -186,6 +193,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         new Error(
                             `Rovo Dev version (${version}) is out of date. Please update Rovo Dev and try again.\nMin version compatible: ${MIN_SUPPORTED_ROVODEV_VERSION}`,
                         ),
+                        false,
                     );
                 }
             } else {
@@ -193,7 +201,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                     ? `Unable to initialize RovoDev at "${this._rovoDevApiClient.baseApiUrl}". Service wasn't ready within 10000ms`
                     : `Unable to initialize RovoDev's client within 10000ms`;
 
-                this.processError(new Error(errorMsg));
+                this.processError(new Error(errorMsg), false);
             }
 
             // sets this flag regardless are we are not going to retry the replay anymore
@@ -220,16 +228,12 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
-
         const parser = new RovoDevResponseParser();
-
-        let messagesSent = 0;
 
         while (true) {
             const { done, value } = await reader.read();
             if (done) {
                 for (const msg of parser.flush()) {
-                    ++messagesSent;
                     await this.processRovoDevResponse(msg);
                 }
                 break;
@@ -237,15 +241,12 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
             const data = decoder.decode(value, { stream: true });
             for (const msg of parser.parse(data)) {
-                ++messagesSent;
                 await this.processRovoDevResponse(msg);
             }
         }
 
-        if (messagesSent) {
-            // Send final complete message when stream ends
-            this.completeChatResponse();
-        }
+        // Send final complete message when stream ends
+        await this.completeChatResponse();
     }
 
     private completeChatResponse() {
@@ -255,13 +256,15 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         });
     }
 
-    private processError(error: Error) {
+    private processError(error: Error, retriable: boolean) {
         const webview = this._webView!;
         return webview.postMessage({
             type: RovoDevProviderMessageType.ErrorMessage,
             message: {
                 text: `Error: ${error.message}`,
-                author: 'RovoDev',
+                source: 'RovoDevError',
+                retriable,
+                uid: v4(),
             },
         });
     }
@@ -273,7 +276,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             type: RovoDevProviderMessageType.UserChatMessage,
             message: {
                 text: message,
-                author: 'User',
+                source: 'User',
             },
         });
 
@@ -308,6 +311,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             case 'user-prompt':
                 // receiving a user-prompt pre-initialized means we are in the 'replay' response
                 if (!this._initialized) {
+                    this._previousPrompt = response.content;
                     return this.sendUserPromptToView(response.content);
                 }
                 return Promise.resolve(false);
@@ -332,6 +336,12 @@ ${message}`;
         }
     }
 
+    private addRetryAfterErrorContextToPrompt(message: string): string {
+        return `<context>The previous response interrupted prematurely because of an error. Continue processing the previous prompt from the point where it was interrupted.
+    <previous_prompt>${message}</previous_prompt>
+</context>`;
+    }
+
     private async executeChat(message: string, suppressEcho?: boolean) {
         if (!message) {
             return;
@@ -341,6 +351,7 @@ ${message}`;
             await this.sendUserPromptToView(message);
         }
 
+        this._previousPrompt = message;
         const payloadToSend = this.addUndoContextToPrompt(message);
 
         if (this._initialized) {
@@ -350,6 +361,24 @@ ${message}`;
         } else {
             this._pendingPrompt = payloadToSend;
         }
+    }
+
+    private async executeRetryPromptAfterError() {
+        const webview = this._webView!;
+
+        if (!this._initialized || !this._previousPrompt) {
+            return;
+        }
+
+        const payloadToSend = this.addRetryAfterErrorContextToPrompt(this._previousPrompt);
+
+        await webview.postMessage({
+            type: RovoDevProviderMessageType.PromptSent,
+        });
+
+        await this.executeApiWithErrorHandling((client) => {
+            return this.processChatResponse(client.chat(payloadToSend));
+        }, true);
     }
 
     async executeReset(): Promise<void> {
@@ -368,17 +397,17 @@ ${message}`;
     private async executeCancel(): Promise<boolean> {
         const webview = this._webView!;
 
-        const success = await this.executeApiWithErrorHandling(async (client) => {
+        const cancelResponse = await this.executeApiWithErrorHandling(async (client) => {
             return await client.cancel();
         });
 
-        if (!success) {
+        if (cancelResponse && (cancelResponse.cancelled || cancelResponse.message === 'No chat in progress')) {
+            return true;
+        } else {
             await webview.postMessage({
                 type: RovoDevProviderMessageType.CancelFailed,
             });
             return false;
-        } else {
-            return true;
         }
     }
 
@@ -477,8 +506,7 @@ ${message}`;
         try {
             await this._prHandler.createPR();
         } catch (e) {
-            console.error('Error creating PR:', e);
-            await this.processError(e as Error);
+            await this.processError(e, false);
         } finally {
             const webview = this._webView!;
             await webview.postMessage({
@@ -499,11 +527,11 @@ ${message}`;
                     this._pendingCancellation = false;
                     this.completeChatResponse();
                 } else {
-                    await this.processError(error);
+                    await this.processError(error, true);
                 }
             }
         } else {
-            await this.processError(new Error('RovoDev client not initialized'));
+            await this.processError(new Error('RovoDev client not initialized'), false);
         }
     }
 


### PR DESCRIPTION
### What Is This Change?

First iteration of the error-handling scenario.

This PR implements the UI for displaying an error message in the chat, which is displayed every time the provider sends an 'error' to the view.

The error can be [retriable](https://english.stackexchange.com/questions/305273/retriable-or-retryable) or not, which will determine if the `Try again` button will be rendered or not:
<img width="365" height="613" alt="image" src="https://github.com/user-attachments/assets/264acfc8-1617-4aa8-88af-d93ed9bc7146" />

Trying again creates a new prompt where we tell the agent that the previous response was interrupted unexpectedly due to an error, we remind the agent what the previous prompt was, and we ask the agent to continue from where it was interrupted.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`