### PR TITLE
Addressed the bug found in jiraIssueWebview for currentUser reset

### DIFF
--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -140,7 +140,7 @@ export class JiraIssueWebview
             //     currentBranches.find(b => b.toLowerCase().indexOf(issue.key.toLowerCase()) !== -1) !== undefined;
 
             this._editUIData.recentPullRequests = [];
-            this._editUIData.currentUser = emptyUser;
+            //this._editUIData.currentUser = emptyUser;
 
             const msg = this._editUIData;
 

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -127,20 +127,9 @@ export class JiraIssueWebview
                 this._panel.title = `${this._issue.key}`;
             }
 
-            // const currentBranches = Container.bitbucketContext ?
-            //     Container.bitbucketContext.getAllRepositores()
-            //         .filter(repo => repo.state.HEAD && repo.state.HEAD.name)
-            //         .map(repo => repo.state.HEAD!.name!)
-            //     : [];
-
             this._editUIData = editUI as EditIssueData;
 
-            // msg.workInProgress = this._issue.assignee.accountId === this._currentUserId &&
-            //     issue.transitions.find(t => t.isInitial && t.to.id === issue.status.id) === undefined &&
-            //     currentBranches.find(b => b.toLowerCase().indexOf(issue.key.toLowerCase()) !== -1) !== undefined;
-
             this._editUIData.recentPullRequests = [];
-            //this._editUIData.currentUser = emptyUser;
 
             const msg = this._editUIData;
 
@@ -148,7 +137,6 @@ export class JiraIssueWebview
 
             this.postMessage(msg);
 
-            // call async-able update functions here
             this.updateEpicChildren();
             this.updateCurrentUser();
             this.updateWatchers();

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -137,6 +137,7 @@ export class JiraIssueWebview
 
             this.postMessage(msg);
 
+            // call async-able update functions here
             this.updateEpicChildren();
             this.updateCurrentUser();
             this.updateWatchers();


### PR DESCRIPTION
Looked to see if it affected votes, watchers, or avatarUrl on page but it did not. Now the user is not reset and the url to the image should not disappear.

### What Is This Change?
- Address the bug where the currentUser would be reset to undefined when we navigate to and from a user.

<img width="713" height="753" alt="Screenshot 2025-07-14 at 3 43 00 PM" src="https://github.com/user-attachments/assets/bacddf7a-5f55-4b10-abb2-163f905e0a82" />
The currentUser would reset make the user undefined and have no avatarURL after navigating back to the issue. Now we do we not have this reset.


### How Has This Been Tested?
- No particular test but now the image does not reset upon reloading of the user.
- This particular value is not used to fetch any data anywhere else in jiraIssueWebview.ts

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change