### PR TITLE
Axon 615 jql custom queries not loading all issues

### DIFF
--- a/src/jira/issuesForJql.ts
+++ b/src/jira/issuesForJql.ts
@@ -21,6 +21,6 @@ export async function issuesForJQL(jql: string, site: DetailedSiteInfo): Promise
         index += searchResults.issues.length;
         issues = issues.concat(searchResults.issues);
         total = searchResults.total;
-    } while (index < total); // Deleted Container.config.jira.explorer.fetchAllQueryResults because it is never called or set anywhere in the code
+    } while (index < total);
     return issues;
 }

--- a/src/jira/issuesForJql.ts
+++ b/src/jira/issuesForJql.ts
@@ -21,6 +21,6 @@ export async function issuesForJQL(jql: string, site: DetailedSiteInfo): Promise
         index += searchResults.issues.length;
         issues = issues.concat(searchResults.issues);
         total = searchResults.total;
-    } while (Container.config.jira.explorer.fetchAllQueryResults && index < total);
+    } while (index < total); // Deleted Container.config.jira.explorer.fetchAllQueryResults because it is never called or set anywhere in the code
     return issues;
 }


### PR DESCRIPTION
### What Is This Change?

- The change has to do with [AXON-615](https://softwareteams.atlassian.net/jira/software/projects/AXON/boards/881?jql=assignee%20%3D%20712020%3Ac3b92f4c-9d55-4280-9337-481143c3d727&selectedIssue=AXON-615). The pervious iteration of Custom JQL filters was calling dead code that stop fetching the issues related to the query after 100 issues. I removed that dead code as the information was not called anywhere else in the codebase and should now fetch all the issues related to the custom query.

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
This is the before with a given query for team AXON:
<img width="614" height="993" alt="Screenshot 2025-07-15 at 11 33 08 AM" src="https://github.com/user-attachments/assets/3765959a-2317-4027-a538-546297f0e4f8" />

This is the after with the same query:
<img width="614" height="1108" alt="Screenshot 2025-07-15 at 11 35 06 AM" src="https://github.com/user-attachments/assets/40953bd6-a934-4414-8919-84f2bc211431" />


### How Has This Been Tested?
- I was using the developer tools in the VSCode extension with breakpoints to analyze the incoming data and noticed that despite there being more issues available, the code exited out prematurely. No specific testing was done as the removed code was not called anywhere so I could not reference why it was used.

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change

[AXON-615]: https://softwareteams.atlassian.net/browse/AXON-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ