### PR TITLE
Axon 297 epics do not show child issues

### DIFF
--- a/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
+++ b/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
@@ -543,6 +543,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     linkTypes={this.state.selectFieldOptions['issuelinks']}
                     isEpic={this.state.isEpic}
                     epicChildren={this.state.epicChildren}
+                    epicChildrenTypes={this.state.selectFieldOptions['issuetype']}
                     handleInlineEdit={this.handleInlineEdit}
                     handleOpenIssue={this.handleOpenIssue}
                     onFetchIssues={async (input: string) =>

--- a/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
+++ b/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
@@ -542,6 +542,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     subtaskTypes={this.state.selectFieldOptions['subtasks']}
                     linkTypes={this.state.selectFieldOptions['issuelinks']}
                     isEpic={this.state.isEpic}
+                    epicChildren={this.state.epicChildren}
                     handleInlineEdit={this.handleInlineEdit}
                     handleOpenIssue={this.handleOpenIssue}
                     onFetchIssues={async (input: string) =>

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/IssueMainPanel.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/IssueMainPanel.tsx
@@ -25,6 +25,7 @@ type Props = {
     onDeleteAttachment: (attachment: any) => void;
     loadingField?: string;
     isEpic: boolean;
+    epicChildren?: any[];
     handleInlineEdit: (field: FieldUI, edit: any) => void;
     subtaskTypes: IssueType[];
     linkTypes: IssueLinkTypeSelectOption[];
@@ -44,6 +45,7 @@ const IssueMainPanel: React.FC<Props> = ({
     onDeleteAttachment,
     loadingField,
     isEpic,
+    epicChildren,
     handleInlineEdit,
     subtaskTypes,
     linkTypes,
@@ -204,6 +206,19 @@ const IssueMainPanel: React.FC<Props> = ({
                         enableSubtasks={{ enable: enableSubtasks, setEnableSubtasks }}
                         handleOpenIssue={handleOpenIssue}
                         issues={subtasks}
+                    />
+                </div>
+            )}
+            {isEpic && epicChildren && epicChildren.length > 0 && (
+                <div>
+                    <ChildIssuesComponent
+                        subtaskTypes={subtaskTypes}
+                        label="Epic Child issues"
+                        loading={loadingField === 'subtasks'}
+                        onSave={(e: any) => handleInlineEdit(fields['subtasks'], e)}
+                        enableSubtasks={{ enable: enableSubtasks, setEnableSubtasks }}
+                        handleOpenIssue={handleOpenIssue}
+                        issues={epicChildren}
                     />
                 </div>
             )}

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/IssueMainPanel.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/IssueMainPanel.tsx
@@ -216,7 +216,7 @@ const IssueMainPanel: React.FC<Props> = ({
                         label="Epic Child issues"
                         loading={loadingField === 'subtasks'}
                         onSave={(e: any) => handleInlineEdit(fields['subtasks'], e)}
-                        enableSubtasks={{ enable: enableSubtasks, setEnableSubtasks }}
+                        enableSubtasks={{ enable: enableSubtasks, setEnableSubtasks }} // Change this for epics
                         handleOpenIssue={handleOpenIssue}
                         issues={epicChildren}
                     />

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/IssueMainPanel.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/IssueMainPanel.tsx
@@ -26,6 +26,7 @@ type Props = {
     loadingField?: string;
     isEpic: boolean;
     epicChildren?: any[];
+    epicChildrenTypes?: IssueType[];
     handleInlineEdit: (field: FieldUI, edit: any) => void;
     subtaskTypes: IssueType[];
     linkTypes: IssueLinkTypeSelectOption[];
@@ -46,6 +47,7 @@ const IssueMainPanel: React.FC<Props> = ({
     loadingField,
     isEpic,
     epicChildren,
+    epicChildrenTypes,
     handleInlineEdit,
     subtaskTypes,
     linkTypes,
@@ -212,7 +214,7 @@ const IssueMainPanel: React.FC<Props> = ({
             {isEpic && epicChildren && epicChildren.length > 0 && (
                 <div>
                     <ChildIssuesComponent
-                        subtaskTypes={subtaskTypes}
+                        subtaskTypes={!epicChildrenTypes ? [] : epicChildrenTypes} // This are not "subtasks" for epics but full issues
                         label="Epic Child issues"
                         loading={loadingField === 'subtasks'}
                         onSave={(e: any) => handleInlineEdit(fields['subtasks'], e)}

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -161,9 +161,9 @@ export class JiraIssueWebview
             this.isRefeshing = false;
         }
     }
-
+    // Progress on getting this function to work lol
     async updateEpicChildren() {
-        if (this._issue.isEpic) {
+        if (this._issue.issuetype.name === 'Epic') {
             const site = this._issue.siteDetails;
             const client = await Container.clientManager.jiraClient(site);
             const fields = await Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(site);

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -138,7 +138,10 @@ export class JiraIssueWebview
             // msg.workInProgress = this._issue.assignee.accountId === this._currentUserId &&
             //     issue.transitions.find(t => t.isInitial && t.to.id === issue.status.id) === undefined &&
             //     currentBranches.find(b => b.toLowerCase().indexOf(issue.key.toLowerCase()) !== -1) !== undefined;
-
+            if (this._issue.issuetype.name === 'Epic') {
+                this._issue.isEpic = true;
+                this._editUIData.isEpic = true;
+            }
             this._editUIData.recentPullRequests = [];
             this._editUIData.currentUser = emptyUser;
 
@@ -169,7 +172,7 @@ export class JiraIssueWebview
             const fields = await Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(site);
             const epicInfo = await Container.jiraSettingsManager.getEpicFieldsForSite(site);
             const res = await client.searchForIssuesUsingJqlGet(
-                `${epicInfo.epicLink.id} = "${this._issue.key}" order by lastViewed DESC`,
+                `parent = "${this._issue.key}" order by lastViewed DESC`,
                 fields,
             );
             const searchResults = await readSearchResults(res, site, epicInfo);


### PR DESCRIPTION
### What Is This Change?
- Made changes that affected the visibility and functionality of epic children for epic issues. There were not showing before on issues nor were there any options to receive them on the UI and now they are present and functional. One issues to point is that for any issues that we fetch from our APIs, the "isEpic", "epicName", and "epicLink" are depreciated return types and now return undefined. May need to address any points of the code later that call on these options (it is also mentioned in the CHANGELOG). 

Before the changes:
<img width="1369" height="1138" alt="Screenshot 2025-07-17 at 1 29 06 PM" src="https://github.com/user-attachments/assets/89c11e34-ebd7-4429-96fe-9ee6a9d93e06" />

After the changes:
<img width="1500" height="974" alt="Screenshot 2025-07-17 at 1 28 42 PM" src="https://github.com/user-attachments/assets/0667df52-2569-4259-9e71-729a3ecabe37" />


### How Has This Been Tested?
- Will make unit tests for these soon.
- When through the code with break points for epic and non-epic issues to see how to handle data. I did not introduce any new data and worked with what we were already receiving.

Basic checks:

- [X] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change