### PR TITLE
[AXON-513]: Updated file component now tracks deletions

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -148,6 +148,7 @@
     border-radius: 4px;
     margin-bottom: 8px;
 }
+
 #tool-return-file-path:hover {
     background-color: var(--vscode-list-hoverBackground);
     cursor: pointer;
@@ -175,4 +176,9 @@
     padding: 8px 12px;
     border-radius: 8px;
     position: relative;
+}
+
+#deleted-file {
+    color: var(--vscode-list-errorForeground);
+    text-decoration: line-through;
 }

--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -291,6 +291,8 @@ const ModifiedFileItem: React.FC<{
     const [isUndoHovered, setIsUndoHovered] = React.useState(false);
     const [isKeepHovered, setIsKeepHovered] = React.useState(false);
 
+    const isDeletion = msg.type === 'delete';
+
     const filePath = msg.filePath;
     if (!filePath) {
         return null;
@@ -325,7 +327,7 @@ const ModifiedFileItem: React.FC<{
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >
-            <div>{filePath}</div>
+            <div id={isDeletion ? 'deleted-file' : undefined}>{filePath}</div>
             <div
                 style={{ display: isHovered ? 'flex' : 'none', alignItems: 'center', flexDirection: 'row', gap: '4px' }}
             >

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -134,14 +134,37 @@ const RovoDevView: React.FC = () => {
     const handleAppendModifiedFileToolReturns = useCallback(
         (toolReturn: ToolReturnGenericMessage) => {
             if (isCodeChangeTool(toolReturn.tool_name)) {
-                const msg = parseToolReturnMessage(toolReturn).filter((msg) => msg.filePath);
-                setTotalModifiedFiles((prev) => {
-                    // Ensure unique file paths
-                    return Array.from(new Map([...prev, ...msg].map((item) => [item.filePath, item])).values());
+                const msg = parseToolReturnMessage(toolReturn).filter((msg) => msg.filePath !== undefined);
+
+                const filesMap = new Map([...totalModifiedFiles].map((item) => [item.filePath!, item]));
+
+                // Logic for handling deletions and modifications
+                msg.forEach((file) => {
+                    if (!file.filePath) {
+                        return;
+                    }
+                    if (file.type === 'delete') {
+                        if (filesMap.has(file.filePath)) {
+                            const existingFile = filesMap.get(file.filePath);
+                            if (existingFile?.type === 'modify') {
+                                filesMap.set(file.filePath, file); // If file was only modified but not created by RovoDev, still show deletion
+                            } else {
+                                filesMap.delete(file.filePath); // If file was created by RovoDev, remove it from the map
+                            }
+                        } else {
+                            filesMap.set(file.filePath, file);
+                        }
+                    } else {
+                        if (!filesMap.has(file.filePath) || filesMap.get(file.filePath)?.type === 'delete') {
+                            filesMap.set(file.filePath, file); // Only add on first modification so we can track if file was created by RovoDev or just modified
+                        }
+                    }
                 });
+
+                setTotalModifiedFiles(Array.from(filesMap.values()));
             }
         },
-        [setTotalModifiedFiles],
+        [totalModifiedFiles],
     );
 
     const removeModifiedFileToolReturns = useCallback(

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -227,4 +227,3 @@ export const isCodeChangeTool = (toolName: string): boolean => {
 };
 
 export const CODE_PLAN_EXECUTE_PROMPT = 'Execute the code plan that you have created';
-

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -225,12 +225,3 @@ export function parseToolReturnMessage(rawMsg: ToolReturnGenericMessage): ToolRe
 export const isCodeChangeTool = (toolName: string): boolean => {
     return ['find_and_replace_code', 'create_file', 'delete_file'].includes(toolName);
 };
-
-export const toolNameIconMap: Record<string, string> = {
-    expand_code_chunks: 'codicon codicon-search',
-    find_and_replace_code: 'codicon codicon-code',
-    create_file: 'codicon codicon-new-file',
-    bash: 'codicon codicon-terminal',
-    delete_file: 'codicon codicon-trash',
-    open_files: 'codicon codicon-go-to-file',
-};


### PR DESCRIPTION
### What Is This Change?

Updated the modified file parsing so files are correctly counted as deleted.

DEMO:
https://www.loom.com/share/8d56c85bd9114945a0fce6e11e281921?sid=6cd45810-4d2d-4069-8480-8b9c4d307c73

### How Has This Been Tested?

Manual tests
Will add UT for Updated File Component in following PR

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`