### PR TITLE
[AXON-582]: Implement code plan button

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -176,3 +176,32 @@
     border-radius: 8px;
     position: relative;
 }
+
+.code-plan-button-container {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 8px;
+}
+.code-plan-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--vscode-editorWidget-border);
+    max-width: 400px;
+    background-color: inherit;
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.code-plan-button:hover {
+    background-color: var(--vscode-list-hoverBackground);
+    cursor: pointer;
+    span {
+        color: var(--vscode-textLink-foreground);
+    }
+}
+
+.code-plan-button span {
+    font-size: 14px;
+    color: var(--vscode-editor-foreground);
+}

--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -8,7 +8,7 @@ import { highlightElement } from '@speed-highlight/core';
 import { detectLanguage } from '@speed-highlight/core/detect';
 import { createPatch } from 'diff';
 import MarkdownIt from 'markdown-it';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
 import {
@@ -112,7 +112,6 @@ export const renderChatHistory = (
     isRetryAfterErrorButtonEnabled: (uid: string) => boolean,
     retryAfterError: () => void,
     getText: (fp: string, lr?: number[]) => Promise<string>,
-    setIsTechnicalPlanCreated: (value: boolean) => void,
 ) => {
     switch (msg.source) {
         case 'ToolReturn':
@@ -125,7 +124,6 @@ export const renderChatHistory = (
                             content={message.technicalPlan}
                             openFile={openFile}
                             getText={getText}
-                            onMount={() => setIsTechnicalPlanCreated(true)}
                         />
                     );
                 }
@@ -370,13 +368,6 @@ type TechnicalPlanProps = {
 };
 
 const TechnicalPlanComponent: React.FC<TechnicalPlanProps> = ({ content, openFile, getText, onMount }) => {
-    useEffect(() => {
-        if (content.logicalChanges.length > 0 && onMount) {
-            // If there are logical changes, we can assume the technical plan is created
-            onMount();
-        }
-    }, [content.logicalChanges, onMount]);
-
     const clarifyingQuestions = content.logicalChanges.flatMap((change) => {
         return change.filesToChange
             .map((file) => {

--- a/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.test.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.test.tsx
@@ -33,4 +33,14 @@ describe('CodePlanButton', () => {
         expect(buttonContainer).toBeTruthy();
         expect(button).toBeTruthy();
     });
+
+    it('is disabled when the disabled prop is true', () => {
+        const mockExecute = jest.fn();
+        const { getByText } = render(<CodePlanButton execute={mockExecute} disabled={true} />);
+
+        const button = getByText('Code plan');
+
+        fireEvent.click(button);
+        expect(mockExecute).toHaveBeenCalledTimes(0);
+    });
 });

--- a/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.test.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+
+import { CodePlanButton } from './CodePlanButton';
+
+describe('CodePlanButton', () => {
+    it('renders correctly', () => {
+        const mockExecute = jest.fn();
+        const { container, getByText } = render(<CodePlanButton execute={mockExecute} />);
+
+        expect(container.querySelector('.code-plan-button-container')).toBeTruthy();
+        expect(getByText('Code plan')).toBeTruthy();
+    });
+
+    it('calls execute function when clicked', () => {
+        const mockExecute = jest.fn();
+
+        const { getByText } = render(<CodePlanButton execute={mockExecute} />);
+
+        const button = getByText('Code plan');
+        fireEvent.click(button);
+
+        expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('has the correct class names', () => {
+        const mockExecute = jest.fn();
+        const { container } = render(<CodePlanButton execute={mockExecute} />);
+
+        const buttonContainer = container.querySelector('.code-plan-button-container');
+        const button = container.querySelector('.code-plan-button');
+
+        expect(buttonContainer).toBeTruthy();
+        expect(button).toBeTruthy();
+    });
+});

--- a/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface CodePlanButtonProps {
+    execute: () => void;
+}
+
+export const CodePlanButton: React.FC<CodePlanButtonProps> = ({ execute }) => {
+    return (
+        <div className="code-plan-button-container">
+            <button className="code-plan-button" onClick={() => execute()}>
+                <span>Code plan</span>
+            </button>
+        </div>
+    );
+};

--- a/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 
 interface CodePlanButtonProps {
     execute: () => void;
+    disabled?: boolean;
 }
 
-export const CodePlanButton: React.FC<CodePlanButtonProps> = ({ execute }) => {
+export const CodePlanButton: React.FC<CodePlanButtonProps> = ({ execute, disabled = false }) => {
     return (
         <div className="code-plan-button-container">
-            <button className="code-plan-button" onClick={() => execute()}>
+            <button disabled={disabled} className="code-plan-button" onClick={() => execute()}>
                 <span>Code plan</span>
             </button>
         </div>

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -234,3 +234,5 @@ export const toolNameIconMap: Record<string, string> = {
     delete_file: 'codicon codicon-trash',
     open_files: 'codicon codicon-go-to-file',
 };
+
+export const CODE_PLAN_EXECUTE_PROMPT = 'Execute the code plan that you have created';


### PR DESCRIPTION
### What Is This Change?

Added button which allows for user to execute the technical plan generated by the agent

Button persists only if there is an active code plan and does not appear if any other types of responses

Demo:
https://www.loom.com/share/8d9a6f0f8f424a019f34caa4ac67454b?sid=1750132a-6beb-4435-9526-10a7066a7722

### How Has This Been Tested?

Added simple UT + manual tests
Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
