### PR TITLE
Skip test coverage collection in release pipeline

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -52,7 +52,7 @@ jobs:
         run: npm run lint
 
       - name: Run unit tests
-        run: npm run test
+        run: npm run test:nocoverage
 
       - name: Generate SSL certs for E2E test
         run: npm run test:e2e:sslcerts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
         run: npm run lint
 
       - name: Run unit tests
-        run: npm run test
+        run: npm run test:nocoverage
 
       - name: Generate SSL certs for E2E test
         run: npm run test:e2e:sslcerts

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "extension:package": "npm run extension:clean && vsce package --baseContentUrl https://raw.githubusercontent.com/atlassian/atlascode/main/",
         "extension:install": "npm run extension:package && code --install-extension ./atlascode-*.vsix --force",
         "test": "rm -rf coverage && npm run test:unit && npm run test:react && istanbul-merge --out coverage/coverage-final.json coverage/react/coverage-final.json coverage/unit/coverage-final.json && echo '\n\nTotal test coverage:' && nyc report --reporter clover --reporter lcov --reporter html --reporter text-summary -t coverage/ --report-dir coverage/",
+        "test:nocoverage": "npm run test:unit -- --collectCoverage false && npm run test:react -- --collectCoverage false",
         "test:unit": "jest -c jest.unit.config.ts",
         "test:react": "jest -c jest.react.config.ts",
         "test:e2e:sslcerts": "cd e2e/sslcerts && ./generate-certs.sh",


### PR DESCRIPTION
### What Is This Change?

In release pipeline we shouldn't collect nor check the UT coverage, as failing the coverage threshold is not something that should block the release.