### PR TITLE
[AXON-621][Rovo Dev] Resize text area on overflow

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -433,7 +433,7 @@ const RovoDevView: React.FC = () => {
                         }
                     >
                         <textarea
-                            style={styles.rovoDevTextareaStyles}
+                            style={{ ...{ 'field-sizing': 'content' }, ...styles.rovoDevTextareaStyles }}
                             placeholder={TextAreaMessages[currentState]}
                             onChange={(element) => setPromptText(element.target.value)}
                             onKeyDown={handleKeyDown}

--- a/src/react/atlascode/rovo-dev/rovoDevViewStyles.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewStyles.tsx
@@ -31,8 +31,6 @@ export const rovoDevTextareaStyles: React.CSSProperties = {
     resize: 'none',
     outline: 'none',
     border: 'none',
-    display: 'flex',
-    flexDirection: 'column',
 };
 
 export const rovoDevButtonStyles: React.CSSProperties = {


### PR DESCRIPTION
### What Is This Change?

This change adds the CSS property `field-sizing: content` to allow the text area for the prompt query to resize automatically based on its content.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`