### PR TITLE
[AXON-676][Rovo Dev] Fixed tool return rendering and wrapping

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -139,18 +139,27 @@ body {
     gap: 4px;
 }
 
-.tool-call-item,
-.tool-return-item {
+.tool-call-item-base,
+.tool-return-item-base {
     display: flex;
     flex-direction: row;
     align-items: center;
-    padding: 4px 8px 4px 0;
     gap: 4px;
+}
+
+.tool-call-item,
+.tool-return-item {
+    padding: 4px 8px 4px 0;
     background-color: inherit;
     color: var(--vscode-editor-foreground);
     width: fit-content;
     border-radius: 4px;
     margin-bottom: 8px;
+}
+
+.tool-return-item code {
+    white-space: pre-wrap;
+    word-break: break-all;
 }
 
 #tool-return-file-path:hover {
@@ -162,7 +171,7 @@ body {
     color: var(--vscode-input-placeholderForeground);
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    word-break: break-all;
 }
 
 .tool-return-bash-command {

--- a/src/react/atlascode/rovo-dev/tools/ToolCallItem.test.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolCallItem.test.tsx
@@ -2,13 +2,14 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import { ToolCallMessage } from '../utils';
-import { ToolCallItem } from './ToolCallItem';
+import { parseToolCallMessage, ToolCallItem } from './ToolCallItem';
 
 describe('ToolCallItem', () => {
     it('renders error message for invalid tool call message', () => {
         const invalidMsg = {} as ToolCallMessage;
+        const toolMessage = parseToolCallMessage(invalidMsg);
 
-        const { getByText } = render(<ToolCallItem msg={invalidMsg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Error: Invalid tool call message')).toBeTruthy();
     });
@@ -20,8 +21,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Expanding code')).toBeTruthy();
     });
@@ -33,8 +35,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Finding and replacing code')).toBeTruthy();
     });
@@ -46,8 +49,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Opening files')).toBeTruthy();
     });
@@ -59,8 +63,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Creating file')).toBeTruthy();
     });
@@ -72,8 +77,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Deleting file')).toBeTruthy();
     });
@@ -85,8 +91,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Executing bash command')).toBeTruthy();
     });
@@ -98,8 +105,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Creating technical plan')).toBeTruthy();
     });
@@ -111,8 +119,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Grep file content with pattern')).toBeTruthy();
     });
@@ -124,8 +133,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('Grep file path')).toBeTruthy();
     });
@@ -137,8 +147,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem msg={msg} />);
+        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} />);
 
         expect(getByText('unknown_tool')).toBeTruthy();
     });
@@ -150,8 +161,9 @@ describe('ToolCallItem', () => {
             source: 'ToolCall',
             tool_call_id: '12345',
         };
+        const toolMessage = parseToolCallMessage(msg);
 
-        render(<ToolCallItem msg={msg} />);
+        render(<ToolCallItem toolMessage={toolMessage} />);
 
         const loadingIcon = document.querySelector('.codicon.codicon-loading.codicon-modifier-spin');
         expect(loadingIcon).toBeTruthy();

--- a/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
@@ -2,23 +2,21 @@ import React from 'react';
 
 import { ToolCallMessage } from '../utils';
 
-export const ToolCallItem: React.FC<{ msg: ToolCallMessage }> = ({ msg }) => {
-    if (!msg.tool_name) {
-        return <div key="invalid-tool-call">Error: Invalid tool call message</div>;
-    }
-
-    const toolMessage = parseToolCallMessage(msg.tool_name);
-
+export const ToolCallItem: React.FC<{ toolMessage: string }> = ({ toolMessage }) => {
     return (
-        <div className="tool-call-item">
+        <div className="tool-call-item-base tool-call-item">
             <i className="codicon codicon-loading codicon-modifier-spin" />
             {toolMessage}
         </div>
     );
 };
 
-function parseToolCallMessage(msg: string): string {
-    switch (msg) {
+export function parseToolCallMessage(msg: ToolCallMessage): string {
+    switch (msg.tool_name) {
+        case '':
+        case null:
+        case undefined:
+            return '';
         case 'expand_code_chunks':
             return 'Expanding code';
         case 'find_and_replace_code':
@@ -38,6 +36,6 @@ function parseToolCallMessage(msg: string): string {
         case 'grep_file_path':
             return 'Grep file path';
         default:
-            return msg;
+            return msg.tool_name;
     }
 }

--- a/src/react/atlascode/rovo-dev/tools/ToolReturnItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolReturnItem.tsx
@@ -15,13 +15,15 @@ export const ToolReturnParsedItem: React.FC<{
 
     return (
         <a
-            className="tool-return-item"
+            className="tool-return-item-base tool-return-item"
             id={msg.filePath ? 'tool-return-file-path' : undefined}
             onClick={() => msg.filePath && openFile(msg.filePath)}
         >
             {toolIcon && <>{toolIcon}</>}
-            {msg.content}
-            {renderTitle(msg)}
+            <div className="tool-return-item-base" style={{ flexWrap: 'wrap' }}>
+                {msg.content}
+                {renderTitle(msg)}
+            </div>
         </a>
     );
 };

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -164,44 +164,29 @@ export function parseToolReturnMessage(rawMsg: ToolReturnGenericMessage): ToolRe
                     });
                 }
             }
-
-            if (resp.length === 0) {
-                // If no matches found, return the raw content
-                resp.push({
-                    content: msg.content,
-                });
-            }
             break;
 
         case 'bash':
             const args = msg.args && JSON.parse(msg.args);
-            let command = '';
-            if (!args || !args.command) {
-                console.warn('Bash command not found in args:', msg.args);
-            } else {
-                command = args.command;
+            if (args?.command) {
+                resp.push({
+                    title: args.command,
+                    content: 'Executed command',
+                    type: 'bash',
+                });
             }
-            resp.push({
-                title: command,
-                content: 'Executed command',
-                type: 'bash',
-            });
             break;
 
         case 'grep_file_content':
             const grepArgs = msg.args && JSON.parse(msg.args);
-
-            let pattern = '';
-            if (!grepArgs || !grepArgs.pattern) {
-                console.warn('Grep pattern not found in args:', msg.args);
-            } else {
-                pattern = grepArgs.pattern;
+            if (grepArgs?.pattern) {
+                const pattern = grepArgs.pattern;
+                resp.push({
+                    content: `Searched file content${pattern ? ` for pattern:` : ''}`,
+                    title: `"${pattern}"`,
+                    type: 'open',
+                });
             }
-            resp.push({
-                content: `Searched file content${pattern ? ` for pattern:` : ''}`,
-                title: `"${pattern}"`,
-                type: 'open',
-            });
             break;
 
         case 'create_technical_plan':


### PR DESCRIPTION
### What Is This Change?

The issue is that the `tool-return` was trying to obtain the context from the current `pendingToolCall`, and when Rovo Dev runs multiple tools simultaneously it returns multiple `tool-call` before their `tool-return` are returned.

To solve this issue, `tool-return` messages are now returned with their corresponding `tool-call` message attached, so context can be easily retrieved.

This change also adjusts the `tool-return` styles to correctly wrap and not exceed the width of the chat container.
With this change, the horizontal scrollbar in chat is not appearing anymore.

| Before | After |
|---|---|
| <img width="321" height="671" alt="image" src="https://github.com/user-attachments/assets/54e455ca-0700-4147-a713-d1fa027bb6d6" /> | <img width="327" height="695" alt="image" src="https://github.com/user-attachments/assets/373bc8b6-67fa-4f1d-a3e3-294b7ab70fc4" /> |

### How Has This Been Tested?

- [X] `npm run lint`
- [ ] `npm run test`
- [X] `manual tests`