### PR TITLE
[AXON-577] Change the Create PR button to appear in chat

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -320,10 +320,13 @@ const RovoDevView: React.FC = () => {
                     }
                     break;
                 case RovoDevProviderMessageType.ReturnText:
-                    break; // This is handled in getOriginalText function
+                case RovoDevProviderMessageType.CreatePRComplete:
+                    break; // This is handled elsewhere
                 default:
                     handleAppendChatHistory({
                         source: 'RovoDevError',
+                        // event.type complains if this is unreachable
+                        // @ts-expect-error ts(2339)
                         text: `Unknown message type: ${event.type}`,
                         isRetriable: false,
                         uid: v4(),
@@ -485,10 +488,16 @@ const RovoDevView: React.FC = () => {
                     retryPromptAfterError,
                     getOriginalText,
                 }}
+                messagingApi={{
+                    postMessage,
+                    postMessageWithReturn,
+                }}
                 pendingToolCall={pendingToolCallMessage}
                 deepPlanCreated={isDeepPlanCreated}
                 executeCodePlan={executeCodePlan}
                 state={currentState}
+                modifiedFiles={totalModifiedFiles}
+                injectMessage={handleAppendChatHistory}
             />
             <div style={styles.rovoDevInputSectionStyles}>
                 <UpdatedFilesComponent
@@ -496,11 +505,6 @@ const RovoDevView: React.FC = () => {
                     onUndo={undoFiles}
                     onKeep={keepFiles}
                     openDiff={openFile}
-                    onCreatePR={() => {
-                        postMessage({
-                            type: RovoDevViewResponseType.CreatePR,
-                        });
-                    }}
                 />
                 <div style={styles.rovoDevPromptContainerStyles}>
                     <div

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -8,6 +8,7 @@ export const enum RovoDevViewResponseType {
     KeepFileChanges = 'keepFileChanges',
     GetOriginalText = 'getOriginalText',
     CreatePR = 'createPR',
+    CreatePRComplete = 'createPRComplete',
     RetryPromptAfterError = 'retryPromptAfterError',
 }
 
@@ -24,4 +25,5 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.KeepFileChanges, { filePaths: string[] }>
     | ReducerAction<RovoDevViewResponseType.GetOriginalText, { filePath: string; range?: number[]; requestId: string }>
     | ReducerAction<RovoDevViewResponseType.RetryPromptAfterError>
-    | ReducerAction<RovoDevViewResponseType.CreatePR>;
+    | ReducerAction<RovoDevViewResponseType.CreatePR>
+    | ReducerAction<RovoDevViewResponseType.CreatePRComplete, { url?: string; error?: string }>;

--- a/src/rovo-dev/rovoDevPullRequestHandler.ts
+++ b/src/rovo-dev/rovoDevPullRequestHandler.ts
@@ -82,7 +82,7 @@ export class RovoDevPullRequestHandler {
 
     // This is the happy path for single small repository
     // There would probably need to be a lot of logic in monorepos/multiple repos etc.
-    public async createPR(): Promise<void> {
+    public async createPR(): Promise<string | undefined> {
         const gitExt = await this.getGitExtension();
         const repo = await this.getGitRepository(gitExt);
         const { branchName, commitMessage } = await this.getBranchAndCommitInfo(repo);
@@ -103,5 +103,7 @@ export class RovoDevPullRequestHandler {
         if (prLink) {
             env.openExternal(Uri.parse(prLink));
         }
+
+        return prLink;
     }
 }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -520,14 +520,18 @@ ${message}`;
     }
 
     private async createPR() {
+        let prLink: string | undefined;
         try {
-            await this._prHandler.createPR();
+            prLink = await this._prHandler.createPR();
         } catch (e) {
             await this.processError(e, false);
         } finally {
             const webview = this._webView!;
             await webview.postMessage({
                 type: RovoDevProviderMessageType.CreatePRComplete,
+                data: {
+                    url: prLink,
+                },
             });
         }
     }

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -34,4 +34,4 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.Initialized>
     | ReducerAction<RovoDevProviderMessageType.CancelFailed>
     | ReducerAction<RovoDevProviderMessageType.ReturnText, { text: string }>
-    | ReducerAction<RovoDevProviderMessageType.CreatePRComplete>;
+    | ReducerAction<RovoDevProviderMessageType.CreatePRComplete, { data: { url?: string } }>;


### PR DESCRIPTION
### What Is This Change?

In-progress PR work, now it looks like this:
<img width="518" height="109" alt="image" src="https://github.com/user-attachments/assets/38792593-69ad-4957-990a-bbdb7a544226" />

The footer appears and disappears as expected, leaving behind the success/error message :D

This is a intermediate state of things - styling, form, and some other stuff is TBD

Big thanks to @cabella-dot <3

### How Has This Been Tested?

Extensive manual tests with anime writing involved (heavily)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] ~If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)~ N/A

Recommendations:
- [x] ~Update the CHANGELOG if making a user facing change~ N/A