### PR TITLE
[Rovo Dev] Remove landing in BBY and fix buttons' pointer style

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -2,6 +2,10 @@ body {
     padding: 0 !important;
 }
 
+.rovoDevChat button {
+    cursor: pointer;
+}
+
 .logical-change-container {
     display: flex;
     flex-direction: column;

--- a/src/react/atlascode/rovo-dev/rovoDevLanding.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevLanding.tsx
@@ -67,6 +67,10 @@ const RovoDevImg = () => {
 };
 
 export const RovoDevLanding: React.FC<{}> = () => {
+    if (process.env.ROVODEV_BBY) {
+        return null;
+    }
+
     return (
         <div
             style={{


### PR DESCRIPTION
### What Is This Change?

The Rovo Dev landing page is not supposed to be shown in BBY, so disabling it there.
Also, added a `cursor: pointer` style for Rovo Dev buttons.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `manual tests`