### PR TITLE
AXON-675: Update sidebar after issue was created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed a bug where the 'Vote for this issue' option was not accessible to the reporter
 - Fixed a bug with the vote calculation where the username who voted for the issue only updated to the correct value after refreshing the page
 - Fixed a bug when Save site button is enabled without valid credentials
-- Fixed a bug when after creating new Jira issue doesn't see this issue in sidebar
+- Fixed a bug where after creating a new Jira issue, the issue would not appear in the sidebar
 
 ## What's new in 3.8.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed a bug where the 'Vote for this issue' option was not accessible to the reporter
 - Fixed a bug with the vote calculation where the username who voted for the issue only updated to the correct value after refreshing the page
 - Fixed a bug when Save site button is enabled without valid credentials
+- Fixed a bug when after creating new Jira issue doesn't see this issue in sidebar
 
 ## What's new in 3.8.6
 

--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
@@ -110,6 +110,10 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
                                 ...{ description: '', summary: '' },
                             },
                         });
+                        // Refresh sidebar tree views after successful issue creation
+                        this.postMessage({
+                            action: 'refreshTreeViews',
+                        });
                     }
                     break;
                 }

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -544,11 +544,11 @@ export class CreateIssueWebview
                                 await client.addAttachments(resp.key, formData);
                             }
                             // TODO: [VSCODE-601] add a new analytic event for issue updates
-                            await commands.executeCommand(
+                            commands.executeCommand(
                                 Commands.RefreshAssignedWorkItemsExplorer,
                                 OnJiraEditedRefreshDelay,
                             );
-                            await commands.executeCommand(Commands.RefreshCustomJqlExplorer, OnJiraEditedRefreshDelay);
+                            commands.executeCommand(Commands.RefreshCustomJqlExplorer, OnJiraEditedRefreshDelay);
 
                             this.postMessage({
                                 type: 'issueCreated',

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -23,6 +23,7 @@ import { Action } from '../ipc/messaging';
 import { fetchCreateIssueUI } from '../jira/fetchIssue';
 import { WebViewID } from '../lib/ipc/models/common';
 import { Logger } from '../logger';
+import { OnJiraEditedRefreshDelay } from '../util/time';
 import { SearchJiraHelper } from '../views/jira/searchJiraHelper';
 import { AbstractIssueEditorWebview } from './abstractIssueEditorWebview';
 import { InitializingWebview } from './abstractWebview';
@@ -543,8 +544,11 @@ export class CreateIssueWebview
                                 await client.addAttachments(resp.key, formData);
                             }
                             // TODO: [VSCODE-601] add a new analytic event for issue updates
-                            commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
-                            commands.executeCommand(Commands.RefreshCustomJqlExplorer);
+                            await commands.executeCommand(
+                                Commands.RefreshAssignedWorkItemsExplorer,
+                                OnJiraEditedRefreshDelay,
+                            );
+                            await commands.executeCommand(Commands.RefreshCustomJqlExplorer, OnJiraEditedRefreshDelay);
 
                             this.postMessage({
                                 type: 'issueCreated',
@@ -570,6 +574,13 @@ export class CreateIssueWebview
                             });
                         }
                     }
+                    break;
+                }
+                case 'refreshTreeViews': {
+                    handled = true;
+                    // Pass delay to allow Jira's indexes to update before refreshing
+                    await commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer, OnJiraEditedRefreshDelay);
+                    await commands.executeCommand(Commands.RefreshCustomJqlExplorer, OnJiraEditedRefreshDelay);
                     break;
                 }
                 case 'openProblemReport': {


### PR DESCRIPTION
### What Is This Change?

✅ Fixed a bug - after creating a new Jira issue doesn't see this issue in the sidebar

After the user creates a new ticket, this ticket doesn't appear in the sidebar.

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

After fix:
https://www.loom.com/share/b0939cb0f1c14b6aa19fd9b274572295?sid=7a967371-156c-44de-afca-03a30d5a9f60

Recommendations:
- [x] Update the CHANGELOG if making a user facing change