### PR TITLE
AXON-689 Add ability to access the code-server from host machine

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -2,11 +2,11 @@ FROM node:23-slim
 
 # Install dependencies and xvfb
 RUN apt-get update \
-    && apt-get install -y wget gpg xauth curl git \ 
+    && apt-get install -y wget gpg xauth curl git \
     && npm install --global playwright@1.53.0 \
     && npx playwright install --with-deps chromium
 
-# install code-server 
+# install code-server
 RUN curl -fsSL https://code-server.dev/install.sh -o install-code-server.sh \
     && sh install-code-server.sh \
     && curl -fL https://open-vsx.org/api/redhat/vscode-yaml/1.18.0/file/redhat.vscode-yaml-1.18.0.vsix -o redhat.vscode-yaml-1.18.0.vsix
@@ -42,10 +42,18 @@ code-server --install-extension ../redhat.vscode-yaml-1.18.0.vsix --force
 echo "installing atlascode"
 code-server --install-extension atlascode-*.vsix --force
 
-echo "starting code-server"
-code-server --auth none --disable-workspace-trust --bind-addr localhost:9988 &
-echo "Running tests"
-npx playwright test ./e2e/tests/**/*.spec.ts --workers=1
+if [[ -z "\${ONLYSERVER}" ]]; then
+    # start tests if ONLYSERVER is not set
+
+    echo "starting code-server"
+    code-server --auth none --disable-workspace-trust --bind-addr localhost:9988 &
+    echo "Running tests"
+    npx playwright test ./e2e/tests/**/*.spec.ts --workers=1
+else
+     # Only start server if ONLYSERVER is set
+    echo "No e2e tests started. Only starting code-server."
+    code-server --auth none --bind-addr 0.0.0.0:9988
+fi
 
 EOF
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -40,3 +40,16 @@ To run E2E tests against changed code, you might need to re-build the extension 
 ```sh
 npm run extension:package
 ```
+
+---
+
+### Running code-server Locally for Testing
+
+1. Follow the first two steps from the [How do I use it?](#how-do-i-use-it) section above.
+
+2. Use the following command to start the testing environment
+```sh
+  npm test:e2e:docker:serve
+```
+
+3. Open *http://127.0.0.1:9988* in browser. The code-server UI should be available.

--- a/e2e/compose.yml
+++ b/e2e/compose.yml
@@ -43,6 +43,7 @@ services:
             - ${PWD}/..:/atlascode
         environment:
             - NODE_TLS_REJECT_UNAUTHORIZED=0
+            - ONLYSERVER
         depends_on:
             - wiremock-mockedteams
             - wiremock-bitbucket
@@ -50,3 +51,4 @@ services:
             - e2e
         ports:
             - '9988:9988'
+            - '31415:31415'

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "test:e2e:sslcerts": "cd e2e/sslcerts && ./generate-certs.sh",
         "test:e2e:docker": "cd e2e && docker compose run --rm atlascode-e2e; status=$?; docker compose down; exit $status",
         "test:e2e:docker:build": "docker build --tag atlascode-e2e - <e2e/Dockerfile",
+        "test:e2e:docker:serve": "cd e2e && npm run test:e2e:docker:build && export ONLYSERVER=1 && docker compose up",
         "devcompile": "npm run clean && npm run devcompile:react && npm run devcompile:extension",
         "devcompile:react": "webpack --mode development --config webpack.react.dev.js --fail-on-warnings",
         "devcompile:extension": "webpack --mode development --config webpack.extension.dev.js --fail-on-warnings",


### PR DESCRIPTION
### What Is This Change?
This change adds a new script to package.json that starts a code-server without launching the e2e tests. And allows dev to explore the testing environment.
<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [X] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [X] Update the CHANGELOG if making a user facing change