### PR TITLE
[AXON-701][Rovo Dev] Fix Deep plan not being rendered

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -235,6 +235,7 @@ const RovoDevView: React.FC = () => {
                         source: 'ToolReturn',
                         tool_name: data.tool_name,
                         content: data.content || '',
+                        parsedContent: data.parsedContent,
                         tool_call_id: data.tool_call_id, // Optional ID for tracking
                         args: data.toolCallMessage.args,
                     };

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -57,7 +57,7 @@ export interface ToolReturnGrepFileContentMessage {
 export interface ToolReturnTechnicalPlanMessage {
     tool_name: 'create_technical_plan';
     source: 'ToolReturn';
-    content: string; // JSON string representing the technical plan
+    parsedContent?: object | undefined;
     tool_call_id: string;
     args?: string;
 }
@@ -65,7 +65,8 @@ export interface ToolReturnTechnicalPlanMessage {
 export interface ToolReturnGenericMessage {
     tool_name: string;
     source: 'ToolReturn' | 'ModifiedFile';
-    content?: any;
+    content: string;
+    parsedContent?: object | undefined;
     tool_call_id: string;
     args?: string;
 }
@@ -190,10 +191,12 @@ export function parseToolReturnMessage(rawMsg: ToolReturnGenericMessage): ToolRe
             break;
 
         case 'create_technical_plan':
-            resp.push({
-                content: 'A cool technical plan',
-                technicalPlan: JSON.parse(msg.content) as TechnicalPlan | undefined,
-            });
+            if (msg.parsedContent) {
+                resp.push({
+                    content: '',
+                    technicalPlan: msg.parsedContent as TechnicalPlan,
+                });
+            }
             break;
 
         default:

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -32,7 +32,7 @@ import { RovoDevApiClient, RovoDevHealthcheckResponse } from './rovoDevApiClient
 import { RovoDevPullRequestHandler } from './rovoDevPullRequestHandler';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from './rovoDevWebviewProviderMessages';
 
-const MIN_SUPPORTED_ROVODEV_VERSION = '0.8.2';
+const MIN_SUPPORTED_ROVODEV_VERSION = '0.9.3';
 
 interface TypedWebview<MessageOut, MessageIn> extends Webview {
     readonly onDidReceiveMessage: Event<MessageIn>;


### PR DESCRIPTION
### What Is This Change?

The technical plan is wasn't being rendered because it was expected from the `content` field of the response as a string, but it's actually an object which goes to the `parsedContent` field instead.

### How Has This Been Tested?

- [X] `npm run lint`
- [x] `npm run test`
- [X] `manual tests`