### PR TITLE
AXON-670: add rendering for retry-prompt

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -300,4 +300,5 @@ body {
     word-break: break-word;
     color: var(--vscode-editor-foreground);
     font-size: 13px;
+    max-width: 100%;
 }

--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -28,6 +28,7 @@ import { ToolReturnParsedItem } from '../tools/ToolReturnItem';
 import {
     ChatMessage,
     CodeSnippetToChange,
+    DefaultMessage,
     ErrorMessage,
     parseToolReturnMessage,
     TechnicalPlan,
@@ -188,6 +189,18 @@ export const renderChatHistory = (
         case 'RovoDev':
         case 'User':
             return <ChatMessageItem index={index} msg={msg} />;
+        case 'RovoDevRetry':
+            const retryMsg: DefaultMessage = {
+                text: 'Unable to process the request ' + '`' + msg.tool_name + '`',
+                source: 'RovoDev',
+            };
+            return (
+                <ChatMessageItem
+                    index={index}
+                    msg={retryMsg}
+                    icon={<StatusErrorIcon color="var(--ds-icon-danger)" label="error-icon" spacing="none" />}
+                />
+            );
         default:
             return <div key={index}>Unknown message type</div>;
     }

--- a/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
+++ b/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
@@ -123,7 +123,7 @@ export const PullRequestForm: React.FC<PullRequestFormProps> = ({
                             </div>
                         </div>
                         <div className="pull-request-form-actions">
-                            <button onClick={() => onCancel()} className="pull-request-cancel-button">
+                            <button type="button" onClick={() => onCancel()} className="pull-request-cancel-button">
                                 Cancel
                             </button>
                             <button type="submit" className="pull-request-submit-button">

--- a/src/react/atlascode/rovo-dev/messaging/ChatHistory.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatHistory.tsx
@@ -135,7 +135,7 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({
                     setCurrentMessage(null);
                     setCurThinkingMessages((prev) => [...prev, newMessage]);
                     break;
-                
+
                 case 'RovoDevError':
                 case 'PullRequest':
                     setMessageBlocks((prev) => [...prev, { messages: newMessage }]);

--- a/src/react/atlascode/rovo-dev/messaging/ChatHistory.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatHistory.tsx
@@ -114,11 +114,20 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({
                         });
                         return;
 
+                    case 'RovoDevRetry':
+                        if (currentMessage) {
+                            setCurThinkingMessages((prev) => [...prev, currentMessage]);
+                        }
+                        setCurrentMessage(null);
+                        setCurThinkingMessages((prev) => [...prev, newMessage]);
+                        return;
+
                     case 'RovoDevError':
                         setMessageBlocks((prev) => [...prev, { messages: newMessage }]);
 
                         setCurrentMessage(null);
                         return;
+
                     case 'ToolReturn':
                         if (currentMessage) {
                             setCurThinkingMessages((prev) => [...prev, currentMessage]);

--- a/src/react/atlascode/rovo-dev/messaging/ChatHistory.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatHistory.tsx
@@ -147,7 +147,7 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({
                         setCurThinkingMessages((prev) => [...prev, currentMessage]);
                         setCurrentMessage(null);
                     }
-                    
+
                     if (newMessage.tool_name === 'create_technical_plan') {
                         const parsedMessage = parseToolReturnMessage(newMessage);
 

--- a/src/react/atlascode/rovo-dev/messaging/ChatHistory.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatHistory.tsx
@@ -146,7 +146,8 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({
                     if (currentMessage) {
                         setCurThinkingMessages((prev) => [...prev, currentMessage]);
                         setCurrentMessage(null);
-                      
+                    }
+                    
                     if (newMessage.tool_name === 'create_technical_plan') {
                         const parsedMessage = parseToolReturnMessage(newMessage);
 

--- a/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
@@ -6,7 +6,8 @@ import { DefaultMessage } from '../utils';
 export const ChatMessageItem: React.FC<{
     msg: DefaultMessage;
     index: number;
-}> = ({ msg, index }) => {
+    icon?: React.ReactNode;
+}> = ({ msg, index, icon }) => {
     const messageTypeStyles = msg.source === 'User' ? 'user-message' : 'agent-message';
 
     const content = (
@@ -18,7 +19,12 @@ export const ChatMessageItem: React.FC<{
     );
 
     return (
-        <div key={index} className={`chat-message ${messageTypeStyles}`}>
+        <div
+            key={index}
+            className={`chat-message ${messageTypeStyles}`}
+            style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '8px' }}
+        >
+            {icon && <div className="message-icon">{icon}</div>}
             <div className="message-content">{content}</div>
         </div>
     );

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -248,6 +248,17 @@ const RovoDevView: React.FC = () => {
                     handleAppendModifiedFileToolReturns(returnMessage);
                     break;
 
+                case 'retry-prompt':
+                    const msg: ToolReturnGenericMessage = {
+                        source: 'RovoDevRetry',
+                        tool_name: data.tool_name,
+                        content: data.content || '',
+                        tool_call_id: data.tool_call_id, // Optional ID for tracking
+                    };
+
+                    handleAppendChatHistory(msg);
+                    break;
+
                 default:
                     appendCurrentResponse(`\n\nUnknown part_kind: ${data.event_kind}\n\n`);
                     break;

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -65,7 +65,7 @@ export interface ToolReturnTechnicalPlanMessage {
 export interface ToolReturnGenericMessage {
     tool_name: string;
     source: 'ToolReturn' | 'ModifiedFile' | 'RovoDevRetry';
-    content?: any;
+    content: string;
     parsedContent?: object | undefined;
     tool_call_id: string;
     args?: string;

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -34,6 +34,7 @@ export interface ToolReturnFileMessage {
     tool_name: 'expand_code_chunks' | 'find_and_replace_code' | 'open_files' | 'create_file' | 'delete_file';
     source: 'ToolReturn';
     content: string;
+    parsedContent?: object | undefined;
     tool_call_id: string;
     args?: string;
 }
@@ -138,13 +139,22 @@ export function parseToolReturnMessage(rawMsg: ToolReturnGenericMessage): ToolRe
         case 'open_files':
         case 'create_file':
         case 'delete_file':
-            const contentArray = msg.content.split('\n\n');
+            const contentArray = msg.parsedContent ? msg.parsedContent : [msg.content];
+            if (!Array.isArray(contentArray)) {
+                console.warn('Invalid content format in ToolReturnMessage:', msg.content);
+                break;
+            }
 
             for (const line of contentArray) {
-                const matches = line.match(
+                if (typeof line !== 'string') {
+                    console.warn('Invalid line format in ToolReturnMessage:', line);
+                    continue;
+                }
+
+                const trimmedLine = line.split('\n\n')[0].trim();
+                const matches = trimmedLine.match(
                     /^Successfully\s+(expanded code chunks|replaced code|opened|created|deleted|updated)(?:\s+in)?\s+(.+)?$/,
                 );
-
                 if (matches && matches.length >= 3) {
                     let filePath = matches[2].trim();
                     // Remove trailing colon if present

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -64,7 +64,7 @@ export interface ToolReturnTechnicalPlanMessage {
 
 export interface ToolReturnGenericMessage {
     tool_name: string;
-    source: 'ToolReturn' | 'ModifiedFile';
+    source: 'ToolReturn' | 'ModifiedFile' | 'RovoDevRetry';
     content?: any;
     tool_call_id: string;
     args?: string;


### PR DESCRIPTION
### What Is This Change?

Added rendering for `retry-prompt` message to indicate that a tool call has failed.

<img width="375" height="519" alt="Screenshot 2025-07-23 at 1 38 06 PM" src="https://github.com/user-attachments/assets/b9e9fdb4-d3ee-4054-baac-2d9487899e1c" />

^^ Signed off by adam btw

### How Has This Been Tested?

manual tests

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
