### PR TITLE
[AXON-522] Force correct initial state for the prompt context

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -412,6 +412,13 @@ const RovoDevView: React.FC = () => {
         [sendButtonDisabled, currentState, isDeepPlanCreated, isDeepPlanToggled, postMessage, promptContextCollection],
     );
 
+    // On the first render, get the context update
+    React.useEffect(() => {
+        postMessage?.({
+            type: RovoDevViewResponseType.ForceUserFocusUpdate,
+        });
+    }, [postMessage]);
+
     const executeCodePlan = useCallback(() => {
         if (currentState !== State.WaitingForPrompt) {
             return;

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -13,6 +13,7 @@ export const enum RovoDevViewResponseType {
     RetryPromptAfterError = 'retryPromptAfterError',
     GetCurrentBranchName = 'getCurrentBranchName',
     AddContext = 'addContext',
+    ForceUserFocusUpdate = 'forceUserFocusUpdate',
 }
 
 export type RovoDevViewResponse =
@@ -26,4 +27,5 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.CreatePR, { payload: { branchName: string; commitMessage: string } }>
     | ReducerAction<RovoDevViewResponseType.CreatePRComplete, { url?: string; error?: string }>
     | ReducerAction<RovoDevViewResponseType.AddContext, { currentContext: RovoDevContext }>
-    | ReducerAction<RovoDevViewResponseType.GetCurrentBranchName>;
+    | ReducerAction<RovoDevViewResponseType.GetCurrentBranchName>
+    | ReducerAction<RovoDevViewResponseType.ForceUserFocusUpdate>;


### PR DESCRIPTION
### What Is This Change?

Quick follow-up for the context PR - correctly set initial state of the context bar

When the user opens up the webview, we:
 * fire an event to the extension process
 * look at the open editors and whatnot
 * send an update back right away

Piggy-backing on the `Initialized` event turned out to be too slow 😱 

### How Has This Been Tested?

`m a n u a l l y`