### PR TITLE
[AXON-522] Quickfix: don't use bad editor tabs as context

### DIFF
--- a/src/react/atlascode/rovo-dev/promptContext/promptContextCollection.tsx
+++ b/src/react/atlascode/rovo-dev/promptContext/promptContextCollection.tsx
@@ -40,7 +40,7 @@ export const PromptContextCollection: React.FC<{
             }}
         >
             {!readonly && <AddContextButton onClick={onAddContext} />}
-            {content.focusInfo && showFocusInfo && (
+            {content.focusInfo && !content.focusInfo.invalid && showFocusInfo && (
                 <PromptContextItem
                     file={content.focusInfo.file}
                     selection={content.focusInfo.selection}

--- a/src/rovo-dev/rovoDevTypes.ts
+++ b/src/rovo-dev/rovoDevTypes.ts
@@ -13,6 +13,9 @@ export type RovoDevContextItem = {
     file: RovoDevContextFileInfo;
     selection?: RovoDevContextSelectionInfo;
     enabled?: boolean;
+    // Optional indication of the editor pointing to an invalid file
+    // e.g. welcome page, webview tab, etc
+    invalid?: boolean;
 };
 
 export type RovoDevContext = {


### PR DESCRIPTION
### What Is This Change?

Some files you can open in vscode editor aren't actually files
With this, things like:
 * welcome page
 * extension webviews
 * literally nothing being open
- will no longer show up in the prompt context :D

### How Has This Been Tested?

`m a n u a l l y`