### PR TITLE
[AXON-721][Rovo Dev] Fire perf telemetry events

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -60,7 +60,7 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
             testExtension === 'ts'
                 ? {
                       statements: 71,
-                      branches: 65,
+                      branches: 64,
                       functions: 64,
                       lines: 71,
                   }

--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -793,6 +793,366 @@ describe('analytics', () => {
         });
     });
 
+    describe('performanceEvent', () => {
+        const originalPlatform = process.platform;
+
+        beforeEach(() => {
+            setProcessPlatform('win32');
+            mockedData.getFirstAAID_value = 'some-user-id';
+        });
+
+        afterAll(() => {
+            setProcessPlatform(originalPlatform);
+        });
+
+        describe('rovodev.response.timeToFirstByte', () => {
+            it('should create a performance event with correct tag and measure', async () => {
+                const measure = 150;
+                const params = { sessionId: 'test-session-123', promptId: 'test-prompt-123' };
+
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstByte', measure, params);
+
+                expect(event.trackEvent.action).toEqual('performanceEvent');
+                expect(event.trackEvent.actionSubject).toEqual('atlascode');
+                expect(event.trackEvent.attributes.tag).toEqual('rovodev.response.timeToFirstByte');
+                expect(event.trackEvent.attributes.measure).toEqual(measure);
+                expect(event.trackEvent.attributes.sessionId).toEqual(params.sessionId);
+                expect(event.trackEvent.attributes.promptId).toEqual(params.promptId);
+            });
+        });
+
+        describe('rovodev.response.timeToFirstMessage', () => {
+            it('should create a performance event with correct tag and measure', async () => {
+                const measure = 250;
+                const params = { sessionId: 'session-456', promptId: 'prompt-456' };
+
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstMessage', measure, params);
+
+                expect(event.trackEvent.action).toEqual('performanceEvent');
+                expect(event.trackEvent.actionSubject).toEqual('atlascode');
+                expect(event.trackEvent.attributes.tag).toEqual('rovodev.response.timeToFirstMessage');
+                expect(event.trackEvent.attributes.measure).toEqual(measure);
+                expect(event.trackEvent.attributes.sessionId).toEqual(params.sessionId);
+                expect(event.trackEvent.attributes.promptId).toEqual(params.promptId);
+            });
+        });
+
+        describe('rovodev.response.timeToTechPlan', () => {
+            it('should create a performance event with correct tag and measure', async () => {
+                const measure = 500;
+                const params = { sessionId: 'session-789', promptId: 'prompt-789' };
+
+                const event = await analytics.performanceEvent('rovodev.response.timeToTechPlan', measure, params);
+
+                expect(event.trackEvent.action).toEqual('performanceEvent');
+                expect(event.trackEvent.actionSubject).toEqual('atlascode');
+                expect(event.trackEvent.attributes.tag).toEqual('rovodev.response.timeToTechPlan');
+                expect(event.trackEvent.attributes.measure).toEqual(measure);
+                expect(event.trackEvent.attributes.sessionId).toEqual(params.sessionId);
+                expect(event.trackEvent.attributes.promptId).toEqual(params.promptId);
+            });
+        });
+
+        describe('rovodev.response.timeToLastMessage', () => {
+            it('should create a performance event with correct tag and measure', async () => {
+                const measure = 1000;
+                const params = { sessionId: 'session-999', promptId: 'prompt-999' };
+
+                const event = await analytics.performanceEvent('rovodev.response.timeToLastMessage', measure, params);
+
+                expect(event.trackEvent.action).toEqual('performanceEvent');
+                expect(event.trackEvent.actionSubject).toEqual('atlascode');
+                expect(event.trackEvent.attributes.tag).toEqual('rovodev.response.timeToLastMessage');
+                expect(event.trackEvent.attributes.measure).toEqual(measure);
+                expect(event.trackEvent.attributes.sessionId).toEqual(params.sessionId);
+                expect(event.trackEvent.attributes.promptId).toEqual(params.promptId);
+            });
+        });
+
+        describe('general performanceEvent behavior', () => {
+            it('should include platform information based on process.platform', async () => {
+                setProcessPlatform('darwin');
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstByte', 100, {
+                    sessionId: 'test-session',
+                    promptId: 'test-prompt',
+                });
+
+                expect(event.trackEvent.platform).toEqual('mac');
+            });
+
+            it('should include origin information', async () => {
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstByte', 100, {
+                    sessionId: 'test-session',
+                    promptId: 'test-prompt',
+                });
+
+                expect(event.trackEvent.origin).toEqual('desktop');
+            });
+
+            it('should handle empty string parameters', async () => {
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstByte', 100, {
+                    sessionId: '',
+                    promptId: '',
+                });
+
+                expect(event.trackEvent.attributes.sessionId).toEqual('');
+                expect(event.trackEvent.attributes.promptId).toEqual('');
+            });
+
+            it('should handle additional parameters in params object', async () => {
+                const params = {
+                    sessionId: 'test-session',
+                    promptId: 'test-prompt',
+                    additionalData: 'extra-info',
+                    numericData: 42,
+                };
+
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstByte', 100, params);
+
+                expect(event.trackEvent.attributes.sessionId).toEqual('test-session');
+                expect(event.trackEvent.attributes.promptId).toEqual('test-prompt');
+                expect(event.trackEvent.attributes.additionalData).toEqual('extra-info');
+                expect(event.trackEvent.attributes.numericData).toEqual(42);
+            });
+
+            it('should work with generic string tag and Record params', async () => {
+                const customTag = 'custom.performance.metric';
+                const measure = 300;
+                const params = {
+                    customParam1: 'value1',
+                    customParam2: 123,
+                    customParam3: true,
+                };
+
+                // Use type assertion to test the generic overload
+                const event = await analytics.performanceEvent(customTag as any, measure, params as any);
+
+                expect(event.trackEvent.attributes.tag).toEqual(customTag);
+                expect(event.trackEvent.attributes.measure).toEqual(measure);
+                expect(event.trackEvent.attributes.customParam1).toEqual('value1');
+                expect(event.trackEvent.attributes.customParam2).toEqual(123);
+                expect(event.trackEvent.attributes.customParam3).toEqual(true);
+            });
+
+            it('should handle null params', async () => {
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstByte', 100, null as any);
+
+                expect(event.trackEvent.attributes.tag).toEqual('rovodev.response.timeToFirstByte');
+                expect(event.trackEvent.attributes.measure).toEqual(100);
+                expect(event.trackEvent.attributes.sessionId).toBeUndefined();
+                expect(event.trackEvent.attributes.promptId).toBeUndefined();
+            });
+
+            it('should handle undefined params', async () => {
+                const event = await analytics.performanceEvent(
+                    'rovodev.response.timeToFirstByte',
+                    100,
+                    undefined as any,
+                );
+
+                expect(event.trackEvent.attributes.tag).toEqual('rovodev.response.timeToFirstByte');
+                expect(event.trackEvent.attributes.measure).toEqual(100);
+                expect(event.trackEvent.attributes.sessionId).toBeUndefined();
+                expect(event.trackEvent.attributes.promptId).toBeUndefined();
+            });
+        });
+
+        describe('event structure validation', () => {
+            it('should return a valid TrackEvent structure', async () => {
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstByte', 100, {
+                    sessionId: 'test-session',
+                    promptId: 'test-prompt',
+                });
+
+                // Validate TrackEvent structure
+                expect(event).toHaveProperty('trackEvent');
+                expect(event).toHaveProperty('userIdType');
+                expect(event).toHaveProperty('userId');
+                expect(event).toHaveProperty('tenantIdType');
+
+                // Validate trackEvent structure
+                expect(event.trackEvent).toHaveProperty('action');
+                expect(event.trackEvent).toHaveProperty('actionSubject');
+                expect(event.trackEvent).toHaveProperty('attributes');
+                expect(event.trackEvent).toHaveProperty('platform');
+                expect(event.trackEvent).toHaveProperty('origin');
+            });
+
+            it('should have consistent action and actionSubject for timeToFirstByte', async () => {
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstByte', 100, {
+                    sessionId: 'test-session',
+                    promptId: 'test-prompt',
+                });
+
+                expect(event.trackEvent.action).toEqual('performanceEvent');
+                expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            });
+
+            it('should have consistent action and actionSubject for timeToFirstMessage', async () => {
+                const event = await analytics.performanceEvent('rovodev.response.timeToFirstMessage', 100, {
+                    sessionId: 'test-session',
+                    promptId: 'test-prompt',
+                });
+
+                expect(event.trackEvent.action).toEqual('performanceEvent');
+                expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            });
+
+            it('should have consistent action and actionSubject for timeToTechPlan', async () => {
+                const event = await analytics.performanceEvent('rovodev.response.timeToTechPlan', 100, {
+                    sessionId: 'test-session',
+                    promptId: 'test-prompt',
+                });
+
+                expect(event.trackEvent.action).toEqual('performanceEvent');
+                expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            });
+
+            it('should have consistent action and actionSubject for timeToLastMessage', async () => {
+                const event = await analytics.performanceEvent('rovodev.response.timeToLastMessage', 100, {
+                    sessionId: 'test-session',
+                    promptId: 'test-prompt',
+                });
+
+                expect(event.trackEvent.action).toEqual('performanceEvent');
+                expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            });
+        });
+    });
+
+    // Rovo Dev event tests
+    describe('Rovo Dev events', () => {
+        const mockSessionId = 'test-session-id';
+        const mockPromptId = 'test-prompt-id';
+
+        beforeEach(() => {
+            setProcessPlatform('win32');
+            mockedData.getFirstAAID_value = 'some-user-id';
+        });
+
+        it('should create rovoDevPromptSentEvent with session and prompt IDs', async () => {
+            const event = await analytics.rovoDevPromptSentEvent(mockSessionId, mockPromptId, 'chat', true);
+
+            expect(event.trackEvent.action).toEqual('rovoDevPromptSent');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
+            expect(event.trackEvent.attributes.source).toEqual('chat');
+            expect(event.trackEvent.attributes.deepPlanEnabled).toEqual(true);
+        });
+
+        it('should create rovoDevNewSessionActionEvent with session information', async () => {
+            const isManuallyCreated = true;
+            const event = await analytics.rovoDevNewSessionActionEvent(mockSessionId, isManuallyCreated);
+
+            expect(event.trackEvent.action).toEqual('rovoDevNewSessionAction');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.isManuallyCreated).toEqual(isManuallyCreated);
+        });
+
+        it('should create rovoDevTechnicalPlanningShownEvent with planning details', async () => {
+            const stepsCount = 5;
+            const filesCount = 3;
+            const questionsCount = 2;
+            const event = await analytics.rovoDevTechnicalPlanningShownEvent(
+                mockSessionId,
+                stepsCount,
+                filesCount,
+                questionsCount,
+            );
+
+            expect(event.trackEvent.action).toEqual('rovoDevTechnicalPlanningShown');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.stepsCount).toEqual(stepsCount);
+            expect(event.trackEvent.attributes.filesCount).toEqual(filesCount);
+            expect(event.trackEvent.attributes.questionsCount).toEqual(questionsCount);
+        });
+
+        it('should create rovoDevFilesSummaryShownEvent for new files summary', async () => {
+            const filesCount = 4;
+            const event = await analytics.rovoDevFilesSummaryShownEvent(mockSessionId, filesCount);
+
+            expect(event.trackEvent.action).toEqual('rovoDevFilesSummaryShown');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.filesCount).toEqual(filesCount);
+        });
+
+        it('should create rovoDevFileChangedActionEvent for undo action', async () => {
+            const action = 'undo';
+            const filesCount = 3;
+            const event = await analytics.rovoDevFileChangedActionEvent(mockSessionId, action, filesCount);
+
+            expect(event.trackEvent.action).toEqual('rovoDevFileChangedAction');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.action).toEqual(action);
+            expect(event.trackEvent.attributes.filesCount).toEqual(filesCount);
+        });
+
+        it('should create rovoDevFileChangedActionEvent for keep action', async () => {
+            const action = 'keep';
+            const filesCount = 2;
+            const event = await analytics.rovoDevFileChangedActionEvent(mockSessionId, action, filesCount);
+
+            expect(event.trackEvent.action).toEqual('rovoDevFileChangedAction');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.action).toEqual(action);
+            expect(event.trackEvent.attributes.filesCount).toEqual(filesCount);
+        });
+
+        it('should create rovoDevStopActionEvent when successful', async () => {
+            const failed = false;
+            const event = await analytics.rovoDevStopActionEvent(mockSessionId, failed);
+
+            expect(event.trackEvent.action).toEqual('rovoDevStopAction');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.failed).toEqual(failed);
+        });
+
+        it('should create rovoDevStopActionEvent when failed', async () => {
+            const failed = true;
+            const event = await analytics.rovoDevStopActionEvent(mockSessionId, failed);
+
+            expect(event.trackEvent.action).toEqual('rovoDevStopAction');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.failed).toEqual(failed);
+        });
+
+        it('should create rovoDevGitPushActionEvent when PR is created', async () => {
+            const prCreated = true;
+            const event = await analytics.rovoDevGitPushActionEvent(mockSessionId, prCreated);
+
+            expect(event.trackEvent.action).toEqual('rovoDevGitPushAction');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.prCreated).toEqual(prCreated);
+        });
+
+        it('should create rovoDevGitPushActionEvent when PR is not created', async () => {
+            const prCreated = false;
+            const event = await analytics.rovoDevGitPushActionEvent(mockSessionId, prCreated);
+
+            expect(event.trackEvent.action).toEqual('rovoDevGitPushAction');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.prCreated).toEqual(prCreated);
+        });
+
+        it('should create rovoDevDetailsExpandedEvent', async () => {
+            const event = await analytics.rovoDevDetailsExpandedEvent(mockSessionId);
+
+            expect(event.trackEvent.action).toEqual('rovoDevDetailsExpanded');
+            expect(event.trackEvent.actionSubject).toEqual('atlascode');
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+        });
+    });
+
     // Platform detection tests
     describe('AnalyticsPlatform', () => {
         beforeEach(() => {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -173,32 +173,27 @@ export async function featureFlagClientInitializedEvent(
 
 // Perf events
 
+type RovoDevPerfEvents =
+    | 'rovodev.response.timeToFirstByte'
+    | 'rovodev.response.timeToFirstMessage'
+    | 'rovodev.response.timeToTechPlan'
+    | 'rovodev.response.timeToLastMessage';
+
 interface RovoDevCommonParams {
     sessionId: string;
     promptId: string;
 }
 
 export async function performanceEvent(
-    tag: 'rovodev.response.timeToFirstByte',
+    tag: RovoDevPerfEvents,
     measure: number,
     params: RovoDevCommonParams,
 ): Promise<TrackEvent>;
 export async function performanceEvent(
-    tag: 'rovodev.response.timeToFirstMessage',
+    tag: string,
     measure: number,
-    params: RovoDevCommonParams,
-): Promise<TrackEvent>;
-export async function performanceEvent(
-    tag: 'rovodev.response.timeToTechPlan',
-    measure: number,
-    params: RovoDevCommonParams,
-): Promise<TrackEvent>;
-export async function performanceEvent(
-    tag: 'rovodev.response.timeToLastMessage',
-    measure: number,
-    params: RovoDevCommonParams,
-): Promise<TrackEvent>;
-export async function performanceEvent(tag: string, measure: number, params: Record<string, any>): Promise<TrackEvent> {
+    params?: Record<string, any>,
+): Promise<TrackEvent> {
     return trackEvent('performanceEvent', 'atlascode', {
         attributes: { tag, measure, ...(params || {}) },
     });

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -171,6 +171,99 @@ export async function featureFlagClientInitializedEvent(
     });
 }
 
+// Perf events
+
+interface RovoDevCommonParams {
+    sessionId: string;
+    promptId: string;
+}
+
+export async function performanceEvent(
+    tag: 'rovodev.response.timeToFirstByte',
+    measure: number,
+    params: RovoDevCommonParams,
+): Promise<TrackEvent>;
+export async function performanceEvent(
+    tag: 'rovodev.response.timeToFirstMessage',
+    measure: number,
+    params: RovoDevCommonParams,
+): Promise<TrackEvent>;
+export async function performanceEvent(
+    tag: 'rovodev.response.timeToTechPlan',
+    measure: number,
+    params: RovoDevCommonParams,
+): Promise<TrackEvent>;
+export async function performanceEvent(
+    tag: 'rovodev.response.timeToLastMessage',
+    measure: number,
+    params: RovoDevCommonParams,
+): Promise<TrackEvent>;
+export async function performanceEvent(tag: string, measure: number, params: Record<string, any>): Promise<TrackEvent> {
+    return trackEvent('performanceEvent', 'atlascode', {
+        attributes: { tag, measure, ...(params || {}) },
+    });
+}
+
+// Rovo Dev events
+
+export async function rovoDevPromptSentEvent(
+    sessionId: string,
+    promptId: string,
+    source: 'replay' | 'chat',
+    deepPlanEnabled: boolean,
+) {
+    return trackEvent('rovoDevPromptSent', 'atlascode', {
+        attributes: { sessionId, promptId, source, deepPlanEnabled },
+    });
+}
+
+export async function rovoDevNewSessionActionEvent(sessionId: string, isManuallyCreated: boolean) {
+    return trackEvent('rovoDevNewSessionAction', 'atlascode', {
+        attributes: { sessionId, isManuallyCreated },
+    });
+}
+
+export async function rovoDevTechnicalPlanningShownEvent(
+    sessionId: string,
+    stepsCount: number,
+    filesCount: number,
+    questionsCount: number,
+) {
+    return trackEvent('rovoDevTechnicalPlanningShown', 'atlascode', {
+        attributes: { sessionId, stepsCount, filesCount, questionsCount },
+    });
+}
+
+export async function rovoDevFilesSummaryShownEvent(sessionId: string, filesCount: number) {
+    return trackEvent('rovoDevFilesSummaryShown', 'atlascode', {
+        attributes: { sessionId, filesCount },
+    });
+}
+
+export async function rovoDevFileChangedActionEvent(sessionId: string, action: 'undo' | 'keep', filesCount: number) {
+    return trackEvent('rovoDevFileChangedAction', 'atlascode', {
+        attributes: { sessionId, action, filesCount },
+    });
+}
+
+export async function rovoDevStopActionEvent(sessionId: string, failed: boolean) {
+    return trackEvent('rovoDevStopAction', 'atlascode', {
+        attributes: { sessionId, failed },
+    });
+}
+
+export async function rovoDevGitPushActionEvent(sessionId: string, prCreated: boolean) {
+    return trackEvent('rovoDevGitPushAction', 'atlascode', {
+        attributes: { sessionId, prCreated },
+    });
+}
+
+export async function rovoDevDetailsExpandedEvent(sessionId: string) {
+    return trackEvent('rovoDevDetailsExpanded', 'atlascode', {
+        attributes: { sessionId },
+    });
+}
+
 // Jira issue events
 
 export async function issueCreatedEvent(site: DetailedSiteInfo, issueKey: string): Promise<TrackEvent> {

--- a/src/rovo-dev/performanceLogger.test.ts
+++ b/src/rovo-dev/performanceLogger.test.ts
@@ -1,0 +1,320 @@
+import { performanceEvent } from '../analytics';
+import { Container } from '../container';
+import { Logger } from '../logger';
+import Perf from '../util/perf';
+import { PerformanceLogger } from './performanceLogger';
+
+// Mock dependencies
+jest.mock('../analytics');
+jest.mock('../container');
+jest.mock('../logger');
+jest.mock('../util/perf');
+
+const mockPerformanceEvent = performanceEvent as jest.MockedFunction<typeof performanceEvent>;
+const mockContainer = Container as jest.Mocked<typeof Container>;
+const mockLogger = Logger as jest.Mocked<typeof Logger>;
+const mockPerf = Perf as jest.Mocked<typeof Perf>;
+
+describe('PerformanceLogger', () => {
+    let performanceLogger: PerformanceLogger;
+    let mockAnalyticsClient: { sendTrackEvent: jest.Mock };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        performanceLogger = new PerformanceLogger();
+
+        // Setup mock analytics client
+        mockAnalyticsClient = {
+            sendTrackEvent: jest.fn().mockResolvedValue(undefined),
+        };
+
+        // Mock Container.analyticsClient as a getter
+        Object.defineProperty(mockContainer, 'analyticsClient', {
+            get: jest.fn(() => mockAnalyticsClient),
+            configurable: true,
+        });
+
+        // Setup default mock returns
+        mockPerf.measure.mockReturnValue(100);
+        mockPerformanceEvent.mockResolvedValue({ type: 'track', event: 'test' } as any);
+    });
+
+    describe('sessionStarted', () => {
+        it('should set the current session ID', () => {
+            const sessionId = 'test-session-123';
+
+            performanceLogger.sessionStarted(sessionId);
+
+            // Verify session is set by calling a method that requires it
+            expect(() => performanceLogger.promptStarted('test-prompt')).not.toThrow();
+        });
+
+        it('should update session ID when called multiple times', () => {
+            performanceLogger.sessionStarted('session-1');
+            performanceLogger.sessionStarted('session-2');
+
+            // Should not throw since session is set
+            expect(() => performanceLogger.promptStarted('test-prompt')).not.toThrow();
+        });
+    });
+
+    describe('promptStarted', () => {
+        it('should throw error if session is not started', () => {
+            const promptId = 'test-prompt-123';
+
+            expect(() => performanceLogger.promptStarted(promptId)).toThrow('Session not started');
+        });
+
+        it('should mark performance start when session is active', () => {
+            const sessionId = 'test-session-123';
+            const promptId = 'test-prompt-123';
+
+            performanceLogger.sessionStarted(sessionId);
+            performanceLogger.promptStarted(promptId);
+
+            expect(mockPerf.mark).toHaveBeenCalledWith(promptId);
+        });
+    });
+
+    describe('promptFirstByteReceived', () => {
+        beforeEach(() => {
+            performanceLogger.sessionStarted('test-session-123');
+        });
+
+        it('should measure performance and send analytics event', async () => {
+            const promptId = 'test-prompt-123';
+            const measureValue = 150;
+            const mockEvent = { type: 'track', event: 'timeToFirstByte' };
+
+            mockPerf.measure.mockReturnValue(measureValue);
+            mockPerformanceEvent.mockResolvedValue(mockEvent as any);
+
+            await performanceLogger.promptFirstByteReceived(promptId);
+
+            expect(mockPerf.measure).toHaveBeenCalledWith(promptId);
+            expect(mockPerformanceEvent).toHaveBeenCalledWith('rovodev.response.timeToFirstByte', measureValue, {
+                sessionId: 'test-session-123',
+                promptId,
+            });
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                `Event fired: rovodev.response.timeToFirstByte ${measureValue} ms`,
+            );
+            expect(mockAnalyticsClient.sendTrackEvent).toHaveBeenCalledWith(mockEvent);
+        });
+
+        it('should handle analytics client errors gracefully', async () => {
+            const promptId = 'test-prompt-123';
+            mockAnalyticsClient.sendTrackEvent.mockRejectedValue(new Error('Network error'));
+
+            await expect(performanceLogger.promptFirstByteReceived(promptId)).rejects.toThrow('Network error');
+        });
+    });
+
+    describe('promptFirstMessageReceived', () => {
+        beforeEach(() => {
+            performanceLogger.sessionStarted('test-session-123');
+        });
+
+        it('should measure performance and send analytics event', async () => {
+            const promptId = 'test-prompt-123';
+            const measureValue = 200;
+            const mockEvent = { type: 'track', event: 'timeToFirstMessage' };
+
+            mockPerf.measure.mockReturnValue(measureValue);
+            mockPerformanceEvent.mockResolvedValue(mockEvent as any);
+
+            await performanceLogger.promptFirstMessageReceived(promptId);
+
+            expect(mockPerf.measure).toHaveBeenCalledWith(promptId);
+            expect(mockPerformanceEvent).toHaveBeenCalledWith('rovodev.response.timeToFirstMessage', measureValue, {
+                sessionId: 'test-session-123',
+                promptId,
+            });
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                `Event fired: rovodev.response.timeToFirstMessage ${measureValue} ms`,
+            );
+            expect(mockAnalyticsClient.sendTrackEvent).toHaveBeenCalledWith(mockEvent);
+        });
+    });
+
+    describe('promptTechnicalPlanReceived', () => {
+        beforeEach(() => {
+            performanceLogger.sessionStarted('test-session-123');
+        });
+
+        it('should measure performance and send analytics event', async () => {
+            const promptId = 'test-prompt-123';
+            const measureValue = 300;
+            const mockEvent = { type: 'track', event: 'timeToTechPlan' };
+
+            mockPerf.measure.mockReturnValue(measureValue);
+            mockPerformanceEvent.mockResolvedValue(mockEvent as any);
+
+            await performanceLogger.promptTechnicalPlanReceived(promptId);
+
+            expect(mockPerf.measure).toHaveBeenCalledWith(promptId);
+            expect(mockPerformanceEvent).toHaveBeenCalledWith('rovodev.response.timeToTechPlan', measureValue, {
+                sessionId: 'test-session-123',
+                promptId,
+            });
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                `Event fired: rovodev.response.timeToTechPlan ${measureValue} ms`,
+            );
+            expect(mockAnalyticsClient.sendTrackEvent).toHaveBeenCalledWith(mockEvent);
+        });
+    });
+
+    describe('promptLastMessageReceived', () => {
+        beforeEach(() => {
+            performanceLogger.sessionStarted('test-session-123');
+        });
+
+        it('should measure performance, clear performance data, and send analytics event', async () => {
+            const promptId = 'test-prompt-123';
+            const measureValue = 500;
+            const mockEvent = { type: 'track', event: 'timeToLastMessage' };
+
+            mockPerf.measure.mockReturnValue(measureValue);
+            mockPerformanceEvent.mockResolvedValue(mockEvent as any);
+
+            await performanceLogger.promptLastMessageReceived(promptId);
+
+            expect(mockPerf.measure).toHaveBeenCalledWith(promptId);
+            expect(mockPerf.clear).toHaveBeenCalledWith(promptId);
+            expect(mockPerformanceEvent).toHaveBeenCalledWith('rovodev.response.timeToLastMessage', measureValue, {
+                sessionId: 'test-session-123',
+                promptId,
+            });
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                `Event fired: rovodev.response.timeToLastMessage ${measureValue} ms`,
+            );
+            expect(mockAnalyticsClient.sendTrackEvent).toHaveBeenCalledWith(mockEvent);
+        });
+
+        it('should clear performance data even if analytics fails', async () => {
+            const promptId = 'test-prompt-123';
+            mockAnalyticsClient.sendTrackEvent.mockRejectedValue(new Error('Analytics error'));
+
+            await expect(performanceLogger.promptLastMessageReceived(promptId)).rejects.toThrow('Analytics error');
+            expect(mockPerf.clear).toHaveBeenCalledWith(promptId);
+        });
+    });
+
+    describe('integration scenarios', () => {
+        it('should handle complete prompt lifecycle', async () => {
+            const sessionId = 'integration-session-123';
+            const promptId = 'integration-prompt-123';
+
+            // Start session
+            performanceLogger.sessionStarted(sessionId);
+
+            // Start prompt
+            performanceLogger.promptStarted(promptId);
+            expect(mockPerf.mark).toHaveBeenCalledWith(promptId);
+
+            // Receive first byte
+            await performanceLogger.promptFirstByteReceived(promptId);
+            expect(mockPerf.measure).toHaveBeenCalledWith(promptId);
+
+            // Receive first message
+            await performanceLogger.promptFirstMessageReceived(promptId);
+            expect(mockPerf.measure).toHaveBeenCalledWith(promptId);
+
+            // Receive technical plan
+            await performanceLogger.promptTechnicalPlanReceived(promptId);
+            expect(mockPerf.measure).toHaveBeenCalledWith(promptId);
+
+            // Receive last message
+            await performanceLogger.promptLastMessageReceived(promptId);
+            expect(mockPerf.measure).toHaveBeenCalledWith(promptId);
+            expect(mockPerf.clear).toHaveBeenCalledWith(promptId);
+
+            // Verify all analytics events were sent
+            expect(mockAnalyticsClient.sendTrackEvent).toHaveBeenCalledTimes(4);
+        });
+
+        it('should handle multiple prompts in same session', async () => {
+            const sessionId = 'multi-prompt-session';
+            const promptId1 = 'prompt-1';
+            const promptId2 = 'prompt-2';
+
+            performanceLogger.sessionStarted(sessionId);
+
+            // First prompt
+            performanceLogger.promptStarted(promptId1);
+            await performanceLogger.promptFirstByteReceived(promptId1);
+
+            // Second prompt
+            performanceLogger.promptStarted(promptId2);
+            await performanceLogger.promptFirstByteReceived(promptId2);
+
+            expect(mockPerf.mark).toHaveBeenCalledWith(promptId1);
+            expect(mockPerf.mark).toHaveBeenCalledWith(promptId2);
+            expect(mockAnalyticsClient.sendTrackEvent).toHaveBeenCalledTimes(2);
+        });
+
+        it('should maintain session context across multiple prompt methods', async () => {
+            const sessionId = 'context-session-123';
+            const promptId = 'context-prompt-123';
+
+            performanceLogger.sessionStarted(sessionId);
+
+            await performanceLogger.promptFirstByteReceived(promptId);
+            await performanceLogger.promptFirstMessageReceived(promptId);
+
+            // Verify sessionId was used in both calls
+            expect(mockPerformanceEvent).toHaveBeenCalledWith(
+                'rovodev.response.timeToFirstByte',
+                expect.any(Number),
+                expect.objectContaining({ sessionId }),
+            );
+            expect(mockPerformanceEvent).toHaveBeenCalledWith(
+                'rovodev.response.timeToFirstMessage',
+                expect.any(Number),
+                expect.objectContaining({ sessionId }),
+            );
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle NaN measurement values', async () => {
+            performanceLogger.sessionStarted('test-session');
+            mockPerf.measure.mockReturnValue(NaN);
+
+            await performanceLogger.promptFirstByteReceived('test-prompt');
+
+            expect(mockPerformanceEvent).toHaveBeenCalledWith(
+                'rovodev.response.timeToFirstByte',
+                NaN,
+                expect.any(Object),
+            );
+        });
+
+        it('should handle zero measurement values', async () => {
+            performanceLogger.sessionStarted('test-session');
+            mockPerf.measure.mockReturnValue(0);
+
+            await performanceLogger.promptFirstMessageReceived('test-prompt');
+
+            expect(mockPerformanceEvent).toHaveBeenCalledWith(
+                'rovodev.response.timeToFirstMessage',
+                0,
+                expect.any(Object),
+            );
+        });
+
+        it('should handle empty string session and prompt IDs', async () => {
+            performanceLogger.sessionStarted('non-empty-session');
+
+            expect(() => performanceLogger.promptStarted('')).not.toThrow();
+            expect(mockPerf.mark).toHaveBeenCalledWith('');
+
+            await performanceLogger.promptFirstByteReceived('');
+            expect(mockPerformanceEvent).toHaveBeenCalledWith(
+                'rovodev.response.timeToFirstByte',
+                expect.any(Number),
+                expect.objectContaining({ promptId: '' }),
+            );
+        });
+    });
+});

--- a/src/rovo-dev/performanceLogger.ts
+++ b/src/rovo-dev/performanceLogger.ts
@@ -1,0 +1,66 @@
+import { performanceEvent } from '../../src/analytics';
+import { Container } from '../../src/container';
+import { Logger } from '../../src/logger';
+import Perf from '../util/perf';
+
+export class PerformanceLogger {
+    private currentSessionId: string = '';
+
+    public sessionStarted(sessionId: string) {
+        this.currentSessionId = sessionId;
+    }
+
+    public promptStarted(promptId: string) {
+        if (!this.currentSessionId) {
+            throw new Error('Session not started');
+        }
+
+        Perf.mark(promptId);
+    }
+
+    public async promptFirstByteReceived(promptId: string) {
+        const measure = Perf.measure(promptId);
+        const evt = await performanceEvent('rovodev.response.timeToFirstByte', measure, {
+            sessionId: this.currentSessionId,
+            promptId,
+        });
+
+        Logger.debug(`Event fired: rovodev.response.timeToFirstByte ${measure} ms`);
+        await Container.analyticsClient.sendTrackEvent(evt);
+    }
+
+    public async promptFirstMessageReceived(promptId: string) {
+        const measure = Perf.measure(promptId);
+        const evt = await performanceEvent('rovodev.response.timeToFirstMessage', measure, {
+            sessionId: this.currentSessionId,
+            promptId,
+        });
+
+        Logger.debug(`Event fired: rovodev.response.timeToFirstMessage ${measure} ms`);
+        await Container.analyticsClient.sendTrackEvent(evt);
+    }
+
+    public async promptTechnicalPlanReceived(promptId: string) {
+        const measure = Perf.measure(promptId);
+        const evt = await performanceEvent('rovodev.response.timeToTechPlan', measure, {
+            sessionId: this.currentSessionId,
+            promptId,
+        });
+
+        Logger.debug(`Event fired: rovodev.response.timeToTechPlan ${measure} ms`);
+        await Container.analyticsClient.sendTrackEvent(evt);
+    }
+
+    public async promptLastMessageReceived(promptId: string) {
+        const measure = Perf.measure(promptId);
+        const evt = await performanceEvent('rovodev.response.timeToLastMessage', measure, {
+            sessionId: this.currentSessionId,
+            promptId,
+        });
+
+        Perf.clear(promptId);
+
+        Logger.debug(`Event fired: rovodev.response.timeToLastMessage ${measure} ms`);
+        await Container.analyticsClient.sendTrackEvent(evt);
+    }
+}

--- a/src/util/perf.test.ts
+++ b/src/util/perf.test.ts
@@ -1,0 +1,195 @@
+import perf from './perf';
+
+describe('perf', () => {
+    beforeEach(() => {
+        // Clear all markers before each test to ensure clean state
+        jest.clearAllMocks();
+    });
+
+    describe('mark', () => {
+        it('should create a marker with the given name', () => {
+            const markerName = 'test-marker';
+
+            expect(() => perf.mark(markerName)).not.toThrow();
+        });
+
+        it('should create multiple markers with different names', () => {
+            expect(() => {
+                perf.mark('marker1');
+                perf.mark('marker2');
+                perf.mark('marker3');
+            }).not.toThrow();
+        });
+
+        it('should overwrite existing marker with same name', () => {
+            const markerName = 'duplicate-marker';
+
+            perf.mark(markerName);
+
+            // Wait a bit to ensure some time passes
+            const start = Date.now();
+            while (Date.now() - start < 5) {
+                // Busy wait for ~5ms
+            }
+
+            const firstMeasurement = perf.measure(markerName);
+
+            // Mark again to reset the timer
+            perf.mark(markerName);
+            const secondMeasurement = perf.measure(markerName);
+
+            // First measurement should be greater since time passed before marking again
+            expect(firstMeasurement).toBeGreaterThan(0);
+            expect(secondMeasurement).toBeGreaterThanOrEqual(0);
+            expect(secondMeasurement).toBeLessThanOrEqual(firstMeasurement);
+        });
+    });
+
+    describe('measure', () => {
+        it('should return a number for existing marker', () => {
+            const markerName = 'existing-marker';
+            perf.mark(markerName);
+
+            const result = perf.measure(markerName);
+
+            expect(typeof result).toBe('number');
+            expect(result).toBeGreaterThanOrEqual(0);
+        });
+
+        it('should return NaN for non-existing marker', () => {
+            const result = perf.measure('non-existing-marker');
+
+            expect(result).toBeNaN();
+        });
+
+        it('should return elapsed time in milliseconds', () => {
+            const markerName = 'time-marker';
+            perf.mark(markerName);
+
+            // Wait a small amount of time (in a real scenario this would be actual work)
+            const start = Date.now();
+            while (Date.now() - start < 10) {
+                // Busy wait for ~10ms
+            }
+
+            const elapsed = perf.measure(markerName);
+
+            expect(elapsed).toBeGreaterThan(0);
+            expect(elapsed).toBeLessThan(1000); // Should be less than 1 second
+        });
+
+        it('should return integer values (truncated)', () => {
+            const markerName = 'truncation-marker';
+            perf.mark(markerName);
+
+            const result = perf.measure(markerName);
+
+            expect(Number.isInteger(result) || Number.isNaN(result)).toBe(true);
+        });
+
+        it('should be able to measure same marker multiple times', () => {
+            const markerName = 'repeated-measure';
+            perf.mark(markerName);
+
+            const firstMeasure = perf.measure(markerName);
+            const secondMeasure = perf.measure(markerName);
+
+            expect(firstMeasure).toBeGreaterThanOrEqual(0);
+            expect(secondMeasure).toBeGreaterThanOrEqual(firstMeasure);
+        });
+    });
+
+    describe('clear', () => {
+        it('should remove existing marker', () => {
+            const markerName = 'marker-to-clear';
+            perf.mark(markerName);
+
+            // Verify marker exists
+            expect(perf.measure(markerName)).not.toBeNaN();
+
+            perf.clear(markerName);
+
+            // Verify marker is removed
+            expect(perf.measure(markerName)).toBeNaN();
+        });
+
+        it('should not throw when clearing non-existing marker', () => {
+            expect(() => perf.clear('non-existing-marker')).not.toThrow();
+        });
+
+        it('should only clear the specified marker', () => {
+            perf.mark('marker1');
+            perf.mark('marker2');
+            perf.mark('marker3');
+
+            perf.clear('marker2');
+
+            expect(perf.measure('marker1')).not.toBeNaN();
+            expect(perf.measure('marker2')).toBeNaN();
+            expect(perf.measure('marker3')).not.toBeNaN();
+        });
+    });
+
+    describe('integration scenarios', () => {
+        it('should handle complete mark-measure-clear cycle', () => {
+            const markerName = 'integration-test';
+
+            // Mark
+            perf.mark(markerName);
+
+            // Measure
+            const measurement = perf.measure(markerName);
+            expect(measurement).toBeGreaterThanOrEqual(0);
+            expect(Number.isInteger(measurement)).toBe(true);
+
+            // Clear
+            perf.clear(markerName);
+            expect(perf.measure(markerName)).toBeNaN();
+        });
+
+        it('should handle multiple concurrent markers', () => {
+            const markers = ['concurrent1', 'concurrent2', 'concurrent3'];
+
+            // Mark all
+            markers.forEach((marker) => perf.mark(marker));
+
+            // Measure all
+            const measurements = markers.map((marker) => perf.measure(marker));
+            measurements.forEach((measurement) => {
+                expect(measurement).toBeGreaterThanOrEqual(0);
+            });
+
+            // Clear some
+            perf.clear(markers[0]);
+            perf.clear(markers[2]);
+
+            // Verify state
+            expect(perf.measure(markers[0])).toBeNaN();
+            expect(perf.measure(markers[1])).not.toBeNaN();
+            expect(perf.measure(markers[2])).toBeNaN();
+        });
+
+        it('should handle marker name edge cases', () => {
+            const edgeCaseNames = [
+                '',
+                ' ',
+                'very-long-marker-name-with-lots-of-characters-and-special-symbols-123-!@#',
+                '🚀🎯⭐', // Unicode/emoji
+                'marker.with.dots',
+                'marker_with_underscores',
+                'UPPERCASE',
+                'mixedCase',
+            ];
+
+            edgeCaseNames.forEach((markerName) => {
+                expect(() => {
+                    perf.mark(markerName);
+                    const measurement = perf.measure(markerName);
+                    expect(measurement).toBeGreaterThanOrEqual(0);
+                    perf.clear(markerName);
+                    expect(perf.measure(markerName)).toBeNaN();
+                }).not.toThrow();
+            });
+        });
+    });
+});

--- a/src/util/perf.ts
+++ b/src/util/perf.ts
@@ -1,0 +1,30 @@
+const NS_PER_SEC = 1e9;
+const NS_PER_MSEC = 1e6;
+
+const markers: Record<string, [number, number]> = {};
+
+function mark(marker: string): void {
+    markers[marker] = process.hrtime();
+}
+
+function measure(marker: string): number {
+    const time = markers[marker];
+    if (!time) {
+        return NaN;
+    }
+
+    const diff = process.hrtime(time);
+    const ns = diff[0] * NS_PER_SEC + diff[1];
+    const ms = ns / NS_PER_MSEC;
+    return Math.trunc(ms);
+}
+
+function clear(marker: string): void {
+    delete markers[marker];
+}
+
+export default {
+    mark,
+    measure,
+    clear,
+};


### PR DESCRIPTION
### What Is This Change?

This change implements the Rovo Dev performance telemetry events, measuring:
- time to respond with the first byte
- time to respond with the first message
- time to respond with a technical plan
- time to respond with the last message

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`