### PR TITLE
[AXON-715][Rovo Dev] Fire 'deep plan shown' telemetry event

### DIFF
--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -11,6 +11,12 @@ import { createPatch } from 'diff';
 import MarkdownIt from 'markdown-it';
 import React, { useCallback } from 'react';
 
+import {
+    CodeSnippetToChange,
+    TechnicalPlan,
+    TechnicalPlanFileToChange,
+    TechnicalPlanLogicalChange,
+} from '../../../../../src/rovo-dev/rovoDevTypes';
 import { ChatMessageItem } from '../messaging/ChatMessageItem';
 import {
     agentMessageStyles,
@@ -22,17 +28,7 @@ import {
     undoKeepButtonStyles,
 } from '../rovoDevViewStyles';
 import { ToolReturnParsedItem } from '../tools/ToolReturnItem';
-import {
-    ChatMessage,
-    CodeSnippetToChange,
-    DefaultMessage,
-    ErrorMessage,
-    parseToolReturnMessage,
-    TechnicalPlan,
-    TechnicalPlanFileToChange,
-    TechnicalPlanLogicalChange,
-    ToolReturnParseResult,
-} from '../utils';
+import { ChatMessage, DefaultMessage, ErrorMessage, parseToolReturnMessage, ToolReturnParseResult } from '../utils';
 
 export const mdParser = new MarkdownIt({
     html: true,

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -1,4 +1,4 @@
-import { RovoDevContext } from 'src/rovo-dev/rovoDevTypes';
+import { RovoDevContext, TechnicalPlan } from '../../../../src/rovo-dev/rovoDevTypes';
 
 export type ToolReturnMessage =
     | ToolReturnFileMessage
@@ -78,28 +78,6 @@ export interface ToolReturnGenericMessage {
 export interface ToolReturnGroupedMessage {
     source: 'ReturnGroup';
     tool_returns: ToolReturnGenericMessage[];
-}
-
-export interface CodeSnippetToChange {
-    startLine: number;
-    endLine: number;
-    code: string;
-}
-
-export interface TechnicalPlanFileToChange {
-    filePath: string;
-    descriptionOfChange: string;
-    clarifyingQuestionIfAny: string | null;
-    codeSnippetsToChange: CodeSnippetToChange[];
-}
-
-export interface TechnicalPlanLogicalChange {
-    summary: string;
-    filesToChange: TechnicalPlanFileToChange[];
-}
-
-export interface TechnicalPlan {
-    logicalChanges: TechnicalPlanLogicalChange[];
 }
 
 export interface ToolReturnParseResult {

--- a/src/rovo-dev/rovoDevTypes.ts
+++ b/src/rovo-dev/rovoDevTypes.ts
@@ -28,3 +28,25 @@ export interface RovoDevPrompt {
     enable_deep_plan?: boolean;
     context?: RovoDevContext;
 }
+
+export interface CodeSnippetToChange {
+    startLine: number;
+    endLine: number;
+    code: string;
+}
+
+export interface TechnicalPlanFileToChange {
+    filePath: string;
+    descriptionOfChange: string;
+    clarifyingQuestionIfAny: string | null;
+    codeSnippetsToChange: CodeSnippetToChange[];
+}
+
+export interface TechnicalPlanLogicalChange {
+    summary: string;
+    filesToChange: TechnicalPlanFileToChange[];
+}
+
+export interface TechnicalPlan {
+    logicalChanges: TechnicalPlanLogicalChange[];
+}

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -21,6 +21,9 @@ import {
     workspace,
 } from 'vscode';
 
+import { rovoDevTechnicalPlanningShownEvent } from '../../src/analytics';
+import { Container } from '../../src/container';
+import { Logger } from '../../src/logger';
 import { rovodevInfo } from '../constants';
 import { RovoDevViewResponse, RovoDevViewResponseType } from '../react/atlascode/rovo-dev/rovoDevViewMessages';
 import { getHtmlForView } from '../webview/common/getHtmlForView';
@@ -28,7 +31,7 @@ import { PerformanceLogger } from './performanceLogger';
 import { RovoDevResponse, RovoDevResponseParser } from './responseParser';
 import { RovoDevApiClient, RovoDevHealthcheckResponse } from './rovoDevApiClient';
 import { RovoDevPullRequestHandler } from './rovoDevPullRequestHandler';
-import { RovoDevContext, RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
+import { RovoDevContext, RovoDevContextItem, RovoDevPrompt, TechnicalPlan } from './rovoDevTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from './rovoDevWebviewProviderMessages';
 
 const MIN_SUPPORTED_ROVODEV_VERSION = '0.9.3';
@@ -418,6 +421,24 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             case 'tool-return':
                 if (fireTelemetry && response.tool_name === 'create_technical_plan' && response.parsedContent) {
                     this._perfLogger.promptTechnicalPlanReceived(this._currentPromptId);
+
+                    const parsedContent = response.parsedContent as TechnicalPlan;
+                    const stepsCount = parsedContent.logicalChanges.length;
+                    const filesCount = parsedContent.logicalChanges.reduce((p, c) => p + c.filesToChange.length, 0);
+                    const questionsCount = parsedContent.logicalChanges.reduce(
+                        (p, c) => p + c.filesToChange.reduce((p2, c2) => p2 + (c2.clarifyingQuestionIfAny ? 1 : 0), 0),
+                        0,
+                    );
+
+                    Logger.debug(
+                        `Event fired: rovoDevTechnicalPlanningShownEvent ${stepsCount} ${filesCount} ${questionsCount}`,
+                    );
+                    rovoDevTechnicalPlanningShownEvent(
+                        this._chatSessionId,
+                        stepsCount,
+                        filesCount,
+                        questionsCount,
+                    ).then((evt) => Container.analyticsClient.sendTrackEvent(evt));
                 }
                 return webview.postMessage({
                     type: RovoDevProviderMessageType.ToolReturn,


### PR DESCRIPTION
### What Is This Change?

Fires 'deep plan shown' telemetry event when the deep plan is returned by Rovo Dev.

### How Has This Been Tested?

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `manual tests`