### PR TITLE
[AXON-716][AXON-718][Rovo Dev] Fire 'Stop prompt', 'Keep file', and 'Undo file' telemetry events

### DIFF
--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -1083,11 +1083,17 @@ describe('analytics', () => {
         it('should create rovoDevFileChangedActionEvent for undo action', async () => {
             const action = 'undo';
             const filesCount = 3;
-            const event = await analytics.rovoDevFileChangedActionEvent(mockSessionId, action, filesCount);
+            const event = await analytics.rovoDevFileChangedActionEvent(
+                mockSessionId,
+                mockPromptId,
+                action,
+                filesCount,
+            );
 
             expect(event.trackEvent.action).toEqual('rovoDevFileChangedAction');
             expect(event.trackEvent.actionSubject).toEqual('atlascode');
             expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
             expect(event.trackEvent.attributes.action).toEqual(action);
             expect(event.trackEvent.attributes.filesCount).toEqual(filesCount);
         });
@@ -1095,32 +1101,40 @@ describe('analytics', () => {
         it('should create rovoDevFileChangedActionEvent for keep action', async () => {
             const action = 'keep';
             const filesCount = 2;
-            const event = await analytics.rovoDevFileChangedActionEvent(mockSessionId, action, filesCount);
+            const event = await analytics.rovoDevFileChangedActionEvent(
+                mockSessionId,
+                mockPromptId,
+                action,
+                filesCount,
+            );
 
             expect(event.trackEvent.action).toEqual('rovoDevFileChangedAction');
             expect(event.trackEvent.actionSubject).toEqual('atlascode');
             expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
             expect(event.trackEvent.attributes.action).toEqual(action);
             expect(event.trackEvent.attributes.filesCount).toEqual(filesCount);
         });
 
         it('should create rovoDevStopActionEvent when successful', async () => {
             const failed = false;
-            const event = await analytics.rovoDevStopActionEvent(mockSessionId, failed);
+            const event = await analytics.rovoDevStopActionEvent(mockSessionId, mockPromptId, failed);
 
             expect(event.trackEvent.action).toEqual('rovoDevStopAction');
             expect(event.trackEvent.actionSubject).toEqual('atlascode');
             expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
             expect(event.trackEvent.attributes.failed).toEqual(failed);
         });
 
         it('should create rovoDevStopActionEvent when failed', async () => {
             const failed = true;
-            const event = await analytics.rovoDevStopActionEvent(mockSessionId, failed);
+            const event = await analytics.rovoDevStopActionEvent(mockSessionId, mockPromptId, failed);
 
             expect(event.trackEvent.action).toEqual('rovoDevStopAction');
             expect(event.trackEvent.actionSubject).toEqual('atlascode');
             expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
             expect(event.trackEvent.attributes.failed).toEqual(failed);
         });
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -235,15 +235,20 @@ export async function rovoDevFilesSummaryShownEvent(sessionId: string, filesCoun
     });
 }
 
-export async function rovoDevFileChangedActionEvent(sessionId: string, action: 'undo' | 'keep', filesCount: number) {
+export async function rovoDevFileChangedActionEvent(
+    sessionId: string,
+    promptId: string,
+    action: 'undo' | 'keep',
+    filesCount: number,
+) {
     return trackEvent('rovoDevFileChangedAction', 'atlascode', {
-        attributes: { sessionId, action, filesCount },
+        attributes: { sessionId, promptId, action, filesCount },
     });
 }
 
-export async function rovoDevStopActionEvent(sessionId: string, failed: boolean) {
+export async function rovoDevStopActionEvent(sessionId: string, promptId: string, failed: boolean) {
     return trackEvent('rovoDevStopAction', 'atlascode', {
-        attributes: { sessionId, failed },
+        attributes: { sessionId, promptId, failed },
     });
 }
 


### PR DESCRIPTION
### What Is This Change?

Fires 'Stop prompt', 'Keep file', and 'Undo file' telemetry events.

### How Has This Been Tested?

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `manual tests`