### PR TITLE
[AXON-522] Add annotation instruction w/ keyboard shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -875,6 +875,12 @@
             "type": "object",
             "title": "Atlassian",
             "properties": {
+                "atlascode.rovodev.showKeybinding": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show the Rovo Dev keybinding annotation in the editor when a selection is present.",
+                    "scope": "window"
+                },
                 "atlascode.rovodev.executablePath": {
                     "type": "string",
                     "description": "The absolute path to the Rovo Dev executable"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -246,15 +246,15 @@ export function registerRovoDevCommands(vscodeContext: ExtensionContext) {
             if (!prompt?.trim()) {
                 return;
             }
-            Container.rovodevWebviewProvder.invokeRovoDevAskCommand(prompt, context);
+            Container.rovodevWebviewProvider.invokeRovoDevAskCommand(prompt, context);
         }),
     );
     vscodeContext.subscriptions.push(
         commands.registerCommand(Commands.RovodevAsk, (prompt: string, context?: RovoDevContext) => {
-            Container.rovodevWebviewProvder.invokeRovoDevAskCommand(prompt, context);
+            Container.rovodevWebviewProvider.invokeRovoDevAskCommand(prompt, context);
         }),
         commands.registerCommand(Commands.RovodevNewSession, () => {
-            Container.rovodevWebviewProvder.executeReset();
+            Container.rovodevWebviewProvider.executeReset();
         }),
     );
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -31,6 +31,7 @@ import { Logger } from './logger';
 import OnboardingProvider from './onboarding/onboardingProvider';
 import { Pipeline } from './pipelines/model';
 import { RovoDevCodeActionProvider } from './rovo-dev/rovoDevCodeActionProvider';
+import { RovoDevDecorator } from './rovo-dev/rovoDevDecorator';
 import { RovoDevWebviewProvider } from './rovo-dev/rovoDevWebviewProvider';
 import { SiteManager } from './siteManager';
 import { AtlascodeUriHandler, ONBOARDING_URL, SETTINGS_URL } from './uriHandler';
@@ -156,11 +157,6 @@ export class Container {
         context.subscriptions.push((this._onboardingWebviewFactory = onboardingV2ViewFactory));
         context.subscriptions.push((this._startWorkWebviewFactory = startWorkV2ViewFactory));
         context.subscriptions.push((this._createPullRequestWebviewFactory = createPullRequestV2ViewFactory));
-        context.subscriptions.push(
-            languages.registerCodeActionsProvider({ scheme: 'file' }, new RovoDevCodeActionProvider(), {
-                providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],
-            }),
-        );
 
         const pipelinesV2Webview = new MultiWebview<Pipeline, PipelineSummaryAction>(
             context.extensionPath,
@@ -203,8 +199,14 @@ export class Container {
         context.subscriptions.push((this._assignedWorkItemsView = new AssignedWorkItemsViewProvider()));
 
         if (!!process.env.ROVODEV_ENABLED) {
+            context.subscriptions.push(new RovoDevDecorator());
             context.subscriptions.push(
-                (this._rovodevWebviewProvder = new RovoDevWebviewProvider(context.extensionPath, context.globalState)),
+                languages.registerCodeActionsProvider({ scheme: 'file' }, new RovoDevCodeActionProvider(), {
+                    providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],
+                }),
+            );
+            context.subscriptions.push(
+                (this._rovodevWebviewProvider = new RovoDevWebviewProvider(context.extensionPath, context.globalState)),
             );
         }
 
@@ -411,8 +413,8 @@ export class Container {
         return this._onboardingProvider;
     }
 
-    private static _rovodevWebviewProvder: RovoDevWebviewProvider;
-    public static get rovodevWebviewProvder() {
-        return this._rovodevWebviewProvder;
+    private static _rovodevWebviewProvider: RovoDevWebviewProvider;
+    public static get rovodevWebviewProvider() {
+        return this._rovodevWebviewProvider;
     }
 }

--- a/src/rovo-dev/rovoDevDecorator.ts
+++ b/src/rovo-dev/rovoDevDecorator.ts
@@ -1,0 +1,69 @@
+/**
+ * RovoDevDecorator
+ *
+ * Handles displaying a keybinding annotation in the editor when a selection is present.
+ * The annotation is shown only if enabled via the `atlascode.rovodev.showKeybinding` setting.
+ * Decoration updates automatically on selection, editor, and configuration changes.
+ */
+import { Disposable, Range, window, workspace } from 'vscode';
+
+export class RovoDevDecorator implements Disposable {
+    private enabled: boolean;
+    private keybindingDecoration;
+
+    constructor() {
+        this.enabled = this.getEnabledSetting();
+        this.keybindingDecoration = window.createTextEditorDecorationType({
+            after: {
+                contentText: RovoDevDecorator.buildKeybindingLabel(),
+                color: '#888888',
+            },
+        });
+        this.updateKeybindingDecoration();
+        window.onDidChangeActiveTextEditor(this.updateKeybindingDecoration, this, []);
+        window.onDidChangeTextEditorSelection(this.updateKeybindingDecoration, this, []);
+        window.onDidChangeTextEditorVisibleRanges(this.updateKeybindingDecoration, this, []);
+        workspace.onDidChangeConfiguration(this.onConfigChange, this, []);
+    }
+
+    private static buildKeybindingLabel(): string {
+        const isMac = process.platform === 'darwin';
+        const cmdKey = isMac ? '⌘' : 'Ctrl';
+        const altKey = isMac ? '⌥' : 'Alt';
+        return '\u2003'.repeat(10) + `${cmdKey} + ${altKey} + A: send to Rovo Dev`;
+    }
+
+    private getEnabledSetting(): boolean {
+        return workspace.getConfiguration('atlascode.rovodev').get('showKeybinding', true);
+    }
+
+    private onConfigChange() {
+        this.enabled = this.getEnabledSetting();
+        this.updateKeybindingDecoration();
+    }
+
+    public updateKeybindingDecoration(): void {
+        const editor = window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+        if (!this.enabled) {
+            editor.setDecorations(this.keybindingDecoration, []);
+            return;
+        }
+        const decorations = editor.selections
+            .filter((selection) => !selection.isEmpty)
+            .map((selection) => {
+                const cursorLine = selection.active.line;
+                const line = editor.document.lineAt(cursorLine);
+                return {
+                    range: new Range(cursorLine, line.text.length, cursorLine, line.text.length),
+                };
+            });
+        editor.setDecorations(this.keybindingDecoration, decorations);
+    }
+
+    public dispose(): void {
+        this.keybindingDecoration.dispose();
+    }
+}

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -887,7 +887,7 @@ export class JiraIssueWebview
                     break;
                 }
                 case 'invokeRovodev': {
-                    Container.rovodevWebviewProvder.invokeRovoDevAskCommand((msg as any).prompt);
+                    Container.rovodevWebviewProvider.invokeRovoDevAskCommand((msg as any).prompt);
                     break;
                 }
                 case 'openPullRequest': {


### PR DESCRIPTION
### What Is This Change?

Add a little annotation showing the prompt and default keybinding to send something to rovodev chat
<img width="538" height="55" alt="image" src="https://github.com/user-attachments/assets/eef887fa-5e9a-4744-a936-76b42a411766" />


Notably, we can only use the default keybinding because it seems that there's no way to dynamically get it through the VSCode API :(

### How Has This Been Tested?

`m a n u a l l y`
