### PR TITLE
[AXON-731][Rovo Dev] Tag Rovo Dev error telemetry events

### DIFF
--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -242,7 +242,7 @@ describe('analytics', () => {
             const capturedBy = 'test-function';
             const additionalParams = 'additional-info';
 
-            const event = await analytics.errorEvent(errorMessage, error, capturedBy, additionalParams);
+            const event = await analytics.errorEvent(undefined, errorMessage, error, capturedBy, additionalParams);
 
             expect(event.trackEvent.action).toEqual('errorEvent_v2');
             expect(event.trackEvent.actionSubject).toEqual('atlascode');
@@ -258,7 +258,7 @@ describe('analytics', () => {
             const error = new Error('Test error');
             error.stack = 'Error: Test error\n    at TestFunction (/Users/realuser/test.js:10:15)';
 
-            const event = await analytics.errorEvent(errorMessage, error);
+            const event = await analytics.errorEvent(undefined, errorMessage, error);
 
             // Check if the username was sanitized
             expect(event.trackEvent.attributes.stack).toContain('/Users/<user>/');
@@ -735,7 +735,7 @@ describe('analytics', () => {
 
         it('should sanitize IP addresses in error messages', async () => {
             const ipErrorMessage = 'connect error 192.168.1.1 failed';
-            const event = await analytics.errorEvent(ipErrorMessage);
+            const event = await analytics.errorEvent(undefined, ipErrorMessage);
 
             expect(event.trackEvent.attributes.message).not.toContain('192.168.1.1');
             expect(event.trackEvent.attributes.message).toContain('<ip>');
@@ -743,16 +743,10 @@ describe('analytics', () => {
 
         it('should sanitize domain names in getaddrinfo errors', async () => {
             const domainErrorMessage = 'getaddrinfo ENOTFOUND example.com';
-            const event = await analytics.errorEvent(domainErrorMessage);
+            const event = await analytics.errorEvent(undefined, domainErrorMessage);
 
             expect(event.trackEvent.attributes.message).not.toContain('example.com');
             expect(event.trackEvent.attributes.message).toContain('<domain>');
-        });
-
-        it('should handle null error messages', async () => {
-            const event = await analytics.errorEvent(undefined as any);
-
-            expect(event.trackEvent.attributes.message).toBeUndefined();
         });
 
         it('should handle anonymous user for analytics events when AAID is not available', async () => {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,7 +1,7 @@
 import { Uri } from 'vscode';
 
 import { ScreenEvent, TrackEvent, UIEvent } from './analytics-node-client/src/types';
-import { CreatePrTerminalSelection, UIErrorInfo } from './analyticsTypes';
+import { CreatePrTerminalSelection, ErrorProductArea, UIErrorInfo } from './analyticsTypes';
 import { DetailedSiteInfo, isEmptySiteInfo, Product, ProductJira, SiteInfo } from './atlclients/authInfo';
 import { BitbucketIssuesTreeViewId, PullRequestTreeViewId } from './constants';
 import { Container } from './container';
@@ -123,19 +123,24 @@ function sanitizeStackTrace(stack?: string): string | undefined {
     return stack || undefined;
 }
 
+interface ErrorEventPayload {
+    productArea: ErrorProductArea;
+    name: string;
+    message?: string;
+    capturedBy?: string;
+    stack?: string;
+    additionalParams?: string;
+}
+
 export async function errorEvent(
+    productArea: ErrorProductArea,
     errorMessage: string,
     error?: Error,
     capturedBy?: string,
     additionalParams?: string,
 ): Promise<TrackEvent> {
-    const attributes: {
-        name: string;
-        message?: string;
-        capturedBy?: string;
-        stack?: string;
-        additionalParams?: string;
-    } = {
+    const attributes: ErrorEventPayload = {
+        productArea,
         message: sanitazeErrorMessage(errorMessage),
         name: error?.name || 'Error',
         capturedBy,

--- a/src/analyticsTypes.ts
+++ b/src/analyticsTypes.ts
@@ -60,3 +60,7 @@ export enum CreatePrTerminalSelection {
     Ignore = 'ignore',
     Disable = 'disable',
 }
+
+// in the future we may use this to classify where the error is coming from:
+// e.g., Jira, Bitbucket, Authentication, Notifications, etc
+export type ErrorProductArea = 'RovoDev' | undefined;

--- a/src/errorReporting.test.ts
+++ b/src/errorReporting.test.ts
@@ -133,28 +133,60 @@ describe('errorReporting', () => {
                 const error = createError('Error1');
                 errorlistener!({ error });
 
-                expect(analytics.errorEvent).toHaveBeenCalledWith(error.message, error, undefined, undefined);
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
+                    error.message,
+                    error,
+                    undefined,
+                    undefined,
+                );
             });
 
             it('with capturedBy', () => {
                 const error = createError('Error1');
                 errorlistener!({ error, capturedBy: 'foo' });
 
-                expect(analytics.errorEvent).toHaveBeenCalledWith(error.message, error, 'foo', undefined);
+                expect(analytics.errorEvent).toHaveBeenCalledWith(undefined, error.message, error, 'foo', undefined);
+            });
+
+            it('with productArea', () => {
+                const error = createError('Error1');
+                errorlistener!({ error, productArea: 'RovoDev' });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    'RovoDev',
+                    error.message,
+                    error,
+                    undefined,
+                    undefined,
+                );
             });
 
             it('with a custom message', () => {
                 const error = createError('Error1');
                 errorlistener!({ error, errorMessage: "what's this" });
 
-                expect(analytics.errorEvent).toHaveBeenCalledWith("what's this", error, undefined, undefined);
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
+                    "what's this",
+                    error,
+                    undefined,
+                    undefined,
+                );
             });
 
             it('with a custom message and capturedBy', () => {
                 const error = createError('Error1');
                 errorlistener!({ error, errorMessage: "what's this", capturedBy: 'fii' });
 
-                expect(analytics.errorEvent).toHaveBeenCalledWith("what's this", error, 'fii', undefined);
+                expect(analytics.errorEvent).toHaveBeenCalledWith(undefined, "what's this", error, 'fii', undefined);
+            });
+
+            it('with productArea, custom message, and capturedBy', () => {
+                const error = createError('Error1');
+                errorlistener!({ error, errorMessage: "what's this", capturedBy: 'fii', productArea: 'RovoDev' });
+
+                expect(analytics.errorEvent).toHaveBeenCalledWith('RovoDev', "what's this", error, 'fii', undefined);
             });
 
             it('with a single param', () => {
@@ -162,7 +194,13 @@ describe('errorReporting', () => {
                 const params = ['single param'];
                 errorlistener!({ error, params });
 
-                expect(analytics.errorEvent).toHaveBeenCalledWith(error.message, error, undefined, 'single param');
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
+                    error.message,
+                    error,
+                    undefined,
+                    'single param',
+                );
             });
 
             it('with multiple params', () => {
@@ -171,6 +209,7 @@ describe('errorReporting', () => {
                 errorlistener!({ error, params });
 
                 expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
                     error.message,
                     error,
                     undefined,
@@ -183,7 +222,13 @@ describe('errorReporting', () => {
                 const params = [] as string[];
                 errorlistener!({ error, params });
 
-                expect(analytics.errorEvent).toHaveBeenCalledWith(error.message, error, undefined, undefined);
+                expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
+                    error.message,
+                    error,
+                    undefined,
+                    undefined,
+                );
             });
 
             it('captured by uncaughtException', () => {
@@ -191,6 +236,7 @@ describe('errorReporting', () => {
                 uncaughtExceptionListener(error);
 
                 expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
                     error.message,
                     error,
                     'NodeJS.uncaughtException',
@@ -203,6 +249,7 @@ describe('errorReporting', () => {
                 uncaughtExceptionMonitorListener(error);
 
                 expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
                     error.message,
                     error,
                     'NodeJS.uncaughtExceptionMonitor',
@@ -215,6 +262,7 @@ describe('errorReporting', () => {
                 unhandledRejectionListener(error);
 
                 expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
                     error.message,
                     error,
                     'NodeJS.unhandledRejection',
@@ -227,19 +275,20 @@ describe('errorReporting', () => {
             it('no extra params', () => {
                 errorlistener!({ error: 'Error1' as any });
 
-                expect(analytics.errorEvent).toHaveBeenCalledWith('Error1', undefined, undefined, undefined);
+                expect(analytics.errorEvent).toHaveBeenCalledWith(undefined, 'Error1', undefined, undefined, undefined);
             });
 
             it('with capturedBy', () => {
                 errorlistener!({ error: 'Error1' as any, capturedBy: 'foo' });
 
-                expect(analytics.errorEvent).toHaveBeenCalledWith('Error1', undefined, 'foo', undefined);
+                expect(analytics.errorEvent).toHaveBeenCalledWith(undefined, 'Error1', undefined, 'foo', undefined);
             });
 
             it('with a custom message', () => {
                 errorlistener!({ error: 'Seg fault' as any, errorMessage: 'Error reading stream buffer' });
 
                 expect(analytics.errorEvent).toHaveBeenCalledWith(
+                    undefined,
                     'Error reading stream buffer: Seg fault',
                     undefined,
                     undefined,

--- a/src/errorReporting.ts
+++ b/src/errorReporting.ts
@@ -3,6 +3,7 @@ import { Disposable } from 'vscode';
 import { errorEvent } from './analytics';
 import { AnalyticsClient } from './analytics-node-client/src/client.min';
 import { TrackEvent } from './analytics-node-client/src/types';
+import { ErrorProductArea } from './analyticsTypes';
 import { Logger } from './logger';
 
 const AtlascodeStackTraceHint = '/.vscode/extensions/atlassian.atlascode-';
@@ -30,28 +31,34 @@ function safeExecute(body: () => void, finallyBody?: () => void): void {
 
 // we need a dedicated listener to be able to remove it during the unregister
 function uncaughtExceptionHandler(error: Error | string): void {
-    errorHandlerWithFilter(error, 'NodeJS.uncaughtException');
+    errorHandlerWithFilter(undefined, error, 'NodeJS.uncaughtException');
 }
 
 // we need a dedicated listener to be able to remove it during the unregister
 function uncaughtExceptionMonitorHandler(error: Error | string): void {
-    errorHandlerWithFilter(error, 'NodeJS.uncaughtExceptionMonitor');
+    errorHandlerWithFilter(undefined, error, 'NodeJS.uncaughtExceptionMonitor');
 }
 
 // we need a dedicated listener to be able to remove it during the unregister
 function unhandledRejectionHandler(error: Error | string): void {
-    errorHandlerWithFilter(error, 'NodeJS.unhandledRejection');
+    errorHandlerWithFilter(undefined, error, 'NodeJS.unhandledRejection');
 }
 
-function errorHandlerWithFilter(error: Error | string, capturedBy: string): void {
+function errorHandlerWithFilter(productArea: ErrorProductArea, error: Error | string, capturedBy: string): void {
     safeExecute(() => {
         if (error instanceof Error && error.stack && error.stack.includes(AtlascodeStackTraceHint)) {
-            errorHandler(error, undefined, undefined, capturedBy);
+            errorHandler(productArea, error, undefined, undefined, capturedBy);
         }
     });
 }
 
-function errorHandler(error: Error | string, errorMessage?: string, params?: string[], capturedBy?: string): void {
+function errorHandler(
+    productArea: ErrorProductArea,
+    error: Error | string,
+    errorMessage?: string,
+    params?: string[],
+    capturedBy?: string,
+): void {
     safeExecute(() => {
         const formattedParams =
             !params || params.length === 0 ? undefined : params.length === 1 ? params[0] : JSON.stringify(params);
@@ -61,10 +68,10 @@ function errorHandler(error: Error | string, errorMessage?: string, params?: str
         let event: Promise<TrackEvent>;
         if (typeof error === 'string') {
             errorMessage = errorMessage ? `${errorMessage}: ${error}` : error;
-            event = errorEvent(errorMessage, undefined, capturedBy, formattedParams);
+            event = errorEvent(productArea, errorMessage, undefined, capturedBy, formattedParams);
         } else {
             errorMessage = errorMessage || error.message;
-            event = errorEvent(errorMessage, error, capturedBy, formattedParams);
+            event = errorEvent(productArea, errorMessage, error, capturedBy, formattedParams);
         }
 
         if (analyticsClient) {
@@ -87,7 +94,7 @@ export function registerErrorReporting(): void {
         process.addListener('unhandledRejection', unhandledRejectionHandler);
 
         _logger_onError_eventRegistration = Logger.onError(
-            (data) => errorHandler(data.error, data.errorMessage, data.params, data.capturedBy),
+            (data) => errorHandler(data.productArea, data.error, data.errorMessage, data.params, data.capturedBy),
             undefined,
         );
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ export async function activate(context: ExtensionContext) {
 }
 
 function activateErrorReporting(): void {
-    if (FeatureFlagClient.checkGate(Features.EnableErrorTelemetry)) {
+    if (Container.isDebugging || FeatureFlagClient.checkGate(Features.EnableErrorTelemetry)) {
         registerAnalyticsClient(Container.analyticsClient);
     } else {
         unregisterErrorReporting();

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,3 +1,4 @@
+import { describe } from '@jest/globals';
 import { expansionCastTo } from 'testsutil';
 import { ConfigurationChangeEvent, Disposable, ExtensionContext, LogOutputChannel, window } from 'vscode';
 
@@ -121,7 +122,11 @@ describe('Logger', () => {
         });
     });
 
-    describe('info', () => {
+    describe.each([false, true])('info', (useInstance) => {
+        const Logger_info: typeof Logger.info = useInstance
+            ? (...args) => Logger.Instance.info(...args)
+            : (...args) => Logger.info(...args);
+
         beforeEach(() => {
             // Set up Logger with Info level
             (configuration.initializing as jest.Mock).mockReturnValue(true);
@@ -130,7 +135,7 @@ describe('Logger', () => {
         });
 
         it('should append message to output channel', () => {
-            Logger.info('test info message');
+            Logger_info('test info message');
 
             expect(mockOutputChannel.appendLine).toHaveBeenCalled();
             const call = (mockOutputChannel.appendLine as jest.Mock).mock.calls[0][0];
@@ -142,13 +147,17 @@ describe('Logger', () => {
             (configuration.get as jest.Mock).mockReturnValue(OutputLevel.Errors);
             Logger.configure(expansionCastTo<ExtensionContext>({ subscriptions: [] }));
 
-            Logger.info('test info message');
+            Logger_info('test info message');
 
             expect(mockOutputChannel.appendLine).not.toHaveBeenCalled();
         });
     });
 
-    describe('debug', () => {
+    describe.each([false, true])('debug', (useInstance) => {
+        const Logger_debug: typeof Logger.debug = useInstance
+            ? (...args) => Logger.Instance.debug(...args)
+            : (...args) => Logger.debug(...args);
+
         beforeEach(() => {
             // Set up Logger with Debug level
             (configuration.initializing as jest.Mock).mockReturnValue(true);
@@ -157,7 +166,7 @@ describe('Logger', () => {
         });
 
         it('should append message to output channel', () => {
-            Logger.debug('test debug message');
+            Logger_debug('test debug message');
 
             expect(mockOutputChannel.appendLine).toHaveBeenCalled();
             const call = (mockOutputChannel.appendLine as jest.Mock).mock.calls[0][0];
@@ -167,7 +176,7 @@ describe('Logger', () => {
         it('should output to console when in debugging mode', () => {
             mockContainerIsDebugging();
 
-            Logger.debug('test debug message');
+            Logger_debug('test debug message');
 
             expect(console.log).toHaveBeenCalled();
             const calls = consoleSpy.mock.calls[0];
@@ -180,14 +189,18 @@ describe('Logger', () => {
             (configuration.get as jest.Mock).mockReturnValue(OutputLevel.Info);
             Logger.configure(expansionCastTo<ExtensionContext>({ subscriptions: [] }));
 
-            Logger.debug('test debug message');
+            Logger_debug('test debug message');
 
             expect(mockOutputChannel.appendLine).not.toHaveBeenCalled();
             expect(console.log).not.toHaveBeenCalled();
         });
     });
 
-    describe('warn', () => {
+    describe.each([false, true])('warn', (useInstance) => {
+        const Logger_warn: typeof Logger.warn = useInstance
+            ? (...args) => Logger.Instance.warn(...args)
+            : (...args) => Logger.warn(...args);
+
         beforeEach(() => {
             // Set up Logger with Debug level
             (configuration.initializing as jest.Mock).mockReturnValue(true);
@@ -196,7 +209,7 @@ describe('Logger', () => {
         });
 
         it('should append message to output channel', () => {
-            Logger.warn('test warning message');
+            Logger_warn('test warning message');
 
             expect(mockOutputChannel.appendLine).toHaveBeenCalled();
             const call = (mockOutputChannel.appendLine as jest.Mock).mock.calls[0][0];
@@ -206,13 +219,17 @@ describe('Logger', () => {
         it('should output to console when in debugging mode', () => {
             mockContainerIsDebugging();
 
-            Logger.warn('test warning message');
+            Logger_warn('test warning message');
 
             expect(console.warn).toHaveBeenCalled();
         });
     });
 
-    describe('error', () => {
+    describe.each([false, true])('error', (useInstance) => {
+        const Logger_error: typeof Logger.error = useInstance
+            ? (...args) => Logger.Instance.error.apply(Logger.Instance, args)
+            : (...args) => Logger.error.apply(Logger, args);
+
         beforeEach(() => {
             // Set up Logger with Error level
             (configuration.initializing as jest.Mock).mockReturnValue(true);
@@ -227,7 +244,7 @@ describe('Logger', () => {
                 eventRegistration = Logger.onError(errorHandlerSpy);
 
                 const testError = new Error('test error message');
-                Logger.error(testError, 'Something went wrong');
+                Logger_error(testError, 'Something went wrong');
 
                 expect(errorHandlerSpy).toHaveBeenCalled();
                 const errorEvent: ErrorEvent = errorHandlerSpy.mock.calls[0][0];
@@ -241,7 +258,7 @@ describe('Logger', () => {
 
         it('should append error to output channel', () => {
             const testError = new Error('test error message');
-            Logger.error(testError, 'Something went wrong');
+            Logger_error(testError, 'Something went wrong');
 
             expect(mockOutputChannel.appendLine).toHaveBeenCalled();
             const call = (mockOutputChannel.appendLine as jest.Mock).mock.calls[0][0];
@@ -253,7 +270,7 @@ describe('Logger', () => {
             mockContainerIsDebugging();
 
             const testError = new Error('test error message');
-            Logger.error(testError, 'Something went wrong');
+            Logger_error(testError, 'Something went wrong');
 
             expect(console.error).toHaveBeenCalled();
         });
@@ -264,7 +281,7 @@ describe('Logger', () => {
             Logger.configure(expansionCastTo<ExtensionContext>({ subscriptions: [] }));
 
             const testError = new Error('test error message');
-            Logger.error(testError, 'Something went wrong');
+            Logger_error(testError, 'Something went wrong');
 
             expect(mockOutputChannel.appendLine).not.toHaveBeenCalled();
             expect(console.error).not.toHaveBeenCalled();

--- a/src/onboarding/onboardingProvider.ts
+++ b/src/onboarding/onboardingProvider.ts
@@ -1,6 +1,7 @@
+import { Logger } from 'src/logger';
 import { commands, env, InputBox, UIKind, window } from 'vscode';
 
-import { authenticateButtonEvent, errorEvent, viewScreenEvent } from '../analytics';
+import { authenticateButtonEvent, viewScreenEvent } from '../analytics';
 import { type AnalyticsClient } from '../analytics-node-client/src/client.min';
 import { BasicAuthInfo, Product, ProductBitbucket, ProductJira, SiteInfo } from '../atlclients/authInfo';
 import { Commands } from '../constants';
@@ -139,9 +140,7 @@ class OnboardingProvider {
 
     private _handleError(message: string, error: Error) {
         window.showErrorMessage(message);
-        errorEvent(message, error, this.id).then((event) => {
-            this._analyticsClient.sendTrackEvent(event);
-        });
+        Logger.error(error, message);
     }
 
     private _handleSkip(product: Product) {

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -376,6 +376,7 @@ const RovoDevView: React.FC = () => {
                         setCurrentState(State.GeneratingResponse);
                     }
                     break;
+
                 case RovoDevProviderMessageType.UserFocusUpdated:
                     setPromptContextCollection((prev) => ({
                         ...prev,
@@ -385,6 +386,7 @@ const RovoDevView: React.FC = () => {
                         },
                     }));
                     break;
+
                 case RovoDevProviderMessageType.ContextAdded:
                     setPromptContextCollection((prev) => ({
                         ...prev,
@@ -396,12 +398,12 @@ const RovoDevView: React.FC = () => {
                 case RovoDevProviderMessageType.CreatePRComplete:
                 case RovoDevProviderMessageType.GetCurrentBranchNameComplete:
                     break; // This is handled elsewhere
+
                 default:
+                    // this is never supposed to happen since there aren't other type of messages
                     handleAppendError({
                         source: 'RovoDevError',
-                        // event.type complains if this is unreachable
-                        // @ts-expect-error ts(2339)
-                        text: `Unknown message type: ${event.type}`,
+                        text: `Unknown message type: ${(event as any).type}`,
                         isRetriable: false,
                         uid: v4(),
                     });

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -391,6 +391,8 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     }
 
     private processError(error: Error, isRetriable: boolean) {
+        Logger.error('RovoDev', error);
+
         const webview = this._webView!;
         return webview.postMessage({
             type: RovoDevProviderMessageType.ErrorMessage,


### PR DESCRIPTION
### What Is This Change?

This change adds a tag on error telemetry events classifying where the error is coming from.
In this change, the only category added is "Rovo Dev", but in the future we can have more like Jira, Bitbucket, Notiications, etc.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`