### PR TITLE
Improve useMessageApi typings

### DIFF
--- a/src/lib/ipc/toUI/onboarding.ts
+++ b/src/lib/ipc/toUI/onboarding.ts
@@ -17,8 +17,6 @@ export type OnboardingMessage =
     | ReducerAction<OnboardingMessageType.SitesUpdate, SitesUpdateMessage>
     | ReducerAction<OnboardingMessageType.LoginResponse>;
 
-export type OnboardingResponse = any;
-
 export interface OnboardingInitMessage {
     jiraSitesConfigured: boolean;
     bitbucketSitesConfigured: boolean;

--- a/src/lib/ipc/toUI/pipelineSummary.ts
+++ b/src/lib/ipc/toUI/pipelineSummary.ts
@@ -11,8 +11,6 @@ export type PipelineSummaryMessage =
     | ReducerAction<PipelineSummaryMessageType.Update, PipelineSummaryUpdateMessage>
     | ReducerAction<PipelineSummaryMessageType.StepsUpdate, PipelineSummaryStepsUpdateMessage>;
 
-export type PipelineSummaryResponse = {};
-
 export interface PipelineSummaryInitMessage {
     pipeline: Pipeline;
 }

--- a/src/lib/ipc/toUI/pullRequestDetails.ts
+++ b/src/lib/ipc/toUI/pullRequestDetails.ts
@@ -58,6 +58,7 @@ export type PullRequestDetailsMessage =
     | ReducerAction<PullRequestDetailsMessageType.UpdateRelatedJiraIssues, PullRequestDetailsRelatedJiraIssuesMessage>
     | ReducerAction<PullRequestDetailsMessageType.UpdateTasks, PullRequestDetailsTasksMessage>;
 export type PullRequestDetailsResponse =
+    | ReducerAction<PullRequestDetailsMessageType.CheckoutBranch, PullRequestDetailsCheckoutBranchMessage>
     | ReducerAction<PullRequestDetailsMessageType.FetchUsersResponse, FetchUsersResponseMessage>
     | ReducerAction<PullRequestDetailsMessageType.UpdateFileDiffs, PullRequestDetailsFileDiffsMessage>
     | ReducerAction<PullRequestDetailsMessageType.PostCommentResponse, VoidResponseMessage>

--- a/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.ts
+++ b/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.ts
@@ -10,11 +10,7 @@ import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
 import { PipelineSummaryAction, PipelineSummaryActionType } from '../../../ipc/fromUI/pipelineSummary';
 import { CommonMessage } from '../../../ipc/toUI/common';
-import {
-    PipelineSummaryMessage,
-    PipelineSummaryMessageType,
-    PipelineSummaryResponse,
-} from '../../../ipc/toUI/pipelineSummary';
+import { PipelineSummaryMessage, PipelineSummaryMessageType } from '../../../ipc/toUI/pipelineSummary';
 import { Logger } from '../../../logger';
 import { MessagePoster, WebviewController } from '../webviewController';
 import { PipelinesSummaryActionApi } from './pipelinesSummaryActionApi';
@@ -38,7 +34,7 @@ export class PipelineSummaryWebviewController implements WebviewController<Pipel
         this.steps = [];
     }
 
-    private postMessage(message: PipelineSummaryMessage | PipelineSummaryResponse | CommonMessage) {
+    private postMessage(message: PipelineSummaryMessage | CommonMessage) {
         this.messagePoster(message);
     }
 

--- a/src/react/atlascode/config/configController.ts
+++ b/src/react/atlascode/config/configController.ts
@@ -16,12 +16,8 @@ import {
     ConfigMessageType,
     ConfigResponse,
     emptyConfigInitMessage,
-    FilterSearchResponseMessage,
-    JQLOptionsResponseMessage,
-    JQLSuggestionsResponseMessage,
     SectionChangeMessage,
     SiteWithAuthInfo,
-    ValidateJqlResponseMessage,
 } from '../../../lib/ipc/toUI/config';
 import { ConnectionTimeout } from '../../../util/time';
 import { PostMessageFunc, useMessagingApi } from '../messagingApi';
@@ -344,7 +340,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
                             ConfigMessageType.JQLOptionsResponse,
                             ConnectionTimeout,
                         );
-                        resolve((response as JQLOptionsResponseMessage).data);
+                        resolve(response.data);
                     } catch (e) {
                         reject(e);
                     }
@@ -390,7 +386,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
                             ConfigMessageType.JQLSuggestionsResponse,
                             ConnectionTimeout,
                         );
-                        resolve((response as JQLSuggestionsResponseMessage).data);
+                        resolve(response.data);
                     } catch (e) {
                         reject(e);
                     }
@@ -436,7 +432,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
                             ConfigMessageType.FilterSearchResponse,
                             ConnectionTimeout,
                         );
-                        resolve((response as FilterSearchResponseMessage).data);
+                        resolve(response.data);
                     } catch (e) {
                         reject(e);
                     }
@@ -474,7 +470,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
                             ConfigMessageType.ValidateJqlResponse,
                             ConnectionTimeout,
                         );
-                        resolve((response as ValidateJqlResponseMessage).data);
+                        resolve(response.data);
                     } catch (e) {
                         reject(e);
                     }

--- a/src/react/atlascode/config/configController.ts
+++ b/src/react/atlascode/config/configController.ts
@@ -270,7 +270,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
         }
     }, []);
 
-    const [postMessage, postMessagePromise] = useMessagingApi<ConfigAction, ConfigMessage, ConfigResponse>(
+    const { postMessage, postMessagePromise } = useMessagingApi<ConfigAction, ConfigMessage, ConfigResponse>(
         onMessageHandler,
     );
 

--- a/src/react/atlascode/onboarding/onboardingController.ts
+++ b/src/react/atlascode/onboarding/onboardingController.ts
@@ -11,7 +11,6 @@ import {
     OnboardingInitMessage,
     OnboardingMessage,
     OnboardingMessageType,
-    OnboardingResponse,
 } from '../../../lib/ipc/toUI/onboarding';
 import { PostMessageFunc, useMessagingApi } from '../messagingApi';
 
@@ -187,7 +186,7 @@ export function useOnboardingController(): [OnboardingState, OnboardingControlle
         }
     }, []);
 
-    const [postMessage] = useMessagingApi<OnboardingAction, OnboardingMessage, OnboardingResponse>(onMessageHandler);
+    const { postMessage } = useMessagingApi<OnboardingAction, OnboardingMessage, never>(onMessageHandler);
 
     const handleConfigChange = useCallback(
         (changes: ConfigChanges, removes?: string[]): void => {

--- a/src/react/atlascode/pipelines/pipelineSummaryController.ts
+++ b/src/react/atlascode/pipelines/pipelineSummaryController.ts
@@ -8,7 +8,6 @@ import {
     PipelineSummaryInitMessage,
     PipelineSummaryMessage,
     PipelineSummaryMessageType,
-    PipelineSummaryResponse,
 } from '../../../lib/ipc/toUI/pipelineSummary';
 import { PipelineLogReference, PipelineStep } from '../../../pipelines/model';
 import { useMessagingApi } from '../messagingApi';
@@ -105,9 +104,7 @@ export function usePipelineSummaryController(): [PipelineSummaryState, PipelineS
         }
     }, []);
 
-    const [postMessage] = useMessagingApi<PipelineSummaryAction, PipelineSummaryMessage, PipelineSummaryResponse>(
-        onMessageHandler,
-    );
+    const { postMessage } = useMessagingApi<PipelineSummaryAction, PipelineSummaryMessage, never>(onMessageHandler);
 
     const sendRefresh = useCallback((): void => {
         dispatch({

--- a/src/react/atlascode/pullrequest/createPullRequestController.ts
+++ b/src/react/atlascode/pullrequest/createPullRequestController.ts
@@ -18,8 +18,6 @@ import {
     CreatePullRequestMessageType,
     CreatePullRequestResponse,
     emptyCreatePullRequestInitMessage,
-    FetchUsersResponseMessage,
-    SubmitResponseMessage,
 } from '../../../lib/ipc/toUI/createPullRequest';
 import { Branch } from '../../../typings/git';
 import { ConnectionTimeout } from '../../../util/time';
@@ -180,7 +178,7 @@ export function useCreatePullRequestController(): [CreatePullRequestState, Creat
                             CreatePullRequestMessageType.FetchUsersResponse,
                             ConnectionTimeout,
                         );
-                        resolve((response as FetchUsersResponseMessage).users);
+                        resolve(response.users);
                     } catch (e) {
                         reject(e);
                     }
@@ -226,7 +224,7 @@ export function useCreatePullRequestController(): [CreatePullRequestState, Creat
                             CreatePullRequestMessageType.SubmitResponse,
                             ConnectionTimeout,
                         );
-                        resolve((response as SubmitResponseMessage).pr);
+                        resolve(response.pr);
                     } catch (e) {
                         reject(e);
                     }

--- a/src/react/atlascode/pullrequest/createPullRequestController.ts
+++ b/src/react/atlascode/pullrequest/createPullRequestController.ts
@@ -16,6 +16,7 @@ import {
     CreatePullRequestInitMessage,
     CreatePullRequestMessage,
     CreatePullRequestMessageType,
+    CreatePullRequestResponse,
     emptyCreatePullRequestInitMessage,
     FetchUsersResponseMessage,
     SubmitResponseMessage,
@@ -144,9 +145,11 @@ export function useCreatePullRequestController(): [CreatePullRequestState, Creat
         }
     }, []);
 
-    const [postMessage, postMessagePromise] = useMessagingApi<CreatePullRequestAction, CreatePullRequestMessage, {}>(
-        onMessageHandler,
-    );
+    const { postMessage, postMessagePromise } = useMessagingApi<
+        CreatePullRequestAction,
+        CreatePullRequestMessage,
+        CreatePullRequestResponse
+    >(onMessageHandler);
 
     const fetchUsers = useCallback(
         (site: BitbucketSite, query: string, abortSignal?: AbortSignal): Promise<User[]> => {

--- a/src/react/atlascode/pullrequest/pullRequestDetailsController.ts
+++ b/src/react/atlascode/pullrequest/pullRequestDetailsController.ts
@@ -364,7 +364,7 @@ export function usePullRequestDetailsController(): [PullRequestDetailsState, Pul
         }
     }, []);
 
-    const [postMessage, postMessagePromise] = useMessagingApi<
+    const { postMessage, postMessagePromise } = useMessagingApi<
         PullRequestDetailsAction,
         PullRequestDetailsMessage,
         PullRequestDetailsResponse

--- a/src/react/atlascode/pullrequest/pullRequestDetailsController.ts
+++ b/src/react/atlascode/pullrequest/pullRequestDetailsController.ts
@@ -19,7 +19,6 @@ import { CommonActionType } from '../../../lib/ipc/fromUI/common';
 import { PullRequestDetailsAction, PullRequestDetailsActionType } from '../../../lib/ipc/fromUI/pullRequestDetails';
 import {
     emptyPullRequestDetailsInitMessage,
-    FetchUsersResponseMessage,
     PullRequestDetailsApprovalMessage,
     PullRequestDetailsBuildStatusesMessage,
     PullRequestDetailsCheckoutBranchMessage,
@@ -409,7 +408,7 @@ export function usePullRequestDetailsController(): [PullRequestDetailsState, Pul
                             PullRequestDetailsMessageType.FetchUsersResponse,
                             ConnectionTimeout,
                         );
-                        resolve((response as FetchUsersResponseMessage).users);
+                        resolve(response.users);
                     } catch (e) {
                         reject(e);
                     }

--- a/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.test.tsx
+++ b/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.test.tsx
@@ -7,7 +7,8 @@ import { RovoDevViewResponseType } from '../rovoDevViewMessages';
 import { DefaultMessage, ToolReturnParseResult } from '../utils';
 import { PullRequestChatItem, PullRequestForm } from './PullRequestForm';
 
-const mockPostMessageWithReturn = jest.fn();
+const mockPostMessage = jest.fn();
+const mockPostMessagePromise = jest.fn();
 const mockOnCancel = jest.fn();
 const mockOnPullRequestCreated = jest.fn();
 const mockSetFormVisible = jest.fn();
@@ -29,7 +30,7 @@ describe('PullRequestForm', () => {
         const { container } = render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                postMessageWithReturn={mockPostMessageWithReturn}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 modifiedFiles={[]}
                 onPullRequestCreated={mockOnPullRequestCreated}
             />,
@@ -41,7 +42,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                postMessageWithReturn={mockPostMessageWithReturn}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={false}
@@ -56,7 +57,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                postMessageWithReturn={mockPostMessageWithReturn}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
@@ -71,12 +72,12 @@ describe('PullRequestForm', () => {
     });
 
     it('fetches branch name when toggle button is clicked', async () => {
-        mockPostMessageWithReturn.mockResolvedValue({ data: { branchName: 'feature-branch' } });
+        mockPostMessagePromise.mockResolvedValue({ data: { branchName: 'feature-branch' } });
 
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                postMessageWithReturn={mockPostMessageWithReturn}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={false}
@@ -87,7 +88,7 @@ describe('PullRequestForm', () => {
         fireEvent.click(screen.getByRole('button', { name: /create pull request/i }));
 
         await waitFor(() => {
-            expect(mockPostMessageWithReturn).toHaveBeenCalledWith(
+            expect(mockPostMessagePromise).toHaveBeenCalledWith(
                 { type: RovoDevViewResponseType.GetCurrentBranchName },
                 RovoDevProviderMessageType.GetCurrentBranchNameComplete,
                 expect.any(Number),
@@ -100,7 +101,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                postMessageWithReturn={mockPostMessageWithReturn}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
@@ -112,12 +113,12 @@ describe('PullRequestForm', () => {
     });
 
     it('submits form with correct data', async () => {
-        mockPostMessageWithReturn.mockResolvedValue({ data: { url: 'http://pr-url.com' } });
+        mockPostMessagePromise.mockResolvedValue({ data: { url: 'http://pr-url.com' } });
 
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                postMessageWithReturn={mockPostMessageWithReturn}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
@@ -134,12 +135,12 @@ describe('PullRequestForm', () => {
         fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
 
         await waitFor(() => {
-            expect(mockPostMessageWithReturn).toHaveBeenCalledWith(
+            expect(mockPostMessagePromise).toHaveBeenCalledWith(
                 {
                     type: RovoDevViewResponseType.CreatePR,
                     payload: { branchName: 'test-branch', commitMessage: 'Test commit message' },
                 },
-                RovoDevViewResponseType.CreatePRComplete,
+                RovoDevProviderMessageType.CreatePRComplete,
                 expect.any(Number),
             );
             expect(mockOnPullRequestCreated).toHaveBeenCalledWith('http://pr-url.com');
@@ -150,7 +151,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                postMessageWithReturn={mockPostMessageWithReturn}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
@@ -159,7 +160,7 @@ describe('PullRequestForm', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /create pr/i }));
 
-        expect(mockPostMessageWithReturn).not.toHaveBeenCalled();
+        expect(mockPostMessagePromise).not.toHaveBeenCalled();
         expect(mockOnPullRequestCreated).not.toHaveBeenCalled();
     });
 });

--- a/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
@@ -1,7 +1,8 @@
 import { random } from 'lodash';
 import * as React from 'react';
+import { RovoDevProviderMessage } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
-import { PostMessageFunc, PostMessagePromiseFunc } from '../../messagingApi';
+import { useMessagingApi } from '../../messagingApi';
 import { ErrorMessageItem, FollowUpActionFooter, OpenFileFunc, TechnicalPlanComponent } from '../common/common';
 import { PullRequestChatItem, PullRequestForm } from '../create-pr/PullRequestForm';
 import { RovoDevLanding } from '../rovoDevLanding';
@@ -30,10 +31,9 @@ interface ChatStreamProps {
         retryPromptAfterError: () => void;
         getOriginalText: (fp: string, lr?: number[]) => Promise<string>;
     };
-    messagingApi: {
-        postMessage: PostMessageFunc<RovoDevViewResponse>;
-        postMessageWithReturn: PostMessagePromiseFunc<RovoDevViewResponse, any>;
-    };
+    messagingApi: ReturnType<
+        typeof useMessagingApi<RovoDevViewResponse, RovoDevProviderMessage, RovoDevProviderMessage>
+    >;
     modifiedFiles?: ToolReturnParseResult[];
     pendingToolCall: string;
     deepPlanCreated: boolean;
@@ -51,7 +51,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
     deepPlanCreated,
     executeCodePlan,
     state,
-    messagingApi: { postMessageWithReturn },
+    messagingApi,
     modifiedFiles,
     onChangesGitPushed,
 }) => {
@@ -131,7 +131,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                                 setCanCreatePR(false);
                                 setIsFormVisible(false);
                             }}
-                            postMessageWithReturn={postMessageWithReturn}
+                            messagingApi={messagingApi}
                             modifiedFiles={modifiedFiles}
                             onPullRequestCreated={(url) => {
                                 setCanCreatePR(false);

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -436,9 +436,11 @@ const RovoDevView: React.FC = () => {
         ],
     );
 
-    const [postMessage, postMessageWithReturn] = useMessagingApi<RovoDevViewResponse, RovoDevProviderMessage, any>(
-        onMessageHandler,
-    );
+    const { postMessage, postMessagePromise } = useMessagingApi<
+        RovoDevViewResponse,
+        RovoDevProviderMessage,
+        RovoDevProviderMessage
+    >(onMessageHandler);
 
     React.useEffect(() => {
         if (outgoingMessage) {
@@ -564,7 +566,7 @@ const RovoDevView: React.FC = () => {
     const getOriginalText = useCallback(
         async (filePath: string, range?: number[]) => {
             const uniqueNonce = `${Math.random()}-${Date.now()}`; // Unique identifier for the request
-            const res = await postMessageWithReturn(
+            const res = await postMessagePromise(
                 {
                     type: RovoDevViewResponseType.GetOriginalText,
                     filePath,
@@ -576,9 +578,9 @@ const RovoDevView: React.FC = () => {
                 uniqueNonce,
             );
 
-            return (res.text as string) || '';
+            return res.text || '';
         },
-        [postMessageWithReturn],
+        [postMessagePromise],
     );
 
     const isRetryAfterErrorButtonEnabled = useCallback(
@@ -616,7 +618,7 @@ const RovoDevView: React.FC = () => {
                 }}
                 messagingApi={{
                     postMessage,
-                    postMessageWithReturn,
+                    postMessagePromise,
                 }}
                 pendingToolCall={pendingToolCallMessage}
                 deepPlanCreated={isDeepPlanCreated}

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -9,7 +9,6 @@ export const enum RovoDevViewResponseType {
     KeepFileChanges = 'keepFileChanges',
     GetOriginalText = 'getOriginalText',
     CreatePR = 'createPR',
-    CreatePRComplete = 'createPRComplete',
     RetryPromptAfterError = 'retryPromptAfterError',
     GetCurrentBranchName = 'getCurrentBranchName',
     AddContext = 'addContext',
@@ -26,7 +25,6 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.KeepFileChanges, { filePaths: string[] }>
     | ReducerAction<RovoDevViewResponseType.GetOriginalText, { filePath: string; range?: number[]; requestId: string }>
     | ReducerAction<RovoDevViewResponseType.CreatePR, { payload: { branchName: string; commitMessage: string } }>
-    | ReducerAction<RovoDevViewResponseType.CreatePRComplete, { url?: string; error?: string }>
     | ReducerAction<RovoDevViewResponseType.RetryPromptAfterError>
     | ReducerAction<RovoDevViewResponseType.GetCurrentBranchName>
     | ReducerAction<RovoDevViewResponseType.AddContext, { currentContext: RovoDevContext }>

--- a/src/react/atlascode/startwork/startWorkController.ts
+++ b/src/react/atlascode/startwork/startWorkController.ts
@@ -142,7 +142,7 @@ export function useStartWorkController(): [StartWorkState, StartWorkControllerAp
                             StartWorkMessageType.StartWorkResponse,
                             ConnectionTimeout,
                         );
-                        resolve(response as StartWorkResponseMessage);
+                        resolve(response);
                     } catch (e) {
                         reject(e);
                     }

--- a/src/react/atlascode/startwork/startWorkController.ts
+++ b/src/react/atlascode/startwork/startWorkController.ts
@@ -109,7 +109,7 @@ export function useStartWorkController(): [StartWorkState, StartWorkControllerAp
         }
     }, []);
 
-    const [postMessage, postMessagePromise] = useMessagingApi<StartWorkAction, StartWorkMessage, StartWorkResponse>(
+    const { postMessage, postMessagePromise } = useMessagingApi<StartWorkAction, StartWorkMessage, StartWorkResponse>(
         onMessageHandler,
     );
 

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -40,6 +40,5 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.ReturnText, { text: string }>
     | ReducerAction<RovoDevProviderMessageType.CreatePRComplete, { data: { url?: string } }>
     | ReducerAction<RovoDevProviderMessageType.GetCurrentBranchNameComplete, { data: { branchName?: string } }>
-    | ReducerAction<RovoDevProviderMessageType.CreatePRComplete, { data: { url?: string } }>
     | ReducerAction<RovoDevProviderMessageType.UserFocusUpdated, { userFocus: RovoDevContextItem }>
     | ReducerAction<RovoDevProviderMessageType.ContextAdded, { context: RovoDevContextItem }>;


### PR DESCRIPTION
### What Is This Change?

The core of this change is in `src/react/atlascode/messagingApi.ts`.

Thanks to this improved typings, when calling `postMessagePromise` the return type is now inferred from the value of the `waitForEvent` argument:

| <img width="570" height="349" alt="image" src="https://github.com/user-attachments/assets/f435c2ba-9879-4e2c-908a-c7c0e5cfb2ac" /> | <img width="521" height="284" alt="image" src="https://github.com/user-attachments/assets/45412b89-4ef9-4902-9e70-024be32194ee" /> |
|---|---|

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`