### PR TITLE
[AXON-728] Keep/Undo buttons disabled when generating response

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -456,6 +456,10 @@ body {
     color: var(--vscode-textLink-foreground);
 }
 
+.modified-file-action:disabled {
+    cursor: not-allowed;
+}
+
 .modified-file-item-info {
     display: flex;
     flex-direction: row;
@@ -505,6 +509,10 @@ body {
 .updated-files-action {
     cursor: pointer;
     padding: 2px 6px;
+}
+
+.updated-files-action:disabled {
+    cursor: not-allowed;
 }
 
 

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.tsx
@@ -9,7 +9,8 @@ export const ModifiedFileItem: React.FC<{
     onUndo: (filePath: string) => void;
     onKeep: (filePath: string) => void;
     onFileClick: (filePath: string) => void;
-}> = ({ msg, onUndo, onKeep, onFileClick }) => {
+    actionsEnabled?: boolean;
+}> = ({ msg, onUndo, onKeep, onFileClick, actionsEnabled = true }) => {
     const isDeletion = msg.type === 'delete';
     const isCreation = msg.type === 'create';
 
@@ -41,10 +42,20 @@ export const ModifiedFileItem: React.FC<{
         <div aria-label="modified-file-item" className="modified-file-item" onClick={() => onFileClick(filePath)}>
             <div id={getId()}>{filePath}</div>
             <div className="modified-file-actions">
-                <button className="modified-file-action" onClick={handleUndo} aria-label="Undo changes to this file">
+                <button
+                    disabled={!actionsEnabled}
+                    className="modified-file-action"
+                    onClick={handleUndo}
+                    aria-label="Undo changes to this file"
+                >
                     <CrossIcon size="small" label="Undo" />
                 </button>
-                <button className="modified-file-action" onClick={handleKeep} aria-label="Keep changes to this file">
+                <button
+                    disabled={!actionsEnabled}
+                    className="modified-file-action"
+                    onClick={handleKeep}
+                    aria-label="Keep changes to this file"
+                >
                     <CheckIcon size="small" label="Keep" />
                 </button>
             </div>

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.test.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.test.tsx
@@ -26,6 +26,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
         expect(container.firstChild).toBeNull();
@@ -38,6 +39,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
         expect(container.firstChild).toBeNull();
@@ -50,6 +52,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
         expect(screen.getByText('3 Updated files')).toBeTruthy();
@@ -62,6 +65,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
         expect(screen.getByText('1 Updated file')).toBeTruthy();
@@ -74,6 +78,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
 
@@ -88,6 +93,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
 
@@ -108,6 +114,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
 
@@ -122,6 +129,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
 
@@ -136,6 +144,7 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
 
@@ -151,9 +160,30 @@ describe('UpdatedFilesComponent', () => {
                 onUndo={mockOnUndo}
                 onKeep={mockOnKeep}
                 openDiff={mockOpenDiff}
+                actionsEnabled={true}
             />,
         );
 
         expect(document.querySelector('.codicon.codicon-source-control')).toBeTruthy();
+    });
+
+    it('disables buttons when actionsEnabled is false', () => {
+        render(
+            <UpdatedFilesComponent
+                modifiedFiles={mockModifiedFiles}
+                onUndo={mockOnUndo}
+                onKeep={mockOnKeep}
+                openDiff={mockOpenDiff}
+                actionsEnabled={false}
+            />,
+        );
+
+        expect(screen.getByText('Undo').closest('button')?.disabled).toBe(true);
+        expect(screen.getByText('Keep').closest('button')?.disabled).toBe(true);
+
+        fireEvent.click(screen.getByText('Undo'));
+        expect(mockOnUndo).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByText('Keep'));
+        expect(mockOnKeep).not.toHaveBeenCalled();
     });
 });

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.tsx
@@ -9,7 +9,8 @@ export const UpdatedFilesComponent: React.FC<{
     onUndo: (filePath: string[]) => void;
     onKeep: (filePath: string[]) => void;
     openDiff: OpenFileFunc;
-}> = ({ modifiedFiles, onUndo, onKeep, openDiff }) => {
+    actionsEnabled?: boolean;
+}> = ({ modifiedFiles, onUndo, onKeep, openDiff, actionsEnabled }) => {
     const handleKeepAll = React.useCallback(() => {
         const filePaths = modifiedFiles.map((msg) => msg.filePath).filter((path) => path !== undefined);
         onKeep(filePaths);
@@ -34,10 +35,18 @@ export const UpdatedFilesComponent: React.FC<{
                     </span>
                 </div>
                 <div>
-                    <button className="updated-files-action secondary" onClick={() => handleUndoAll()}>
+                    <button
+                        disabled={!actionsEnabled}
+                        className="updated-files-action secondary"
+                        onClick={() => handleUndoAll()}
+                    >
                         Undo
                     </button>
-                    <button className="updated-files-action primary" onClick={() => handleKeepAll()}>
+                    <button
+                        disabled={!actionsEnabled}
+                        className="updated-files-action primary"
+                        onClick={() => handleKeepAll()}
+                    >
                         Keep
                     </button>
                 </div>
@@ -51,6 +60,7 @@ export const UpdatedFilesComponent: React.FC<{
                             onFileClick={(path: string) => openDiff(path, true)}
                             onUndo={(path: string) => onUndo([path])}
                             onKeep={(path: string) => onKeep([path])}
+                            actionsEnabled={actionsEnabled}
                         />
                     );
                 })}

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -613,6 +613,7 @@ const RovoDevView: React.FC = () => {
                     onUndo={undoFiles}
                     onKeep={keepFiles}
                     openDiff={openFile}
+                    actionsEnabled={currentState === State.WaitingForPrompt}
                 />
                 <div className="prompt-container">
                     {' '}


### PR DESCRIPTION
### What Is This Change?
Disable total and specific keep/undo buttons when rovo dev is still responding
<img width="331" height="226" alt="Screenshot 2025-07-28 at 3 26 50 PM" src="https://github.com/user-attachments/assets/641097de-7849-42af-8ebb-eb7648939814" />
<img width="302" height="216" alt="Screenshot 2025-07-28 at 3 27 30 PM" src="https://github.com/user-attachments/assets/d9c5d834-98d7-4de8-b5f5-c421642cb3a9" />


### How Has This Been Tested?

Updated UT

manual tests

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`