### PR TITLE
[AXON-730] Fix state error when 'replay' and 'pending prompt'

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -61,7 +61,7 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
                 ? {
                       statements: 71,
                       branches: 64,
-                      functions: 64,
+                      functions: 63,
                       lines: 71,
                   }
                 : /* tsx */ {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -61,7 +61,7 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
                 ? {
                       statements: 71,
                       branches: 64,
-                      functions: 63,
+                      functions: 64,
                       lines: 71,
                   }
                 : /* tsx */ {

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -30,7 +30,7 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.PromptSent, RovoDevPrompt>
     | ReducerAction<RovoDevProviderMessageType.Response, RovoDevObjectResponse>
     | ReducerAction<RovoDevProviderMessageType.UserChatMessage, { message: ChatMessage }>
-    | ReducerAction<RovoDevProviderMessageType.CompleteMessage>
+    | ReducerAction<RovoDevProviderMessageType.CompleteMessage, { isReplay?: boolean }>
     | ReducerAction<RovoDevProviderMessageType.ToolCall, RovoDevObjectResponse>
     | ReducerAction<RovoDevProviderMessageType.ToolReturn, RovoDevObjectResponse>
     | ReducerAction<RovoDevProviderMessageType.ErrorMessage, { message: ErrorMessage }>


### PR DESCRIPTION
### What Is This Change?

When replay would occur, it would not send that the response is generating to the frontend and it would send `CompleteMessage` event to the frontend which changes the state to `Waiting`. This messed up the streaming because we would not group messages if the state is still waiting for prompt. Now when replay is triggered or there is a pending prompt, the state is changes to `GeneratingResponse` so the stream can act correctly 

### How Has This Been Tested?

manual tests


- [x] `npm run lint`
- [x] `npm run test`
