### PR TITLE
AXON-702: upgrade react-hook-form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
                 "react-dom": "^16.13.1",
                 "react-dropzone": "^14.3.8",
                 "react-editext": "3.6.1",
-                "react-hook-form": "^4.9.8",
+                "react-hook-form": "^7.60.0",
                 "react-uid": "^2.2.0",
                 "scheduler": "^0.19.0",
                 "semver": "^7.7.2",
@@ -25236,11 +25236,19 @@
             }
         },
         "node_modules/react-hook-form": {
-            "version": "4.10.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-hook-form/-/react-hook-form-4.10.2.tgz",
-            "integrity": "sha512-Ule/KqHBwUvuubqGC4WDvOARS6VjlULSS+WHspgQ5FhFKR4ytHDc4AMpjVfnv+Wbz2TEbMp9/ZHmuZsUksPCiA==",
+            "version": "7.61.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-hook-form/-/react-hook-form-7.61.1.tgz",
+            "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/react-hook-form"
+            },
             "peerDependencies": {
-                "react": "^16.8.0"
+                "react": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
         "node_modules/react-input-autosize": {

--- a/package.json
+++ b/package.json
@@ -1411,7 +1411,7 @@
         "react-dom": "^16.13.1",
         "react-dropzone": "^14.3.8",
         "react-editext": "3.6.1",
-        "react-hook-form": "^4.9.8",
+        "react-hook-form": "^7.60.0",
         "react-uid": "^2.2.0",
         "scheduler": "^0.19.0",
         "semver": "^7.7.2",

--- a/src/react/atlascode/common/feedback/FeedbackDialogButton.tsx
+++ b/src/react/atlascode/common/feedback/FeedbackDialogButton.tsx
@@ -25,11 +25,17 @@ type FeedbackDialogButtonProps = {
 export const FeedbackDialogButton: React.FunctionComponent<FeedbackDialogButtonProps> = ({ user, postMessageFunc }) => {
     const [formOpen, setFormOpen] = useState(false);
 
-    const { register, handleSubmit, errors, watch, formState, reset } = useForm<FeedbackData>({
+    const {
+        register,
+        handleSubmit,
+        formState: { errors, isValid },
+        watch,
+        reset,
+    } = useForm<FeedbackData>({
         mode: 'onChange',
     });
 
-    const watches = watch(['canBeContacted']);
+    const canBeContacted = watch('canBeContacted');
 
     const submitForm = useCallback(
         (data: FeedbackData) => {
@@ -64,7 +70,7 @@ export const FeedbackDialogButton: React.FunctionComponent<FeedbackDialogButtonP
                     <Grid container direction="column" spacing={2}>
                         <Grid item>
                             <TextField
-                                name="type"
+                                {...register('type')}
                                 defaultValue={FeedbackType.Question}
                                 select
                                 required
@@ -76,7 +82,6 @@ export const FeedbackDialogButton: React.FunctionComponent<FeedbackDialogButtonP
                                 helperText={errors.type ? errors.type.message : undefined}
                                 fullWidth
                                 error={!!errors.type}
-                                inputRef={register}
                             >
                                 <MenuItem key={FeedbackType.Question} value={FeedbackType.Question}>
                                     Ask a question
@@ -94,6 +99,9 @@ export const FeedbackDialogButton: React.FunctionComponent<FeedbackDialogButtonP
                         </Grid>
                         <Grid item>
                             <TextField
+                                {...register('description', {
+                                    required: 'Description is required',
+                                })}
                                 required
                                 multiline
                                 rows={3}
@@ -103,14 +111,13 @@ export const FeedbackDialogButton: React.FunctionComponent<FeedbackDialogButtonP
                                 helperText={errors.description ? errors.description.message : undefined}
                                 fullWidth
                                 error={!!errors.description}
-                                inputRef={register({
-                                    required: 'Description URL is required',
-                                })}
                             />
                         </Grid>
                         <Grid item>
                             <TextField
-                                name="userName"
+                                {...register('userName', {
+                                    required: 'Your name is required',
+                                })}
                                 defaultValue={user.userName}
                                 required
                                 autoComplete="off"
@@ -120,22 +127,17 @@ export const FeedbackDialogButton: React.FunctionComponent<FeedbackDialogButtonP
                                 helperText={errors.userName ? errors.userName.message : undefined}
                                 fullWidth
                                 error={!!errors.userName}
-                                inputRef={register({
-                                    required: 'Your name is required',
-                                })}
                             />
                         </Grid>
                         <Grid item>
                             <ToggleWithLabel
                                 control={
                                     <Switch
-                                        name="canBeContacted"
+                                        {...register('canBeContacted')}
                                         defaultChecked={true}
                                         size="small"
                                         color="primary"
                                         id="canBeContacted"
-                                        value="canBeContacted"
-                                        inputRef={register}
                                     />
                                 }
                                 label="Atlassian can contact me about this feedback"
@@ -144,10 +146,12 @@ export const FeedbackDialogButton: React.FunctionComponent<FeedbackDialogButtonP
                             />
                         </Grid>
                         <Grid item>
-                            {watches.canBeContacted && (
+                            {canBeContacted && (
                                 <TextField
+                                    {...register('emailAddress', {
+                                        required: 'Your contact email is required',
+                                    })}
                                     required
-                                    name="emailAddress"
                                     defaultValue={user.emailAddress}
                                     autoComplete="off"
                                     margin="dense"
@@ -156,21 +160,13 @@ export const FeedbackDialogButton: React.FunctionComponent<FeedbackDialogButtonP
                                     helperText={errors.emailAddress ? errors.emailAddress.message : undefined}
                                     fullWidth
                                     error={!!errors.emailAddress}
-                                    inputRef={register({
-                                        required: 'Your contact email is required',
-                                    })}
                                 />
                             )}
                         </Grid>
                     </Grid>
                 </DialogContent>
                 <DialogActions>
-                    <Button
-                        disabled={!formState.isValid}
-                        onClick={handleSubmit(submitForm)}
-                        variant="contained"
-                        color="primary"
-                    >
+                    <Button disabled={!isValid} onClick={handleSubmit(submitForm)} variant="contained" color="primary">
                         Submit
                     </Button>
                     <Button onClick={handleDialogClose} color="primary">

--- a/src/react/atlascode/common/pmf/PMFDialog.tsx
+++ b/src/react/atlascode/common/pmf/PMFDialog.tsx
@@ -27,7 +27,14 @@ export type PMFDialogProps = {
 };
 
 export const PMFDialog: React.FunctionComponent<PMFDialogProps> = ({ open, onCancel, onSave }) => {
-    const { register, handleSubmit, errors, formState, triggerValidation, control, reset } = useForm<PMFData>({
+    const {
+        register,
+        handleSubmit,
+        formState: { errors, isValid },
+        trigger,
+        control,
+        reset,
+    } = useForm<PMFData>({
         mode: 'onChange',
     });
 
@@ -44,8 +51,8 @@ export const PMFDialog: React.FunctionComponent<PMFDialogProps> = ({ open, onCan
     }, [onCancel, reset]);
 
     const handleLevelBlur = useCallback(() => {
-        triggerValidation('level');
-    }, [triggerValidation]);
+        trigger('level');
+    }, [trigger]);
 
     // BUG: TextFields scroll when not focused. see: https://github.com/mui-org/material-ui/issues/20170
     return (
@@ -57,13 +64,16 @@ export const PMFDialog: React.FunctionComponent<PMFDialogProps> = ({ open, onCan
                 <Grid container direction="column" spacing={2}>
                     <Grid item>
                         <Controller
-                            as={
+                            name="level"
+                            control={control}
+                            rules={{ required: 'Level is required' }}
+                            render={({ field }) => (
                                 <FormControl component="fieldset" onBlur={handleLevelBlur}>
                                     <FormLabel component="legend" required error={errors.level !== undefined}>
                                         How disappointed would you feel if you could no longer use Atlassian for VS Code
                                         extension?
                                     </FormLabel>
-                                    <RadioGroup aria-label="level" name="level">
+                                    <RadioGroup aria-label="level" {...field}>
                                         <FormControlLabel
                                             value={PMFLevel.VERY}
                                             control={<Radio autoFocus color="primary" />}
@@ -84,14 +94,12 @@ export const PMFDialog: React.FunctionComponent<PMFDialogProps> = ({ open, onCan
                                         {errors.level ? errors.level.message : ''}
                                     </FormHelperText>
                                 </FormControl>
-                            }
-                            rules={{ required: 'Level is required' }}
-                            name="level"
-                            control={control}
+                            )}
                         />
                     </Grid>
                     <Grid item>
                         <TextField
+                            {...register('improvements')}
                             multiline
                             rows={3}
                             variant="outlined"
@@ -101,11 +109,11 @@ export const PMFDialog: React.FunctionComponent<PMFDialogProps> = ({ open, onCan
                             name="improvements"
                             label="How can we improve this extension for you?"
                             fullWidth
-                            inputRef={register}
                         />
                     </Grid>
                     <Grid item>
                         <TextField
+                            {...register('alternative')}
                             multiline
                             rows={3}
                             variant="outlined"
@@ -115,11 +123,11 @@ export const PMFDialog: React.FunctionComponent<PMFDialogProps> = ({ open, onCan
                             name="alternative"
                             label="What would you use as an alternative if this extension were no longer available?"
                             fullWidth
-                            inputRef={register}
                         />
                     </Grid>
                     <Grid item>
                         <TextField
+                            {...register('benefits')}
                             multiline
                             rows={3}
                             variant="outlined"
@@ -129,18 +137,12 @@ export const PMFDialog: React.FunctionComponent<PMFDialogProps> = ({ open, onCan
                             name="benefits"
                             label="What are the main benefits you receive from this extension?"
                             fullWidth
-                            inputRef={register}
                         />
                     </Grid>
                 </Grid>
             </DialogContent>
             <DialogActions>
-                <Button
-                    disabled={!formState.isValid}
-                    onClick={handleSubmit(handleSave)}
-                    variant="contained"
-                    color="primary"
-                >
+                <Button disabled={!isValid} onClick={handleSubmit(handleSave)} variant="contained" color="primary">
                     Submit
                 </Button>
                 <Button onClick={handleDialogClose} color="primary">

--- a/src/react/atlascode/config/jira/jql/JQLEditDialog.tsx
+++ b/src/react/atlascode/config/jira/jql/JQLEditDialog.tsx
@@ -56,7 +56,12 @@ export const JQLEditDialog: React.FunctionComponent<JQLEditDialogProps> = ({
         return await controller.fetchJqlOptions(site);
     }, [site]);
 
-    const { register, handleSubmit, errors, formState, control } = useForm<FormFields>({
+    const {
+        register,
+        handleSubmit,
+        formState: { errors, isValid },
+        control,
+    } = useForm<FormFields>({
         mode: 'onChange',
     });
 
@@ -131,6 +136,9 @@ export const JQLEditDialog: React.FunctionComponent<JQLEditDialogProps> = ({
                 <Grid container direction="column" spacing={2}>
                     <Grid item>
                         <TextField
+                            {...register('name', {
+                                required: 'Name is required',
+                            })}
                             required
                             id="name"
                             name="name"
@@ -139,19 +147,16 @@ export const JQLEditDialog: React.FunctionComponent<JQLEditDialogProps> = ({
                             helperText={errors.name ? errors.name.message : undefined}
                             fullWidth
                             error={!!errors.name}
-                            inputRef={register({
-                                required: 'Name is required',
-                            })}
                         />
                     </Grid>
                     <Grid item>
                         <Controller
                             control={control}
                             name="site"
-                            sites={sites}
                             defaultValue={site.id}
-                            as={
+                            render={({ field }) => (
                                 <SiteSelector
+                                    {...field}
                                     label="Select a site"
                                     required
                                     error={!!errors.site}
@@ -160,7 +165,7 @@ export const JQLEditDialog: React.FunctionComponent<JQLEditDialogProps> = ({
                                     fullWidth
                                     onSiteChange={handleSiteChange}
                                 />
-                            }
+                            )}
                         />
                     </Grid>
                     <Grid item>
@@ -168,8 +173,9 @@ export const JQLEditDialog: React.FunctionComponent<JQLEditDialogProps> = ({
                             <Controller
                                 control={control}
                                 name="jql"
-                                as={
+                                render={({ field }) => (
                                     <JQLInput
+                                        {...field}
                                         defaultValue={jqlEntry ? jqlEntry.query : ''}
                                         loading={jqlRestOptions.loading}
                                         disabled={jqlRestOptions.loading}
@@ -185,19 +191,14 @@ export const JQLEditDialog: React.FunctionComponent<JQLEditDialogProps> = ({
                                         helperText={errors.jql ? errors.jql.message : undefined}
                                         error={!!errors.jql}
                                     />
-                                }
+                                )}
                             />
                         </div>
                     </Grid>
                 </Grid>
             </DialogContent>
             <DialogActions>
-                <Button
-                    disabled={!formState.isValid}
-                    onClick={handleSubmit(handleSave)}
-                    variant="contained"
-                    color="primary"
-                >
+                <Button disabled={!isValid} onClick={handleSubmit(handleSave)} variant="contained" color="primary">
                     Save JQL
                 </Button>
                 <Button onClick={onCancel} color="primary">


### PR DESCRIPTION
### What Is This Change?
Upgrade react-hook-form to 7.60.0
This is a subtask for our main goal of [upgrading the React version](https://hello.atlassian.net/wiki/spaces/AIDO/pages/5629249869/Upgrade+React+estimation+strategy).


### How Has This Been Tested?

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change