### PR TITLE
[AXON-686][Rovo Dev] Fix Undo does not remove newly created files

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -61,7 +61,7 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
                 ? {
                       statements: 71,
                       branches: 64,
-                      functions: 64,
+                      functions: 63,
                       lines: 71,
                   }
                 : /* tsx */ {

--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -167,7 +167,7 @@ body {
     word-break: break-all;
 }
 
-#tool-return-file-path:hover {
+.tool-return-file-path:hover {
     background-color: var(--vscode-list-hoverBackground);
     cursor: pointer;
 }
@@ -463,12 +463,12 @@ body {
     gap: 4px;
 }
 
-#deleted-file {
+.deleted-file {
     color: var(--vscode-list-errorForeground);
     text-decoration: line-through;
 }
 
-#created-file {
+.created-file {
     color: var(--vscode-gitDecoration-untrackedResourceForeground);
 }
 

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.test.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.test.tsx
@@ -41,7 +41,7 @@ describe('ModifiedFileItem', () => {
         render(<ModifiedFileItem msg={msg} onUndo={mockOnUndo} onKeep={mockOnKeep} onFileClick={mockOnFileClick} />);
 
         fireEvent.click(screen.getByLabelText('Undo changes to this file'));
-        expect(mockOnUndo).toHaveBeenCalledWith('/path/to/file.ts');
+        expect(mockOnUndo).toHaveBeenCalledWith(msg);
         expect(mockOnFileClick).not.toHaveBeenCalled();
     });
 
@@ -50,29 +50,30 @@ describe('ModifiedFileItem', () => {
         render(<ModifiedFileItem msg={msg} onUndo={mockOnUndo} onKeep={mockOnKeep} onFileClick={mockOnFileClick} />);
 
         fireEvent.click(screen.getByLabelText('Keep changes to this file'));
-        expect(mockOnKeep).toHaveBeenCalledWith('/path/to/file.ts');
+        expect(mockOnKeep).toHaveBeenCalledWith(msg);
         expect(mockOnFileClick).not.toHaveBeenCalled();
     });
 
-    it('renders with deleted-file id for deletion type', () => {
+    it('renders with deleted-file class for deletion type', () => {
         const msg = createMockMsg('delete', '/path/to/file.ts');
         render(<ModifiedFileItem msg={msg} onUndo={mockOnUndo} onKeep={mockOnKeep} onFileClick={mockOnFileClick} />);
 
-        expect(screen.getByText('/path/to/file.ts').id).toBe('deleted-file');
+        expect(screen.getByText('/path/to/file.ts').className).toContain('deleted-file');
     });
 
-    it('renders with created-file id for creation type', () => {
+    it('renders with created-file class for creation type', () => {
         const msg = createMockMsg('create', '/path/to/file.ts');
         render(<ModifiedFileItem msg={msg} onUndo={mockOnUndo} onKeep={mockOnKeep} onFileClick={mockOnFileClick} />);
 
-        expect(screen.getByText('/path/to/file.ts').id).toBe('created-file');
+        expect(screen.getByText('/path/to/file.ts').className).toContain('created-file');
     });
 
-    it('renders without id for modify type', () => {
+    it('renders without class for modify type', () => {
         const msg = createMockMsg('modify', '/path/to/file.ts');
         render(<ModifiedFileItem msg={msg} onUndo={mockOnUndo} onKeep={mockOnKeep} onFileClick={mockOnFileClick} />);
 
-        expect(screen.getByText('/path/to/file.ts').id).toBe('');
+        expect(screen.getByText('/path/to/file.ts').className).not.toContain('deleted-file');
+        expect(screen.getByText('/path/to/file.ts').className).not.toContain('created-file');
     });
 
     it('returns null when filePath is not provided', () => {

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.tsx
@@ -6,45 +6,42 @@ import { ToolReturnParseResult } from '../../utils';
 
 export const ModifiedFileItem: React.FC<{
     msg: ToolReturnParseResult;
-    onUndo: (filePath: string) => void;
-    onKeep: (filePath: string) => void;
+    onUndo: (file: ToolReturnParseResult) => void;
+    onKeep: (file: ToolReturnParseResult) => void;
     onFileClick: (filePath: string) => void;
 }> = ({ msg, onUndo, onKeep, onFileClick }) => {
-    const isDeletion = msg.type === 'delete';
-    const isCreation = msg.type === 'create';
-
-    const getId = () => {
-        if (isDeletion) {
-            return 'deleted-file';
+    const getClassName = (msg: ToolReturnParseResult) => {
+        switch (msg.type) {
+            case 'delete':
+                return 'deleted-file';
+            case 'create':
+                return 'created-file';
+            default:
+                return undefined;
         }
-        if (isCreation) {
-            return 'created-file';
-        }
-        return undefined;
     };
 
     const filePath = msg.filePath;
     if (!filePath) {
         return null;
     }
-    const handleUndo = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        onUndo(filePath);
-    };
-
-    const handleKeep = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        onKeep(filePath);
-    };
 
     return (
         <div aria-label="modified-file-item" className="modified-file-item" onClick={() => onFileClick(filePath)}>
-            <div id={getId()}>{filePath}</div>
+            <div className={getClassName(msg)}>{filePath}</div>
             <div className="modified-file-actions">
-                <button className="modified-file-action" onClick={handleUndo} aria-label="Undo changes to this file">
+                <button
+                    className="modified-file-action"
+                    onClick={() => onUndo(msg)}
+                    aria-label="Undo changes to this file"
+                >
                     <CrossIcon size="small" label="Undo" />
                 </button>
-                <button className="modified-file-action" onClick={handleKeep} aria-label="Keep changes to this file">
+                <button
+                    className="modified-file-action"
+                    onClick={() => onKeep(msg)}
+                    aria-label="Keep changes to this file"
+                >
                     <CheckIcon size="small" label="Keep" />
                 </button>
             </div>

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.tsx
@@ -26,22 +26,24 @@ export const ModifiedFileItem: React.FC<{
         return null;
     }
 
+    const handleUndo = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onUndo(msg);
+    };
+
+    const handleKeep = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onKeep(msg);
+    };
+
     return (
         <div aria-label="modified-file-item" className="modified-file-item" onClick={() => onFileClick(filePath)}>
             <div className={getClassName(msg)}>{filePath}</div>
             <div className="modified-file-actions">
-                <button
-                    className="modified-file-action"
-                    onClick={() => onUndo(msg)}
-                    aria-label="Undo changes to this file"
-                >
+                <button className="modified-file-action" onClick={handleUndo} aria-label="Undo changes to this file">
                     <CrossIcon size="small" label="Undo" />
                 </button>
-                <button
-                    className="modified-file-action"
-                    onClick={() => onKeep(msg)}
-                    aria-label="Keep changes to this file"
-                >
+                <button className="modified-file-action" onClick={handleKeep} aria-label="Keep changes to this file">
                     <CheckIcon size="small" label="Keep" />
                 </button>
             </div>

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.test.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.test.tsx
@@ -78,7 +78,7 @@ describe('UpdatedFilesComponent', () => {
         );
 
         fireEvent.click(screen.getByText('Undo'));
-        expect(mockOnUndo).toHaveBeenCalledWith(['src/file1.ts', 'src/file2.ts', 'src/file3.ts']);
+        expect(mockOnUndo).toHaveBeenCalledWith(mockModifiedFiles);
     });
 
     it('calls onKeep with all file paths when Keep All is clicked', () => {
@@ -92,27 +92,7 @@ describe('UpdatedFilesComponent', () => {
         );
 
         fireEvent.click(screen.getByText('Keep'));
-        expect(mockOnKeep).toHaveBeenCalledWith(['src/file1.ts', 'src/file2.ts', 'src/file3.ts']);
-    });
-
-    it('filters out undefined file paths', () => {
-        const filesWithUndefined: ToolReturnParseResult[] = [
-            { filePath: 'src/file1.ts', content: 'content1' },
-            { filePath: undefined, content: 'content2' },
-            { filePath: 'src/file3.ts', content: 'content3' },
-        ];
-
-        render(
-            <UpdatedFilesComponent
-                modifiedFiles={filesWithUndefined}
-                onUndo={mockOnUndo}
-                onKeep={mockOnKeep}
-                openDiff={mockOpenDiff}
-            />,
-        );
-
-        fireEvent.click(screen.getByText('Keep'));
-        expect(mockOnKeep).toHaveBeenCalledWith(['src/file1.ts', 'src/file3.ts']);
+        expect(mockOnKeep).toHaveBeenCalledWith(mockModifiedFiles);
     });
 
     it('renders ModifiedFileItem for each file', () => {

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.tsx
@@ -6,20 +6,10 @@ import { ModifiedFileItem } from './ModifiedFileItem';
 
 export const UpdatedFilesComponent: React.FC<{
     modifiedFiles: ToolReturnParseResult[];
-    onUndo: (filePath: string[]) => void;
-    onKeep: (filePath: string[]) => void;
+    onUndo: (files: ToolReturnParseResult[]) => void;
+    onKeep: (files: ToolReturnParseResult[]) => void;
     openDiff: OpenFileFunc;
 }> = ({ modifiedFiles, onUndo, onKeep, openDiff }) => {
-    const handleKeepAll = React.useCallback(() => {
-        const filePaths = modifiedFiles.map((msg) => msg.filePath).filter((path) => path !== undefined);
-        onKeep(filePaths);
-    }, [onKeep, modifiedFiles]);
-
-    const handleUndoAll = React.useCallback(() => {
-        const filePaths = modifiedFiles.map((msg) => msg.filePath).filter((path) => path !== undefined);
-        onUndo(filePaths);
-    }, [onUndo, modifiedFiles]);
-
     if (!modifiedFiles || modifiedFiles.length === 0) {
         return null;
     }
@@ -34,10 +24,10 @@ export const UpdatedFilesComponent: React.FC<{
                     </span>
                 </div>
                 <div>
-                    <button className="updated-files-action secondary" onClick={() => handleUndoAll()}>
+                    <button className="updated-files-action secondary" onClick={() => onUndo(modifiedFiles)}>
                         Undo
                     </button>
-                    <button className="updated-files-action primary" onClick={() => handleKeepAll()}>
+                    <button className="updated-files-action primary" onClick={() => onKeep(modifiedFiles)}>
                         Keep
                     </button>
                 </div>
@@ -49,8 +39,8 @@ export const UpdatedFilesComponent: React.FC<{
                             key={index}
                             msg={msg}
                             onFileClick={(path: string) => openDiff(path, true)}
-                            onUndo={(path: string) => onUndo([path])}
-                            onKeep={(path: string) => onKeep([path])}
+                            onUndo={(file: ToolReturnParseResult) => onUndo([file])}
+                            onKeep={(file: ToolReturnParseResult) => onKeep([file])}
                         />
                     );
                 })}

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -16,7 +16,7 @@ import { ChatStream } from './messaging/ChatStream';
 import { PromptInputBox } from './prompt-box/prompt-input/PromptInput';
 import { PromptContextCollection } from './prompt-box/promptContext/promptContextCollection';
 import { UpdatedFilesComponent } from './prompt-box/updated-files/UpdatedFilesComponent';
-import { RovoDevViewResponse, RovoDevViewResponseType } from './rovoDevViewMessages';
+import { ModifiedFile, RovoDevViewResponse, RovoDevViewResponseType } from './rovoDevViewMessages';
 import * as styles from './rovoDevViewStyles';
 import { parseToolCallMessage } from './tools/ToolCallItem';
 import {
@@ -198,8 +198,8 @@ const RovoDevView: React.FC = () => {
     );
 
     const removeModifiedFileToolReturns = useCallback(
-        (filePaths: string[]) => {
-            setTotalModifiedFiles((prev) => prev.filter((x) => !filePaths.includes(x.filePath!)));
+        (files: ToolReturnParseResult[]) => {
+            setTotalModifiedFiles((prev) => prev.filter((x) => !files.includes(x)));
         },
         [setTotalModifiedFiles],
     );
@@ -525,23 +525,23 @@ const RovoDevView: React.FC = () => {
     );
 
     const undoFiles = useCallback(
-        (filePaths: string[]) => {
+        (files: ToolReturnParseResult[]) => {
             postMessage({
                 type: RovoDevViewResponseType.UndoFileChanges,
-                filePaths,
+                files: files.map((file) => ({ filePath: file.filePath, type: file.type }) as ModifiedFile),
             });
-            removeModifiedFileToolReturns(filePaths);
+            removeModifiedFileToolReturns(files);
         },
         [postMessage, removeModifiedFileToolReturns],
     );
 
     const keepFiles = useCallback(
-        (filePaths: string[]) => {
+        (files: ToolReturnParseResult[]) => {
             postMessage({
                 type: RovoDevViewResponseType.KeepFileChanges,
-                filePaths,
+                files: files.map((file) => ({ filePath: file.filePath, type: file.type }) as ModifiedFile),
             });
-            removeModifiedFileToolReturns(filePaths);
+            removeModifiedFileToolReturns(files);
         },
         [postMessage, removeModifiedFileToolReturns],
     );
@@ -575,7 +575,7 @@ const RovoDevView: React.FC = () => {
     const onChangesGitPushed = useCallback(
         (msg: DefaultMessage, pullRequestCreated: boolean) => {
             if (totalModifiedFiles.length > 0) {
-                keepFiles(totalModifiedFiles.map((file) => file.filePath!));
+                keepFiles(totalModifiedFiles);
             }
 
             setChatStream((prev) => [...prev, msg]);

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -18,12 +18,17 @@ export const enum RovoDevViewResponseType {
     ReportThinkingDrawerExpanded = 'reportThinkingDrawerExpanded',
 }
 
+export interface ModifiedFile {
+    filePath: string;
+    type: 'modify' | 'create' | 'delete';
+}
+
 export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.Prompt, RovoDevPrompt>
     | ReducerAction<RovoDevViewResponseType.CancelResponse>
     | ReducerAction<RovoDevViewResponseType.OpenFile, { filePath: string; tryShowDiff: boolean; range?: number[] }>
-    | ReducerAction<RovoDevViewResponseType.UndoFileChanges, { filePaths: string[] }>
-    | ReducerAction<RovoDevViewResponseType.KeepFileChanges, { filePaths: string[] }>
+    | ReducerAction<RovoDevViewResponseType.UndoFileChanges, { files: ModifiedFile[] }>
+    | ReducerAction<RovoDevViewResponseType.KeepFileChanges, { files: ModifiedFile[] }>
     | ReducerAction<RovoDevViewResponseType.GetOriginalText, { filePath: string; range?: number[]; requestId: string }>
     | ReducerAction<RovoDevViewResponseType.CreatePR, { payload: { branchName: string; commitMessage: string } }>
     | ReducerAction<RovoDevViewResponseType.RetryPromptAfterError>

--- a/src/react/atlascode/rovo-dev/tools/ToolReturnItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolReturnItem.tsx
@@ -15,8 +15,7 @@ export const ToolReturnParsedItem: React.FC<{
 
     return (
         <a
-            className="tool-return-item-base tool-return-item"
-            id={msg.filePath ? 'tool-return-file-path' : undefined}
+            className={`tool-return-item-base tool-return-item ${msg.filePath ? 'tool-return-file-path' : ''}`}
             onClick={() => msg.filePath && openFile(msg.filePath)}
         >
             {toolIcon && <>{toolIcon}</>}

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -35,7 +35,11 @@ import {
 import { Container } from '../../src/container';
 import { Logger } from '../../src/logger';
 import { rovodevInfo } from '../constants';
-import { RovoDevViewResponse, RovoDevViewResponseType } from '../react/atlascode/rovo-dev/rovoDevViewMessages';
+import {
+    ModifiedFile,
+    RovoDevViewResponse,
+    RovoDevViewResponseType,
+} from '../react/atlascode/rovo-dev/rovoDevViewMessages';
 import { getHtmlForView } from '../webview/common/getHtmlForView';
 import { PerformanceLogger } from './performanceLogger';
 import { RovoDevResponse, RovoDevResponseParser } from './responseParser';
@@ -205,11 +209,11 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         break;
 
                     case RovoDevViewResponseType.UndoFileChanges:
-                        await this.executeUndoFiles(e.filePaths);
+                        await this.executeUndoFiles(e.files);
                         break;
 
                     case RovoDevViewResponseType.KeepFileChanges:
-                        await this.executeKeepFiles(e.filePaths);
+                        await this.executeKeepFiles(e.files);
                         break;
 
                     case RovoDevViewResponseType.GetOriginalText:
@@ -886,31 +890,35 @@ ${message}`;
         }
     }
 
-    private async executeUndoFiles(filePaths: string[]) {
-        const promises = filePaths.map(async (filePath) => {
-            const resolvedPath = this.makeRelativePathAbsolute(filePath);
-            const cachedFilePath = await this.rovoDevApiClient!.getCacheFilePath(filePath);
+    private async executeUndoFiles(files: ModifiedFile[]) {
+        const promises = files.map(async (file) => {
+            const resolvedPath = this.makeRelativePathAbsolute(file.filePath);
             await this.getPromise((callback) => fs.rm(resolvedPath, callback));
-            await this.getPromise((callback) => fs.copyFile(cachedFilePath, resolvedPath, callback));
-            await this.getPromise((callback) => fs.rm(cachedFilePath, callback));
+
+            if (file.type !== 'create') {
+                const cachedFilePath = await this.rovoDevApiClient!.getCacheFilePath(file.filePath);
+                await this.getPromise((callback) => fs.copyFile(cachedFilePath, resolvedPath, callback));
+                await this.getPromise((callback) => fs.rm(cachedFilePath, callback));
+            }
         });
 
         await Promise.all(promises);
 
-        this._revertedChanges.push(...filePaths);
+        const paths = files.map((x) => x.filePath);
+        this._revertedChanges.push(...paths);
 
-        this.fireTelemetryEvent('rovoDevFileChangedActionEvent', this._currentPromptId, 'undo', filePaths.length);
+        this.fireTelemetryEvent('rovoDevFileChangedActionEvent', this._currentPromptId, 'undo', files.length);
     }
 
-    private async executeKeepFiles(filePaths: string[]) {
-        const promises = filePaths.map(async (filePath) => {
-            const cachedFilePath = await this.rovoDevApiClient!.getCacheFilePath(filePath);
+    private async executeKeepFiles(files: ModifiedFile[]) {
+        const promises = files.map(async (file) => {
+            const cachedFilePath = await this.rovoDevApiClient!.getCacheFilePath(file.filePath);
             await this.getPromise((callback) => fs.rm(cachedFilePath, callback));
         });
 
         await Promise.all(promises);
 
-        this.fireTelemetryEvent('rovoDevFileChangedActionEvent', this._currentPromptId, 'keep', filePaths.length);
+        this.fireTelemetryEvent('rovoDevFileChangedActionEvent', this._currentPromptId, 'keep', files.length);
     }
 
     private async createPR(commitMessage?: string, branchName?: string): Promise<void> {


### PR DESCRIPTION
### What Is This Change?

When undoing a newly created file, the new file should simply be deleted.
When undoing a modified or deleted file, copying over the cache into the "new file" is still correct.

### How Has This Been Tested?

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`