### PR TITLE
AXON-703: upgrade react-editext to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
                 "react-async-hook": "^4.0.0",
                 "react-dom": "^16.13.1",
                 "react-dropzone": "^14.3.8",
-                "react-editext": "3.6.1",
+                "react-editext": "7.0.0",
                 "react-hook-form": "^4.9.8",
                 "react-uid": "^2.2.0",
                 "scheduler": "^0.19.0",
@@ -12901,11 +12901,6 @@
             "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
             "dev": true
         },
-        "node_modules/classnames": {
-            "version": "2.5.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/classnames/-/classnames-2.5.1.tgz",
-            "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
-        },
         "node_modules/clean-stack": {
             "version": "2.2.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -24964,19 +24959,15 @@
             }
         },
         "node_modules/react-editext": {
-            "version": "3.6.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-editext/-/react-editext-3.6.1.tgz",
-            "integrity": "sha512-SYLq59gOBCefB/TF5DR/xjszOqqgflspUUeQRJ0NXINszv/bMuYkCzdMJRTNrcqNEbvwmFoNPZgGyTsFueMpOw==",
-            "dependencies": {
-                "classnames": "^2.2.6"
-            },
+            "version": "7.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-editext/-/react-editext-7.0.0.tgz",
+            "integrity": "sha512-uGiYPn55YCK2mV6PdF6IJBiVG0dVPSe7F5mSBlCG8KOWV4Yyi/O8OpdViXv+rg7fNXDR0s9f0GK9nqBN3WUWbA==",
+            "license": "MIT",
             "engines": {
-                "node": ">=8",
-                "npm": ">=5"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "prop-types": "^15.7.2",
-                "react": "^15.0.0 || ^16.0.0"
+                "react": ">=16"
             }
         },
         "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -1434,7 +1434,7 @@
         "react-async-hook": "^4.0.0",
         "react-dom": "^16.13.1",
         "react-dropzone": "^14.3.8",
-        "react-editext": "3.6.1",
+        "react-editext": "7.0.0",
         "react-hook-form": "^4.9.8",
         "react-uid": "^2.2.0",
         "scheduler": "^0.19.0",

--- a/src/webviews/components/issue/InlineSubtaskEditor.tsx
+++ b/src/webviews/components/issue/InlineSubtaskEditor.tsx
@@ -147,7 +147,7 @@ export default class InlineSubtaskEditor extends React.Component<Props, State> {
                             placeholder: 'What needs to be done?',
                             style: { width: '100%' },
                         }}
-                        mainContainerClassName="ac-inline-edit-main_container-left-margin"
+                        containerProps={{ className: 'ac-inline-edit-main_container-left-margin' }}
                         editButtonClassName="ac-hidden"
                         cancelButtonClassName="ac-inline-cancel-button"
                         saveButtonClassName="ac-inline-save-button"


### PR DESCRIPTION
### What Is This Change?
Upgrade react-editext to 7.0.0
This is a subtask for our main goal of [upgrading the React version](https://hello.atlassian.net/wiki/spaces/AIDO/pages/5629249869/Upgrade+React+estimation+strategy).

### How Has This Been Tested?


Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change