### PR TITLE
[AXON-741] Add all bits in multiselection to context if needed

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -59,10 +59,10 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
         global:
             testExtension === 'ts'
                 ? {
-                      statements: 71,
-                      branches: 64,
-                      functions: 63,
-                      lines: 71,
+                      statements: 70,
+                      branches: 62,
+                      functions: 62,
+                      lines: 70,
                   }
                 : /* tsx */ {
                       statements: 7,


### PR DESCRIPTION
### What Is This Change?

Quick fix to add multiple bits of selection to context at once when multi-selection is used in the editor

### How Has This Been Tested?

```
m a n u a  l l y
```

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] ~If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)~

Recommendations:
- [x] ~Update the CHANGELOG if making a user facing change~