### PR TITLE
[AXON-739] Add codicon distribution to vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -47,6 +47,7 @@ bitbucket-pipelines.yml
 *.vsix
 *.orig
 node_modules/
+!node_modules/@vscode/codicons/dist/**
 webpack.*
 build/**/*.map
 .readme/


### PR DESCRIPTION
### What Is This Change?

Add `codicon` distribution to vsix, based on this:
https://github.com/microsoft/vscode-extension-samples/issues/692

| Before | After |
|-|-|
|  <img width="321" height="146" alt="image" src="https://github.com/user-attachments/assets/58fb4939-97bf-41e2-88bb-45684fbbc35a" /> | <img width="272" height="152" alt="image" src="https://github.com/user-attachments/assets/6f830ef4-4ac8-436f-a451-1ca6ccc64f4e" /> |

This was very specifically a problem in the vsix distribution, not when running the debugger

### How Has This Been Tested?

`npm run extension:install`

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] ~If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)~

Recommendations:
- [x] ~Update the CHANGELOG if making a user facing change~