### PR TITLE
[AXON-759] change light mode syntax highlighting theme to be more readable

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -2,6 +2,19 @@ body {
     padding: 0 !important;
 }
 
+.rovoDevChat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    box-sizing: border-box;
+    background-color: var(--vscode-editor-background);
+    font-size: var(--vscode-font-size);
+    font-family: var(--vscode-font-family);
+    height: 100vh;
+    margin: auto;
+    max-width: 800px;
+}
+
 .rovoDevChat button {
     cursor: pointer;
 }

--- a/src/react/atlascode/rovo-dev/RovoDevCodeHighlighting.css
+++ b/src/react/atlascode/rovo-dev/RovoDevCodeHighlighting.css
@@ -4,31 +4,33 @@
 
 [class*=shj-lang-] {
     white-space: pre;
-    color: #112;
+    color: var(--vscode-editor-foreground);
     text-shadow: none;
     box-sizing: border-box;
-    background: #fff;
+    background: var(--vscode-editor-background);
     border-radius: 10px;
     max-width: min(100%, 100vw);
     margin: 10px 0;
     padding: 30px 20px;
-    font: 18px/24px Consolas, Courier New, Monaco, Andale Mono, Ubuntu Mono, monospace;
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
+    font-weight: var(--vscode-editor-font-weight);
     box-shadow: 0 0 5px #0001;
 }
 
 .shj-inline {
     border-radius: 5px;
     margin: 0;
-    padding: 4px 8px;
+    padding: 2px 5px;
     display: inline-block;
 }
 
 [class*=shj-lang-]::selection {
-    background: #bdf5;
+    background: var(--vscode-editor-selectionBackground);
 }
 
 [class*=shj-lang-] ::selection {
-    background: #bdf5;
+    background: var(--vscode-editor-selectionBackground);
 }
 
 [class*=shj-lang-] > div {
@@ -79,6 +81,10 @@
     color: #7d8;
 }
 
+.shj-syn-bool {
+    color: #3bf;
+}
+
 .shj-syn-type,
 .shj-syn-oper {
     color: #5af;
@@ -105,7 +111,49 @@
     padding: 5px 7px;
 }
 
-/* DARK MODE */
+/* Light theme overrides */
+
+.vscode-light {
+    
+    [class*=shj-lang-] {
+        color: #24292f;
+        background: #fff;
+    }
+
+    .shj-syn-deleted,
+    .shj-syn-err,
+    .shj-syn-kwd {
+        color: #cf222e;
+    }
+
+    .shj-syn-class {
+        color: #953800;
+    }
+
+    .shj-numbers,
+    .shj-syn-cmnt {
+        color: #6e7781;
+    }
+
+    .shj-syn-type,
+    .shj-syn-oper,
+    .shj-syn-num,
+    .shj-syn-section,
+    .shj-syn-var,
+    .shj-syn-bool {
+        color: #0550ae;
+    }
+
+    .shj-syn-str {
+        color: #0a3069;
+    }
+
+    .shj-syn-func {
+        color: #8250df;
+    }
+}
+
+/* Dark theme overrides */
 
 .vscode-dark {
     

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -17,7 +17,6 @@ import { PromptInputBox } from './prompt-box/prompt-input/PromptInput';
 import { PromptContextCollection } from './prompt-box/promptContext/promptContextCollection';
 import { UpdatedFilesComponent } from './prompt-box/updated-files/UpdatedFilesComponent';
 import { ModifiedFile, RovoDevViewResponse, RovoDevViewResponseType } from './rovoDevViewMessages';
-import * as styles from './rovoDevViewStyles';
 import { parseToolCallMessage } from './tools/ToolCallItem';
 import {
     ChatMessage,
@@ -586,7 +585,7 @@ const RovoDevView: React.FC = () => {
     }, [postMessage]);
 
     return (
-        <div className="rovoDevChat" style={styles.rovoDevContainerStyles}>
+        <div className="rovoDevChat">
             <ChatStream
                 chatHistory={chatStream}
                 currentThinking={curThinkingMessages}

--- a/src/react/atlascode/rovo-dev/rovoDevViewStyles.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewStyles.tsx
@@ -1,33 +1,5 @@
 import React from 'react';
 
-export const rovoDevContainerStyles: React.CSSProperties = {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    boxSizing: 'border-box',
-    backgroundColor: 'var(--vscode-editor-background)',
-    fontSize: 'var(--vscode-font-size)',
-    fontFamily: 'var(--vscode-font-family)',
-    height: '100vh',
-    margin: 'auto',
-    maxWidth: '800px',
-};
-
-export const rovoDevInputSectionStyles: React.CSSProperties = {
-    width: '100%',
-    borderTop: '1px solid var(--vscode-panel-border)',
-    background: 'var(--vscode-sideBar-background)',
-    padding: '16px',
-    borderRadius: '12px 12px 0px 0px',
-};
-
-export const rovoDevPromptContainerStyles: React.CSSProperties = {
-    display: 'flex',
-    width: '100%',
-    flexDirection: 'column',
-    gap: '2px',
-};
-
 export const rovoDevTextareaStyles: React.CSSProperties = {
     width: '100%',
     background: 'inherit',
@@ -35,15 +7,6 @@ export const rovoDevTextareaStyles: React.CSSProperties = {
     resize: 'none',
     outline: 'none',
     border: 'none',
-};
-
-export const rovoDevButtonStyles: React.CSSProperties = {
-    marginLeft: 'auto',
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    flexWrap: 'wrap',
 };
 
 export const rovoDevPromptButtonStyles: React.CSSProperties = {
@@ -86,42 +49,12 @@ export function rovoDevDeepPlanStylesSelector(isClicked: boolean, isDisabled: bo
     }
 }
 
-export const rovoDevTextareaContainerStyles: React.CSSProperties = {
-    width: '100%',
-    border: '1px solid var(--vscode-input-border)',
-    borderRadius: '2px',
-    background: 'var(--vscode-input-background)',
-    padding: '8px',
-};
-
-export const outerChatContainerStyles: React.CSSProperties = {
-    width: '100%',
-    overflowY: 'auto',
-    display: 'flex',
-    flexDirection: 'column',
-    flexGrow: '1',
-    gap: '12px',
-    padding: '10px 16px 0 16px',
-};
-
-export const chatMessagesContainerStyles: React.CSSProperties = {
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-};
-
 export const chatMessageStyles: React.CSSProperties = {
     maxWidth: '100%',
     marginBottom: '8px',
     padding: '8px 12px',
     borderRadius: '8px',
     position: 'relative',
-};
-
-export const userMessageStyles: React.CSSProperties = {
-    backgroundColor: 'var(--vscode-editor-selectionBackground)',
-    alignSelf: 'flex-end',
-    borderBottomRightRadius: '0px',
 };
 
 export const agentMessageStyles: React.CSSProperties = {
@@ -145,17 +78,6 @@ export const messageContentStyles: React.CSSProperties = {
     whiteSpace: 'normal',
     wordBreak: 'break-word',
     color: 'var(--vscode-editor-foreground)',
-};
-
-export const undoKeepButtonStyles: React.CSSProperties = {
-    cursor: 'pointer',
-    padding: '2px 6px',
-    borderRadius: '2px',
-};
-
-export const inlineModifyButtonStyles: React.CSSProperties = {
-    padding: '2px 4px !important',
-    backgroundColor: 'var(--vscode-list-hoverBackground)',
 };
 
 export const inChatButtonStyles: React.CSSProperties = {


### PR DESCRIPTION
### What Is This Change?

Switched the light mode theme to have more readable syntax highlighting

Before: 
<img width="638" height="508" alt="Screenshot 2025-07-30 at 3 32 13 PM" src="https://github.com/user-attachments/assets/ba6e1b6a-c32d-45e6-84e9-fa9a2feead2f" />

After:
<img width="541" height="501" alt="Screenshot 2025-07-30 at 3 32 23 PM" src="https://github.com/user-attachments/assets/50f53f4a-6852-4087-b4b0-4614e25f2631" />

_Also_, removed unused styles in rovoDevStyles.tsx
### How Has This Been Tested?

M a n u a l

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`