### PR TITLE
[AXON-767] Added better error handling for pr creation

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -378,6 +378,10 @@ body {
     color: var(--vscode-input-foreground);
 }
 
+.pull-request-form-field input[type="text"]:focus {
+    outline: var(--vscode-focusBorder) solid 1px;
+}
+
 .pull-request-form-actions {
     display: flex;
     flex-direction: row;

--- a/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
+++ b/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
@@ -88,6 +88,11 @@ export const PullRequestForm: React.FC<PullRequestFormProps> = ({
             ConnectionTimeout,
         );
         setPullRequestLoading(false);
+
+        if (response.data.error) {
+            console.error(`Error creating PR: ${response.data.error}`);
+            return;
+        }
         onPullRequestCreated(response.data.url || '');
     };
 

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -38,7 +38,7 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.Initialized>
     | ReducerAction<RovoDevProviderMessageType.CancelFailed>
     | ReducerAction<RovoDevProviderMessageType.ReturnText, { text: string }>
-    | ReducerAction<RovoDevProviderMessageType.CreatePRComplete, { data: { url?: string } }>
+    | ReducerAction<RovoDevProviderMessageType.CreatePRComplete, { data: { url?: string; error?: string } }>
     | ReducerAction<RovoDevProviderMessageType.GetCurrentBranchNameComplete, { data: { branchName?: string } }>
     | ReducerAction<RovoDevProviderMessageType.UserFocusUpdated, { userFocus: RovoDevContextItem }>
     | ReducerAction<RovoDevProviderMessageType.ContextAdded, { context: RovoDevContextItem }>;


### PR DESCRIPTION
### What Is This Change?
Added better error handling for the pr creation functionality
* added gitErrorCode to give better understanding of what went wrong

Fixed input border to be styled with vscode variables when focused

success:
<img width="774" height="70" alt="Screenshot 2025-07-30 at 5 31 38 PM" src="https://github.com/user-attachments/assets/41d03b7f-6533-4281-a54b-6b424caa2372" />

error:
<img width="299" height="348" alt="Screenshot 2025-07-30 at 6 06 01 PM" src="https://github.com/user-attachments/assets/c8e36450-2cf7-415a-9fa4-02d1be4b5496" />


### How Has This Been Tested?
m a n u a l

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`