### PR TITLE
AXON-738: Start work redesign: Layout

### DIFF
--- a/src/analyticsTypes.ts
+++ b/src/analyticsTypes.ts
@@ -39,6 +39,9 @@ export enum AnalyticsView {
 
     StartWorkPage = 'page:v2:jira:startWork',
 
+    // v3
+    StartWorkPageV3 = 'page:v3:jira:startWork',
+
     // Reserved for future use
 
     Other = 'other',

--- a/src/react/atlascode/startwork/v3/StartWorkPageV3.tsx
+++ b/src/react/atlascode/startwork/v3/StartWorkPageV3.tsx
@@ -1,10 +1,36 @@
+import { Box, Button, Typography } from '@material-ui/core';
 import React from 'react';
+import { AnalyticsView } from 'src/analyticsTypes';
+
+import { AtlascodeErrorBoundary } from '../../common/ErrorBoundary';
+import { StartWorkControllerContext, useStartWorkController } from '../startWorkController';
+import { CreateBranchSection, TaskInfoSection, UpdateStatusSection } from './components';
 
 const StartWorkPageV3: React.FunctionComponent = () => {
+    const [state, controller] = useStartWorkController();
+
     return (
-        <div>
-            <h1>Start Work</h1>
-        </div>
+        <StartWorkControllerContext.Provider value={controller}>
+            <AtlascodeErrorBoundary
+                context={{ view: AnalyticsView.StartWorkPageV3 }}
+                postMessageFunc={controller.postMessage}
+            >
+                <Box marginTop={7} maxWidth="654px" padding={3} marginX="auto">
+                    <Box marginBottom={2}>
+                        <Typography variant="h3" style={{ fontWeight: 700 }}>
+                            Start work
+                        </Typography>
+                    </Box>
+
+                    <TaskInfoSection state={state} controller={controller} />
+                    <CreateBranchSection state={state} controller={controller} />
+                    <UpdateStatusSection state={state} controller={controller} />
+                    <Button variant="contained" color="primary">
+                        Create branch
+                    </Button>
+                </Box>
+            </AtlascodeErrorBoundary>
+        </StartWorkControllerContext.Provider>
     );
 };
 

--- a/src/react/atlascode/startwork/v3/components/CreateBranchSection.test.tsx
+++ b/src/react/atlascode/startwork/v3/components/CreateBranchSection.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { CreateBranchSection } from './CreateBranchSection';
+
+jest.mock('../../../../vscode/theme/styles', () => ({
+    VSCodeStylesContext: React.createContext({
+        descriptionForeground: '#666666',
+        foreground: '#000000',
+        background: '#ffffff',
+    }),
+}));
+
+const mockController = {
+    postMessage: jest.fn(),
+    refresh: jest.fn(),
+    openLink: jest.fn(),
+    startWork: jest.fn(),
+    closePage: jest.fn(),
+    openJiraIssue: jest.fn(),
+    openSettings: jest.fn(),
+};
+
+const mockState: any = {
+    issue: {
+        key: 'TEST-123',
+        summary: 'Test Issue',
+        status: {
+            id: '1',
+            name: 'To Do',
+            statusCategory: {
+                key: 'new',
+                colorName: 'blue',
+            },
+        },
+        transitions: [],
+        issuetype: {
+            name: 'Task',
+            iconUrl: 'test-icon.png',
+        },
+    },
+    repoData: [],
+    customTemplate: '{{prefix}}/{{issueKey}}-{{summary}}',
+    customPrefixes: [],
+    isSomethingLoading: false,
+};
+
+describe('CreateBranchSection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render "Create branch" title', () => {
+        render(<CreateBranchSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('Create branch')).toBeDefined();
+    });
+
+    it('should render "New local branch" label', () => {
+        render(<CreateBranchSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('New local branch')).toBeDefined();
+    });
+
+    it('should render "Source branch" label', () => {
+        render(<CreateBranchSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('Source branch')).toBeDefined();
+    });
+
+    it('should render "Push the new branch to remote" checkbox', () => {
+        render(<CreateBranchSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('Push the new branch to remote')).toBeDefined();
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).toBeDefined();
+    });
+
+    it('should render settings button', () => {
+        render(<CreateBranchSection state={mockState} controller={mockController} />);
+
+        const buttons = screen.getAllByRole('button');
+        expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it('should render with proper layout structure', () => {
+        render(<CreateBranchSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('Create branch')).toBeDefined();
+        expect(screen.getByText('New local branch')).toBeDefined();
+        expect(screen.getByText('Source branch')).toBeDefined();
+        expect(screen.getByText('Push the new branch to remote')).toBeDefined();
+    });
+});

--- a/src/react/atlascode/startwork/v3/components/CreateBranchSection.tsx
+++ b/src/react/atlascode/startwork/v3/components/CreateBranchSection.tsx
@@ -1,0 +1,88 @@
+import {
+    Box,
+    Checkbox,
+    FormControlLabel,
+    Grid,
+    IconButton,
+    makeStyles,
+    TextField,
+    Theme,
+    Typography,
+} from '@material-ui/core';
+import SettingsIcon from '@material-ui/icons/Settings';
+import { Autocomplete } from '@material-ui/lab';
+import React, { useContext } from 'react';
+
+import { VSCodeStyles, VSCodeStylesContext } from '../../../../vscode/theme/styles';
+import { CreateBranchSectionProps } from '../types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    settingsButton: (props: VSCodeStyles) => ({
+        '& .MuiSvgIcon-root': {
+            fill: 'none',
+            stroke: props.descriptionForeground,
+            strokeWidth: 1.5,
+        },
+    }),
+}));
+
+export const CreateBranchSection: React.FC<CreateBranchSectionProps> = ({ state, controller }) => {
+    const vscStyles = useContext(VSCodeStylesContext);
+    const classes = useStyles(vscStyles);
+
+    return (
+        <Box
+            border={1}
+            borderRadius={3}
+            borderColor="var(--vscode-list-inactiveSelectionBackground)"
+            padding={3}
+            marginBottom={2}
+        >
+            <Box marginBottom={2}>
+                <Typography variant="h5" style={{ fontWeight: 700 }}>
+                    Create branch
+                </Typography>
+            </Box>
+
+            <Grid container spacing={2} direction="column">
+                <Grid item>
+                    <Typography variant="body2">New local branch</Typography>
+                    <Grid container spacing={1} alignItems="center">
+                        <Grid item xs>
+                            <TextField
+                                fullWidth
+                                size="small"
+                                value="ALT-1156-bb-pr-creation-integration-is-cool-yeah-lets-go"
+                                variant="outlined"
+                            />
+                        </Grid>
+                        <Grid item>
+                            <IconButton size="small" color="default" className={classes.settingsButton}>
+                                <SettingsIcon fontSize="small" />
+                            </IconButton>
+                        </Grid>
+                    </Grid>
+                </Grid>
+
+                <Grid item xs={9}>
+                    <Typography variant="body2">Source branch</Typography>
+                    <Autocomplete
+                        options={[
+                            'bb-pr-creation-integration-is-cool-yeah-yeah-lets-go',
+                            'main',
+                            'develop',
+                            'feature/new-branch',
+                        ]}
+                        value="bb-pr-creation-integration-is-cool-yeah-lets-go"
+                        renderInput={(params) => <TextField {...params} size="small" variant="outlined" fullWidth />}
+                        size="small"
+                    />
+                </Grid>
+
+                <Grid item>
+                    <FormControlLabel control={<Checkbox defaultChecked />} label="Push the new branch to remote" />
+                </Grid>
+            </Grid>
+        </Box>
+    );
+};

--- a/src/react/atlascode/startwork/v3/components/TaskInfoSection.test.tsx
+++ b/src/react/atlascode/startwork/v3/components/TaskInfoSection.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { TaskInfoSection } from './TaskInfoSection';
+
+const mockController = {
+    postMessage: jest.fn(),
+    refresh: jest.fn(),
+    openLink: jest.fn(),
+    startWork: jest.fn(),
+    closePage: jest.fn(),
+    openJiraIssue: jest.fn(),
+    openSettings: jest.fn(),
+};
+
+const mockState: any = {
+    issue: {
+        key: 'TEST-123',
+        summary: 'Test Issue Summary',
+        status: {
+            id: '1',
+            name: 'To Do',
+            statusCategory: {
+                key: 'new',
+                colorName: 'blue',
+            },
+        },
+        transitions: [],
+        issuetype: {
+            name: 'Task',
+            iconUrl: 'test-icon.png',
+        },
+    },
+    repoData: [],
+    customTemplate: '{{prefix}}/{{issueKey}}-{{summary}}',
+    customPrefixes: [],
+    isSomethingLoading: false,
+};
+
+describe('TaskInfoSection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render "For" label', () => {
+        render(<TaskInfoSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('For')).toBeDefined();
+    });
+
+    it('should render issue key as link', () => {
+        render(<TaskInfoSection state={mockState} controller={mockController} />);
+
+        const link = screen.getByText('TEST-123');
+        expect(link).toBeDefined();
+    });
+
+    it('should render issue summary', () => {
+        render(<TaskInfoSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('Test Issue Summary')).toBeDefined();
+    });
+
+    it('should render issue type icon', () => {
+        render(<TaskInfoSection state={mockState} controller={mockController} />);
+
+        const icon = screen.getByTitle('Task');
+        expect(icon).toBeDefined();
+    });
+
+    it('should call openJiraIssue when link is clicked', () => {
+        render(<TaskInfoSection state={mockState} controller={mockController} />);
+
+        const link = screen.getByText('TEST-123');
+        link.click();
+
+        expect(mockController.openJiraIssue).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render with proper layout structure', () => {
+        render(<TaskInfoSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('For')).toBeDefined();
+        expect(screen.getByText('TEST-123')).toBeDefined();
+        expect(screen.getByText('Test Issue Summary')).toBeDefined();
+        expect(screen.getByTitle('Task')).toBeDefined();
+    });
+});

--- a/src/react/atlascode/startwork/v3/components/TaskInfoSection.tsx
+++ b/src/react/atlascode/startwork/v3/components/TaskInfoSection.tsx
@@ -1,0 +1,52 @@
+import { Box, Grid, Link, Typography } from '@material-ui/core';
+import React from 'react';
+
+import { TaskInfoSectionProps } from '../types';
+
+export const TaskInfoSection: React.FC<TaskInfoSectionProps> = ({ state, controller }) => {
+    return (
+        <Box marginBottom={2}>
+            <Grid container alignItems="center" spacing={1}>
+                <Grid item>
+                    <Grid container alignItems="center" spacing={1} wrap="nowrap">
+                        <Grid item>
+                            <Typography variant="h5">For</Typography>
+                        </Grid>
+                        <Grid item>
+                            <Box
+                                border={1}
+                                borderRadius={3}
+                                padding={0.5}
+                                borderColor={'var(--vscode-list-inactiveSelectionBackground)'}
+                            >
+                                <Grid container alignItems="center" spacing={1} wrap="nowrap">
+                                    <Grid item>
+                                        <Box
+                                            width="14px"
+                                            height="14px"
+                                            style={{
+                                                backgroundImage: `url(${state.issue.issuetype.iconUrl})`,
+                                                backgroundSize: 'contain',
+                                            }}
+                                            title={state.issue.issuetype.name}
+                                        />
+                                    </Grid>
+                                    <Grid item>
+                                        <Typography variant="h5">
+                                            <Link onClick={controller.openJiraIssue} style={{ cursor: 'pointer' }}>
+                                                {state.issue.key}
+                                            </Link>
+                                        </Typography>
+                                    </Grid>
+                                    <Grid item>
+                                        <Typography variant="h5">{state.issue.summary}</Typography>
+                                    </Grid>
+                                </Grid>
+                            </Box>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </Grid>
+        </Box>
+    );
+};

--- a/src/react/atlascode/startwork/v3/components/UpdateStatusSection.test.tsx
+++ b/src/react/atlascode/startwork/v3/components/UpdateStatusSection.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { UpdateStatusSection } from './UpdateStatusSection';
+
+const mockController = {
+    postMessage: jest.fn(),
+    refresh: jest.fn(),
+    openLink: jest.fn(),
+    startWork: jest.fn(),
+    closePage: jest.fn(),
+    openJiraIssue: jest.fn(),
+    openSettings: jest.fn(),
+};
+
+const mockState: any = {
+    issue: {
+        key: 'TEST-123',
+        summary: 'Test Issue Summary',
+        status: {
+            id: '1',
+            name: 'To Do',
+            statusCategory: {
+                key: 'new',
+                colorName: 'blue',
+            },
+        },
+        transitions: [
+            {
+                id: 'transition-1',
+                name: 'Start Progress',
+                to: {
+                    id: '2',
+                    name: 'In Progress',
+                    statusCategory: {
+                        key: 'indeterminate',
+                        colorName: 'yellow',
+                    },
+                },
+                isInitial: false,
+            },
+            {
+                id: 'transition-2',
+                name: 'Done',
+                to: {
+                    id: '3',
+                    name: 'Done',
+                    statusCategory: {
+                        key: 'done',
+                        colorName: 'green',
+                    },
+                },
+                isInitial: false,
+            },
+        ],
+        issuetype: {
+            name: 'Task',
+            iconUrl: 'test-icon.png',
+        },
+    },
+    repoData: [],
+    customTemplate: '{{prefix}}/{{issueKey}}-{{summary}}',
+    customPrefixes: [],
+    isSomethingLoading: false,
+};
+
+describe('UpdateStatusSection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render "Update work item status" title', () => {
+        render(<UpdateStatusSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('Update work item status')).toBeDefined();
+    });
+
+    it('should render current status lozenge', () => {
+        render(<UpdateStatusSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('To Do')).toBeDefined();
+    });
+
+    it('should render checkbox as checked by default', () => {
+        render(<UpdateStatusSection state={mockState} controller={mockController} />);
+
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).toBeDefined();
+    });
+
+    it('should render transition dropdown', () => {
+        render(<UpdateStatusSection state={mockState} controller={mockController} />);
+
+        const dropdown = screen.getByRole('button');
+        expect(dropdown).toBeDefined();
+    });
+
+    it('should select in-progress transition by default', () => {
+        render(<UpdateStatusSection state={mockState} controller={mockController} />);
+
+        // The component should select the "In Progress" transition by default
+        // because it contains "progress" in the name
+        expect(screen.getByDisplayValue('transition-1')).toBeDefined();
+    });
+
+    it('should handle transition change', () => {
+        render(<UpdateStatusSection state={mockState} controller={mockController} />);
+
+        const dropdown = screen.getByRole('button');
+        fireEvent.mouseDown(dropdown);
+
+        expect(screen.getByText('Done')).toBeDefined();
+    });
+
+    it('should render with proper layout structure', () => {
+        render(<UpdateStatusSection state={mockState} controller={mockController} />);
+
+        expect(screen.getByText('Update work item status')).toBeDefined();
+        expect(screen.getByText('To Do')).toBeDefined();
+        expect(screen.getByRole('checkbox')).toBeDefined();
+        expect(screen.getByRole('button')).toBeDefined();
+    });
+});

--- a/src/react/atlascode/startwork/v3/components/UpdateStatusSection.tsx
+++ b/src/react/atlascode/startwork/v3/components/UpdateStatusSection.tsx
@@ -1,0 +1,86 @@
+import Lozenge from '@atlaskit/lozenge';
+import { emptyTransition, Transition } from '@atlassianlabs/jira-pi-common-models';
+import { Box, Checkbox, FormControlLabel, Grid, MenuItem, TextField, Typography } from '@material-ui/core';
+import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt';
+import React, { useEffect, useState } from 'react';
+
+import { colorToLozengeAppearanceMap } from '../../../../vscode/theme/colors';
+import { UpdateStatusSectionProps } from '../types';
+
+export const UpdateStatusSection: React.FC<UpdateStatusSectionProps> = ({ state, controller }) => {
+    const [selectedTransition, setSelectedTransition] = useState<Transition>(emptyTransition);
+
+    useEffect(() => {
+        const inProgressTransitionGuess: Transition =
+            state.issue.transitions.find((t) => !t.isInitial && t.to.name.toLocaleLowerCase().includes('progress')) ||
+            state.issue.transitions.find((t) => !t.isInitial) ||
+            state.issue.transitions?.[0] ||
+            emptyTransition;
+        setSelectedTransition(inProgressTransitionGuess);
+    }, [state.issue]);
+
+    const handleTransitionChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+        const transitionId = event.target.value as string;
+        const transition = state.issue.transitions.find((t) => t.id === transitionId);
+        if (transition) {
+            setSelectedTransition(transition);
+        }
+    };
+
+    return (
+        <Box
+            border={1}
+            borderRadius={3}
+            borderColor="var(--vscode-list-inactiveSelectionBackground)"
+            padding={3}
+            marginBottom={2}
+        >
+            <FormControlLabel
+                control={<Checkbox defaultChecked />}
+                label={
+                    <Typography variant="h5" style={{ fontWeight: 700 }}>
+                        Update work item status
+                    </Typography>
+                }
+            />
+
+            <Grid container alignItems="center" justifyContent="flex-start" spacing={1}>
+                <Grid item>
+                    <Lozenge appearance={colorToLozengeAppearanceMap[state.issue.status.statusCategory.colorName]}>
+                        {state.issue.status.name}
+                    </Lozenge>
+                </Grid>
+                <Box display="flex" alignItems="center">
+                    <ArrowRightAltIcon />
+                </Box>
+                <Grid item>
+                    <Box minWidth={150}>
+                        <TextField
+                            select
+                            size="small"
+                            value={selectedTransition.id}
+                            onChange={handleTransitionChange}
+                            variant="outlined"
+                        >
+                            {state.issue.transitions
+                                .filter((transition) => transition.to.id !== state.issue.status.id)
+                                .map((transition) => {
+                                    return (
+                                        <MenuItem key={transition.id} value={transition.id}>
+                                            <Lozenge
+                                                appearance={
+                                                    colorToLozengeAppearanceMap[transition.to.statusCategory.colorName]
+                                                }
+                                            >
+                                                {transition.to.name}
+                                            </Lozenge>
+                                        </MenuItem>
+                                    );
+                                })}
+                        </TextField>
+                    </Box>
+                </Grid>
+            </Grid>
+        </Box>
+    );
+};

--- a/src/react/atlascode/startwork/v3/components/index.ts
+++ b/src/react/atlascode/startwork/v3/components/index.ts
@@ -1,0 +1,3 @@
+export { TaskInfoSection } from './TaskInfoSection';
+export { CreateBranchSection } from './CreateBranchSection';
+export { UpdateStatusSection } from './UpdateStatusSection';

--- a/src/react/atlascode/startwork/v3/types.ts
+++ b/src/react/atlascode/startwork/v3/types.ts
@@ -1,0 +1,10 @@
+import { StartWorkControllerApi, StartWorkState } from '../startWorkController';
+
+export interface SectionProps {
+    state: StartWorkState;
+    controller: StartWorkControllerApi;
+}
+
+export type TaskInfoSectionProps = SectionProps;
+export type CreateBranchSectionProps = SectionProps;
+export type UpdateStatusSectionProps = SectionProps;


### PR DESCRIPTION
### What Is This Change?

Prepares the StartWork Page V3 layout.
**Note**: Layout-only preparation - functionality will be implemented in the next PR.

**Result**:
<img width="1124" height="878" alt="image" src="https://github.com/user-attachments/assets/52c2c68b-12b8-4c69-8bcd-38b753329de0" />

**How to test:**

Create `.env`
Add `ATLASCODE_FF_OVERRIDES=atlascode-start-work-v3=true`


Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change