### PR TITLE
AXON-750: change cannot get client error message to more meaningful

### DIFF
--- a/src/atlclients/authStore.ts
+++ b/src/atlclients/authStore.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import PQueue from 'p-queue';
-import { cannotGetClientFor } from 'src/constants';
 import { Disposable, Event, EventEmitter, ExtensionContext, version, window } from 'vscode';
 
 import { loggedOutEvent } from '../analytics';
@@ -272,7 +271,9 @@ export class CredentialManager implements Disposable {
                 await Container.credentialManager.refreshAccessToken(site);
             } catch (e) {
                 Logger.error(e, 'error refreshing token');
-                return Promise.reject(`${cannotGetClientFor}: ${site.product.name} ... ${e}`);
+                return Promise.reject(
+                    `Your ${site.product.name} session has expired. Please sign in again to continue.`,
+                );
             }
         } else {
             Logger.debug(`This process isn't in charge of refreshing credentials.`);

--- a/src/atlclients/clientManager.test.ts
+++ b/src/atlclients/clientManager.test.ts
@@ -384,7 +384,9 @@ describe('ClientManager', () => {
 
             (window.showErrorMessage as jest.Mock).mockResolvedValue(undefined);
 
-            await expect(clientManager.jiraClient(mockCloudSite)).rejects.toThrow('cannot get client for: Jira');
+            await expect(clientManager.jiraClient(mockCloudSite)).rejects.toThrow(
+                'Unable to connect to Jira. Please sign in again to continue.',
+            );
 
             expect(window.showErrorMessage).toHaveBeenCalled();
             expect(Logger.error).toHaveBeenCalled();
@@ -487,7 +489,9 @@ describe('ClientManager', () => {
             (window.showErrorMessage as jest.Mock).mockResolvedValue('View Atlascode settings');
             (commands.executeCommand as jest.Mock).mockResolvedValue(undefined);
 
-            await expect(clientManager.jiraClient(mockCloudSite)).rejects.toThrow('cannot get client for: Jira');
+            await expect(clientManager.jiraClient(mockCloudSite)).rejects.toThrow(
+                'Unable to connect to Jira. Please sign in again to continue.',
+            );
 
             expect(commands.executeCommand).toHaveBeenCalledWith('atlascode.showConfigPage');
         });
@@ -496,7 +500,9 @@ describe('ClientManager', () => {
             mockCredentialManager.getAuthInfo.mockResolvedValue(null);
             mockCacheMap.getItem.mockReturnValue(null);
 
-            await expect(clientManager.jiraClient(mockCloudSite)).rejects.toThrow('cannot get client for: Jira');
+            await expect(clientManager.jiraClient(mockCloudSite)).rejects.toThrow(
+                'Unable to connect to Jira. Please sign in again to continue.',
+            );
         });
     });
 });

--- a/src/atlclients/clientManager.ts
+++ b/src/atlclients/clientManager.ts
@@ -12,7 +12,6 @@ import { ServerRepositoriesApi } from '../bitbucket/bitbucket-server/repositorie
 import { ClientError, HTTPClient } from '../bitbucket/httpClient';
 import { BitbucketApi } from '../bitbucket/model';
 import { configuration } from '../config/configuration';
-import { cannotGetClientFor } from '../constants';
 import { Container } from '../container';
 import {
     basicJiraTransportFactory,
@@ -317,6 +316,8 @@ export class ClientManager implements Disposable {
             this._agentChanged = false;
         }
 
-        return client ? client : Promise.reject(new Error(`${cannotGetClientFor}: ${site.product.name}`));
+        return client
+            ? client
+            : Promise.reject(new Error(`Unable to connect to ${site.product.name}. Please sign in again to continue.`));
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,6 @@ export const GlobalStateVersionKey = 'atlascodeVersion';
 export const AxiosUserAgent = 'atlascode/2.x axios/0.19.2';
 
 export const bbAPIConnectivityError = new Error('cannot connect to bitbucket api');
-export const cannotGetClientFor = 'cannot get client for';
 
 export const enum Commands {
     BitbucketSelectContainer = 'atlascode.bb.selectContainer',


### PR DESCRIPTION
### What Is This Change?
Currently, after 401/403 error, we mark the auth state as Invalid, block client creation, and show the popup with real error ( not meaningful for user ) - cannot get client for: [product]. In this PR I've updated cannot get client error messages to more meaningful:
- `Unable to connect to ${site.product.name}. Please sign in again to continue.` for cases when invalid credentials during client creation were used
- `Your ${site.product.name} session has expired. Please sign in again to continue.`  in case of token refresh failure
<img width="876" height="81" alt="Screenshot 2025-07-30 at 15 05 42" src="https://github.com/user-attachments/assets/b03895ad-1180-41c6-b130-4e3aae5a66ce" />


<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change