### PR TITLE
[AXON-742] Make PR button tied to the broader workspace state

### DIFF
--- a/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.test.tsx
+++ b/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.test.tsx
@@ -4,7 +4,7 @@ import { RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderM
 import { forceCastTo } from 'testsutil/miscFunctions';
 
 import { RovoDevViewResponseType } from '../rovoDevViewMessages';
-import { DefaultMessage, ToolReturnParseResult } from '../utils';
+import { DefaultMessage } from '../utils';
 import { PullRequestChatItem, PullRequestForm } from './PullRequestForm';
 
 const mockPostMessage = jest.fn();
@@ -13,29 +13,9 @@ const mockOnCancel = jest.fn();
 const mockOnPullRequestCreated = jest.fn();
 const mockSetFormVisible = jest.fn();
 
-const mockModifiedFiles = forceCastTo<ToolReturnParseResult[]>([
-    {
-        content: 'file content',
-        filePath: 'src/file.ts',
-        type: 'modify',
-    },
-]);
-
 describe('PullRequestForm', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-    });
-
-    it('renders null when no modified files', () => {
-        const { container } = render(
-            <PullRequestForm
-                onCancel={mockOnCancel}
-                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
-                modifiedFiles={[]}
-                onPullRequestCreated={mockOnPullRequestCreated}
-            />,
-        );
-        expect(container.firstChild).toBeNull();
     });
 
     it('renders button when form is not visible', () => {
@@ -43,7 +23,6 @@ describe('PullRequestForm', () => {
             <PullRequestForm
                 onCancel={mockOnCancel}
                 messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
-                modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={false}
                 setFormVisible={mockSetFormVisible}
@@ -58,7 +37,6 @@ describe('PullRequestForm', () => {
             <PullRequestForm
                 onCancel={mockOnCancel}
                 messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
-                modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
                 setFormVisible={mockSetFormVisible}
@@ -78,7 +56,6 @@ describe('PullRequestForm', () => {
             <PullRequestForm
                 onCancel={mockOnCancel}
                 messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
-                modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={false}
                 setFormVisible={mockSetFormVisible}
@@ -102,7 +79,6 @@ describe('PullRequestForm', () => {
             <PullRequestForm
                 onCancel={mockOnCancel}
                 messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
-                modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
             />,
@@ -119,7 +95,6 @@ describe('PullRequestForm', () => {
             <PullRequestForm
                 onCancel={mockOnCancel}
                 messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
-                modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
             />,
@@ -152,7 +127,6 @@ describe('PullRequestForm', () => {
             <PullRequestForm
                 onCancel={mockOnCancel}
                 messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
-                modifiedFiles={mockModifiedFiles}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
             />,

--- a/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
+++ b/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
@@ -6,7 +6,7 @@ import { ConnectionTimeout } from 'src/util/time';
 import { useMessagingApi } from '../../messagingApi';
 import { mdParser } from '../common/common';
 import { RovoDevViewResponse, RovoDevViewResponseType } from '../rovoDevViewMessages';
-import { DefaultMessage, ToolReturnParseResult } from '../utils';
+import { DefaultMessage } from '../utils';
 
 const PullRequestButton: React.FC<{
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
@@ -29,7 +29,6 @@ interface PullRequestFormProps {
     messagingApi: ReturnType<
         typeof useMessagingApi<RovoDevViewResponse, RovoDevProviderMessage, RovoDevProviderMessage>
     >;
-    modifiedFiles?: ToolReturnParseResult[];
     onPullRequestCreated: (url: string) => void;
     isFormVisible?: boolean;
     setFormVisible?: (visible: boolean) => void;
@@ -38,14 +37,10 @@ interface PullRequestFormProps {
 export const PullRequestForm: React.FC<PullRequestFormProps> = ({
     onCancel,
     messagingApi: { postMessagePromise },
-    modifiedFiles,
     onPullRequestCreated,
     isFormVisible = false,
     setFormVisible,
 }) => {
-    if (!modifiedFiles || modifiedFiles.length === 0) {
-        return null;
-    }
     const [isPullRequestLoading, setPullRequestLoading] = React.useState(false);
     const [isBranchNameLoading, setBranchNameLoading] = React.useState(false);
     const [branchName, setBranchName] = React.useState<string | undefined>(undefined);

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -419,6 +419,7 @@ const RovoDevView: React.FC = () => {
                 case RovoDevProviderMessageType.ReturnText:
                 case RovoDevProviderMessageType.CreatePRComplete:
                 case RovoDevProviderMessageType.GetCurrentBranchNameComplete:
+                case RovoDevProviderMessageType.CheckGitChangesComplete:
                     break; // This is handled elsewhere
 
                 default:

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -16,6 +16,7 @@ export const enum RovoDevViewResponseType {
     ReportChangedFilesPanelShown = 'reportChangedFilesPanelShown',
     ReportChangesGitPushed = 'reportChangesGitPushed',
     ReportThinkingDrawerExpanded = 'reportThinkingDrawerExpanded',
+    CheckGitChanges = 'checkGitChanges',
 }
 
 export interface ModifiedFile {
@@ -37,4 +38,5 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.ForceUserFocusUpdate>
     | ReducerAction<RovoDevViewResponseType.ReportChangedFilesPanelShown, { filesCount: number }>
     | ReducerAction<RovoDevViewResponseType.ReportChangesGitPushed, { pullRequestCreated: boolean }>
-    | ReducerAction<RovoDevViewResponseType.ReportThinkingDrawerExpanded>;
+    | ReducerAction<RovoDevViewResponseType.ReportThinkingDrawerExpanded>
+    | ReducerAction<RovoDevViewResponseType.CheckGitChanges>;

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -259,6 +259,15 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         );
                         break;
 
+                    case RovoDevViewResponseType.CheckGitChanges:
+                        await this._prHandler.isGitStateClean().then((isClean) => {
+                            this._webView?.postMessage({
+                                type: RovoDevProviderMessageType.CheckGitChangesComplete,
+                                hasChanges: !isClean,
+                            });
+                        });
+                        break;
+
                     case RovoDevViewResponseType.ReportThinkingDrawerExpanded:
                         this.fireTelemetryEvent('rovoDevDetailsExpandedEvent', this._currentPromptId);
                         break;

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -20,6 +20,7 @@ export const enum RovoDevProviderMessageType {
     GetCurrentBranchNameComplete = 'getCurrentBranchNameComplete',
     UserFocusUpdated = 'userFocusUpdated',
     ContextAdded = 'contextAdded',
+    CheckGitChangesComplete = 'checkGitChangesComplete',
 }
 
 export interface RovoDevObjectResponse {
@@ -41,4 +42,5 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.CreatePRComplete, { data: { url?: string; error?: string } }>
     | ReducerAction<RovoDevProviderMessageType.GetCurrentBranchNameComplete, { data: { branchName?: string } }>
     | ReducerAction<RovoDevProviderMessageType.UserFocusUpdated, { userFocus: RovoDevContextItem }>
-    | ReducerAction<RovoDevProviderMessageType.ContextAdded, { context: RovoDevContextItem }>;
+    | ReducerAction<RovoDevProviderMessageType.ContextAdded, { context: RovoDevContextItem }>
+    | ReducerAction<RovoDevProviderMessageType.CheckGitChangesComplete, { hasChanges: boolean }>;


### PR DESCRIPTION
### What Is This Change?

With this change, the behaviour of the Create PR button in rovodev chat is conditional on the overall state of the workspace as seen by the VSCode git integration - as opposed to the changes we track in the chat drawer

This is more in line with our original intention - but there are some interesting implications, please refer to the loom in #axon on this :)

### How Has This Been Tested?

`m a n u a l l y`

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] ~If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)~

Recommendations:
- [x] ~Update the CHANGELOG if making a user facing change~