### PR TITLE
GH#665 - treat selectFieldOptions['issuetype'] as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ---
 
+## What's new in 3.8.8
+
+### Features
+
+### Bug Fixes
+
+- Fixed a bug where issues would not render due to malformed epic fields (#665)
+
 ## What's new in 3.8.7
 
 ### Features

--- a/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
+++ b/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
@@ -566,7 +566,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
                     epicChildrenTypes={
                         this.state.siteDetails.isCloud
                             ? this.state.selectFieldOptions['issuetype']
-                            : this.state.selectFieldOptions['issuetype'].filter((type) => {
+                            : this.state.selectFieldOptions['issuetype']?.filter((type) => {
                                   return type.name !== 'Epic'; // The array is size 4 by default so no perf problems, filter reduces to 3
                               })
                     }


### PR DESCRIPTION
### What Is This Change?

Quick fix for #665 - let's treat the `issuetype` field as optional for the purpose of epic types

### How Has This Been Tested?

Manually - although I couldn't reproduce the original issue on the Jira Server instances available, nor in the cloud :(

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change