### PR TITLE
Made small changes to loading state that gets rid of little spinner after selection or non-selection

### DIFF
--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -869,6 +869,11 @@ export abstract class AbstractIssueEditorPage<
                                     onChange={(selected: any) => {
                                         this.handleSelectChange(selectField, selected);
                                     }}
+                                    onMenuClose={() => {
+                                        if (this.state.loadingField === field.key) {
+                                            this.setState({ isSomethingLoading: false, loadingField: '' });
+                                        }
+                                    }}
                                 />
                             );
                         }
@@ -904,6 +909,11 @@ export abstract class AbstractIssueEditorPage<
                                                         this.handleSelectChange(selectField, selected);
                                                     },
                                                 )}
+                                                onMenuClose={() => {
+                                                    if (this.state.loadingField === field.key) {
+                                                        this.setState({ isSomethingLoading: false, loadingField: '' });
+                                                    }
+                                                }}
                                             />
                                             {errDiv}
                                         </React.Fragment>
@@ -934,6 +944,11 @@ export abstract class AbstractIssueEditorPage<
                                     }}
                                     onChange={(selected: any) => {
                                         this.handleSelectChange(selectField, selected);
+                                    }}
+                                    onMenuClose={() => {
+                                        if (this.state.loadingField === field.key) {
+                                            this.setState({ isSomethingLoading: false, loadingField: '' });
+                                        }
                                     }}
                                 />
                             );
@@ -978,6 +993,11 @@ export abstract class AbstractIssueEditorPage<
                                                         this.handleSelectChange(selectField, selected);
                                                     },
                                                 )}
+                                                onMenuClose={() => {
+                                                    if (this.state.loadingField === field.key) {
+                                                        this.setState({ isSomethingLoading: false, loadingField: '' });
+                                                    }
+                                                }}
                                             />
                                             {errDiv}
                                         </React.Fragment>
@@ -1006,6 +1026,11 @@ export abstract class AbstractIssueEditorPage<
                                     loadOptions={async (input: any) =>
                                         await this.loadSelectOptionsForField(field as SelectFieldUI, input)
                                     }
+                                    onMenuClose={() => {
+                                        if (this.state.loadingField === field.key) {
+                                            this.setState({ isSomethingLoading: false, loadingField: '' });
+                                        }
+                                    }}
                                 />
                             );
                         }
@@ -1050,6 +1075,11 @@ export abstract class AbstractIssueEditorPage<
                                                 loadOptions={async (input: any) =>
                                                     await this.loadSelectOptionsForField(field as SelectFieldUI, input)
                                                 }
+                                                onMenuClose={() => {
+                                                    if (this.state.loadingField === field.key) {
+                                                        this.setState({ isSomethingLoading: false, loadingField: '' });
+                                                    }
+                                                }}
                                             />
                                             {errDiv}
                                         </React.Fragment>
@@ -1096,6 +1126,11 @@ export abstract class AbstractIssueEditorPage<
                                     loadOptions={async (input: any) =>
                                         await this.loadSelectOptionsForField(field as SelectFieldUI, input)
                                     }
+                                    onMenuClose={() => {
+                                        if (this.state.loadingField === field.key) {
+                                            this.setState({ isSomethingLoading: false, loadingField: '' });
+                                        }
+                                    }}
                                 ></AsyncCreatableSelect>
                             );
                         }
@@ -1144,6 +1179,11 @@ export abstract class AbstractIssueEditorPage<
                                                 loadOptions={async (input: any) =>
                                                     await this.loadSelectOptionsForField(field as SelectFieldUI, input)
                                                 }
+                                                onMenuClose={() => {
+                                                    if (this.state.loadingField === field.key) {
+                                                        this.setState({ isSomethingLoading: false, loadingField: '' });
+                                                    }
+                                                }}
                                             ></AsyncCreatableSelect>
                                             {errDiv}
                                         </React.Fragment>

--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
@@ -284,15 +284,15 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
                 project: newValue,
                 fieldValues: this.state.fieldValues,
             });
-        }
-
-        if (field.valueType === ValueType.IssueType) {
+        } else if (field.valueType === ValueType.IssueType) {
             this.setState({ loadingField: field.key, isSomethingLoading: true });
             this.postMessage({
                 action: 'setIssueType',
                 issueType: newValue,
                 fieldValues: this.state.fieldValues,
             });
+        } else {
+            this.setState({ isSomethingLoading: false, loadingField: '' });
         }
     };
 


### PR DESCRIPTION
### What Is This Change?

Loom Link Here soon :)

### How Has This Been Tested?

Went on Cloud and Server instances to see if anything was effected. Created Issues just fine for all Select UITypes but found a bug not caused by this mentioned in [AXON-786](https://softwareteams.atlassian.net/browse/AXON-786) about the assignee select type not working on Server. This is a state management that refreshed the spinner state for each field.

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [X] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change