### PR TITLE
AXON-788: Persist e2e trace artifacts

### DIFF
--- a/e2e/tests/bitbucket/repositoryConnection.spec.ts
+++ b/e2e/tests/bitbucket/repositoryConnection.spec.ts
@@ -7,7 +7,8 @@ test.skip('Adding Bitbucket repository works', async ({ page, context }) => {
 
     await connectRepository(page);
 
-    const createPullRequestButton = page.getByRole('treeitem', { name: 'Create pull request' });
+    // const createPullRequestButton = page.getByRole('treeitem', { name: 'Create pull request' });
+    const createPullRequestButton = page.getByRole('treeitem', { name: 'Failed test !!!!' });
     await createPullRequestButton.waitFor({ state: 'visible' });
 
     await expect(page.getByRole('treeitem', { name: 'mock-repository' }).first()).toBeVisible();

--- a/e2e/tests/bitbucket/repositoryConnection.spec.ts
+++ b/e2e/tests/bitbucket/repositoryConnection.spec.ts
@@ -7,7 +7,6 @@ test.skip('Adding Bitbucket repository works', async ({ page, context }) => {
 
     await connectRepository(page);
 
-    // const createPullRequestButton = page.getByRole('treeitem', { name: 'Create pull request' });
     const createPullRequestButton = page.getByRole('treeitem', { name: 'Create pull request' });
     await createPullRequestButton.waitFor({ state: 'visible' });
 

--- a/e2e/tests/bitbucket/repositoryConnection.spec.ts
+++ b/e2e/tests/bitbucket/repositoryConnection.spec.ts
@@ -8,7 +8,7 @@ test.skip('Adding Bitbucket repository works', async ({ page, context }) => {
     await connectRepository(page);
 
     // const createPullRequestButton = page.getByRole('treeitem', { name: 'Create pull request' });
-    const createPullRequestButton = page.getByRole('treeitem', { name: 'Failed test !!!!' });
+    const createPullRequestButton = page.getByRole('treeitem', { name: 'Create pull request' });
     await createPullRequestButton.waitFor({ state: 'visible' });
 
     await expect(page.getByRole('treeitem', { name: 'mock-repository' }).first()).toBeVisible();

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -6,10 +6,7 @@ export default defineConfig({
             width: 1600,
             height: 800,
         },
-    },
-    use: {
-        // Docs: https://playwright.dev/docs/videos
-        // To see all of the videos, change this to 'on'
         video: 'retain-on-failure',
+        trace: 'retain-on-failure',
     },
 });


### PR DESCRIPTION
### What Is This Change?

Store trace.zip after e2e tests (for debug)

### How Has This Been Tested?

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change