### PR TITLE
[AXON-772, AXON-788]: Reconfigure GitHub's build pipeline to run in parallel unit tests and E2E tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:
@@ -24,6 +26,7 @@ jobs:
         with:
           name: node-modules
           path: node_modules/
+          retention-days: 1
 
   lint:
     needs: install-dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,63 +25,56 @@ jobs:
       - name: Run linter
         run: npm run lint
 
-  unit-tests:
+  tests:
     needs: [lint]
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        test-type: [unit, e2e]
+    
+    env:
+      ATLASCODE_FX3_API_KEY: ${{ secrets.ATLASCODE_FX3_API_KEY }}
+      ATLASCODE_FX3_ENVIRONMENT: ${{ vars.ATLASCODE_FX3_ENVIRONMENT }}
+      ATLASCODE_FX3_TARGET_APP: ${{ vars.ATLASCODE_FX3_TARGET_APP }}
+      ATLASCODE_FX3_TIMEOUT: ${{ vars.ATLASCODE_FX3_TIMEOUT }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
-      
-      - name: Install dependencies
-        run: |
-          npm ci --no-audit
-      
-      - name: Run unit tests
-        run: npm run test
 
-  e2e-tests:
-    needs: [lint]
-    runs-on: ubuntu-latest
-    env:
-      ATLASCODE_FX3_API_KEY: ${{ secrets.ATLASCODE_FX3_API_KEY }}
-      ATLASCODE_FX3_ENVIRONMENT: ${{ vars.ATLASCODE_FX3_ENVIRONMENT }}
-      ATLASCODE_FX3_TARGET_APP: ${{ vars.ATLASCODE_FX3_TARGET_APP }}
-      ATLASCODE_FX3_TIMEOUT: ${{ vars.ATLASCODE_FX3_TIMEOUT }}
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-      
       - name: Install dependencies
-        run: |
-          npm ci --no-audit
+        run: npm ci --no-audit
 
       - name: Build and package the extension
+        if: matrix.test-type == 'e2e'
         run: npm run extension:package
 
       - name: Generate SSL certs for E2E test
+        if: matrix.test-type == 'e2e'
         run: npm run test:e2e:sslcerts
 
       - name: Fetch E2E image
+        if: matrix.test-type == 'e2e'
         run: |
           docker pull ghcr.io/atlassian/atlascode-e2e:latest
           docker tag ghcr.io/atlassian/atlascode-e2e:latest atlascode-e2e
 
+      - name: Run unit tests
+        if: matrix.test-type == 'unit'
+        run: npm run test
+
       - name: Run E2E tests
+        if: matrix.test-type == 'e2e'
         run: npm run test:e2e:docker
 
       - name: Upload E2E artifacts
-        if: always()
+        if: matrix.test-type == 'e2e'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-test-results
           path: ./test-results
           retention-days: 1
-  

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,9 @@ on:
       - '**'
 
 jobs:
-  install-dependencies:
+
+
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,29 +22,6 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci --no-audit
-
-      - name: Upload node_modules
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-modules
-          path: node_modules/
-          retention-days: 1
-
-  lint:
-    needs: install-dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Download node_modules
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules
-          path: node_modules/
       
       - name: Run linter
         run: npm run lint
@@ -57,11 +36,9 @@ jobs:
           node-version: 20
           cache: 'npm'
       
-      - name: Download node_modules
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules
-          path: node_modules/
+      - name: Install dependencies
+        run: |
+          npm ci --no-audit
       
       - name: Run unit tests
         run: npm run test
@@ -80,11 +57,11 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - name: Download node_modules
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules
-          path: node_modules/
+      
+      - name: Install dependencies
+        run: |
+          npm ci --no-audit
+          npm audit
 
       - name: Generate SSL certs for E2E test
         run: npm run test:e2e:sslcerts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci --no-audit
+          npm audit
       
       - name: Run linter
         run: npm run lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,23 +6,11 @@ on:
       - '**'
 
 jobs:
-
-  build:
-
+  install-dependencies:
     runs-on: ubuntu-latest
-
-    env:
-      ATLASCODE_FX3_API_KEY: ${{ secrets.ATLASCODE_FX3_API_KEY }}
-      ATLASCODE_FX3_ENVIRONMENT: ${{ vars.ATLASCODE_FX3_ENVIRONMENT }}
-      ATLASCODE_FX3_TARGET_APP: ${{ vars.ATLASCODE_FX3_TARGET_APP }}
-      ATLASCODE_FX3_TIMEOUT: ${{ vars.ATLASCODE_FX3_TIMEOUT }}
-
     steps:
-
       - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
@@ -30,16 +18,70 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci --no-audit
-          npm audit
 
-      - name: Build and package the extension
-        run: npm run extension:package
+      - name: Upload node_modules
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules/
 
+  lint:
+    needs: install-dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Download node_modules
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules/
+      
       - name: Run linter
         run: npm run lint
 
+  unit-tests:
+    needs: [lint, install-dependencies]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      
+      - name: Download node_modules
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules/
+      
       - name: Run unit tests
         run: npm run test
+
+  e2e-tests:
+    needs: [lint, install-dependencies]
+    runs-on: ubuntu-latest
+    env:
+      ATLASCODE_FX3_API_KEY: ${{ secrets.ATLASCODE_FX3_API_KEY }}
+      ATLASCODE_FX3_ENVIRONMENT: ${{ vars.ATLASCODE_FX3_ENVIRONMENT }}
+      ATLASCODE_FX3_TARGET_APP: ${{ vars.ATLASCODE_FX3_TARGET_APP }}
+      ATLASCODE_FX3_TIMEOUT: ${{ vars.ATLASCODE_FX3_TIMEOUT }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Download node_modules
+        uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules/
 
       - name: Generate SSL certs for E2E test
         run: npm run test:e2e:sslcerts
@@ -51,3 +93,12 @@ jobs:
 
       - name: Run E2E tests
         run: npm run test:e2e:docker
+
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          path: ./test-results
+          retention-days: 1
+  

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
 
-
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +26,7 @@ jobs:
         run: npm run lint
 
   unit-tests:
-    needs: [lint, install-dependencies]
+    needs: [lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +43,7 @@ jobs:
         run: npm run test
 
   e2e-tests:
-    needs: [lint, install-dependencies]
+    needs: [lint]
     runs-on: ubuntu-latest
     env:
       ATLASCODE_FX3_API_KEY: ${{ secrets.ATLASCODE_FX3_API_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
         run: npm run test:e2e:docker
 
       - name: Upload E2E artifacts
-        if: matrix.test-type == 'e2e'
+        if: matrix.test-type == 'e2e' && always() && hasFiles('./test-results/**') != ''
         uses: actions/upload-artifact@v4
         with:
           name: e2e-test-results

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     
     strategy:
+      fail-fast: true
       matrix:
         test-type: [unit, e2e]
     

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,9 @@ jobs:
       ATLASCODE_FX3_TIMEOUT: ${{ vars.ATLASCODE_FX3_TIMEOUT }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
@@ -60,7 +62,9 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci --no-audit
-          npm audit
+
+      - name: Build and package the extension
+        run: npm run extension:package
 
       - name: Generate SSL certs for E2E test
         run: npm run test:e2e:sslcerts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
         run: npm run test:e2e:docker
 
       - name: Upload E2E artifacts
-        if: matrix.test-type == 'e2e' && always() && hasFiles('./test-results/**') != ''
+        if: matrix.test-type == 'e2e' && always() && hashFiles('./test-results/**') != ''
         uses: actions/upload-artifact@v4
         with:
           name: e2e-test-results


### PR DESCRIPTION
### What Is This Change?

- Split e2e and unit test jobs to run in parallel, reducing average build time from 14:30 to 9:30 (~30%)
- Introduced fail-fast strategy: if one of the test jobs fails, the other is auto cancelled
- Added step to upload e2e artifacts for easier debugging in case of failures

### How Has This Been Tested?

Before: 
<img width="2548" height="464" alt="Screenshot 2025-08-04 at 18 29 20" src="https://github.com/user-attachments/assets/8d4dfbfc-24e6-4aaf-9f7d-62d9c11d57b2" />

<hr/>

After:

<img width="2540" height="494" alt="Screenshot 2025-08-04 at 18 28 06" src="https://github.com/user-attachments/assets/889543c0-b4f5-4abf-a7da-e8bda4f80079" />

e2e artifacts:

<img width="2549" height="815" alt="Screenshot 2025-08-04 at 17 11 08" src="https://github.com/user-attachments/assets/3afff37c-f2d6-4bc5-84b4-7a54128cc863" />

<hr/>

@marcomura please go to Repository settings, find rule, click Edit and instead of 'build' add 'lint', 'tests(unit)', 'tests(e2e)'

<img width="956" height="628" alt="Screenshot 2025-08-04 at 19 01 10" src="https://github.com/user-attachments/assets/a3297eb2-2b25-4bdd-8cb5-afdae7d87748" />
