### PR TITLE
AXON-323-can-not-remove-reviewer-from-PR

### DIFF
--- a/src/bitbucket/bitbucket-cloud/pullRequests.test.ts
+++ b/src/bitbucket/bitbucket-cloud/pullRequests.test.ts
@@ -1112,6 +1112,107 @@ describe('CloudPullRequestApi', () => {
             });
             expect(result.data.id).toBe('123');
         });
+
+        it('should remove all reviewers when empty array is provided', async () => {
+            const mockApiResponse = {
+                data: {
+                    ...mockPullRequest.data,
+                    id: '123',
+                    author: { account_id: 'author-id', display_name: 'Author' },
+                    participants: [],
+                    source: {
+                        repository: { full_name: 'test-owner/test-repo' },
+                        branch: { name: 'feature' },
+                        commit: { hash: 'abc123' },
+                    },
+                    destination: {
+                        repository: { full_name: 'test-owner/test-repo' },
+                        branch: { name: 'main' },
+                        commit: { hash: 'def456' },
+                    },
+                    links: { html: { href: 'https://pr.url' } },
+                },
+            };
+            mockHttpClient.put.mockResolvedValue(mockApiResponse);
+
+            const result = await api.update(mockPullRequest, 'Test PR', 'Test summary', []);
+
+            expect(mockHttpClient.put).toHaveBeenCalledWith('/repositories/test-owner/test-repo/pullrequests/123', {
+                title: 'Test PR',
+                summary: { raw: 'Test summary' },
+                reviewers: [],
+            });
+            expect(result.data.id).toBe('123');
+        });
+
+        it('should remove specific reviewers by providing filtered reviewer list', async () => {
+            const mockApiResponse = {
+                data: {
+                    ...mockPullRequest.data,
+                    id: '123',
+                    author: { account_id: 'author-id', display_name: 'Author' },
+                    participants: [],
+                    source: {
+                        repository: { full_name: 'test-owner/test-repo' },
+                        branch: { name: 'feature' },
+                        commit: { hash: 'abc123' },
+                    },
+                    destination: {
+                        repository: { full_name: 'test-owner/test-repo' },
+                        branch: { name: 'main' },
+                        commit: { hash: 'def456' },
+                    },
+                    links: { html: { href: 'https://pr.url' } },
+                },
+            };
+            mockHttpClient.put.mockResolvedValue(mockApiResponse);
+
+            const remainingReviewers = ['reviewer1', 'reviewer3'];
+            const result = await api.update(mockPullRequest, 'Test PR', 'Test summary', remainingReviewers);
+
+            expect(mockHttpClient.put).toHaveBeenCalledWith('/repositories/test-owner/test-repo/pullrequests/123', {
+                title: 'Test PR',
+                summary: { raw: 'Test summary' },
+                reviewers: [
+                    { type: 'user', account_id: 'reviewer1' },
+                    { type: 'user', account_id: 'reviewer3' },
+                ],
+            });
+            expect(result.data.id).toBe('123');
+        });
+
+        it('should handle reviewer removal when only one reviewer remains', async () => {
+            const mockApiResponse = {
+                data: {
+                    ...mockPullRequest.data,
+                    id: '123',
+                    author: { account_id: 'author-id', display_name: 'Author' },
+                    participants: [],
+                    source: {
+                        repository: { full_name: 'test-owner/test-repo' },
+                        branch: { name: 'feature' },
+                        commit: { hash: 'abc123' },
+                    },
+                    destination: {
+                        repository: { full_name: 'test-owner/test-repo' },
+                        branch: { name: 'main' },
+                        commit: { hash: 'def456' },
+                    },
+                    links: { html: { href: 'https://pr.url' } },
+                },
+            };
+            mockHttpClient.put.mockResolvedValue(mockApiResponse);
+
+            const remainingReviewers = ['reviewer1'];
+            const result = await api.update(mockPullRequest, 'Test PR', 'Test summary', remainingReviewers);
+
+            expect(mockHttpClient.put).toHaveBeenCalledWith('/repositories/test-owner/test-repo/pullrequests/123', {
+                title: 'Test PR',
+                summary: { raw: 'Test summary' },
+                reviewers: [{ type: 'user', account_id: 'reviewer1' }],
+            });
+            expect(result.data.id).toBe('123');
+        });
     });
 
     describe('getReviewers', () => {

--- a/src/bitbucket/bitbucket-server/pullRequests.test.ts
+++ b/src/bitbucket/bitbucket-server/pullRequests.test.ts
@@ -1734,6 +1734,98 @@ describe('ServerPullRequestApi', () => {
             );
             expect(result.data.title).toBe('Updated Title');
         });
+
+        it('should remove all reviewers when empty array is provided', async () => {
+            const mockUpdateResponse = {
+                data: {
+                    ...getPullRequestData,
+                    title: 'Test PR',
+                    description: 'Test description',
+                    version: 2,
+                },
+            };
+
+            mockPut.mockResolvedValue(mockUpdateResponse);
+
+            const result = await api.update(mockPullRequest, 'Test PR', 'Test description', []);
+
+            expect(mockPut).toHaveBeenCalledWith(
+                '/rest/api/1.0/projects/testproject/repos/testrepo/pull-requests/123',
+                {
+                    version: 1,
+                    title: 'Test PR',
+                    description: 'Test description',
+                    reviewers: [],
+                },
+                {
+                    markup: true,
+                    avatarSize: 64,
+                },
+            );
+            expect(result.data.title).toBe('Test PR');
+        });
+
+        it('should remove specific reviewers by providing filtered reviewer list', async () => {
+            const mockUpdateResponse = {
+                data: {
+                    ...getPullRequestData,
+                    title: 'Test PR',
+                    description: 'Test description',
+                    version: 2,
+                },
+            };
+
+            mockPut.mockResolvedValue(mockUpdateResponse);
+
+            const remainingReviewers = ['reviewer1', 'reviewer3'];
+            const result = await api.update(mockPullRequest, 'Test PR', 'Test description', remainingReviewers);
+
+            expect(mockPut).toHaveBeenCalledWith(
+                '/rest/api/1.0/projects/testproject/repos/testrepo/pull-requests/123',
+                {
+                    version: 1,
+                    title: 'Test PR',
+                    description: 'Test description',
+                    reviewers: [{ user: { name: 'reviewer1' } }, { user: { name: 'reviewer3' } }],
+                },
+                {
+                    markup: true,
+                    avatarSize: 64,
+                },
+            );
+            expect(result.data.title).toBe('Test PR');
+        });
+
+        it('should handle reviewer removal when only one reviewer remains', async () => {
+            const mockUpdateResponse = {
+                data: {
+                    ...getPullRequestData,
+                    title: 'Test PR',
+                    description: 'Test description',
+                    version: 2,
+                },
+            };
+
+            mockPut.mockResolvedValue(mockUpdateResponse);
+
+            const remainingReviewers = ['reviewer1'];
+            const result = await api.update(mockPullRequest, 'Test PR', 'Test description', remainingReviewers);
+
+            expect(mockPut).toHaveBeenCalledWith(
+                '/rest/api/1.0/projects/testproject/repos/testrepo/pull-requests/123',
+                {
+                    version: 1,
+                    title: 'Test PR',
+                    description: 'Test description',
+                    reviewers: [{ user: { name: 'reviewer1' } }],
+                },
+                {
+                    markup: true,
+                    avatarSize: 64,
+                },
+            );
+            expect(result.data.title).toBe('Test PR');
+        });
     });
 
     describe('getComments', () => {

--- a/src/react/atlascode/pullrequest/Reviewers.tsx
+++ b/src/react/atlascode/pullrequest/Reviewers.tsx
@@ -1,22 +1,97 @@
-import { Avatar, Badge, Box, CircularProgress, Grid, Tooltip, Typography } from '@material-ui/core';
+import { Avatar, Badge, Box, CircularProgress, Grid, IconButton, Tooltip, Typography } from '@material-ui/core';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CloseIcon from '@material-ui/icons/Close';
 import { AvatarGroup } from '@material-ui/lab';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { BitbucketSite, Reviewer, User } from '../../../bitbucket/model';
 import StoppedIcon from '../icons/StoppedIcon';
 import { AddReviewers } from './AddReviewers';
+
+type RemovableReviewerAvatarProps = {
+    participant: Reviewer;
+    onRemove?: (participant: Reviewer) => void;
+    showRemoveButton?: boolean;
+};
+
+const RemovableReviewerAvatar: React.FunctionComponent<RemovableReviewerAvatarProps> = ({
+    participant,
+    onRemove,
+    showRemoveButton = false,
+}) => {
+    const [isHovered, setIsHovered] = useState(false);
+
+    return (
+        <Box position="relative" onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+            <Badge
+                style={{ borderWidth: '0px' }}
+                overlap="circle"
+                anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right',
+                }}
+                invisible={participant.status === 'UNAPPROVED'}
+                badgeContent={
+                    participant.status === 'CHANGES_REQUESTED' ? (
+                        <Tooltip title="Requested changes">
+                            <Box bgcolor={'white'} borderRadius={'100%'}>
+                                <StoppedIcon fontSize={'small'} htmlColor={'#FFAB00'} />
+                            </Box>
+                        </Tooltip>
+                    ) : (
+                        <Tooltip title="Approved">
+                            <Box bgcolor={'white'} borderRadius={'100%'}>
+                                <CheckCircleIcon fontSize={'small'} htmlColor={'#07b82b'} />
+                            </Box>
+                        </Tooltip>
+                    )
+                }
+            >
+                <Tooltip title={participant.displayName}>
+                    <Avatar alt={participant.displayName} src={participant.avatarUrl} />
+                </Tooltip>
+            </Badge>
+            {showRemoveButton && isHovered && onRemove && (
+                <IconButton
+                    size="small"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onRemove(participant);
+                    }}
+                    style={{
+                        position: 'absolute',
+                        top: -8,
+                        right: -8,
+                        backgroundColor: 'var(--vscode-button-background)',
+                        color: 'var(--vscode-button-foreground)',
+                        padding: 2,
+                        width: 20,
+                        height: 20,
+                        zIndex: 1,
+                    }}
+                    title={`Remove ${participant.displayName}`}
+                >
+                    <CloseIcon fontSize="small" />
+                </IconButton>
+            )}
+        </Box>
+    );
+};
+
 type ReviewersProps = {
     site: BitbucketSite;
     onUpdateReviewers: (reviewers: User[]) => Promise<void>;
     participants: Reviewer[];
     isLoading: boolean;
+    allowRemoveReviewers?: boolean;
 };
+
 export const Reviewers: React.FunctionComponent<ReviewersProps> = ({
     site,
     onUpdateReviewers,
     participants,
     isLoading,
+    allowRemoveReviewers = true,
 }) => {
     const [activeParticipants, setActiveParticipants] = useState<Reviewer[]>([]);
     const [isFetchingReviewer, setIsFetchingReviewers] = useState<boolean>(false);
@@ -32,6 +107,29 @@ export const Reviewers: React.FunctionComponent<ReviewersProps> = ({
             }
         },
         [onUpdateReviewers],
+    );
+
+    const handleRemoveReviewer = useCallback(
+        async (reviewerToRemove: Reviewer) => {
+            if (!allowRemoveReviewers) {
+                return;
+            }
+
+            const updatedReviewers = participants
+                .filter((p) => p.accountId !== reviewerToRemove.accountId)
+                .map((p) => ({
+                    accountId: p.accountId,
+                    displayName: p.displayName,
+                    avatarUrl: p.avatarUrl,
+                    url: p.url,
+                    mention: p.mention,
+                    userName: p.userName,
+                    emailAddress: p.emailAddress,
+                }));
+
+            await handleUpdateReviewers(updatedReviewers);
+        },
+        [participants, allowRemoveReviewers, handleUpdateReviewers],
     );
 
     useEffect(() => {
@@ -55,35 +153,12 @@ export const Reviewers: React.FunctionComponent<ReviewersProps> = ({
                     ) : (
                         <AvatarGroup max={5}>
                             {activeParticipants.map((participant) => (
-                                <Badge
-                                    style={{ borderWidth: '0px' }}
-                                    overlap="circle"
-                                    anchorOrigin={{
-                                        vertical: 'top',
-                                        horizontal: 'right',
-                                    }}
-                                    invisible={participant.status === 'UNAPPROVED'}
+                                <RemovableReviewerAvatar
                                     key={participant.accountId}
-                                    badgeContent={
-                                        participant.status === 'CHANGES_REQUESTED' ? (
-                                            <Tooltip title="Requested changes">
-                                                <Box bgcolor={'white'} borderRadius={'100%'}>
-                                                    <StoppedIcon fontSize={'small'} htmlColor={'#FFAB00'} />
-                                                </Box>
-                                            </Tooltip>
-                                        ) : (
-                                            <Tooltip title="Approved">
-                                                <Box bgcolor={'white'} borderRadius={'100%'}>
-                                                    <CheckCircleIcon fontSize={'small'} htmlColor={'#07b82b'} />
-                                                </Box>
-                                            </Tooltip>
-                                        )
-                                    }
-                                >
-                                    <Tooltip title={participant.displayName}>
-                                        <Avatar alt={participant.displayName} src={participant.avatarUrl} />
-                                    </Tooltip>
-                                </Badge>
+                                    participant={participant}
+                                    onRemove={allowRemoveReviewers ? handleRemoveReviewer : undefined}
+                                    showRemoveButton={allowRemoveReviewers && participant.role === 'REVIEWER'}
+                                />
                             ))}
                         </AvatarGroup>
                     )}


### PR DESCRIPTION
### Ticket:
https://softwareteams.atlassian.net/browse/AXON-323

### What Is This Change?
I can not remove a reviewer from a PR

### How Has This Been Tested?

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change