### PR TITLE
[AXON-795] Added noImplicitOverride to TypeScript compiler

### DIFF
--- a/src/atlclients/strategy.ts
+++ b/src/atlclients/strategy.ts
@@ -118,7 +118,7 @@ class JiraStrategy extends Strategy {
 }
 
 class JiraDevStrategy extends JiraStrategy {
-    public tokenAuthorizationData(code: string): string {
+    public override tokenAuthorizationData(code: string): string {
         const data = JSON.stringify({
             grant_type: 'authorization_code',
             code: code,
@@ -130,7 +130,7 @@ class JiraDevStrategy extends JiraStrategy {
         return data;
     }
 
-    public authorizeUrl(state: string): string {
+    public override authorizeUrl(state: string): string {
         if (!this.data.scope || !this.data.authParams) {
             throw new Error('No scope or authParams for this strategy');
         }

--- a/src/bitbucket/bbContext.ts
+++ b/src/bitbucket/bbContext.ts
@@ -173,7 +173,7 @@ export class BitbucketContext extends Disposable {
         return this._mirrorsCache.getItem<string[]>(hostname) || [];
     }
 
-    dispose() {
+    override dispose() {
         this.disposeForNow();
         this._disposable.dispose();
     }

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -35,7 +35,7 @@ export class Configuration extends Disposable {
         super(() => this.dispose());
     }
 
-    dispose() {
+    override dispose() {
         this._onDidChange.dispose();
     }
 

--- a/src/jira/projectManager.ts
+++ b/src/jira/projectManager.ts
@@ -26,7 +26,7 @@ export class JiraProjectManager extends Disposable {
         super(() => this.dispose());
     }
 
-    dispose() {}
+    override dispose() {}
 
     public async getProjectForKey(site: DetailedSiteInfo, projectKey: string): Promise<Project | undefined> {
         if (projectKey.trim() === '') {

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -45,7 +45,7 @@ export class SiteManager extends Disposable {
         this._disposable = Disposable.from(Container.credentialManager.onDidAuthChange(this.onDidAuthChange, this));
     }
 
-    dispose() {
+    override dispose() {
         this._disposable.dispose();
         this._onDidSitesAvailableChange.dispose();
     }

--- a/src/uriHandler/atlascodeUriHandler.ts
+++ b/src/uriHandler/atlascodeUriHandler.ts
@@ -70,7 +70,7 @@ export class AtlascodeUriHandler extends Disposable implements UriHandler {
         }
     }
 
-    dispose(): void {
+    override dispose(): void {
         this.disposables.dispose();
     }
 }

--- a/src/views/BitbucketExplorer.ts
+++ b/src/views/BitbucketExplorer.ts
@@ -73,7 +73,7 @@ export abstract class BitbucketExplorer extends Explorer implements Disposable {
         }
     }
 
-    dispose() {
+    override dispose() {
         super.dispose();
         this._disposable.dispose();
     }

--- a/src/views/Explorer.ts
+++ b/src/views/Explorer.ts
@@ -55,7 +55,7 @@ export abstract class Explorer extends Disposable {
         }
     }
 
-    dispose() {
+    override dispose() {
         console.log('explorer disposed');
         if (this.treeDataProvider) {
             this.treeDataProvider.dispose();

--- a/src/views/HelpExplorer.ts
+++ b/src/views/HelpExplorer.ts
@@ -21,7 +21,7 @@ export class HelpExplorer extends Explorer implements Disposable {
         return emptyProduct;
     }
 
-    dispose() {
+    override dispose() {
         super.dispose();
     }
 

--- a/src/views/authStatusBar.ts
+++ b/src/views/authStatusBar.ts
@@ -62,7 +62,8 @@ export class AuthStatusBar extends Disposable {
             await this.generateStatusbarItem(ProductBitbucket);
         }
     }
-    dispose() {
+
+    override dispose() {
         this._authenticationStatusBarItems.forEach((item) => {
             item.dispose();
         });

--- a/src/views/helpDataProvider.ts
+++ b/src/views/helpDataProvider.ts
@@ -12,7 +12,7 @@ export class HelpDataProvider extends BaseTreeDataProvider {
         super();
     }
 
-    getTreeItem(element: AbstractBaseNode) {
+    override getTreeItem(element: AbstractBaseNode) {
         return element.getTreeItem();
     }
 

--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -95,7 +95,7 @@ export class CustomJQLViewProvider extends Disposable implements TreeDataProvide
         }
     }
 
-    public dispose() {
+    public override dispose() {
         this._disposable.dispose();
     }
 

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.ts
@@ -97,7 +97,7 @@ export class AssignedWorkItemsViewProvider extends Disposable implements TreeDat
         commands.executeCommand(`${AssignedWorkItemsViewProviderId}.focus`, {});
     }
 
-    public dispose(): void {
+    public override dispose(): void {
         this._disposable.dispose();
     }
 

--- a/src/views/nodes/commitNode.ts
+++ b/src/views/nodes/commitNode.ts
@@ -48,7 +48,7 @@ export class CommitNode extends AbstractBaseNode {
         }
     }
 
-    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         if (!element) {
             return await this.fetchDataAndProcessChildren();
         }

--- a/src/views/nodes/commitSectionNode.ts
+++ b/src/views/nodes/commitSectionNode.ts
@@ -24,7 +24,7 @@ export class CommitSectionNode extends AbstractBaseNode {
         return item;
     }
 
-    async getChildren(element?: IssueNode): Promise<CommitNode[] | SimpleNode[]> {
+    override async getChildren(element?: IssueNode): Promise<CommitNode[] | SimpleNode[]> {
         if (this.commits.length === 0 && this.loading) {
             return [new SimpleNode('Loading...')];
         }

--- a/src/views/nodes/directoryNode.ts
+++ b/src/views/nodes/directoryNode.ts
@@ -16,7 +16,7 @@ export class DirectoryNode extends AbstractBaseNode {
         return item;
     }
 
-    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         const directoryNodes: DirectoryNode[] = Array.from(
             this.directoryData.subdirs.values(),
             (subdir) => new DirectoryNode(subdir),

--- a/src/views/nodes/issueNode.ts
+++ b/src/views/nodes/issueNode.ts
@@ -31,7 +31,7 @@ export class IssueNode extends AbstractBaseNode {
         return treeItem;
     }
 
-    async getChildren(element?: IssueNode): Promise<IssueNode[]> {
+    override async getChildren(element?: IssueNode): Promise<IssueNode[]> {
         if (element) {
             return element.getChildren();
         }

--- a/src/views/nodes/pullRequestFilesNode.ts
+++ b/src/views/nodes/pullRequestFilesNode.ts
@@ -55,7 +55,7 @@ export class PullRequestFilesNode extends AbstractBaseNode {
         return item;
     }
 
-    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         return [];
     }
 }

--- a/src/views/notifications/atlassianNotificationNotifier.ts
+++ b/src/views/notifications/atlassianNotificationNotifier.ts
@@ -38,7 +38,7 @@ export class AtlassianNotificationNotifier extends Disposable implements Notific
         this._disposable.push(Disposable.from(Container.credentialManager.onDidAuthChange(this.onDidAuthChange, this)));
     }
 
-    public dispose() {
+    public override dispose() {
         this._disposable.forEach((e) => e.dispose());
     }
 

--- a/src/views/notifications/authNotifier.ts
+++ b/src/views/notifications/authNotifier.ts
@@ -29,7 +29,7 @@ export class AuthNotifier extends Disposable implements NotificationNotifier {
         this._jiraEnabled = Container.config.jira.enabled;
     }
 
-    public dispose() {
+    public override dispose() {
         this._disposable.forEach((d) => d.dispose());
     }
 

--- a/src/views/notifications/notificationManager.ts
+++ b/src/views/notifications/notificationManager.ts
@@ -101,7 +101,7 @@ export class NotificationManagerImpl extends Disposable {
         }
     }
 
-    public dispose() {
+    public override dispose() {
         this._disposable.forEach((e) => e.dispose());
     }
 

--- a/src/views/pipelines/PipelinesTree.ts
+++ b/src/views/pipelines/PipelinesTree.ts
@@ -65,7 +65,7 @@ export class PipelinesTree extends BaseTreeDataProvider {
         this._onDidChangeTreeData.fire(null);
     }
 
-    getTreeItem(element: AbstractBaseNode): TreeItem | Promise<TreeItem> {
+    override getTreeItem(element: AbstractBaseNode): TreeItem | Promise<TreeItem> {
         return element.getTreeItem();
     }
 
@@ -86,12 +86,12 @@ export class PipelinesTree extends BaseTreeDataProvider {
         return this._childrenMap.size === 0 ? emptyBitbucketNodes : Array.from(this._childrenMap.values());
     }
 
-    public refresh() {
+    public override refresh() {
         this._childrenMap.clear();
         this._onDidChangeTreeData.fire(null);
     }
 
-    async dispose() {
+    override async dispose() {
         this._disposable.dispose();
     }
 }
@@ -129,7 +129,7 @@ class PipelinesRepoNode extends AbstractBaseNode {
         this._pipelines = this._pipelines.concat(newPipelines);
     }
 
-    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         if (!this.workspaceRepo.mainSiteRemote.site) {
             return Promise.resolve([
                 new SimpleNode(`Please login to ${ProductBitbucket.name}`, {
@@ -237,7 +237,7 @@ export class PipelineNode extends AbstractBaseNode {
         return item;
     }
 
-    getChildren(element: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override getChildren(element: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         return this._repoNode.getChildren(element);
     }
 }

--- a/src/views/pullRequestNodeDataProvider.ts
+++ b/src/views/pullRequestNodeDataProvider.ts
@@ -158,7 +158,7 @@ export class PullRequestNodeDataProvider extends BaseTreeDataProvider {
         }
     }
 
-    async refresh() {
+    override async refresh() {
         await this.updateChildren();
         this._onDidChangeTreeData.fire(null);
     }
@@ -217,7 +217,7 @@ export class PullRequestNodeDataProvider extends BaseTreeDataProvider {
         this._onDidChangeTreeData.fire(null);
     }
 
-    async getTreeItem(element: AbstractBaseNode): Promise<TreeItem> {
+    override async getTreeItem(element: AbstractBaseNode): Promise<TreeItem> {
         return element.getTreeItem();
     }
 
@@ -247,7 +247,7 @@ export class PullRequestNodeDataProvider extends BaseTreeDataProvider {
         return [createPRNode, this._headerNode, ...Array.from(this._childrenMap!.values())];
     }
 
-    dispose() {
+    override dispose() {
         if (this._childrenMap) {
             this._childrenMap.forEach((node) => node.dispose());
         }

--- a/src/views/pullrequest/pullRequestNode.ts
+++ b/src/views/pullrequest/pullRequestNode.ts
@@ -179,7 +179,7 @@ export class PullRequestTitlesNode extends AbstractBaseNode {
         this.refresh();
     }
 
-    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         if (element) {
             return element.getChildren();
         }
@@ -228,7 +228,7 @@ export class DescriptionNode extends AbstractBaseNode {
         return item;
     }
 
-    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         return [];
     }
 }
@@ -251,7 +251,7 @@ export class NextPageNode extends AbstractBaseNode {
         return item;
     }
 
-    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         return [];
     }
 }

--- a/src/views/pullrequest/repositoriesNode.ts
+++ b/src/views/pullrequest/repositoriesNode.ts
@@ -145,7 +145,7 @@ export class RepositoriesNode extends AbstractBaseNode {
         return this.treeItem;
     }
 
-    async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
+    override async getChildren(element?: AbstractBaseNode): Promise<AbstractBaseNode[]> {
         if (element) {
             return element.getChildren();
         }

--- a/src/webview/ExplorerFocusManager.ts
+++ b/src/webview/ExplorerFocusManager.ts
@@ -39,7 +39,7 @@ export class ExplorerFocusManager extends Disposable {
         return this._onFocusEvent.event;
     }
 
-    dispose() {
+    override dispose() {
         this._onFocusEvent.dispose();
         this._disposable.dispose();
     }

--- a/src/webviews/abstractIssueEditorWebview.test.ts
+++ b/src/webviews/abstractIssueEditorWebview.test.ts
@@ -61,8 +61,8 @@ class TestIssueEditorWebview extends AbstractIssueEditorWebview {
     }
 
     // Add mock methods for abstract webview functionality
-    postMessage = jest.fn();
-    formatErrorReason = jest.fn((error: any, defaultMessage: string) => defaultMessage);
+    override postMessage = jest.fn();
+    override formatErrorReason = jest.fn((error: any, defaultMessage: string) => defaultMessage);
 
     // Expose protected methods for testing
     public testFormatSelectOptions(msg: FetchQueryAction, result: any, valueType?: ValueType): any[] {

--- a/src/webviews/abstractIssueEditorWebview.ts
+++ b/src/webviews/abstractIssueEditorWebview.ts
@@ -62,7 +62,7 @@ export abstract class AbstractIssueEditorWebview extends AbstractReactWebview {
         return suggestions;
     }
 
-    protected async onMessageReceived(msg: any): Promise<boolean> {
+    protected override async onMessageReceived(msg: any): Promise<boolean> {
         let handled = await super.onMessageReceived(msg);
 
         if (!handled) {

--- a/src/webviews/components/ErrorBanner.tsx
+++ b/src/webviews/components/ErrorBanner.tsx
@@ -13,13 +13,13 @@ export default class ErrorBanner extends React.Component<
         };
     }
 
-    componentWillReceiveProps(nextProps: any) {
+    override componentWillReceiveProps(nextProps: any) {
         this.setState({
             errorDetails: nextProps.errorDetails,
         });
     }
 
-    render() {
+    override render() {
         const errorMarkup = [];
         if (isErrorCollection(this.state.errorDetails)) {
             Object.keys(this.state.errorDetails.errors).forEach((key) => {

--- a/src/webviews/components/Offline.tsx
+++ b/src/webviews/components/Offline.tsx
@@ -6,7 +6,7 @@ export default class Offline extends React.Component<{}, {}> {
         super(props);
     }
 
-    render() {
+    override render() {
         return (
             <ModalTransition>
                 <Modal

--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -196,7 +196,7 @@ export abstract class AbstractIssueEditorPage<
         return handled;
     }
 
-    postMessage<T extends CommonEditorPageEmit>(e: T) {
+    override postMessage<T extends CommonEditorPageEmit>(e: T) {
         this._api.postMessage(e);
     }
 

--- a/src/webviews/components/issue/CreateIssueProblems.tsx
+++ b/src/webviews/components/issue/CreateIssueProblems.tsx
@@ -51,7 +51,7 @@ export default class CreateIssueProblems extends WebviewComponent<Action, Accept
         this.setState({ isErrorBannerOpen: false, errorDetails: undefined });
     };
 
-    public render() {
+    public override render() {
         const issueTypeProblems: any[] = [];
         Object.keys(this.state.problems).forEach((problemKey) => {
             const problem = this.state.problems[problemKey];

--- a/src/webviews/components/issue/InlineIssueLinkEditor.tsx
+++ b/src/webviews/components/issue/InlineIssueLinkEditor.tsx
@@ -48,7 +48,7 @@ export default class InlineIssueLinksEditor extends React.Component<Props, State
         };
     }
 
-    componentWillReceiveProps(nextProps: any) {
+    override componentWillReceiveProps(nextProps: any) {
         const newState: any = {};
 
         if (nextProps.linkTypes && nextProps.linkTypes !== this.state.linkTypes) {
@@ -111,7 +111,7 @@ export default class InlineIssueLinksEditor extends React.Component<Props, State
         });
     };
 
-    render() {
+    override render() {
         return (
             <React.Fragment>
                 <div className="label-and-button">

--- a/src/webviews/components/issue/InlineSubtaskEditor.tsx
+++ b/src/webviews/components/issue/InlineSubtaskEditor.tsx
@@ -62,7 +62,7 @@ export default class InlineSubtaskEditor extends React.Component<Props, State> {
         };
     }
 
-    componentWillReceiveProps(nextProps: any) {
+    override componentWillReceiveProps(nextProps: any) {
         const newState: any = {};
 
         if (nextProps.subtaskTypes && nextProps.subtaskTypes !== this.state.subtaskTypes) {
@@ -105,7 +105,7 @@ export default class InlineSubtaskEditor extends React.Component<Props, State> {
         });
     };
 
-    render() {
+    override render() {
         return (
             <React.Fragment>
                 <div className="label-and-button">

--- a/src/webviews/components/issue/IssueList.tsx
+++ b/src/webviews/components/issue/IssueList.tsx
@@ -64,7 +64,7 @@ export default class IssueList extends React.Component<
         super(props);
     }
 
-    render() {
+    override render() {
         return (
             <TableTree
                 columns={[IssueKey, Summary, Priority, StatusColumn]}

--- a/src/webviews/components/issue/NavItem.tsx
+++ b/src/webviews/components/issue/NavItem.tsx
@@ -13,7 +13,7 @@ export default class NavItem extends React.Component<
     },
     {}
 > {
-    render() {
+    override render() {
         return (
             <div className="ac-icon-with-text">
                 {this.props.iconUrl && <img style={{ paddingRight: '5px' }} src={this.props.iconUrl} />}

--- a/src/webviews/components/issue/ParticipantList.tsx
+++ b/src/webviews/components/issue/ParticipantList.tsx
@@ -34,7 +34,7 @@ export class ParticipantList extends React.Component<Props, State> {
         return result;
     }
 
-    render() {
+    override render() {
         return <React.Fragment>{this.userList()}</React.Fragment>;
     }
 }

--- a/src/webviews/components/issue/PullRequests.tsx
+++ b/src/webviews/components/issue/PullRequests.tsx
@@ -27,7 +27,7 @@ export default class PullRequests extends React.Component<
         }
     }
 
-    render() {
+    override render() {
         return this.props.pullRequests.map((pr: PullRequestData) => {
             const title = `${pr.destination!.repo!.displayName} - Pull request #${pr.id}`;
             return (

--- a/src/webviews/components/issue/StartWorkPage.tsx
+++ b/src/webviews/components/issue/StartWorkPage.tsx
@@ -295,7 +295,7 @@ export default class StartWorkPage extends WebviewComponent<Emit, Accept, {}, St
         });
     }
 
-    render() {
+    override render() {
         if (this.state.data.issue.key === '' && !this.state.isErrorBannerOpen && this.state.isOnline) {
             this.postMessage({ action: 'refreshIssue' });
             return <AtlLoader />;

--- a/src/webviews/components/issue/TransitionMenu.tsx
+++ b/src/webviews/components/issue/TransitionMenu.tsx
@@ -54,7 +54,7 @@ export class TransitionMenu extends React.Component<Props, State> {
         };
     }
 
-    componentWillReceiveProps(nextProps: any) {
+    override componentWillReceiveProps(nextProps: any) {
         const selectedTransition = this.getCurrentTransition(nextProps.currentStatus, nextProps.transitions);
         this.setState({
             selectedTransition: selectedTransition,
@@ -81,7 +81,7 @@ export class TransitionMenu extends React.Component<Props, State> {
         this.props.onStatusChange(item);
     };
 
-    render() {
+    override render() {
         if (!Array.isArray(this.props.transitions) || this.props.transitions.length < 1) {
             return <div />;
         }

--- a/src/webviews/components/issue/VotesForm.tsx
+++ b/src/webviews/components/issue/VotesForm.tsx
@@ -109,7 +109,8 @@ export default class VotesForm extends React.Component<MyProps, MyState> {
             </div>
         );
     };
-    render() {
+
+    override render() {
         return (
             <div className="ac-inline-items-container">
                 {this.props.allowVoting && <div className="ac-inline-item">{this.getStartStop()}</div>}

--- a/src/webviews/components/issue/WatchesForm.tsx
+++ b/src/webviews/components/issue/WatchesForm.tsx
@@ -116,7 +116,8 @@ export default class WatchesForm extends React.Component<MyProps, MyState> {
             </div>
         );
     };
-    render() {
+
+    override render() {
         const commonSelectProps: any = {
             isMulti: false,
             className: 'ac-select-container',

--- a/src/webviews/components/issue/WorklogForm.tsx
+++ b/src/webviews/components/issue/WorklogForm.tsx
@@ -72,7 +72,7 @@ export default class WorklogForm extends React.Component<MyProps, MyState> {
         this.handleClose();
     };
 
-    render() {
+    override render() {
         const defaultDate = this.state.started.trim() !== '' ? this.state.started : format(Date.now(), formatString);
         return (
             <div>

--- a/src/webviews/components/issue/Worklogs.tsx
+++ b/src/webviews/components/issue/Worklogs.tsx
@@ -29,7 +29,7 @@ export default class Worklogs extends React.Component<{ worklogs: WorklogContain
         super(props);
     }
 
-    render() {
+    override render() {
         return (
             <TableTree
                 columns={[Author, Comment, TimeSpent, Created]}

--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
@@ -77,7 +77,7 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
         this.state = emptyState;
     }
 
-    onMessageReceived(e: any): boolean {
+    override onMessageReceived(e: any): boolean {
         let handled = super.onMessageReceived(e);
 
         if (!handled) {
@@ -242,7 +242,7 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
         }
     };
 
-    protected handleInlineEdit = async (field: FieldUI, newValue: any) => {
+    protected override handleInlineEdit = async (field: FieldUI, newValue: any) => {
         let typedVal = newValue;
         let fieldkey = field.key;
 
@@ -346,7 +346,7 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
         );
     };
 
-    public render() {
+    public override render() {
         if (!this.state.fieldValues['issuetype']?.id && !this.state.isErrorBannerOpen && this.state.isOnline) {
             this.postMessage({ action: 'refresh' });
             return <AtlLoader />;

--- a/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
+++ b/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
@@ -83,7 +83,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
         return this.state.key.substring(0, this.state.key.indexOf('-'));
     };
 
-    onMessageReceived(e: any): boolean {
+    override onMessageReceived(e: any): boolean {
         const handled = super.onMessageReceived(e);
 
         if (!handled) {
@@ -208,7 +208,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
         );
     };
 
-    protected handleInlineEdit = async (field: FieldUI, newValue: any) => {
+    protected override handleInlineEdit = async (field: FieldUI, newValue: any) => {
         switch (field.uiType) {
             case UIType.Subtasks: {
                 this.setState({ isSomethingLoading: true, loadingField: field.key });
@@ -315,7 +315,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
         );
     };
 
-    protected handleCreateComment = (commentBody: string, restriction?: CommentVisibility) => {
+    protected override handleCreateComment = (commentBody: string, restriction?: CommentVisibility) => {
         this.setState({ isSomethingLoading: true, loadingField: 'comment', commentText: '', isEditingComment: false });
         const commentAction: IssueCommentAction = {
             action: 'comment',
@@ -752,7 +752,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
         );
     }
 
-    public render() {
+    public override render() {
         if (
             (Object.keys(this.state.fields).length < 1 || Object.keys(this.state.fieldValues).length < 1) &&
             !this.state.isErrorBannerOpen &&

--- a/src/webviews/components/pmfBanner.tsx
+++ b/src/webviews/components/pmfBanner.tsx
@@ -58,7 +58,7 @@ export default class PMFBBanner extends React.Component<
         return val;
     };
 
-    render() {
+    override render() {
         const { isOpen } = this.state;
 
         const radioItems = [

--- a/src/webviews/components/pullrequest/PopoutMentionPicker.tsx
+++ b/src/webviews/components/pullrequest/PopoutMentionPicker.tsx
@@ -48,7 +48,7 @@ export default class PopoutMentionPicker extends React.Component<
         this.props.onUserMentioned(value);
     };
 
-    render() {
+    override render() {
         const { isOpen } = this.state;
         return (
             <Dropdown

--- a/src/webviews/createIssueProblemsWebview.ts
+++ b/src/webviews/createIssueProblemsWebview.ts
@@ -29,7 +29,7 @@ export class CreateIssueProblemsWebview extends AbstractReactWebview {
         return ProductJira;
     }
 
-    async createOrShow(column?: ViewColumn, site?: DetailedSiteInfo, project?: Project): Promise<void> {
+    override async createOrShow(column?: ViewColumn, site?: DetailedSiteInfo, project?: Project): Promise<void> {
         await super.createOrShow(column);
         this._site = site;
         this._project = project;

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -92,7 +92,7 @@ export class CreateIssueWebview
         return ProductJira;
     }
 
-    protected onPanelDisposed() {
+    protected override onPanelDisposed() {
         this.reset();
         super.onPanelDisposed();
     }
@@ -102,7 +102,7 @@ export class CreateIssueWebview
         this._siteDetails = emptySiteInfo;
     }
 
-    async createOrShow(column?: ViewColumn, data?: PartialIssue): Promise<void> {
+    override async createOrShow(column?: ViewColumn, data?: PartialIssue): Promise<void> {
         await super.createOrShow(column);
 
         this.initialize(data);
@@ -549,7 +549,7 @@ export class CreateIssueWebview
         return [payload, worklog, issuelinks, attachments];
     }
 
-    protected async onMessageReceived(msg: Action): Promise<boolean> {
+    protected override async onMessageReceived(msg: Action): Promise<boolean> {
         let handled = await super.onMessageReceived(msg);
 
         if (!handled) {

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -88,7 +88,7 @@ export class JiraIssueWebview
         return ProductJira;
     }
 
-    setIconPath() {
+    override setIconPath() {
         this._panel!.iconPath = Resources.icons.get(iconSet.JIRAICON);
     }
 
@@ -306,7 +306,7 @@ export class JiraIssueWebview
         return '';
     }
 
-    protected async onMessageReceived(msg: Action): Promise<boolean> {
+    protected override async onMessageReceived(msg: Action): Promise<boolean> {
         let handled = await super.onMessageReceived(msg);
 
         if (!handled) {

--- a/src/webviews/startWorkOnIssueWebview.ts
+++ b/src/webviews/startWorkOnIssueWebview.ts
@@ -39,7 +39,7 @@ export class StartWorkOnIssueWebview
         return 'startWorkOnIssueScreen';
     }
 
-    setIconPath() {
+    override setIconPath() {
         this._panel!.iconPath = Resources.icons.get(iconSet.JIRAICON);
     }
 
@@ -71,7 +71,7 @@ export class StartWorkOnIssueWebview
         await this.forceUpdateIssue();
     }
 
-    protected async onMessageReceived(e: Action): Promise<boolean> {
+    protected override async onMessageReceived(e: Action): Promise<boolean> {
         let handled = await super.onMessageReceived(e);
 
         if (!handled) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "noImplicitAny": true,
+        "noImplicitOverride": true,
         "strictNullChecks": true,
         "noUnusedLocals": true,
         "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
### What Is This Change?

Specifying `override` when overriding a member of the base class is not mandatory in TypeScript, but it's strongly encouraged as this will prevent refactoring in the base class to accidentally break the  overrides in the subclass.

The compiler's option `noImplicitOverride` makes specifying `override` mandatory.

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`