### PR TITLE
[NO-ISSUE] Fix tool icon placement

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -160,7 +160,7 @@ body {
 .tool-return-item-base {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: flex-start;
     gap: 4px;
 }
 

--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -29,7 +29,6 @@ import { ChatMessage, DefaultMessage, ErrorMessage, parseToolReturnMessage } fro
 export const mdParser = new MarkdownIt({
     html: true,
     breaks: true,
-    linkify: true,
     typographer: true,
 });
 

--- a/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
@@ -30,7 +30,7 @@ export const ChatMessageItem: React.FC<{
             </div>
             {msg.source === 'User' && msg.context && (
                 <div className="message-context">
-                    <PromptContextCollection content={msg.context} direction="column" align="right" />
+                    <PromptContextCollection content={msg.context} direction="column" align="right" inChat={true} />
                 </div>
             )}
         </>

--- a/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextCollection.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextCollection.tsx
@@ -11,7 +11,8 @@ export const PromptContextCollection: React.FC<{
     onToggleActiveItem?: (enabled: boolean) => void;
     readonly?: boolean;
     onRemoveContext?: (item: RovoDevContextItem) => void;
-}> = ({ content, direction = 'row', align = 'left', onToggleActiveItem, readonly = true, onRemoveContext }) => {
+    inChat?: boolean;
+}> = ({ content, direction = 'row', align = 'left', onToggleActiveItem, readonly = true, onRemoveContext, inChat }) => {
     if (content.focusInfo?.invalid && !content.contextItems?.length) {
         return null;
     }
@@ -31,6 +32,7 @@ export const PromptContextCollection: React.FC<{
                 gap: direction === 'column' ? 1 : 4,
                 width: '100%',
                 boxSizing: 'border-box',
+                marginBottom: inChat ? '8px' : 0,
             }}
         >
             {/* Disabled for now in favor of the larger button outside the collection */}

--- a/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextItem.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextItem.tsx
@@ -18,7 +18,6 @@ const chipStyle: React.CSSProperties = {
     opacity: 0.85,
     lineHeight: 1.1,
     maxWidth: 220,
-    marginBottom: '8px',
 };
 
 const iconStyle: React.CSSProperties = {

--- a/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextItem.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextItem.tsx
@@ -18,6 +18,7 @@ const chipStyle: React.CSSProperties = {
     opacity: 0.85,
     lineHeight: 1.1,
     maxWidth: 220,
+    marginBottom: '8px',
 };
 
 const iconStyle: React.CSSProperties = {


### PR DESCRIPTION
### What Is This Change?

Fixed the tool icon placement to be `flex-start` instead of center for larger tool returns
<img width="455" height="325" alt="Screenshot 2025-08-04 at 4 42 05 PM" src="https://github.com/user-attachments/assets/c9263316-1dd4-459d-8c90-ad29b66476fa" />

Fixed prompt context margin when it is in the chat so the spacing is consistent
<img width="451" height="152" alt="Screenshot 2025-08-04 at 4 57 29 PM" src="https://github.com/user-attachments/assets/8f3ab637-abc5-4332-9c80-22691bacf9cb" />

Removed `linkify` which registered file names as href links in markdown
<img width="149" height="49" alt="Screenshot 2025-08-04 at 4 57 35 PM" src="https://github.com/user-attachments/assets/cd672ec2-305b-4238-9e69-1015ef3e16da" />

### How Has This Been Tested?

Manual

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
