### PR TITLE
Rovo Dev: Hide context on replay

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -601,7 +601,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         if (context.focusInfo && context.focusInfo.enabled && !context.focusInfo.invalid) {
             extra += `
             <context>
-                Consider that the user has the following open in the editor:
+                I have this open in editor:
                     <name>${context.focusInfo.file.name}</name>
                         <absolute_path>${context.focusInfo.file.absolutePath}</absolute_path>
                         <relative_path>${context.focusInfo.file.relativePath}</relative_path>
@@ -617,7 +617,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         if (context.contextItems && context.contextItems.length > 0) {
             extra += `
                 <context>
-                    The user has the following additional context items:
+                    I have these additional context items:
                     ${context.contextItems
                         .map(
                             (item) => `


### PR DESCRIPTION

### What Is This Change?

- Bug: When replaying messages that had <context> on them, that would show in the UI. 
- Fix: when inspecting the user message, if the <context> tags are there, remove them and the content within them 

### How Has This Been Tested?
Manual. The regex was tested with the help of Copilot on several different cases. 


### Known issue:
- The pretty "file tokens" don't show up on the replay. 

<img width="1638" height="180" alt="Screenshot 2025-08-06 at 5 20 12 PM" src="https://github.com/user-attachments/assets/0b65221a-ed4f-4aa7-a6e9-d22ce847a51f" />
<img width="801" height="1374" alt="Screenshot 2025-08-06 at 5 19 16 PM" src="https://github.com/user-attachments/assets/40d4a960-5998-45d9-84d4-1b9745d843f1" />