### PR TITLE
Axon 322 status button is clipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### Bug Fixes
 
 - Fixed a bug where issues would not render due to malformed epic fields (#665)
-
+- Fixed status button in smaller screen size
+- 
 ## What's new in 3.8.7
 
 ### Features

--- a/src/webviews/components/issue/view-issue-screen/sidebar/IssueSidebarButtonGroup.tsx
+++ b/src/webviews/components/issue/view-issue-screen/sidebar/IssueSidebarButtonGroup.tsx
@@ -79,7 +79,7 @@ export const IssueSidebarButtonGroup: React.FC<Props> = ({
                 display: 'flex',
                 flexDirection: 'row',
                 alignItems: 'center',
-                flexWrap: 'wrap',
+                flexWrap: 'wrap-reverse',
                 width: '100%',
                 justifyContent: 'space-between',
                 gap: '4px 0',

--- a/src/webviews/components/issue/view-issue-screen/sidebar/IssueSidebarButtonGroup.tsx
+++ b/src/webviews/components/issue/view-issue-screen/sidebar/IssueSidebarButtonGroup.tsx
@@ -79,8 +79,10 @@ export const IssueSidebarButtonGroup: React.FC<Props> = ({
                 display: 'flex',
                 flexDirection: 'row',
                 alignItems: 'center',
+                flexWrap: 'wrap',
                 width: '100%',
                 justifyContent: 'space-between',
+                gap: '4px 0',
             }}
         >
             <Box style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '4px' }}>


### PR DESCRIPTION
### What Is This Change?

 Fixed status button in smaller screen size
 
 Before/After: https://www.loom.com/share/5704269f572b44fabf1a837e95ec94f7?sid=d74ae920-a7cb-4e49-a939-fad430aa558d

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Recommendations:
- [x] Update the CHANGELOG if making a user facing change