### PR TITLE
[AXON-810] Fix replay stream bug

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -69,9 +69,7 @@ const RovoDevView: React.FC = () => {
     const [currentMessage, setCurrentMessage] = useState<DefaultMessage | null>(null);
     const [curThinkingMessages, setCurThinkingMessages] = useState<ChatMessage[]>([]);
 
-    const [currentState, setCurrentState] = useState(
-        process.env.ROVODEV_BBY ? State.GeneratingResponse : State.WaitingForPrompt,
-    );
+    const [currentState, setCurrentState] = useState(State.WaitingForPrompt);
 
     const [promptText, setPromptText] = useState('');
     const [pendingToolCallMessage, setPendingToolCallMessage] = useState('');

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -108,7 +108,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
     private get rovoDevApiClient() {
         if (!this._rovoDevApiClient) {
-            const rovoDevPort = true ? 9999 : this.getWorkspacePort();
+            const rovoDevPort = this.getWorkspacePort();
             const rovoDevHost = process.env[rovodevInfo.envVars.host] || 'localhost';
             if (rovoDevPort) {
                 this._rovoDevApiClient = new RovoDevApiClient(rovoDevHost, rovoDevPort);
@@ -680,9 +680,7 @@ ${message}`;
             context,
         };
 
-        if (text) {
-            await this.sendPromptSentToView({ text, enable_deep_plan, context });
-        }
+        await this.sendPromptSentToView({ text, enable_deep_plan, context });
 
         let payloadToSend = this.addUndoContextToPrompt(text);
         payloadToSend = this.addContextToPrompt(payloadToSend, context);

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -281,7 +281,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         this.beginNewSession();
                         if (this.isBBY) {
                             // TODO: we should obtain the session id from the boysenberry environment
-                            await this.sendPromptSentToView({ text: '', enable_deep_plan: false, context: undefined });
                             await this.executeReplay();
                         }
                     } else {
@@ -849,6 +848,7 @@ ${message}`;
 
     private async executeReplay(): Promise<void> {
         this.beginNewPrompt('replay');
+        await this.sendPromptSentToView({ text: '', enable_deep_plan: false, context: undefined });
 
         await this.executeApiWithErrorHandling(async (client) => {
             return this.processChatResponse('replay', client.replay());


### PR DESCRIPTION
### What Is This Change?

Now sends `Sent Prompt` signal to view regardless of ``suppression so all messages will change the state to `Generating Response`

This allows for pending prompt + replay messages to be rendered correctly

### How Has This Been Tested?

Manually
Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
