### PR TITLE
[AXON-784] Fix error message placement in chat

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -364,10 +364,11 @@ const RovoDevView: React.FC = () => {
                     break;
 
                 case RovoDevProviderMessageType.ErrorMessage:
-                    handleAppendError(event.message);
                     if (currentState !== State.WaitingForPrompt) {
                         finalizeResponse();
                     }
+                    handleAppendError(event.message);
+
                     break;
 
                 case RovoDevProviderMessageType.NewSession:


### PR DESCRIPTION
### What Is This Change?
<img width="314" height="337" alt="Screenshot 2025-08-08 at 11 47 41 AM" src="https://github.com/user-attachments/assets/59f4ed26-f34b-4260-8050-727ee4973f15" />

Reorder error message placement so Error message is at end of chat stream

### How Has This Been Tested?
Manual 

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
