### PR TITLE
Automatically enable Rovo Dev for internal users

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,8 +51,6 @@ export async function activate(context: ExtensionContext) {
 
     // this disables the main Atlassian activity bar when we are in BBY
     setCommandContext(CommandContext.BbyEnvironmentActive, !!process.env.ROVODEV_BBY);
-    // this disables the Rovo Dev activity bar unless it's explicitely enabled
-    setCommandContext(CommandContext.RovoDevEnabled, !!process.env.ROVODEV_ENABLED);
 
     // Mark ourselves as the PID in charge of refreshing credentials and start listening for pings.
     context.globalState.update('rulingPid', pid);
@@ -113,7 +111,7 @@ export async function activate(context: ExtensionContext) {
         // icon to appear in the activity bar
         activateBitbucketFeatures();
         activateYamlFeatures(context);
-    } else if (!!process.env.ROVODEV_ENABLED) {
+    } else {
         commands.executeCommand('workbench.view.extension.atlascode-rovo-dev');
     }
 
@@ -215,7 +213,7 @@ async function sendAnalytics(version: string, globalState: Memento) {
 // this method is called when your extension is deactivated
 export function deactivate() {
     if (!process.env.ROVODEV_BBY) {
-        if (!!process.env.ROVODEV_ENABLED) {
+        if (Container.isRovoDevEnabled) {
             deactivateRovoDevProcessManager();
         }
 

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -153,7 +153,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
         // Register the initialization of the process when the webview is ready
         this.onWebviewResolved(() => {
-            if (!!process.env.ROVODEV_ENABLED && !process.env.ROVODEV_BBY) {
+            if (!process.env.ROVODEV_BBY) {
                 initializeRovoDevProcessManager(context);
             } else {
                 this.signalProcessStarted();
@@ -292,7 +292,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             }
         });
 
-        if (!!process.env.ROVODEV_ENABLED && !process.env.ROVODEV_BBY) {
+        if (!process.env.ROVODEV_BBY) {
             workspace.onDidChangeWorkspaceFolders(() => {
                 if (!this._disabled) {
                     webview.postMessage({

--- a/webpack.extension.dev.js
+++ b/webpack.extension.dev.js
@@ -82,7 +82,6 @@ module.exports = [
                     process.env.ATLASCODE_EXP_OVERRIDES_STRING,
                 ),
                 'process.env.ROVODEV_BBY': JSON.stringify(process.env.ROVODEV_BBY),
-                'process.env.ROVODEV_ENABLED': JSON.stringify(process.env.ROVODEV_ENABLED),
             }),
         ],
     },

--- a/webpack.extension.prod.js
+++ b/webpack.extension.prod.js
@@ -108,7 +108,6 @@ module.exports = [
                     process.env.ATLASCODE_EXP_OVERRIDES_STRING,
                 ),
                 'process.env.ROVODEV_BBY': JSON.stringify(process.env.ROVODEV_BBY),
-                'process.env.ROVODEV_ENABLED': JSON.stringify(process.env.ROVODEV_ENABLED),
             }),
         ],
         externals: ['vscode'],

--- a/webpack.react.dev.js
+++ b/webpack.react.dev.js
@@ -66,7 +66,6 @@ module.exports = {
             'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
             'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_STRING),
             'process.env.ROVODEV_BBY': JSON.stringify(process.env.ROVODEV_BBY),
-            'process.env.ROVODEV_ENABLED': JSON.stringify(process.env.ROVODEV_ENABLED),
         }),
     ],
     module: {

--- a/webpack.react.prod.js
+++ b/webpack.react.prod.js
@@ -104,7 +104,6 @@ module.exports = {
             'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
             'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_STRING),
             'process.env.ROVODEV_BBY': JSON.stringify(process.env.ROVODEV_BBY),
-            'process.env.ROVODEV_ENABLED': JSON.stringify(process.env.ROVODEV_ENABLED),
         }),
     ],
     performance: {


### PR DESCRIPTION
### What Is This Change?

This change queries the endpoint http://github.internal.atlassian.com/ to detect if the user is an internal user.

After detection, this change automatically enables Rovo Dev for internal users.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`