### PR TITLE
AXON-835: fix race condition issue while connecting instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed a bug where Jira site icon is broken in create Jira issue page
 - Fixed a bug with getting the error when deleting multiple instances
 - Fixed a bug where we could not assign people to a Jira issue as DC users
+- Fixed race condition issue when connecting multiple instances
 
 ## What's new in 3.8.8
 
@@ -25,7 +26,8 @@
 
 - Fixed a bug where issues would not render due to malformed epic fields (#665)
 - Fixed status button in smaller screen size
-- 
+-
+
 ## What's new in 3.8.7
 
 ### Features

--- a/src/atlclients/loginManager.ts
+++ b/src/atlclients/loginManager.ts
@@ -105,12 +105,14 @@ export class LoginManager {
             await Promise.all(
                 siteDetails.map(async (siteInfo) => {
                     await this._credentialManager.saveAuthInfo(siteInfo, oauthInfo);
-                    this._siteManager.addSites([siteInfo]);
                     authenticatedEvent(siteInfo, isOnboarding, source).then((e) => {
                         this._analyticsClient.sendTrackEvent(e);
                     });
                 }),
             );
+
+            // Add all sites at once to prevent race condition
+            this._siteManager.addSites(siteDetails);
         } catch (e) {
             Logger.error(e, `Error authenticating with provider '${provider}'`);
             vscode.window.showErrorMessage(`There was an error authenticating with provider '${provider}': ${e}`);

--- a/src/lib/webview/controller/config/configWebviewController.ts
+++ b/src/lib/webview/controller/config/configWebviewController.ts
@@ -143,7 +143,15 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                         });
                     }
                 } else {
-                    this._api.authenticateCloud(msg.siteInfo, this._settingsUrl);
+                    try {
+                        await this._api.authenticateCloud(msg.siteInfo, this._settingsUrl);
+                    } catch (e) {
+                        this._logger.error(e, 'Cloud authentication error');
+                        this.postMessage({
+                            type: CommonMessageType.Error,
+                            reason: formatError(e, 'Cloud authentication error'),
+                        });
+                    }
                 }
                 this._analytics.fireAuthenticateButtonEvent(id, msg.siteInfo, isCloud);
                 break;

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -81,7 +81,7 @@ export class SiteManager extends Disposable {
             if (newSites.length === 0) {
                 notify = false;
             }
-            allSites = allSites.concat(newSites);
+            allSites.push(...newSites);
         } else {
             allSites = newSites;
         }


### PR DESCRIPTION
### What Is This Change?
**Problem**
There was a race condition occurring during the authentication process when connecting multiple instances simultaneously. The issue was in the `LoginManager.saveDetails()` method where sites were being added to the SiteManager individually within a `Promise.all` loop, causing potential race conditions and inconsistent state. 
**It was causing the different amount of connected instances.** 

**Root Cause**
`this._siteManager.addSites([siteInfo])` was called inside the Promise.all map function, meaning multiple calls to addSites could occur concurrently
<img width="981" height="662" alt="Screenshot 2025-08-11 at 15 41 16" src="https://github.com/user-attachments/assets/c1b73af0-4371-42f8-99a0-444e65b9fb13" />


**Solution**
Move the site addition outside the parallel execution and add all sites at once after all credentials have been saved
<img width="1068" height="54" alt="Screenshot 2025-08-11 at 15 44 59" src="https://github.com/user-attachments/assets/cf969ca9-4c44-4bd5-9a9c-9f47283dfc67" />



**Additional Improvements**
- Made cloud authentication call await to properly handle async errors as it is in Bitbucket flow
- Replaced concat() with spread operator (push(...newSites)) for better performance when adding multiple sites

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change