### PR TITLE
AXON-777: remove extra calls to get auth info

### DIFF
--- a/src/atlclients/authStore.ts
+++ b/src/atlclients/authStore.ts
@@ -29,7 +29,7 @@ import {
 } from './authInfo';
 import { Negotiator } from './negotiate';
 import { OAuthRefesher } from './oauthRefresher';
-import { Tokens } from './tokens';
+
 const keychainServiceNameV3 = version.endsWith('-insider') ? 'atlascode-insiders-authinfoV3' : 'atlascode-authinfoV3';
 
 enum Priority {
@@ -397,7 +397,7 @@ export class CredentialManager implements Disposable {
     /**
      * Calls the OAuth provider and updates the access token.
      */
-    private async refreshAccessToken(site: DetailedSiteInfo): Promise<Tokens | undefined> {
+    private async refreshAccessToken(site: DetailedSiteInfo): Promise<void> {
         const credentials = await this.getAuthInfoForProductAndCredentialId(site, false);
         if (!isOAuthInfo(credentials)) {
             return undefined;
@@ -405,7 +405,7 @@ export class CredentialManager implements Disposable {
         Logger.debug(`refreshingAccessToken for ${site.baseApiUrl} credentialID: ${site.credentialId}`);
 
         const provider: OAuthProvider | undefined = oauthProviderForSite(site);
-        const newTokens = undefined;
+
         if (provider && credentials) {
             const tokenResponse = await this._refresher.getNewTokens(provider, credentials.refresh);
             if (tokenResponse.tokens) {
@@ -424,7 +424,6 @@ export class CredentialManager implements Disposable {
                 this.saveAuthInfo(site, credentials);
             }
         }
-        return newTokens;
     }
 
     /**


### PR DESCRIPTION
### What Is This Change?

The `getSitesWithAuth()` method in `vscConfigActionApi` was making redundant authentication calls for sites that shared the same credentialId. This commonly occurs in OAuth scenarios where a single authentication token provides access to multiple Jira/Bitbucket sites.

**Performance Impact:**
- Multiple unnecessary OAuth token refresh calls during config page loads
- Redundant getAuthInfo() calls for sites with identical credentials
- Slower UI loading times due to serial authentication checks

**Fix:**
- Implemented credential-based deduplication in getSitesWithAuth() to eliminate redundant authentication calls

Also, removed unused newTokens variable

<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change