### PR TITLE
[AXON-809] Fix message streaming scramble

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -504,6 +504,15 @@ const RovoDevView: React.FC = () => {
         });
     }, [postMessage]);
 
+    // Notify the backend that the webview is ready
+    // This is used to initialize the process manager if needed
+    // and to signal that the webview is ready to receive messages
+    React.useEffect(() => {
+        postMessage?.({
+            type: RovoDevViewResponseType.WebviewReady,
+        });
+    }, [postMessage]);
+
     const executeCodePlan = useCallback(() => {
         if (currentState !== State.WaitingForPrompt) {
             return;

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -16,6 +16,7 @@ export const enum RovoDevViewResponseType {
     ReportChangesGitPushed = 'reportChangesGitPushed',
     ReportThinkingDrawerExpanded = 'reportThinkingDrawerExpanded',
     CheckGitChanges = 'checkGitChanges',
+    WebviewReady = 'webviewReady',
 }
 
 export interface ModifiedFile {
@@ -37,4 +38,5 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.ReportChangedFilesPanelShown, { filesCount: number }>
     | ReducerAction<RovoDevViewResponseType.ReportChangesGitPushed, { pullRequestCreated: boolean }>
     | ReducerAction<RovoDevViewResponseType.ReportThinkingDrawerExpanded>
-    | ReducerAction<RovoDevViewResponseType.CheckGitChanges>;
+    | ReducerAction<RovoDevViewResponseType.CheckGitChanges>
+    | ReducerAction<RovoDevViewResponseType.WebviewReady>;


### PR DESCRIPTION
### What Is This Change?

In BBY, ww see the message scrambling because the replay would take place before the webview is rendered. This caused the states to not change to accept messages.

Now, the webview sends a message to the extension when it is successfully rendered. Now the replay will only take place when the webview is ready for messages

### How Has This Been Tested?

Manually

Cannot inject extension into BBy so will deploy to staging once merged

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`