### PR TITLE
[AXON-847] Rovo Dev: Improvements in tcp ports and process management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
                 "@types/uuid": "^10.0.0",
                 "@types/vscode": ">=1.77.0 <=1.96.0",
                 "@types/websocket": "^1.0.0",
+                "@types/ws": "^8.18.1",
                 "@vscode/vsce": "^3.6.0",
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
@@ -7410,6 +7411,15 @@
             "version": "1.0.10",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/websocket/-/websocket-1.0.10.tgz",
             "integrity": "sha512-svjGZvPB7EzuYS94cI7a+qhwgGU1y89wUgjT6E2wVUfmAGIvRfT7obBvRtnhXCSsoMdlG4gBFGE7MfkIXZLoww==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -1466,6 +1466,7 @@
         "@types/uuid": "^10.0.0",
         "@types/vscode": ">=1.77.0 <=1.96.0",
         "@types/websocket": "^1.0.0",
+        "@types/ws": "^8.18.1",
         "@vscode/vsce": "^3.6.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",

--- a/src/container.ts
+++ b/src/container.ts
@@ -220,11 +220,7 @@ export class Container {
             }),
         );
         context.subscriptions.push(
-            (this._rovodevWebviewProvider = new RovoDevWebviewProvider(
-                context,
-                context.extensionPath,
-                context.globalState,
-            )),
+            (this._rovodevWebviewProvider = new RovoDevWebviewProvider(context, context.extensionPath)),
         );
 
         this.configureRovodevSettingsCommands(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import {
     BB_PIPELINES_FILENAME,
 } from './pipelines/yaml/pipelinesYamlHelper';
 import { registerResources } from './resources';
-import { deactivateRovoDevProcessManager } from './rovo-dev/rovoDevProcessManager';
+import { RovoDevProcessManager } from './rovo-dev/rovoDevProcessManager';
 import { GitExtension } from './typings/git';
 import { FeatureFlagClient, Features } from './util/featureFlags';
 import Performance from './util/perf';
@@ -207,10 +207,7 @@ async function sendAnalytics(version: string, globalState: Memento) {
 // this method is called when your extension is deactivated
 export function deactivate() {
     if (!process.env.ROVODEV_BBY) {
-        if (Container.isRovoDevEnabled) {
-            deactivateRovoDevProcessManager();
-        }
-
+        RovoDevProcessManager.deactivateRovoDevProcessManager();
         NotificationManagerImpl.getInstance().stopListening();
     }
 

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -168,8 +168,8 @@ async function getOrAssignPortForWorkspace(): Promise<number> {
     const portEnd = rovodevInfo.portRange.end;
 
     for (let port = portStart; port <= portEnd; ++port) {
-        if (await isPortAvailable(8899)) {
-            return 8899;
+        if (await isPortAvailable(port)) {
+            return port;
         }
     }
 

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -45,100 +45,6 @@ function GetRovoDevURIs(context: ExtensionContext) {
 
 type RovoDevURIs = ReturnType<typeof GetRovoDevURIs>;
 
-// TODO - make this file a class
-let rovoDevProcess: ChildProcess | undefined;
-
-let disposables: Disposable[] = [];
-
-// Reference to the RovoDev webview provider for sending errors to chat
-// This is ensured to be initialized before the entrypoint `initializeRovoDevProcessManager` is invoked.
-let rovoDevWebviewProvider: RovoDevWebviewProvider;
-
-export function setRovoDevWebviewProvider(provider: any) {
-    rovoDevWebviewProvider = provider;
-}
-
-async function downloadBinaryThenInitialize(context: ExtensionContext, rovoDevURIs: RovoDevURIs) {
-    const baseDir = rovoDevURIs.RovoDevBaseDir;
-    const versionDir = rovoDevURIs.RovoDevVersionDir;
-    const zipUrl = rovoDevURIs.RovoDevZipUrl;
-
-    if (!zipUrl) {
-        rovoDevWebviewProvider.signalRovoDevDisabled();
-        rovoDevWebviewProvider.sendErrorToChat(
-            `Rovo Dev is not supported for the following platform/architecture: ${process.platform}/${process.arch}`,
-        );
-        return;
-    }
-
-    try {
-        if (fs.existsSync(baseDir)) {
-            await getFsPromise((callback) => fs.rm(baseDir, { recursive: true, force: true }, callback));
-        }
-
-        const onProgressChange = (downloadedBytes: number, totalBytes: number | undefined) => {
-            if (totalBytes) {
-                rovoDevWebviewProvider.signalDownloadProgress(downloadedBytes, totalBytes);
-            }
-        };
-
-        await downloadAndUnzip(zipUrl, baseDir, versionDir, true, onProgressChange);
-
-        await getFsPromise((callback) => fs.mkdir(versionDir, { recursive: true }, callback));
-    } catch (error) {
-        const message = `Unable to update Rovo Dev:\n${error.message}\n\nTo try again, please close VS Code and reopen it.`;
-        rovoDevWebviewProvider.signalRovoDevDisabled();
-        rovoDevWebviewProvider.sendErrorToChat(message);
-        throw error;
-    }
-
-    rovoDevWebviewProvider.signalBinaryDownloadEnded();
-
-    await initializeRovoDevProcessManager(context);
-}
-
-export async function initializeRovoDevProcessManager(context: ExtensionContext) {
-    const rovoDevURIs = GetRovoDevURIs(context);
-
-    rovoDevProcess = undefined;
-
-    if (!fs.existsSync(rovoDevURIs.RovoDevBinPath)) {
-        rovoDevWebviewProvider.signalBinaryDownloadStarted();
-        await downloadBinaryThenInitialize(context, rovoDevURIs);
-        return;
-    }
-
-    // Listen for workspace folder changes
-    const listener = workspace.onDidChangeWorkspaceFolders((event) => {
-        if (!rovoDevProcess && event.added.length > 0) {
-            showWorkspaceLoadedMessageAndStartProcess(rovoDevURIs);
-        } else if (event.removed.length === workspace.workspaceFolders?.length) {
-            showWorkspaceClosedMessageAndStopProcess(event.removed);
-        }
-    });
-
-    context.subscriptions.push(listener);
-    disposables.push(listener);
-
-    await showWorkspaceLoadedMessageAndStartProcess(rovoDevURIs);
-}
-
-export function deactivateRovoDevProcessManager() {
-    for (const obj of disposables) {
-        obj.dispose();
-    }
-    disposables = [];
-
-    // On deactivate, stop all workspace processes
-    if (workspace.workspaceFolders) {
-        for (const folder of workspace.workspaceFolders) {
-            stopWorkspaceProcess(folder.uri.fsPath);
-        }
-    }
-
-    showWorkspaceClosedMessage();
-}
-
 function isPortAvailable(port: number): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
         const server = net.createServer();
@@ -160,112 +66,6 @@ function isPortAvailable(port: number): Promise<boolean> {
 
         server.listen(port, '127.0.0.1');
     });
-}
-
-async function getOrAssignPortForWorkspace(): Promise<number> {
-    const portStart = rovodevInfo.portRange.start;
-    const portEnd = rovodevInfo.portRange.end;
-
-    for (let port = portStart; port <= portEnd; ++port) {
-        if (await isPortAvailable(port)) {
-            return port;
-        }
-    }
-
-    throw new Error('unable to find an available port.');
-}
-
-// Helper to stop a process by terminal name
-function stopWorkspaceProcess(workspacePath: string) {
-    if (rovoDevProcess) {
-        rovoDevProcess.kill();
-        rovoDevProcess = undefined;
-    }
-}
-
-// Helper to start the background process
-function startWorkspaceProcess(workspacePath: string, port: number, rovoDevURIs: RovoDevURIs) {
-    stopWorkspaceProcess(workspacePath);
-
-    access(rovoDevURIs.RovoDevBinPath, constants.X_OK, (err) => {
-        if (err) {
-            throw new Error(`executable not found.`);
-        }
-
-        getCloudCredentials().then((creds) => {
-            const defaultUsername = 'cooluser@atlassian.com';
-            const { username, key } = creds || {};
-
-            const env: NodeJS.ProcessEnv = {
-                USER: process.env.USER,
-                USER_EMAIL: username || defaultUsername,
-                ...(key ? { USER_API_TOKEN: key } : {}),
-            };
-            let stderrData = '';
-
-            rovoDevProcess = spawn(
-                rovoDevURIs.RovoDevBinPath,
-                [`serve`, `${port}`, `--application-id`, `com.atlassian.vscode`],
-                {
-                    cwd: workspacePath,
-                    stdio: ['ignore', 'pipe', 'pipe'],
-                    detached: true,
-                    env,
-                },
-            )
-                .on('spawn', () => rovoDevWebviewProvider.signalProcessStarted(port))
-                .on('exit', (code) => {
-                    rovoDevProcess = undefined;
-
-                    if (code !== 0) {
-                        if (stderrData.includes('auth token')) {
-                            throw new Error(
-                                `please login by providing an API Token. You can do this via Atlassian: Open Settings -> Authentication -> Other Options`,
-                            );
-                        } else {
-                            // default error message
-                            throw new Error(`process exited with code ${code}, see the log for details.`);
-                        }
-                    }
-                });
-
-            if (rovoDevProcess.stderr) {
-                rovoDevProcess.stderr.on('data', (data) => {
-                    stderrData += data.toString();
-                });
-            }
-        });
-    });
-}
-
-async function showWorkspaceLoadedMessageAndStartProcess(rovoDevURIs: RovoDevURIs) {
-    // skip if the port has been pre-assigned or there is no workspace folder open
-    if (process.env[rovodevInfo.envVars.port] || !workspace.workspaceFolders) {
-        return;
-    }
-
-    const folder = workspace.workspaceFolders[0];
-
-    try {
-        const port = await getOrAssignPortForWorkspace();
-        startWorkspaceProcess(folder.uri.fsPath, port, rovoDevURIs);
-    } catch (error) {
-        rovoDevWebviewProvider.signalRovoDevDisabled();
-        rovoDevWebviewProvider.sendErrorToChat(`Unable to start Rovo Dev:\n${error.message}`);
-    }
-}
-
-function showWorkspaceClosedMessageAndStopProcess(
-    removedFolders: readonly { uri: { fsPath: string }; name: string }[],
-) {
-    for (const folder of removedFolders) {
-        stopWorkspaceProcess(folder.uri.fsPath);
-        console.log(`Rovo Dev: Workspace closed: ${folder.name}`);
-    }
-}
-
-function showWorkspaceClosedMessage() {
-    console.log('Rovo Dev: Workspace closed or extension deactivated.');
 }
 
 /**
@@ -297,4 +97,209 @@ async function getCloudCredentials(): Promise<{ username: string; key: string; h
 
     const results = (await Promise.all(promises)).filter((result) => result !== undefined);
     return results.length > 0 ? results[0] : undefined;
+}
+
+export class RovoDevProcessManager extends Disposable {
+    private static disposables: Disposable[] = [];
+
+    // Reference to the RovoDev webview provider for sending errors to chat
+    // This is ensured to be initialized before the entrypoint `initializeRovoDevProcessManager` is invoked.
+    static rovoDevWebviewProvider: RovoDevWebviewProvider;
+    public static setRovoDevWebviewProvider(provider: RovoDevWebviewProvider) {
+        this.rovoDevWebviewProvider = provider;
+    }
+
+    private static rovoDevInstance: RovoDevInstance | undefined;
+    private static stopRovoDevInstance() {
+        if (this.rovoDevInstance) {
+            this.rovoDevInstance.stop();
+            this.rovoDevInstance = undefined;
+        }
+    }
+
+    private static async downloadBinaryThenInitialize(context: ExtensionContext, rovoDevURIs: RovoDevURIs) {
+        const baseDir = rovoDevURIs.RovoDevBaseDir;
+        const versionDir = rovoDevURIs.RovoDevVersionDir;
+        const zipUrl = rovoDevURIs.RovoDevZipUrl;
+
+        if (!zipUrl) {
+            this.rovoDevWebviewProvider.signalRovoDevDisabled();
+            this.rovoDevWebviewProvider.sendErrorToChat(
+                `Rovo Dev is not supported for the following platform/architecture: ${process.platform}/${process.arch}`,
+            );
+            return;
+        }
+
+        try {
+            if (fs.existsSync(baseDir)) {
+                await getFsPromise((callback) => fs.rm(baseDir, { recursive: true, force: true }, callback));
+            }
+
+            const onProgressChange = (downloadedBytes: number, totalBytes: number | undefined) => {
+                if (totalBytes) {
+                    this.rovoDevWebviewProvider.signalDownloadProgress(downloadedBytes, totalBytes);
+                }
+            };
+
+            await downloadAndUnzip(zipUrl, baseDir, versionDir, true, onProgressChange);
+
+            await getFsPromise((callback) => fs.mkdir(versionDir, { recursive: true }, callback));
+        } catch (error) {
+            const message = `Unable to update Rovo Dev:\n${error.message}\n\nTo try again, please close VS Code and reopen it.`;
+            this.rovoDevWebviewProvider.signalRovoDevDisabled();
+            this.rovoDevWebviewProvider.sendErrorToChat(message);
+            throw error;
+        }
+
+        this.rovoDevWebviewProvider.signalBinaryDownloadEnded();
+
+        await this.initializeRovoDevProcessManager(context);
+    }
+
+    public static async initializeRovoDevProcessManager(context: ExtensionContext) {
+        const rovoDevURIs = GetRovoDevURIs(context);
+
+        this.rovoDevInstance = undefined;
+
+        if (!fs.existsSync(rovoDevURIs.RovoDevBinPath)) {
+            this.rovoDevWebviewProvider.signalBinaryDownloadStarted();
+            await this.downloadBinaryThenInitialize(context, rovoDevURIs);
+            return;
+        }
+
+        // Listen for workspace folder changes
+        const listener = workspace.onDidChangeWorkspaceFolders((event) => {
+            if (!this.rovoDevInstance && event.added.length > 0) {
+                this.startRovoDev(rovoDevURIs.RovoDevBinPath);
+            } else if (event.removed.length === workspace.workspaceFolders?.length) {
+                this.stopRovoDevInstance();
+            }
+        });
+
+        context.subscriptions.push(listener);
+        this.disposables.push(listener);
+
+        await this.startRovoDev(rovoDevURIs.RovoDevBinPath);
+    }
+
+    public static deactivateRovoDevProcessManager() {
+        for (const obj of this.disposables) {
+            obj.dispose();
+        }
+        this.disposables = [];
+
+        // On deactivate, stop all workspace processes
+        this.stopRovoDevInstance();
+    }
+
+    private static async getOrAssignPortForWorkspace(): Promise<number> {
+        const portStart = rovodevInfo.portRange.start;
+        const portEnd = rovodevInfo.portRange.end;
+
+        for (let port = portStart; port <= portEnd; ++port) {
+            if (await isPortAvailable(port)) {
+                return port;
+            }
+        }
+
+        throw new Error('unable to find an available port.');
+    }
+
+    private static async startRovoDev(rovoDevBinPath: string) {
+        // skip there is no workspace folder open
+        if (!workspace.workspaceFolders) {
+            return;
+        }
+
+        const folder = workspace.workspaceFolders[0];
+
+        try {
+            const port = await this.getOrAssignPortForWorkspace();
+            this.rovoDevInstance = new RovoDevInstance(
+                this.rovoDevWebviewProvider,
+                folder.uri.fsPath,
+                port,
+                rovoDevBinPath,
+            );
+        } catch (error) {
+            this.rovoDevWebviewProvider.signalRovoDevDisabled();
+            this.rovoDevWebviewProvider.sendErrorToChat(`Unable to start Rovo Dev:\n${error.message}`);
+        }
+    }
+}
+
+class RovoDevInstance extends Disposable {
+    private rovoDevProcess: ChildProcess | undefined;
+
+    public get isRunning() {
+        return !!this.rovoDevProcess;
+    }
+
+    constructor(
+        rovoDevWebviewProvider: RovoDevWebviewProvider,
+        workspacePath: string,
+        port: number,
+        rovoDevBinPath: string,
+    ) {
+        super(() => this.stop());
+
+        this.stop();
+
+        access(rovoDevBinPath, constants.X_OK, (err) => {
+            if (err) {
+                throw new Error(`executable not found.`);
+            }
+
+            getCloudCredentials().then((creds) => {
+                const defaultUsername = 'cooluser@atlassian.com';
+                const { username, key } = creds || {};
+
+                const env: NodeJS.ProcessEnv = {
+                    USER: process.env.USER,
+                    USER_EMAIL: username || defaultUsername,
+                    ...(key ? { USER_API_TOKEN: key } : {}),
+                };
+                let stderrData = '';
+
+                this.rovoDevProcess = spawn(
+                    rovoDevBinPath,
+                    [`serve`, `${port}`, `--application-id`, `com.atlassian.vscode`],
+                    {
+                        cwd: workspacePath,
+                        stdio: ['ignore', 'pipe', 'pipe'],
+                        detached: true,
+                        env,
+                    },
+                )
+                    .on('spawn', () => rovoDevWebviewProvider.signalProcessStarted(port))
+                    .on('exit', (code) => {
+                        this.rovoDevProcess = undefined;
+
+                        if (code !== 0) {
+                            if (stderrData.includes('auth token')) {
+                                throw new Error(
+                                    `please login by providing an API Token. You can do this via Atlassian: Open Settings -> Authentication -> Other Options`,
+                                );
+                            } else {
+                                // default error message
+                                throw new Error(`process exited with code ${code}, see the log for details.`);
+                            }
+                        }
+                    });
+
+                if (this.rovoDevProcess.stderr) {
+                    this.rovoDevProcess.stderr.on('data', (data) => {
+                        stderrData += data.toString();
+                    });
+                }
+            });
+        });
+    }
+
+    public stop() {
+        if (this.rovoDevProcess) {
+            this.rovoDevProcess.kill();
+            this.rovoDevProcess = undefined;
+        }
+    }
 }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -10,7 +10,6 @@ import {
     Disposable,
     Event,
     ExtensionContext,
-    Memento,
     Position,
     Range,
     TextEditor,
@@ -107,32 +106,22 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
     private _disposables: Disposable[] = [];
 
-    private _globalState: Memento;
     private _extensionPath: string;
     private _extensionUri: Uri;
 
     private _context: ExtensionContext;
 
     private get rovoDevApiClient() {
-        if (!this._rovoDevApiClient) {
-            const rovoDevPort = this.getWorkspacePort();
-            const rovoDevHost = process.env[rovodevInfo.envVars.host] || 'localhost';
-            if (rovoDevPort) {
-                this._rovoDevApiClient = new RovoDevApiClient(rovoDevHost, rovoDevPort);
-            }
-        }
-
         return this._rovoDevApiClient;
     }
 
-    constructor(context: ExtensionContext, extensionPath: string, globalState: Memento) {
+    constructor(context: ExtensionContext, extensionPath: string) {
         super(() => {
             this._dispose();
         });
 
         this._extensionPath = extensionPath;
         this._extensionUri = Uri.file(this._extensionPath);
-        this._globalState = globalState;
         this._context = context;
         // Register the webview view provider
         this._disposables.push(
@@ -146,26 +135,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
         // Register this provider with the process manager for error handling
         setRovoDevWebviewProvider(this);
-    }
-
-    private getWorkspacePort(): number | undefined {
-        const workspaceFolders = workspace.workspaceFolders;
-        if (!workspaceFolders || workspaceFolders.length === 0) {
-            return undefined;
-        }
-
-        const globalPort = process.env[rovodevInfo.envVars.port];
-        if (globalPort) {
-            return parseInt(globalPort);
-        }
-
-        const wsPath = workspaceFolders[0].uri.fsPath;
-        const mapping = this._globalState.get<{ [key: string]: number }>(rovodevInfo.mappingKey);
-        if (mapping && mapping[wsPath]) {
-            return mapping[wsPath];
-        }
-
-        return undefined;
     }
 
     public resolveWebviewView(
@@ -275,10 +244,14 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         break;
 
                     case RovoDevViewResponseType.WebviewReady:
-                        if (!process.env.ROVODEV_BBY) {
-                            initializeRovoDevProcessManager(this._context);
+                        if (process.env.ROVODEV_BBY) {
+                            const port = parseInt(process.env[rovodevInfo.envVars.port] || '0');
+                            if (!port) {
+                                throw new Error('Rovo Dev port not set');
+                            }
+                            this.signalProcessStarted(port);
                         } else {
-                            this.signalProcessStarted();
+                            initializeRovoDevProcessManager(this._context);
                         }
                 }
             } catch (error) {
@@ -1102,7 +1075,11 @@ ${message}`;
         });
     }
 
-    public async signalProcessStarted() {
+    public async signalProcessStarted(rovoDevPort: number) {
+        // initialize the API client
+        const rovoDevHost = process.env[rovodevInfo.envVars.host] || 'localhost';
+        this._rovoDevApiClient = new RovoDevApiClient(rovoDevHost, rovoDevPort);
+
         const webView = this._webView!;
 
         // wait for Rovo Dev to be ready, for up to 10 seconds


### PR DESCRIPTION
### What Is This Change?

#### This PR changes the following things:

1. **TCP port**

Currently, the ports are assigned to workspaces using a globalState map, creating an association that was kept forever.
This has the main problem that ports were not checked for availability, and the process will fail if the port is already in use.

With this change, Rovo Dev will attempt to start the service on the first available port of the configured range.

2. **Process management**

Currently, there is a very rudimental logic to handle multiple folder in a workspace, spawning a Rovo Dev process for each of the folder.

With this change, we remove the support for multiple folders, and we spawn a single Rovo Dev instance for the first folder being opened by the workspace.

In the future we may want Rovo Dev to natively support multiple folders in a single instance.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`