### PR TITLE
[AXON-849] Enable primary site evaluation in siteManager

### DIFF
--- a/src/siteManager.test.ts
+++ b/src/siteManager.test.ts
@@ -395,4 +395,58 @@ describe('SiteManager', () => {
             expect(result.hostname).toBeUndefined();
         });
     });
+
+    describe('resolvePrimarySite', () => {
+        it('should set primarySite to undefined if no cloud sites exist', () => {
+            const serverSite = createDetailedSiteInfo(ProductJira, 'server', 'user1', false);
+            storedSites.set(`${ProductJira.key}Sites`, [serverSite]);
+
+            siteManager.resolvePrimarySite();
+
+            expect(siteManager.primarySite).toBeUndefined();
+        });
+
+        it('should set primarySite to the first cloud site sorted by name', () => {
+            const cloudSiteA = createDetailedSiteInfo(ProductJira, 'cloudA', 'userA', true);
+            cloudSiteA.name = 'Alpha';
+            const cloudSiteB = createDetailedSiteInfo(ProductJira, 'cloudB', 'userB', true);
+            cloudSiteB.name = 'Beta';
+            storedSites.set(`${ProductJira.key}Sites`, [cloudSiteB, cloudSiteA]);
+
+            siteManager.resolvePrimarySite();
+
+            expect(siteManager.primarySite).toEqual(cloudSiteA);
+        });
+
+        it('should not change primarySite if already set to the first cloud site', () => {
+            const cloudSiteA = createDetailedSiteInfo(ProductJira, 'cloudA', 'userA', true);
+            cloudSiteA.name = 'Alpha';
+            const cloudSiteB = createDetailedSiteInfo(ProductJira, 'cloudB', 'userB', true);
+            cloudSiteB.name = 'Beta';
+            storedSites.set(`${ProductJira.key}Sites`, [cloudSiteA, cloudSiteB]);
+
+            siteManager.resolvePrimarySite();
+            const firstPrimary = siteManager.primarySite;
+
+            // Call again, should not change
+            siteManager.resolvePrimarySite();
+            expect(siteManager.primarySite).toBe(firstPrimary);
+        });
+
+        it('should update primarySite when cloud sites change', () => {
+            const cloudSiteA = createDetailedSiteInfo(ProductJira, 'cloudA', 'userA', true);
+            cloudSiteA.name = 'Alpha';
+            storedSites.set(`${ProductJira.key}Sites`, [cloudSiteA]);
+
+            siteManager.resolvePrimarySite();
+            expect(siteManager.primarySite).toEqual(cloudSiteA);
+
+            const cloudSiteB = createDetailedSiteInfo(ProductJira, 'cloudB', 'userB', true);
+            cloudSiteB.name = 'Beta';
+            storedSites.set(`${ProductJira.key}Sites`, [cloudSiteB]);
+
+            siteManager.resolvePrimarySite();
+            expect(siteManager.primarySite).toEqual(cloudSiteB);
+        });
+    });
 });


### PR DESCRIPTION
### What Is This Change?

In `siteManager`, we now track the "primary site" - one of the Jira Cloud sites which we will use for feature gating processes down the line. This supports both OAuth and API token auth sites

We also now distribute the primary site as part of the `siteManager` update event - and it's available globally through `Container.siteManager.primarySite`

This update introduces the site resolution and makes it available, a follow-up change will hook it into the FeatureGate machinery

### How Has This Been Tested?

Manually - by flipping through different authentication types and edge cases ;)
<img width="550" height="80" alt="image" src="https://github.com/user-attachments/assets/fc0febdd-2c95-4c84-9683-9d0ac84ffe3c" />

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change