### PR TITLE
[AXON-856] fix message breaking on error retry

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -335,6 +335,9 @@ const RovoDevView: React.FC = () => {
                     break;
 
                 case RovoDevProviderMessageType.Response:
+                    if (currentState === State.WaitingForPrompt) {
+                        setCurrentState(State.GeneratingResponse);
+                    }
                     handleResponse(event.dataObject);
                     break;
 
@@ -352,10 +355,16 @@ const RovoDevView: React.FC = () => {
                     break;
 
                 case RovoDevProviderMessageType.ToolCall:
+                    if (currentState === State.WaitingForPrompt) {
+                        setCurrentState(State.GeneratingResponse);
+                    }
                     handleResponse(event.dataObject);
                     break;
 
                 case RovoDevProviderMessageType.ToolReturn:
+                    if (currentState === State.WaitingForPrompt) {
+                        setCurrentState(State.GeneratingResponse);
+                    }
                     handleResponse(event.dataObject);
                     break;
 

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -93,6 +93,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private _disabled = false;
     private _initialized = false;
 
+    private _chatBusy = false;
     private _chatSessionId: string = '';
     private _currentPromptId: string = '';
     private _currentPrompt: RovoDevPrompt | undefined;
@@ -465,6 +466,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     }
 
     private completeChatResponse(sourceApi: 'replay' | 'chat' | 'error') {
+        this._chatBusy = false;
         const webview = this._webView!;
         return webview.postMessage({
             type: RovoDevProviderMessageType.CompleteMessage,
@@ -654,7 +656,7 @@ ${message}`;
     }
 
     private async executeChat({ text, enable_deep_plan, context }: RovoDevPrompt, suppressEcho?: boolean) {
-        if (!text) {
+        if (!text || this._chatBusy) {
             return;
         }
 
@@ -677,6 +679,7 @@ ${message}`;
 
         const currentPrompt = this._currentPrompt;
         const fetchOp = async (client: RovoDevApiClient) => {
+            this._chatBusy = true;
             const response = await client.chat(payloadToSend, enable_deep_plan);
 
             this.fireTelemetryEvent('rovoDevPromptSentEvent', this._currentPromptId, !!currentPrompt.enable_deep_plan);
@@ -696,9 +699,7 @@ ${message}`;
     }
 
     private async executeRetryPromptAfterError() {
-        const webview = this._webView!;
-
-        if (!this._initialized || !this._currentPrompt) {
+        if (!this._initialized || !this._currentPrompt || this._chatBusy) {
             return;
         }
 
@@ -708,14 +709,14 @@ ${message}`;
         const payloadToSend = this.addRetryAfterErrorContextToPrompt(currentPrompt.text);
 
         // we need to echo back the prompt to the View since it's not user submitted
-        await webview.postMessage({
-            type: RovoDevProviderMessageType.PromptSent,
+        await this.sendPromptSentToView({
             text: payloadToSend,
             enable_deep_plan: currentPrompt.enable_deep_plan,
             context: currentPrompt.context,
         });
 
         const fetchOp = async (client: RovoDevApiClient) => {
+            this._chatBusy = true;
             const response = await client.chat(payloadToSend, currentPrompt.enable_deep_plan);
 
             this.fireTelemetryEvent('rovoDevPromptSentEvent', this._currentPromptId, !!currentPrompt.enable_deep_plan);
@@ -832,6 +833,7 @@ ${message}`;
 
         if (success) {
             this.fireTelemetryEvent('rovoDevStopActionEvent', this._currentPromptId);
+            this._chatBusy = false;
             return true;
         } else {
             this.fireTelemetryEvent('rovoDevStopActionEvent', this._currentPromptId, true);
@@ -999,6 +1001,7 @@ ${message}`;
             try {
                 return await func(this.rovoDevApiClient);
             } catch (error) {
+                this._chatBusy = false;
                 if (cancellationAware && this._pendingCancellation && error.cause?.code === 'UND_ERR_SOCKET') {
                     this._pendingCancellation = false;
                     this.completeChatResponse('error');


### PR DESCRIPTION
### What Is This Change?

in `rovoDevWebviewProvider` added `_chatBusy` so we do not call the chat endpoint while there is a current message. This led to some weird functionality

in `rovoDevView` added fallback state changes for worst case handling

### How Has This Been Tested?

manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`