### PR TITLE
AXON-857: modified files drawer is not updated on replay

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -270,7 +270,7 @@ const RovoDevView: React.FC = () => {
     }, []);
 
     const handleResponse = useCallback(
-        (data: RovoDevResponse) => {
+        (data: RovoDevResponse, isReplay?: boolean) => {
             switch (data.event_kind) {
                 case 'text':
                     if (!data.content) {
@@ -302,7 +302,9 @@ const RovoDevView: React.FC = () => {
 
                     setPendingToolCallMessage(DEFAULT_LOADING_MESSAGE); // Clear pending tool call
                     handleAppendToolReturn(returnMessage);
-                    handleAppendModifiedFileToolReturns(returnMessage);
+                    if (!isReplay) {
+                        handleAppendModifiedFileToolReturns(returnMessage);
+                    }
                     break;
 
                 case 'retry-prompt':
@@ -365,7 +367,8 @@ const RovoDevView: React.FC = () => {
                     if (currentState === State.WaitingForPrompt) {
                         setCurrentState(State.GeneratingResponse);
                     }
-                    handleResponse(event.dataObject);
+                    const isReplay = event.isReplay || false;
+                    handleResponse(event.dataObject, isReplay);
                     break;
 
                 case RovoDevProviderMessageType.ErrorMessage:

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -522,6 +522,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                 return webview.postMessage({
                     type: RovoDevProviderMessageType.ToolReturn,
                     dataObject: response,
+                    isReplay: sourceApi === 'replay',
                 });
 
             case 'retry-prompt':

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -27,6 +27,7 @@ export const enum RovoDevProviderMessageType {
 
 export interface RovoDevObjectResponse {
     dataObject: RovoDevResponse;
+    isReplay?: boolean;
 }
 
 export type RovoDevProviderMessage =


### PR DESCRIPTION
### What Is This Change?

Now passing a field to UI saying if a tool-return is from the replay

if it is, it will not be counted in the modified files drawer

### How Has This Been Tested?

manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`