### PR TITLE
Add debug-mode only commands to speed up development

### DIFF
--- a/package.json
+++ b/package.json
@@ -456,6 +456,21 @@
                 "command": "atlascode.showOnboardingFlow",
                 "title": "Show Onboarding Flow",
                 "category": "Atlassian"
+            },
+            {
+                "command": "atlascode.debug.quickCommand",
+                "title": "[DEBUG] Atlascode: Quick command",
+                "enablement": "atlascode:debugMode"
+            },
+            {
+                "command": "atlascode.debug.quickLogin",
+                "title": "[DEBUG] Atlascode: Quick login",
+                "enablement": "atlascode:debugMode"
+            },
+            {
+                "command": "atlascode.debug.quickLogout",
+                "title": "[DEBUG] Atlascode: Quick logout",
+                "enablement": "atlascode:debugMode"
             }
         ],
         "viewsContainers": {

--- a/src/commandContext.ts
+++ b/src/commandContext.ts
@@ -13,6 +13,7 @@ export enum CommandContext {
     IsBBAuthenticated = 'atlascode:isBBAuthenticated',
     RovoDevEnabled = 'atlascode:rovoDevEnabled',
     BbyEnvironmentActive = 'atlascode:bbyEnvironmentActive',
+    DebugMode = 'atlascode:debugMode',
 }
 
 export function setCommandContext(key: CommandContext | string, value: any) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { isMinimalIssue, MinimalIssue, MinimalIssueOrKeyAndSite } from '@atlassianlabs/jira-pi-common-models';
-import { commands, env, ExtensionContext, TextEditor, Uri, window } from 'vscode';
+import { commands, Disposable, env, ExtensionContext, TextEditor, Uri, window } from 'vscode';
 
 import {
     cloneRepositoryButtonEvent,
@@ -8,7 +8,7 @@ import {
     Registry,
     viewScreenEvent,
 } from './analytics';
-import { DetailedSiteInfo, ProductBitbucket, ProductJira } from './atlclients/authInfo';
+import { BasicAuthInfo, DetailedSiteInfo, ProductBitbucket, ProductJira } from './atlclients/authInfo';
 import { showBitbucketDebugInfo } from './bitbucket/bbDebug';
 import { rerunPipeline } from './commands/bitbucket/rerunPipeline';
 import { runPipeline } from './commands/bitbucket/runPipeline';
@@ -270,4 +270,87 @@ export function registerRovoDevCommands(vscodeContext: ExtensionContext) {
             });
         }),
     );
+}
+
+/**
+ * Commands to help with extension development, only enabled in debug mode
+ */
+export function registerDebugCommands(vscodeContext: ExtensionContext): Disposable {
+    const siteList = process.env.DEBUG_SITE_LIST?.split(',') || [];
+
+    const disposable = Disposable.from(
+        // Trigger arbitrary logic quickly when needed
+        commands.registerCommand(Commands.DebugQuickCommand, async () => {
+            if (!Container.isDebugging) {
+                return;
+            }
+
+            window.showInformationMessage('[DEBUG] Atlascode: Quick command');
+
+            // Add your logic here
+        }),
+
+        // Login to a cloud site with API token
+        commands.registerCommand(Commands.DebugQuickLogin, async () => {
+            if (!Container.isDebugging) {
+                return;
+            }
+
+            if (!process.env.DEBUG_USER_EMAIL || !process.env.DEBUG_USER_API_TOKEN || !siteList.length) {
+                window.showErrorMessage(
+                    'This command requires the following environment variables to be set: DEBUG_USER_EMAIL, DEBUG_USER_API_TOKEN, DEBUG_SITE_LIST',
+                );
+                return;
+            }
+
+            const selection = await window.showQuickPick(siteList, {
+                placeHolder: 'Select a site',
+            });
+
+            if (!selection) {
+                return;
+            }
+
+            Container.loginManager.userInitiatedServerLogin(
+                {
+                    host: selection,
+                    product: ProductJira,
+                },
+                {
+                    username: process.env.DEBUG_USER_EMAIL,
+                    password: process.env.DEBUG_USER_API_TOKEN,
+                } as BasicAuthInfo,
+            );
+        }),
+
+        // Log out of a cloud site
+        commands.registerCommand(Commands.DebugQuickLogout, async () => {
+            if (!Container.isDebugging) {
+                return;
+            }
+
+            if (!process.env.DEBUG_USER_EMAIL || !process.env.DEBUG_USER_API_TOKEN || !siteList.length) {
+                window.showErrorMessage(
+                    'This command requires the following environment variables to be set: DEBUG_USER_EMAIL, DEBUG_USER_API_TOKEN, DEBUG_SITE_LIST',
+                );
+                return;
+            }
+
+            const selection = await window.showQuickPick(siteList, {
+                placeHolder: 'Select a site',
+            });
+            if (!selection) {
+                return;
+            }
+
+            const info = Container.siteManager?.getSiteForHostname(ProductJira, selection);
+            if (info) {
+                await Container.clientManager.removeClient(info);
+                await Container.siteManager.removeSite(info);
+            }
+        }),
+    );
+    vscodeContext.subscriptions.push(disposable);
+
+    return disposable;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,6 +90,11 @@ export const enum Commands {
     OpenRovoDevConfig = 'atlascode.openRovoDevConfig',
     OpenRovoDevMcpJson = 'atlascode.openRovoDevMcpJson',
     OpenRovoDevGlobalMemory = 'atlascode.openRovoDevGlobalMemory',
+
+    // Debug mode-only commands
+    DebugQuickCommand = 'atlascode.debug.quickCommand',
+    DebugQuickLogin = 'atlascode.debug.quickLogin',
+    DebugQuickLogout = 'atlascode.debug.quickLogout',
 }
 
 // Rovodev port mapping settings

--- a/src/container.ts
+++ b/src/container.ts
@@ -12,6 +12,7 @@ import { CheckoutHelper } from './bitbucket/interfaces';
 import { PullRequest, WorkspaceRepo } from './bitbucket/model';
 import { BitbucketCloudPullRequestLinkProvider } from './bitbucket/terminal-link/createPrLinkProvider';
 import { CommandContext, setCommandContext } from './commandContext';
+import { registerDebugCommands } from './commands';
 import { openPullRequest } from './commands/bitbucket/pullRequest';
 import { configuration, IConfig } from './config/configuration';
 import { Commands } from './constants';
@@ -91,6 +92,11 @@ export class Container {
             deviceId: this.machineId,
             enable: this.getAnalyticsEnable(),
         });
+
+        if (this.isDebugging) {
+            setCommandContext(CommandContext.DebugMode, true);
+            registerDebugCommands(context);
+        }
 
         this._cancellationManager = new Map();
         this._analyticsApi = new VSCAnalyticsApi(this._analyticsClient, this.isRemote, this.isWebUI);


### PR DESCRIPTION
### What Is This Change?

Debug-only commands to log in and out of sites. No effect on the properly distributed version of the extension

### How Has This Been Tested?

Manually - see loom in #axon

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change