### PR TITLE
[AXON-849] Implement proper cleanup at credential change

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,15 +95,18 @@
         "commands": [
             {
                 "command": "atlascode.rovodev.askInteractive",
-                "title": "Rovo Dev: Quick Ask"
+                "title": "Rovo Dev: Quick Ask",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.rovodev.askRovoDev",
-                "title": "Ask Rovo Dev"
+                "title": "Ask Rovo Dev",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.rovodev.addToContext",
-                "title": "Add selection to Rovo Dev context"
+                "title": "Add selection to Rovo Dev context",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.rovodev.newChatSession",
@@ -112,7 +115,8 @@
                     "dark": "resources/dark/add.svg",
                     "light": "resources/light/add.svg"
                 },
-                "category": "Atlassian"
+                "category": "Atlassian",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.rovodev.showTerminal",
@@ -124,19 +128,22 @@
                 "command": "atlascode.openRovoDevConfig",
                 "title": "Open Rovo Dev settings file",
                 "category": "Atlascode",
-                "description": "Opens the ~/.rovodev/config.yaml file in the editor."
+                "description": "Opens the ~/.rovodev/config.yaml file in the editor.",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.openRovoDevMcpJson",
                 "title": "Open Rovo Dev MCP configuration",
                 "category": "Atlascode",
-                "description": "Opens the ~/.rovodev/mcp.json file in the editor."
+                "description": "Opens the ~/.rovodev/mcp.json file in the editor.",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.openRovoDevGlobalMemory",
                 "title": "Open Rovo Dev Global Memory file",
                 "category": "Atlascode",
-                "description": "Opens the ~/.rovodev/.agent.md file in the editor."
+                "description": "Opens the ~/.rovodev/.agent.md file in the editor.",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.jira.todoIssue",

--- a/src/rovo-dev/rovoDevCodeActionProvider.ts
+++ b/src/rovo-dev/rovoDevCodeActionProvider.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { Commands } from 'src/constants';
+import { Container } from 'src/container';
 import * as vscode from 'vscode';
 
 export class RovoDevCodeActionProvider implements vscode.CodeActionProvider {
@@ -9,6 +10,11 @@ export class RovoDevCodeActionProvider implements vscode.CodeActionProvider {
         context: vscode.CodeActionContext,
         token: vscode.CancellationToken,
     ): vscode.ProviderResult<vscode.CodeAction[]> {
+        // Disable completely if Rovo Dev is not enabled
+        if (!Container.isRovoDevEnabled) {
+            return [];
+        }
+
         // Only show if there is a selection
         if (!range || range.isEmpty) {
             return [];

--- a/src/rovo-dev/rovoDevDecorator.ts
+++ b/src/rovo-dev/rovoDevDecorator.ts
@@ -5,6 +5,7 @@
  * The annotation is shown only if enabled via the `atlascode.rovodev.showKeybinding` setting.
  * Decoration updates automatically on selection, editor, and configuration changes.
  */
+import { Container } from 'src/container';
 import { Range, ThemeColor, window, workspace } from 'vscode';
 
 export class RovoDevDecorator {
@@ -47,7 +48,7 @@ export class RovoDevDecorator {
         if (!editor) {
             return;
         }
-        if (!this.enabled) {
+        if (!Container.isRovoDevEnabled || !this.enabled) {
             editor.setDecorations(this.keybindingDecoration, []);
             return;
         }

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -101,7 +101,7 @@ async function getCloudCredentials(): Promise<{ username: string; key: string; h
     return results.length > 0 ? results[0] : undefined;
 }
 
-export class RovoDevProcessManager extends Disposable {
+export class RovoDevProcessManager {
     private static disposables: Disposable[] = [];
 
     // Reference to the RovoDev webview provider for sending errors to chat

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -383,12 +383,18 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         // Listen for active editor changes
         this._disposables.push(
             window.onDidChangeActiveTextEditor((editor) => {
+                if (!Container.isRovoDevEnabled) {
+                    return;
+                }
                 this.forceUserFocusUpdate(editor);
             }),
         );
         // Listen for selection changes
         this._disposables.push(
             window.onDidChangeTextEditorSelection((event) => {
+                if (!Container.isRovoDevEnabled) {
+                    return;
+                }
                 this.forceUserFocusUpdate(event.textEditor);
             }),
         );


### PR DESCRIPTION
### What Is This Change?

Added missing bits for Rovodev cleanup that happens when the functionality gets toggled (e.g. on settings change or authentication).

As a general rule - we now store a `Disposable` container with all rovodev-related stuff, and `dispose`/re-create it when needed.

There are also some safeguards now around command declaration and implementation that check against `Container.isRovoDevEnabled`

The one thing notably missing here is the non-rovodev webview integrations - will catch them up in a follow-up PR

### How Has This Been Tested?

Manually, through exhaustive use of the new debug commands :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change