### PR TITLE
[AXON-849] fix: the rovodev button now appears in issue view when exp…

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -247,6 +247,9 @@ export class Container {
         );
 
         context.subscriptions.push(this._rovodevDisposable);
+
+        // Refresh all issue views to show the secret button
+        this.jiraIssueViewManager.refreshAll();
     }
 
     static disableRovoDev(context: ExtensionContext) {
@@ -259,6 +262,9 @@ export class Container {
         this._rovodevDisposable.dispose();
         this._rovodevDisposable = undefined;
         RovoDevProcessManager.deactivateRovoDevProcessManager();
+
+        // Refresh all issue views to hide the secret button
+        this.jiraIssueViewManager.refreshAll();
     }
 
     static configureRovodevSettingsCommands(context: ExtensionContext) {

--- a/src/webview/singleViewFactory.ts
+++ b/src/webview/singleViewFactory.ts
@@ -162,7 +162,7 @@ export class SingleWebview<FD, R> implements ReactWebview<FD> {
         }
     }
 
-    private fireAdditionalSettings(settings: AdditionalSettings) {
+    protected fireAdditionalSettings(settings: AdditionalSettings) {
         this.postMessage({ type: CommonMessageType.AdditionalSettings, settings });
     }
 

--- a/src/webviews/abstractWebview.ts
+++ b/src/webviews/abstractWebview.ts
@@ -162,7 +162,7 @@ export abstract class AbstractReactWebview implements ReactWebview {
         }
     }
 
-    private fireAdditionalSettings(settings: AdditionalSettings) {
+    protected fireAdditionalSettings(settings: AdditionalSettings) {
         this.postMessage({ type: CommonMessageType.AdditionalSettings, settings });
     }
 

--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -204,7 +204,7 @@ export abstract class AbstractIssueEditorPage<
                 break;
             }
             case 'additionalSettings': {
-                this.setState({ isRovoDevEnabled: e.rovoDevEnabled });
+                this.setState({ isRovoDevEnabled: e.settings.rovoDevEnabled });
                 break;
             }
         }

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -100,6 +100,10 @@ export class JiraIssueWebview
     }
 
     async invalidate() {
+        // TODO: we might want to also update feature gates here?
+        this.fireAdditionalSettings({
+            rovoDevEnabled: Container.isRovoDevEnabled,
+        });
         await this.forceUpdateIssue();
         Container.jiraActiveIssueStatusBar.handleActiveIssueChange(this._issue.key);
         Container.pmfStats.touchActivity();


### PR DESCRIPTION
### What Is This Change?

> ⚠️ Note: this is a daisy chain PR since the other one got stuck w/ E2E tests lol
>
> I forgot how GH handles daisy chain PRs, let's see what happens with this one

The change: our experimental `rovodev` button in the issue view now appears and disappears as expected

There's still a minor issue with it not appearing properly the 1st time around - and I'd rather not spend more time hunting this down right now, since there's going to be a ton of iteration on that, anyway

### How Has This Been Tested?

Manually, see loom in #axon

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change