### PR TITLE
AXON-840: cleanup auth flow from extra calls

### DIFF
--- a/src/atlclients/responseHandlers/JiraPKCEResponseHandler.ts
+++ b/src/atlclients/responseHandlers/JiraPKCEResponseHandler.ts
@@ -69,8 +69,6 @@ export class JiraPKCEResponseHandler extends ResponseHandler {
 
     public async accessibleResources(accessToken: string): Promise<AccessibleResource[]> {
         try {
-            const resources: AccessibleResource[] = [];
-
             const resourcesResponse = await this.axios(this.strategy.accessibleResourcesUrl(), {
                 method: 'GET',
                 headers: {
@@ -81,11 +79,7 @@ export class JiraPKCEResponseHandler extends ResponseHandler {
                 ...this.agent,
             });
 
-            resourcesResponse.data.forEach((resource: AccessibleResource) => {
-                resources.push(resource);
-            });
-
-            return resources;
+            return resourcesResponse.data;
         } catch (err) {
             Logger.error(err, 'Error fetching Jira resources');
             throw new Error(`Error fetching Jira resources: ${err}`);

--- a/src/jira/fetchIssue.test.ts
+++ b/src/jira/fetchIssue.test.ts
@@ -70,7 +70,7 @@ describe('fetchIssue', () => {
         };
 
         (Container.jiraSettingsManager as any) = {
-            getMinimalIssueFieldIdsForSite: jest.fn().mockResolvedValue(mockFieldIds),
+            getMinimalIssueFieldIdsForSite: jest.fn().mockReturnValue(mockFieldIds),
             getEpicFieldsForSite: jest.fn().mockResolvedValue(mockEpicInfo),
             getAllFieldsForSite: jest.fn().mockResolvedValue(mockFields),
             getIssueLinkTypes: jest.fn().mockResolvedValue(mockIssueLinkTypes),
@@ -182,9 +182,9 @@ describe('fetchIssue', () => {
             expect(FeatureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
                 Experiments.AtlascodePerformanceExperiment,
             );
-            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockSiteDetails);
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSiteDetails);
             expect(Container.jiraSettingsManager.getEpicFieldsForSite).toHaveBeenCalledWith(mockSiteDetails);
+            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockEpicInfo);
             expect(mockClient.getIssue).toHaveBeenCalledWith(mockIssueKey, mockFieldIds);
             expect(jiraPiCommonModels.minimalIssueFromJsonObject).toHaveBeenCalledWith(
                 mockIssueResponse,
@@ -201,9 +201,9 @@ describe('fetchIssue', () => {
             expect(FeatureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
                 Experiments.AtlascodePerformanceExperiment,
             );
-            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockSiteDetails);
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSiteDetails);
             expect(Container.jiraSettingsManager.getEpicFieldsForSite).toHaveBeenCalledWith(mockSiteDetails);
+            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockEpicInfo);
             expect(mockClient.getIssue).toHaveBeenCalledWith(mockIssueKey, mockFieldIds);
             expect(jiraPiCommonModels.minimalIssueFromJsonObject).toHaveBeenCalledWith(
                 mockIssueResponse,
@@ -232,8 +232,9 @@ describe('fetchIssue', () => {
             const result = await getCachedOrFetchMinimalIssue(mockIssueKey, mockSiteDetails);
 
             expect(SearchJiraHelper.findIssue).toHaveBeenCalledWith(mockIssueKey);
-            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockSiteDetails);
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSiteDetails);
+            expect(Container.jiraSettingsManager.getEpicFieldsForSite).toHaveBeenCalledWith(mockSiteDetails);
+            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockEpicInfo);
             expect(mockClient.getIssue).toHaveBeenCalledWith(mockIssueKey, mockFieldIds);
             expect(result).toBe(mockMinimalIssue);
         });
@@ -246,8 +247,9 @@ describe('fetchIssue', () => {
 
             expect(SearchJiraHelper.findIssue).toHaveBeenCalledWith(mockIssueKey);
             expect(jiraPiCommonModels.isMinimalIssue).toHaveBeenCalledWith(mockMinimalIssue);
-            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockSiteDetails);
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSiteDetails);
+            expect(Container.jiraSettingsManager.getEpicFieldsForSite).toHaveBeenCalledWith(mockSiteDetails);
+            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockEpicInfo);
             expect(mockClient.getIssue).toHaveBeenCalledWith(mockIssueKey, mockFieldIds);
             expect(result).toBe(mockMinimalIssue);
         });

--- a/src/jira/fetchIssue.ts
+++ b/src/jira/fetchIssue.ts
@@ -52,18 +52,19 @@ export async function fetchMinimalIssue(
 ): Promise<MinimalIssue<DetailedSiteInfo>> {
     const performanceEnabled = FeatureFlagClient.checkExperimentValue(Experiments.AtlascodePerformanceExperiment);
     if (performanceEnabled) {
-        const [fieldIds, client, epicInfo] = await Promise.all([
-            Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(siteDetails),
+        const [client, epicInfo] = await Promise.all([
             Container.clientManager.jiraClient(siteDetails),
             Container.jiraSettingsManager.getEpicFieldsForSite(siteDetails),
         ]);
+        const fieldIds = Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(epicInfo);
 
         const res = await client.getIssue(issue, fieldIds);
         return minimalIssueFromJsonObject(res, siteDetails, epicInfo);
     }
-    const fieldIds = await Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(siteDetails);
     const client = await Container.clientManager.jiraClient(siteDetails);
     const epicInfo = await Container.jiraSettingsManager.getEpicFieldsForSite(siteDetails);
+    const fieldIds = Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(epicInfo);
+
     const res = await client.getIssue(issue, fieldIds);
     return minimalIssueFromJsonObject(res, siteDetails, epicInfo);
 }

--- a/src/jira/issuesForJql.test.ts
+++ b/src/jira/issuesForJql.test.ts
@@ -82,7 +82,7 @@ describe('issuesForJQL', () => {
         // Setup default mock implementations
         mockClient.searchForIssuesUsingJqlGet.mockResolvedValue({});
         (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
-        (Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite as jest.Mock).mockResolvedValue(mockFields);
+        (Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite as jest.Mock).mockReturnValue(mockFields);
         (Container.jiraSettingsManager.getEpicFieldsForSite as jest.Mock).mockResolvedValue(mockEpicFieldInfo);
         (Container.jiraSettingsManager.getIssueLinkTypes as jest.Mock).mockResolvedValue([]);
         (Container.jiraSettingsManager.getIssueCreateMetadata as jest.Mock).mockResolvedValue({});
@@ -101,8 +101,8 @@ describe('issuesForJQL', () => {
 
         // Verify dependencies were called with correct parameters
         expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSite);
-        expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockSite);
         expect(Container.jiraSettingsManager.getEpicFieldsForSite).toHaveBeenCalledWith(mockSite);
+        expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockEpicFieldInfo);
         expect(Container.jiraSettingsManager.getIssueLinkTypes).toHaveBeenCalledWith(mockSite);
         expect(Container.jiraSettingsManager.getIssueCreateMetadata).toHaveBeenCalledWith('TEST', mockSite);
         expect(mockClient.searchForIssuesUsingJqlGet).toHaveBeenCalledWith(mockJql, mockFields, MAX_RESULTS, 0);
@@ -123,8 +123,8 @@ describe('issuesForJQL', () => {
 
         // Verify dependencies were called with correct parameters
         expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSite);
-        expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockSite);
         expect(Container.jiraSettingsManager.getEpicFieldsForSite).toHaveBeenCalledWith(mockSite);
+        expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(mockEpicFieldInfo);
         expect(mockClient.searchForIssuesUsingJqlGet).toHaveBeenCalledWith(mockJql, mockFields, MAX_RESULTS, 0);
         expect(readSearchResults).toHaveBeenCalledWith({}, mockSite, mockEpicFieldInfo);
 

--- a/src/jira/issuesForJql.ts
+++ b/src/jira/issuesForJql.ts
@@ -11,10 +11,8 @@ export async function issuesForJQL(jql: string, site: DetailedSiteInfo): Promise
     const performanceEnabled = FeatureFlagClient.checkExperimentValue(Experiments.AtlascodePerformanceExperiment);
     let issues: MinimalIssue<DetailedSiteInfo>[] = [];
     if (performanceEnabled) {
-        const [fields, epicFieldInfo] = await Promise.all([
-            Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(site),
-            Container.jiraSettingsManager.getEpicFieldsForSite(site),
-        ]);
+        const epicFieldInfo = await Container.jiraSettingsManager.getEpicFieldsForSite(site);
+        const fields = Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(epicFieldInfo);
 
         let index = 0;
         let total = 0;
@@ -39,8 +37,8 @@ export async function issuesForJQL(jql: string, site: DetailedSiteInfo): Promise
             }
         }
     } else {
-        const fields = await Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(site);
         const epicFieldInfo = await Container.jiraSettingsManager.getEpicFieldsForSite(site);
+        const fields = Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(epicFieldInfo);
 
         let index = 0;
         let total = 0;

--- a/src/jira/settingsManager.test.ts
+++ b/src/jira/settingsManager.test.ts
@@ -179,19 +179,20 @@ describe('JiraSettingsManager', () => {
     });
 
     describe('getMinimalIssueFieldIdsForSite', () => {
-        beforeEach(() => {
-            // Mock getEpicFieldsForSite for tests
-            jest.spyOn(settingsManager, 'getEpicFieldsForSite').mockImplementation(async () => {
-                return {
-                    epicsEnabled: true,
-                    epicLink: { id: 'custom-epic-link', name: 'Epic Link' },
-                    epicName: { id: 'custom-epic-name', name: 'Epic Name' },
-                } as EpicFieldInfo;
-            });
-        });
+        const mockEpicInfoEnabled = {
+            epicsEnabled: true,
+            epicLink: { id: 'custom-epic-link', name: 'Epic Link' },
+            epicName: { id: 'custom-epic-name', name: 'Epic Name' },
+        } as EpicFieldInfo;
 
-        it('should return minimal issue fields including epic fields when epics are enabled', async () => {
-            const result = await settingsManager.getMinimalIssueFieldIdsForSite(mockSiteDetails);
+        const mockEpicInfoDisabled = {
+            epicsEnabled: false,
+            epicLink: { id: 'custom-epic-link', name: 'Epic Link' },
+            epicName: { id: 'custom-epic-name', name: 'Epic Name' },
+        } as EpicFieldInfo;
+
+        it('should return minimal issue fields including epic fields when epics are enabled', () => {
+            const result = settingsManager.getMinimalIssueFieldIdsForSite(mockEpicInfoEnabled);
 
             // Check that all default fields are included
             expect(result).toContain('summary');
@@ -210,16 +211,8 @@ describe('JiraSettingsManager', () => {
             expect(result).toContain('custom-epic-name');
         });
 
-        it('should return minimal issue fields without epic fields when epics are disabled', async () => {
-            jest.spyOn(settingsManager, 'getEpicFieldsForSite').mockImplementation(async () => {
-                return {
-                    epicsEnabled: false,
-                    epicLink: { id: 'custom-epic-link', name: 'Epic Link' },
-                    epicName: { id: 'custom-epic-name', name: 'Epic Name' },
-                } as EpicFieldInfo;
-            });
-
-            const result = await settingsManager.getMinimalIssueFieldIdsForSite(mockSiteDetails);
+        it('should return minimal issue fields without epic fields when epics are disabled', () => {
+            const result = settingsManager.getMinimalIssueFieldIdsForSite(mockEpicInfoDisabled);
 
             // Check that all default fields are included
             expect(result).toContain('summary');

--- a/src/jira/settingsManager.ts
+++ b/src/jira/settingsManager.ts
@@ -91,9 +91,8 @@ export class JiraSettingsManager extends Disposable {
         return this._issueLinkTypesStore.get(site.id)!;
     }
 
-    public async getMinimalIssueFieldIdsForSite(site: DetailedSiteInfo): Promise<string[]> {
+    public getMinimalIssueFieldIdsForSite(epicInfo: EpicFieldInfo): string[] {
         const fields = Array.from(minimalDefaultIssueFields);
-        const epicInfo = await this.getEpicFieldsForSite(site);
 
         if (epicInfo.epicsEnabled) {
             fields.push(epicInfo.epicLink.id, epicInfo.epicName.id);

--- a/src/webviews/jiraIssueWebview.test.ts
+++ b/src/webviews/jiraIssueWebview.test.ts
@@ -406,7 +406,7 @@ describe('JiraIssueWebview', () => {
                 ],
             };
 
-            (Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite as jest.Mock).mockResolvedValue([
+            (Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite as jest.Mock).mockReturnValue([
                 'summary',
                 'status',
             ]);
@@ -422,6 +422,7 @@ describe('JiraIssueWebview', () => {
             await jiraIssueWebview.updateEpicChildren();
 
             expect(Container.jiraSettingsManager.getEpicFieldsForSite).toHaveBeenCalledWith(mockSiteDetails);
+            expect(Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite).toHaveBeenCalledWith(epicInfo);
             expect(mockJiraClient.searchForIssuesUsingJqlGet).toHaveBeenCalledWith(
                 `parent = "${epicIssue.key}" order by lastViewed DESC`,
                 ['summary', 'status'],

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -195,11 +195,11 @@ export class JiraIssueWebview
                 Experiments.AtlascodePerformanceExperiment,
             );
             if (performanceEnabled) {
-                const [client, fields, epicInfo] = await Promise.all([
+                const [client, epicInfo] = await Promise.all([
                     Container.clientManager.jiraClient(site),
-                    Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(site),
                     Container.jiraSettingsManager.getEpicFieldsForSite(site),
                 ]);
+                const fields = Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(epicInfo);
                 let jqlQuery: string = '';
                 if (site.isCloud) {
                     jqlQuery = `parent = "${this._issue.key}" order by lastViewed DESC`;
@@ -211,8 +211,8 @@ export class JiraIssueWebview
                 this.postMessage({ type: 'epicChildrenUpdate', epicChildren: searchResults.issues });
             } else {
                 const client = await Container.clientManager.jiraClient(site);
-                const fields = await Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(site);
                 const epicInfo = await Container.jiraSettingsManager.getEpicFieldsForSite(site);
+                const fields = Container.jiraSettingsManager.getMinimalIssueFieldIdsForSite(epicInfo);
 
                 let jqlQuery: string = '';
                 if (site.isCloud) {


### PR DESCRIPTION
### What Is This Change?

1. This PR updates the `softRefreshOauth` logic to prevent duplicate concurrent refresh calls for the same credential key. Previously, if multiple requests ( from several connected instances or from several places in app where we need fresh credentials ) were made with the same key, each would initialize its own refresh, potentially causing 403 errors. 
In this PR Promise caching is added, so only one refresh request is executed, while all parallel callers await the same promise. 

2. Added some optimization for Jira field fetching process to reduce redundant API calls to Jira

3. Added missing `await` for `saveAuthInfo` method, removed unnecessary manual array construction in `accessibleResources` method


<!--
Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change