### PR TITLE
[AXON-863, AXON-864][Rovo Dev] Handle clear and prune commands

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -395,7 +395,7 @@ const RovoDevView: React.FC = () => {
                     handleAppendError(event.message);
                     break;
 
-                case RovoDevProviderMessageType.NewSession:
+                case RovoDevProviderMessageType.ClearChat:
                     clearChatHistory();
                     setPendingToolCallMessage('');
                     setCurrentState(State.WaitingForPrompt);

--- a/src/rovo-dev/responseParser.ts
+++ b/src/rovo-dev/responseParser.ts
@@ -89,6 +89,26 @@ interface RovoDevWarningChunk {
     data: RovoDevWarningResponseRaw;
 }
 
+// ??
+interface RovoDevClearResponseRaw {
+    message: string;
+}
+
+interface RovoDevClearChunk {
+    event_kind: 'clear';
+    data: RovoDevClearResponseRaw;
+}
+
+// ??
+interface RovoDevPruneResponseRaw {
+    message: string;
+}
+
+interface RovoDevPruneChunk {
+    event_kind: 'prune';
+    data: RovoDevPruneResponseRaw;
+}
+
 type RovoDevSingleResponseRaw =
     | RovoDevUserPromptResponseRaw
     | RovoDevTextResponseRaw
@@ -96,7 +116,9 @@ type RovoDevSingleResponseRaw =
     | RovoDevToolReturnResponseRaw
     | RovoDevRetryPromptResponseRaw
     | RovoDevWarningResponseRaw
-    | RovoDevExceptionResponseRaw;
+    | RovoDevExceptionResponseRaw
+    | RovoDevClearResponseRaw
+    | RovoDevPruneResponseRaw;
 
 type RovoDevSingleChunk =
     | RovoDevUserPromptChunk
@@ -105,7 +127,9 @@ type RovoDevSingleChunk =
     | RovoDevToolReturnChunk
     | RovoDevRetryPromptChunk
     | RovoDevExceptionChunk
-    | RovoDevWarningChunk;
+    | RovoDevWarningChunk
+    | RovoDevClearChunk
+    | RovoDevPruneChunk;
 
 // https://ai.pydantic.dev/api/messages/#pydantic_ai.messages.PartStartEvent
 interface RovoDevPartStartResponseRaw {
@@ -179,6 +203,16 @@ export interface RovoDevWarningResponse {
     title?: string;
 }
 
+export interface RovoDevClearResponse {
+    event_kind: 'clear';
+    message: string;
+}
+
+export interface RovoDevPruneResponse {
+    event_kind: 'prune';
+    message: string;
+}
+
 export type RovoDevResponse =
     | RovoDevUserPromptResponse
     | RovoDevTextResponse
@@ -186,7 +220,9 @@ export type RovoDevResponse =
     | RovoDevToolReturnResponse
     | RovoDevRetryPromptResponse
     | RovoDevExceptionResponse
-    | RovoDevWarningResponse;
+    | RovoDevWarningResponse
+    | RovoDevClearResponse
+    | RovoDevPruneResponse;
 
 // parsing functions for specific response types
 
@@ -285,6 +321,20 @@ function parseResponseWarning(data: RovoDevWarningResponseRaw): RovoDevWarningRe
         event_kind: 'warning',
         message: data.message,
         title: data.title,
+    };
+}
+
+function parseResponseClear(data: RovoDevWarningResponseRaw): RovoDevClearResponse {
+    return {
+        event_kind: 'clear',
+        message: data.message,
+    };
+}
+
+function parseResponsePrune(data: RovoDevWarningResponseRaw): RovoDevPruneResponse {
+    return {
+        event_kind: 'prune',
+        message: data.message,
     };
 }
 
@@ -456,6 +506,18 @@ export class RovoDevResponseParser {
                     throw new Error(`Rovo Dev parser error: ${chunk.event_kind} seem to be split`);
                 }
                 return parseResponseWarning(chunk.data);
+
+            case 'clear':
+                if (buffer) {
+                    throw new Error(`Rovo Dev parser error: ${chunk.event_kind} seem to be split`);
+                }
+                return parseResponseClear(chunk.data);
+
+            case 'prune':
+                if (buffer) {
+                    throw new Error(`Rovo Dev parser error: ${chunk.event_kind} seem to be split`);
+                }
+                return parseResponsePrune(chunk.data);
 
             default:
                 throw new Error(`Rovo Dev parser error: unknown event kind: ${(chunk as any).event_kind}`);

--- a/src/rovo-dev/rovoDevApiClient.ts
+++ b/src/rovo-dev/rovoDevApiClient.ts
@@ -94,7 +94,6 @@ export class RovoDevApiClient {
     }
 
     /** Invokes the POST `/v2/replay` API
-     *
      * @returns {Promise<Response>} An object representing the API response.
      */
     public replay(): Promise<Response> {
@@ -115,6 +114,24 @@ export class RovoDevApiClient {
      */
     public tool(tool_name: string, args: Record<string, string>) {
         throw new Error('Method not implemented: tool');
+    }
+
+    /** Invokes the POST `/v2/clear` API
+     * @returns {Promise<string>} The message returned by the clear API.
+     */
+    public async clear(): Promise<string> {
+        const response = await this.fetchApi('/v2/clear', 'POST');
+        const responseJson = await response.json();
+        return responseJson.message;
+    }
+
+    /** Invokes the POST `/v2/prune` API
+     * @returns {Promise<string>} The message returned by the prune API.
+     */
+    public async prune(): Promise<string> {
+        const response = await this.fetchApi('/v2/prune', 'POST');
+        const responseJson = await response.json();
+        return responseJson.message;
     }
 
     /** Invokes the GET `/v2/cache-file-path` API.

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -13,7 +13,7 @@ export const enum RovoDevProviderMessageType {
     ToolCall = 'toolCall',
     ToolReturn = 'toolReturn',
     ErrorMessage = 'errorMessage',
-    NewSession = 'newSession',
+    ClearChat = 'clearChat',
     SetInitState = 'setInitState',
     WorkspaceChanged = 'workspaceChanged',
     SetDownloadProgress = 'setDownloadProgress',
@@ -40,7 +40,7 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.ToolCall, RovoDevObjectResponse>
     | ReducerAction<RovoDevProviderMessageType.ToolReturn, RovoDevObjectResponse>
     | ReducerAction<RovoDevProviderMessageType.ErrorMessage, { message: ErrorMessage }>
-    | ReducerAction<RovoDevProviderMessageType.NewSession>
+    | ReducerAction<RovoDevProviderMessageType.ClearChat>
     | ReducerAction<RovoDevProviderMessageType.SetInitState, { newState: RovoDevInitState }>
     | ReducerAction<RovoDevProviderMessageType.WorkspaceChanged, { workspaceCount: number }>
     | ReducerAction<RovoDevProviderMessageType.SetDownloadProgress, { downloadedBytes: number; totalBytes: number }>


### PR DESCRIPTION
### What Is This Change?

This change handles the special prompts `/clear` and `/prune`, for which Rovo Dev responds with custom messages.

On `clear` response, we clear the chat.
On `prune` response, we simply display the message information in the chat.

![clear](https://github.com/user-attachments/assets/757cc047-bf96-4fb9-a73b-2fd1882ef94f)

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`