### PR TITLE
[Rov Dev] Fix workspace initialization

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -259,6 +259,13 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         break;
 
                     case RovoDevViewResponseType.WebviewReady:
+                        if (!this.isBoysenberry && !this.isDisabled) {
+                            await webview.postMessage({
+                                type: RovoDevProviderMessageType.WorkspaceChanged,
+                                workspaceCount: workspace.workspaceFolders?.length || 0,
+                            });
+                        }
+
                         const port = parseInt(process.env[rovodevInfo.envVars.port] || '0');
                         if (port) {
                             this.signalProcessStarted(port);
@@ -284,13 +291,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                     });
                 }
             });
-
-            if (!this.isDisabled) {
-                webview.postMessage({
-                    type: RovoDevProviderMessageType.WorkspaceChanged,
-                    workspaceCount: workspace.workspaceFolders?.length || 0,
-                });
-            }
         }
     }
 


### PR DESCRIPTION
### What Is This Change?

The issue is that the webview is much slower than the provider to initialize, so when the `WorkspaceChanged` event was sent the webview wasn't initialized yet, and the message got lost.

Moved the postMessage(`WorkspaceChanged`) after `WebviewReady` is received.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`
