### PR TITLE
Fallback FeatureFlag client for when updating the user fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
                 "command": "atlascode.rovodev.showTerminal",
                 "title": "Trail Logs",
                 "icon": "$(terminal)",
-                "category": "Rovo Dev"
+                "category": "Rovo Dev",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.openRovoDevConfig",

--- a/src/commands/jira/startWorkOnIssue.ts
+++ b/src/commands/jira/startWorkOnIssue.ts
@@ -3,12 +3,12 @@ import { isMinimalIssue, MinimalIssue, MinimalIssueOrKeyAndSite } from '@atlassi
 import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { Container } from '../../container';
 import { fetchMinimalIssue } from '../../jira/fetchIssue';
-import { FeatureFlagClient, Features } from '../../util/featureFlags';
+import { Features } from '../../util/featureFlags';
 
 export async function startWorkOnIssue(issueOrKeyAndSite: MinimalIssueOrKeyAndSite<DetailedSiteInfo>) {
     let issue: MinimalIssue<DetailedSiteInfo>;
 
-    if (FeatureFlagClient.checkGate(Features.StartWorkV3)) {
+    if (Container.featureFlagClient.checkGate(Features.StartWorkV3)) {
         issue = await fetchMinimalIssue(issueOrKeyAndSite.key, issueOrKeyAndSite.siteDetails);
     } else {
         if (isMinimalIssue(issueOrKeyAndSite)) {
@@ -24,7 +24,7 @@ export async function startWorkOnIssue(issueOrKeyAndSite: MinimalIssueOrKeyAndSi
 
     const { startWorkV3WebviewFactory, startWorkWebviewFactory } = Container;
 
-    const factory = FeatureFlagClient.checkGate(Features.StartWorkV3)
+    const factory = Container.featureFlagClient.checkGate(Features.StartWorkV3)
         ? startWorkV3WebviewFactory
         : startWorkWebviewFactory;
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -182,26 +182,12 @@ export class Container {
         this._bitbucketHelper = new BitbucketCheckoutHelper(context.globalState);
         context.subscriptions.push(new HelpExplorer());
 
+        this._featureFlagClient = FeatureFlagClient.getInstance();
+
         try {
-            await FeatureFlagClient.initialize({
-                analyticsClient: this._analyticsClient,
-                identifiers: {
-                    analyticsAnonymousId: this.machineId,
-                    tenantId: this._siteManager.primarySite?.id,
-                },
+            await this._featureFlagClient.initialize({
+                analyticsAnonymousId: this.machineId,
             });
-
-            if (!process.env.ROVODEV_BBY) {
-                this._siteManager.onDidSitesAvailableChange(async () => {
-                    await FeatureFlagClient.updateUser({ tenantId: this._siteManager.primarySite?.id });
-
-                    if (FeatureFlagClient.checkGate(Features.RovoDevEnabled)) {
-                        this.enableRovoDev(context);
-                    } else {
-                        this.disableRovoDev(context);
-                    }
-                });
-            }
 
             Logger.debug(`FeatureFlagClient: Succesfully initialized the client.`);
             featureFlagClientInitializedEvent(true).then((e) => {
@@ -209,10 +195,27 @@ export class Container {
             });
         } catch (err) {
             const error = err as FeatureFlagClientInitError;
-            Logger.debug(`FeatureFlagClient: Failed to initialize the client: ${error.reason}`);
-            featureFlagClientInitializedEvent(false, error.errorType, error.reason).then((e) => {
+            Logger.debug(`FeatureFlagClient: Failed to initialize the client: ${error.message}`);
+            featureFlagClientInitializedEvent(false, error.errorType, error.message).then((e) => {
                 this.analyticsClient.sendTrackEvent(e);
             });
+        }
+
+        if (!process.env.ROVODEV_BBY) {
+            this._siteManager.onDidSitesAvailableChange(async () => {
+                if (await this.updateFeatureFlagTenantId(this._siteManager.primarySite?.id)) {
+                    if (this._featureFlagClient.checkGate(Features.RovoDevEnabled)) {
+                        this.enableRovoDev(context);
+                    } else {
+                        this.disableRovoDev(context);
+                    }
+                }
+            });
+        }
+
+        const tenantId = this._siteManager.primarySite?.id;
+        if (tenantId) {
+            await this.updateFeatureFlagTenantId(tenantId);
         }
 
         context.subscriptions.push(AtlascodeUriHandler.create(this._analyticsApi, this._bitbucketHelper));
@@ -223,9 +226,19 @@ export class Container {
 
         this._onboardingProvider = new OnboardingProvider();
 
-        if (process.env.ROVODEV_BBY || FeatureFlagClient.checkGate(Features.RovoDevEnabled)) {
+        if (process.env.ROVODEV_BBY || this.featureFlagClient.checkGate(Features.RovoDevEnabled)) {
             this._isRovoDevEnabled = true;
             this.enableRovoDev(context);
+        }
+    }
+
+    static async updateFeatureFlagTenantId(tenantId: string | undefined): Promise<boolean> {
+        try {
+            await this._featureFlagClient.updateUser({ tenantId });
+            return true;
+        } catch (err) {
+            Logger.error('RovoDev', err, "FeatureFlagClient: Failed to update user's tenantId");
+            return false;
         }
     }
 
@@ -373,7 +386,12 @@ export class Container {
         this._context.globalState.update(ConfigTargetKey, target);
     }
 
-    private static _isInAtlassianNetwork: boolean | undefined = undefined;
+    private static _featureFlagClient: FeatureFlagClient;
+    public static get featureFlagClient() {
+        return this._featureFlagClient;
+    }
+
+    private static _isInAtlassianNetwork: boolean | undefined;
     public static get isInAtlassianNetwork() {
         return this._isInAtlassianNetwork;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import {
 import { registerResources } from './resources';
 import { RovoDevProcessManager } from './rovo-dev/rovoDevProcessManager';
 import { GitExtension } from './typings/git';
-import { FeatureFlagClient, Features } from './util/featureFlags';
+import { Features } from './util/featureFlags';
 import Performance from './util/perf';
 import { NotificationManagerImpl } from './views/notifications/notificationManager';
 
@@ -114,7 +114,7 @@ export async function activate(context: ExtensionContext) {
 }
 
 function activateErrorReporting(): void {
-    if (Container.isDebugging || FeatureFlagClient.checkGate(Features.EnableErrorTelemetry)) {
+    if (Container.isDebugging || Container.featureFlagClient.checkGate(Features.EnableErrorTelemetry)) {
         registerAnalyticsClient(Container.analyticsClient);
     } else {
         unregisterErrorReporting();
@@ -212,5 +212,5 @@ export function deactivate() {
     }
 
     unregisterErrorReporting();
-    FeatureFlagClient.dispose();
+    Container.featureFlagClient.dispose();
 }

--- a/src/jira/fetchIssue.test.ts
+++ b/src/jira/fetchIssue.test.ts
@@ -2,7 +2,7 @@ import { createIssueUI, editIssueUI } from '@atlassianlabs/jira-metaui-client';
 import { DEFAULT_API_VERSION } from '@atlassianlabs/jira-pi-client';
 import * as jiraPiCommonModels from '@atlassianlabs/jira-pi-common-models';
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
-import { Experiments, FeatureFlagClient } from 'src/util/featureFlags';
+import { Experiments } from 'src/util/featureFlags';
 import { expansionCastTo } from 'testsutil';
 
 import { DetailedSiteInfo } from '../atlclients/authInfo';
@@ -62,7 +62,9 @@ describe('fetchIssue', () => {
         jest.clearAllMocks();
 
         // Mock FeatureFlagClient to return false by default
-        (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(false);
+        (Container.featureFlagClient as any) = {
+            checkExperimentValue: jest.fn().mockReturnValue(false),
+        };
 
         // Setup Container mock
         (Container.clientManager as any) = {
@@ -109,11 +111,11 @@ describe('fetchIssue', () => {
     describe('fetchCreateIssueUI', () => {
         it('should call client manager and createIssueUI with parallel fetching when performance is enabled', async () => {
             // Enable performance mode
-            (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
+            (Container.featureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
 
             const result = await fetchCreateIssueUI(mockSiteDetails, mockProjectKey);
 
-            expect(FeatureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
+            expect(Container.featureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
                 Experiments.AtlascodePerformanceExperiment,
             );
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSiteDetails);
@@ -143,7 +145,7 @@ describe('fetchIssue', () => {
             // Performance mode is disabled by default in beforeEach
             const result = await fetchCreateIssueUI(mockSiteDetails, mockProjectKey);
 
-            expect(FeatureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
+            expect(Container.featureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
                 Experiments.AtlascodePerformanceExperiment,
             );
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSiteDetails);
@@ -175,11 +177,11 @@ describe('fetchIssue', () => {
     describe('fetchMinimalIssue', () => {
         it('should fetch issue data with parallel calls when performance is enabled', async () => {
             // Enable performance mode
-            (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
+            (Container.featureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
 
             const result = await fetchMinimalIssue(mockIssueKey, mockSiteDetails);
 
-            expect(FeatureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
+            expect(Container.featureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
                 Experiments.AtlascodePerformanceExperiment,
             );
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSiteDetails);
@@ -198,7 +200,7 @@ describe('fetchIssue', () => {
             // Performance mode is disabled by default in beforeEach
             const result = await fetchMinimalIssue(mockIssueKey, mockSiteDetails);
 
-            expect(FeatureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
+            expect(Container.featureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
                 Experiments.AtlascodePerformanceExperiment,
             );
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockSiteDetails);
@@ -258,11 +260,11 @@ describe('fetchIssue', () => {
     describe('fetchEditIssueUI', () => {
         it('should call client manager and editIssueUI with parallel fetching when performance is enabled', async () => {
             // Enable performance mode
-            (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
+            (Container.featureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
 
             const result = await fetchEditIssueUI(mockMinimalIssue);
 
-            expect(FeatureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
+            expect(Container.featureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
                 Experiments.AtlascodePerformanceExperiment,
             );
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockMinimalIssue.siteDetails);
@@ -290,7 +292,7 @@ describe('fetchIssue', () => {
             // Performance mode is disabled by default in beforeEach
             const result = await fetchEditIssueUI(mockMinimalIssue);
 
-            expect(FeatureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
+            expect(Container.featureFlagClient.checkExperimentValue).toHaveBeenCalledWith(
                 Experiments.AtlascodePerformanceExperiment,
             );
             expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockMinimalIssue.siteDetails);

--- a/src/jira/fetchIssue.ts
+++ b/src/jira/fetchIssue.ts
@@ -7,7 +7,7 @@ import {
     MinimalORIssueLink,
 } from '@atlassianlabs/jira-pi-common-models';
 import { CreateMetaTransformerResult } from '@atlassianlabs/jira-pi-meta-models';
-import { Experiments, FeatureFlagClient } from 'src/util/featureFlags';
+import { Experiments } from 'src/util/featureFlags';
 
 import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { Container } from '../container';
@@ -18,7 +18,7 @@ export async function fetchCreateIssueUI(
     projectKey: string,
 ): Promise<CreateMetaTransformerResult<DetailedSiteInfo>> {
     const client = await Container.clientManager.jiraClient(siteDetails);
-    if (FeatureFlagClient.checkExperimentValue(Experiments.AtlascodePerformanceExperiment)) {
+    if (Container.featureFlagClient.checkExperimentValue(Experiments.AtlascodePerformanceExperiment)) {
         const [fields, issuelinkTypes, cMeta] = await Promise.all([
             Container.jiraSettingsManager.getAllFieldsForSite(siteDetails),
             Container.jiraSettingsManager.getIssueLinkTypes(siteDetails),
@@ -50,7 +50,9 @@ export async function fetchMinimalIssue(
     issue: string,
     siteDetails: DetailedSiteInfo,
 ): Promise<MinimalIssue<DetailedSiteInfo>> {
-    const performanceEnabled = FeatureFlagClient.checkExperimentValue(Experiments.AtlascodePerformanceExperiment);
+    const performanceEnabled = Container.featureFlagClient.checkExperimentValue(
+        Experiments.AtlascodePerformanceExperiment,
+    );
     if (performanceEnabled) {
         const [client, epicInfo] = await Promise.all([
             Container.clientManager.jiraClient(siteDetails),
@@ -71,7 +73,7 @@ export async function fetchMinimalIssue(
 
 export async function fetchEditIssueUI(issue: MinimalIssue<DetailedSiteInfo>): Promise<EditIssueUI<DetailedSiteInfo>> {
     const client = await Container.clientManager.jiraClient(issue.siteDetails);
-    if (FeatureFlagClient.checkExperimentValue(Experiments.AtlascodePerformanceExperiment)) {
+    if (Container.featureFlagClient.checkExperimentValue(Experiments.AtlascodePerformanceExperiment)) {
         const [fields, issuelinkTypes, cMeta] = await Promise.all([
             Container.jiraSettingsManager.getAllFieldsForSite(issue.siteDetails),
             Container.jiraSettingsManager.getIssueLinkTypes(issue.siteDetails),

--- a/src/jira/issuesForJql.ts
+++ b/src/jira/issuesForJql.ts
@@ -1,5 +1,5 @@
 import { MinimalIssue, readSearchResults } from '@atlassianlabs/jira-pi-common-models';
-import { Experiments, FeatureFlagClient } from 'src/util/featureFlags';
+import { Experiments } from 'src/util/featureFlags';
 
 import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { Container } from '../container';
@@ -8,7 +8,9 @@ export const MAX_RESULTS = 100;
 
 export async function issuesForJQL(jql: string, site: DetailedSiteInfo): Promise<MinimalIssue<DetailedSiteInfo>[]> {
     const client = await Container.clientManager.jiraClient(site);
-    const performanceEnabled = FeatureFlagClient.checkExperimentValue(Experiments.AtlascodePerformanceExperiment);
+    const performanceEnabled = Container.featureFlagClient.checkExperimentValue(
+        Experiments.AtlascodePerformanceExperiment,
+    );
     let issues: MinimalIssue<DetailedSiteInfo>[] = [];
     if (performanceEnabled) {
         const epicFieldInfo = await Container.jiraSettingsManager.getEpicFieldsForSite(site);

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.test.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.test.ts
@@ -4,7 +4,6 @@ import { createEmptyMinimalIssue, MinimalIssue, Transition } from '@atlassianlab
 import { DetailedSiteInfo, emptySiteInfo, ProductBitbucket } from '../../../../atlclients/authInfo';
 import { BitbucketBranchingModel, WorkspaceRepo } from '../../../../bitbucket/model';
 import { Container } from '../../../../container';
-import { FeatureFlagClient } from '../../../../util/featureFlags';
 import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
 import { StartWorkAction, StartWorkActionType } from '../../../ipc/fromUI/startWork';
@@ -162,7 +161,9 @@ describe('StartWorkWebviewController', () => {
         (formatError as jest.Mock).mockReturnValue('Formatted error message');
 
         // Mock FeatureFlagClient to return false by default (old version)
-        (FeatureFlagClient.checkGate as jest.Mock).mockReturnValue(false);
+        (Container.featureFlagClient as any) = {
+            checkGate: jest.fn().mockReturnValue(false),
+        };
 
         controller = new StartWorkWebviewController(
             mockMessagePoster,
@@ -467,7 +468,7 @@ describe('StartWorkWebviewController', () => {
 
             it('should refresh and post init message with repo data (old version - includes customBranchType)', async () => {
                 // Mock FeatureFlagClient to return false (old version)
-                (FeatureFlagClient.checkGate as jest.Mock).mockReturnValue(false);
+                (Container.featureFlagClient.checkGate as jest.Mock).mockReturnValue(false);
 
                 await controller.onMessageReceived({ type: CommonActionType.Refresh });
 
@@ -500,7 +501,7 @@ describe('StartWorkWebviewController', () => {
 
             it('should refresh and post init message with repo data (new version - excludes customBranchType)', async () => {
                 // Mock FeatureFlagClient to return true (new version)
-                (FeatureFlagClient.checkGate as jest.Mock).mockReturnValue(true);
+                (Container.featureFlagClient.checkGate as jest.Mock).mockReturnValue(true);
 
                 await controller.onMessageReceived({ type: CommonActionType.Refresh });
 

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -5,7 +5,7 @@ import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import { BitbucketBranchingModel } from '../../../../bitbucket/model';
 import { Commands } from '../../../../constants';
 import { Container } from '../../../../container';
-import { FeatureFlagClient, Features } from '../../../../util/featureFlags';
+import { Features } from '../../../../util/featureFlags';
 import { OnJiraEditedRefreshDelay } from '../../../../util/time';
 import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
@@ -86,7 +86,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                                 },
                             ),
                             // Only add customBranchType for old version (not V3)
-                            ...(FeatureFlagClient.checkGate(Features.StartWorkV3) ? [] : [customBranchType]),
+                            ...(Container.featureFlagClient.checkGate(Features.StartWorkV3) ? [] : [customBranchType]),
                         ];
                         const developmentBranch = repoDetails.developmentBranch;
                         const href = repoDetails.url;

--- a/src/util/featureFlags/featureFlagClient.ts
+++ b/src/util/featureFlags/featureFlagClient.ts
@@ -3,22 +3,21 @@ import { FetcherOptions } from '@atlaskit/feature-gate-js-client/dist/types/clie
 import { NewFeatureGateOptions } from '@atlaskit/feature-gate-js-client/dist/types/client/types';
 
 import { ClientInitializedErrorType } from '../../analytics';
-import { AnalyticsClient } from '../../analytics-node-client/src/client.min';
 import { Logger } from '../../logger';
 import { ExperimentGates, ExperimentGateValues, Experiments, FeatureGateValues, Features } from './features';
 import { FeatureGateClient } from './utils';
 
-export type FeatureFlagClientOptions = {
-    analyticsClient: AnalyticsClient;
-    identifiers: Identifiers;
-};
+type NewFetcherOptions = FetcherOptions &
+    Pick<NewFeatureGateOptions, 'loggingEnabled'> &
+    Pick<ClientOptions, 'ignoreWindowUndefined'>;
 
-type Options = ClientOptions & Omit<NewFeatureGateOptions, keyof ClientOptions>;
-export class FeatureFlagClientInitError {
+export class FeatureFlagClientInitError extends Error {
     constructor(
         public errorType: ClientInitializedErrorType,
-        public reason: string,
-    ) {}
+        message: string,
+    ) {
+        super(message);
+    }
 }
 
 export enum PerimeterType {
@@ -27,22 +26,87 @@ export enum PerimeterType {
 
 const INIT_RETRY_COUNT = 5;
 
-export abstract class FeatureFlagClient {
-    private static featureGateOverrides: FeatureGateValues;
-    private static experimentValueOverride: ExperimentGateValues;
-    private static options?: FeatureFlagClientOptions;
-
-    private static isExperimentationDisabled = false;
-
-    // TODO: rework this implementation to not be static
-    // - now that we're no longer using a static FG client
-    private static client?: FeatureGateClient = undefined;
-
-    private static async buildClientOptions(): Promise<FetcherOptions> {
-        if (!this.options) {
-            throw new Error('FeatureFlagClient not initialized');
+export class FeatureFlagClient {
+    private static singleton: FeatureFlagClient | undefined;
+    public static getInstance() {
+        if (!this.singleton) {
+            this.singleton = new FeatureFlagClient();
         }
+        return this.singleton;
+    }
+
+    private readonly featureGateOverrides: FeatureGateValues;
+    private readonly experimentValueOverride: ExperimentGateValues;
+    private readonly isExperimentationDisabled: boolean;
+
+    private clientOptions: NewFetcherOptions = {} as any;
+    private identifiers: Identifiers = {};
+    private clientBasic?: FeatureGateClient;
+    private clientWithTenant?: FeatureGateClient;
+    private tenantId?: string;
+
+    // for debugging purposes, to ensure initialized is called only once
+    private initializedCalled = false;
+
+    private get client() {
+        return this.clientWithTenant ?? this.clientBasic;
+    }
+
+    private constructor() {
         this.isExperimentationDisabled = !!process.env.ATLASCODE_NO_EXP;
+
+        this.featureGateOverrides = {} as FeatureGateValues;
+        this.experimentValueOverride = {} as ExperimentGateValues;
+        this.initializeOverrides();
+    }
+
+    /**
+     * Workaround to account for a TLS-related ECONNRESET that sometimes occurs in undici
+     * when node attempts a naked `fetch`. The regular client implementation of
+     * FeatureGates doesn't let us reset the state fully - hence the odd logic here
+     * where we re-initialize the client from scratch
+     */
+    private async initializeWithRetry(
+        clientOptions: FetcherOptions,
+        identifiers: Identifiers,
+        retriesLeft: number = INIT_RETRY_COUNT,
+    ): Promise<FeatureGateClient> {
+        // at least it should try one time
+        if (retriesLeft < 1) {
+            retriesLeft = 1;
+        }
+
+        while (--retriesLeft >= 0) {
+            try {
+                const client = new FeatureGateClient();
+                await client.initialize(clientOptions, identifiers);
+                return client;
+            } catch (err) {
+                if (retriesLeft) {
+                    Logger.info(
+                        `FeatureFlagClient: Retrying reinitialization (${retriesLeft} retries left). Reason: ${err}`,
+                    );
+                } else {
+                    const errorMessage = typeof err === 'string' ? err : err.message;
+                    throw new FeatureFlagClientInitError(ClientInitializedErrorType.Failed, errorMessage);
+                }
+            }
+        }
+
+        throw new Error('This line is supposed to be unreachable.');
+    }
+
+    public async initialize(identifiers: Omit<Identifiers, 'tenantId'>): Promise<void> {
+        if (this.initializedCalled) {
+            throw new FeatureFlagClientInitError(
+                ClientInitializedErrorType.Failed,
+                'FeatureFlagClient already initialized',
+            );
+        }
+
+        if (!identifiers.analyticsAnonymousId) {
+            throw new FeatureFlagClientInitError(ClientInitializedErrorType.IdMissing, 'analyticsAnonymousId not set');
+        }
 
         const targetApp = process.env.ATLASCODE_FX3_TARGET_APP;
         const environment = process.env.ATLASCODE_FX3_ENVIRONMENT as FeatureGateEnvironment;
@@ -50,118 +114,67 @@ export abstract class FeatureFlagClient {
         const timeout = process.env.ATLASCODE_FX3_TIMEOUT;
 
         if (!targetApp || !environment || !apiKey || !timeout) {
-            return Promise.reject(
-                new FeatureFlagClientInitError(ClientInitializedErrorType.Skipped, 'env data not set'),
-            );
+            throw new FeatureFlagClientInitError(ClientInitializedErrorType.Skipped, 'env data not set');
         }
 
-        const loggingEnabled = this.isExperimentationDisabled ? 'disabled' : 'always';
-        const clientOptions: Options = {
+        if (this.isExperimentationDisabled) {
+            return;
+        }
+
+        this.clientOptions = {
             apiKey,
             environment,
             targetApp,
             fetchTimeoutMs: Number.parseInt(timeout),
-            loggingEnabled,
+            loggingEnabled: 'always',
             perimeter: PerimeterType.COMMERCIAL,
             ignoreWindowUndefined: true,
         };
 
-        return clientOptions as any;
-    }
-
-    /**
-     * Workaround to account for a TLS-related ECONNRESET that sometimes occurs in undici
-     * when node attempts a naked `fetch`. The regular static client implementation of
-     * FeatureGates doesn't let us reset the state fully - hence the odd logic here
-     * where we re-initialize the client from scratch
-     */
-    private static async initializeWithRetry(
-        clientOptions: FetcherOptions,
-        identifiers: Identifiers,
-        maxRetries: number = INIT_RETRY_COUNT,
-    ): Promise<FeatureGateClient> {
-        for (let i = 0; i < maxRetries; i++) {
-            try {
-                const client = new FeatureGateClient();
-                await client.initialize(clientOptions, identifiers);
-                return client;
-            } catch (err) {
-                if (i < maxRetries - 1) {
-                    Logger.info(
-                        `FeatureFlagClient: Retrying reinitialization (${maxRetries - i - 1} retries left). Reason: ${err}`,
-                    );
-                }
-            }
-        }
-        return Promise.reject(
-            new FeatureFlagClientInitError(ClientInitializedErrorType.Failed, 'FeatureFlagClient: Max retries reached'),
-        );
-    }
-
-    public static async initialize(options: FeatureFlagClientOptions): Promise<void> {
-        if (!options.identifiers.analyticsAnonymousId) {
-            return Promise.reject(
-                new FeatureFlagClientInitError(ClientInitializedErrorType.IdMissing, 'analyticsAnonymousId not set'),
-            );
-        }
-
-        this.options = options;
-        this.initializeOverrides();
-
-        const clientOptions = await this.buildClientOptions();
+        this.initializedCalled = true;
+        this.identifiers = { ...identifiers };
 
         Logger.debug(
-            `FeatureGates: initializing, target: ${clientOptions.targetApp}, environment: ${clientOptions.environment}`,
+            `FeatureGates: initializing, target: ${this.clientOptions.targetApp}, environment: ${this.clientOptions.environment}`,
         );
-        try {
-            this.client = await this.initializeWithRetry(clientOptions, options.identifiers);
-        } catch (err) {
-            return Promise.reject(new FeatureFlagClientInitError(ClientInitializedErrorType.Failed, err));
-        }
+
+        this.clientBasic = await this.initializeWithRetry(this.clientOptions, this.identifiers);
     }
 
-    public static async updateUser({ tenantId }: { tenantId?: string }): Promise<void> {
-        if (!this.client || !this.options) {
-            Logger.error(new Error('FeatureFlagClient not initialized'));
+    public async updateUser({ tenantId }: { tenantId?: string }): Promise<void> {
+        if (!this.isInitialized()) {
             return;
         }
 
-        if (tenantId === this.options.identifiers.tenantId) {
+        if (!tenantId) {
+            this.clientWithTenant?.shutdownStatsig();
+            this.clientWithTenant = undefined;
+            this.tenantId = undefined;
+            return;
+        }
+
+        if (tenantId === this.tenantId) {
             // no change needed, avoid unnecessary updates
             return;
         }
 
+        Logger.debug(
+            `FeatureGates: initializing for tenant ${tenantId}, target: ${this.clientOptions.targetApp}, environment: ${this.clientOptions.environment}`,
+        );
+
         // FeatureGates stores the identifiers object and uses it in comparison down the line
         // hence we use a copy instead of modifying the original here
-        this.options.identifiers = {
-            ...this.options.identifiers,
+        this.tenantId = tenantId;
+        const identifiers = {
+            ...this.identifiers,
             tenantId,
         };
 
-        const clientOptions = await this.buildClientOptions();
-
-        try {
-            await this.client.updateUser(clientOptions, this.options.identifiers);
-            return;
-        } catch (e) {
-            Logger.error(new Error(`FeatureFlagClient: Failed to update user: ${e}`));
-        }
-
-        // Attempt to re-initialize with the new identifiers
-        try {
-            this.client = await this.initializeWithRetry(clientOptions, this.options.identifiers);
-        } catch (err) {
-            Logger.error(err, 'FeatureFlagClient: Failed to re-initialize');
-        }
-
-        // TODO: maybe we need some fallback to asynchronously re-initialize the client with back-off here?
-        // Leaving this for the next iteration
+        this.clientWithTenant = undefined;
+        this.clientWithTenant = await this.initializeWithRetry(this.clientOptions, identifiers);
     }
 
-    private static initializeOverrides(): void {
-        this.featureGateOverrides = {} as FeatureGateValues;
-        this.experimentValueOverride = {} as ExperimentGateValues;
-
+    private initializeOverrides(): void {
         if (process.env.ATLASCODE_FF_OVERRIDES) {
             const ffSplit = (process.env.ATLASCODE_FF_OVERRIDES || '')
                 .split(',')
@@ -196,7 +209,7 @@ export abstract class FeatureFlagClient {
         }
     }
 
-    private static parseBoolOverride<T>(setting: string): { key: T; value: boolean } | undefined {
+    private parseBoolOverride<T>(setting: string): { key: T; value: boolean } | undefined {
         const [key, valueRaw] = setting
             .trim()
             .split('=', 2)
@@ -210,7 +223,7 @@ export abstract class FeatureFlagClient {
         }
     }
 
-    private static parseStringOverride(setting: string): { key: Experiments; value: string } | undefined {
+    private parseStringOverride(setting: string): { key: Experiments; value: string } | undefined {
         const [key, value] = setting
             .trim()
             .split('=', 2)
@@ -222,11 +235,11 @@ export abstract class FeatureFlagClient {
         }
     }
 
-    public static isInitialized(): boolean {
-        return this.client !== undefined && !this.isExperimentationDisabled && this.client.initializeCompleted();
+    private isInitialized(): boolean {
+        return !!this.client?.initializeCompleted();
     }
 
-    public static checkGate(gate: Features): boolean {
+    public checkGate(gate: Features): boolean {
         if (this.featureGateOverrides.hasOwnProperty(gate)) {
             return this.featureGateOverrides[gate];
         }
@@ -241,7 +254,7 @@ export abstract class FeatureFlagClient {
         return gateValue;
     }
 
-    public static checkExperimentValue(experiment: Experiments): any {
+    public checkExperimentValue(experiment: Experiments): any {
         // unknown experiment name
         if (!ExperimentGates.hasOwnProperty(experiment)) {
             return undefined;
@@ -265,7 +278,7 @@ export abstract class FeatureFlagClient {
         return gateValue;
     }
 
-    public static dispose() {
+    public dispose() {
         this.client?.shutdownStatsig();
     }
 }

--- a/src/views/notifications/notificationManager.test.ts
+++ b/src/views/notifications/notificationManager.test.ts
@@ -13,16 +13,13 @@ jest.mock('./authNotifier', () => ({
         })),
     },
 }));
-jest.mock('../../util/featureFlags', () => ({
-    Features: {},
-    FeatureFlagClient: {
-        checkGate: jest.fn(() => Promise.resolve(true)),
-    },
-}));
 jest.mock('../../container', () => ({
     Container: {
         analyticsClient: {
             sendTrackEvent: jest.fn(),
+        },
+        featureFlagClient: {
+            checkGate: jest.fn(() => Promise.resolve(true)),
         },
         credentialManager: {
             onDidAuthChange: jest.fn(),

--- a/src/views/notifications/notificationManager.ts
+++ b/src/views/notifications/notificationManager.ts
@@ -4,7 +4,7 @@ import { AuthInfoEvent, isRemoveAuthEvent, Product, ProductBitbucket, ProductJir
 import { configuration } from '../../config/configuration';
 import { Container } from '../../container';
 import { Logger } from '../../logger';
-import { FeatureFlagClient, Features } from '../../util/featureFlags';
+import { Features } from '../../util/featureFlags';
 import { Time } from '../../util/time';
 import { AtlassianNotificationNotifier } from './atlassianNotificationNotifier';
 import { AuthNotifier } from './authNotifier';
@@ -110,7 +110,7 @@ export class NotificationManagerImpl extends Disposable {
             NotificationManagerImpl.instance = new NotificationManagerImpl();
 
             NotificationManagerImpl.instance.notifiers.add(AuthNotifier.getInstance());
-            if (FeatureFlagClient.checkGate(Features.AtlassianNotifications)) {
+            if (Container.featureFlagClient.checkGate(Features.AtlassianNotifications)) {
                 NotificationManagerImpl.instance.notifiers.add(AtlassianNotificationNotifier.getInstance());
             }
 

--- a/src/webview/singleViewFactory.ts
+++ b/src/webview/singleViewFactory.ts
@@ -15,7 +15,6 @@ import { AnalyticsApi } from '../lib/analyticsApi';
 import { CommonActionType } from '../lib/ipc/fromUI/common';
 import { AdditionalSettings, CommonMessageType } from '../lib/ipc/toUI/common';
 import { WebviewController } from '../lib/webview/controller/webviewController';
-import { FeatureFlagClient } from '../util/featureFlags';
 import { ExperimentGateValues, Experiments, FeatureGateValues, Features } from '../util/featureFlags/features';
 import { UIWebsocket } from '../ws';
 import { VSCWebviewControllerFactory } from './vscWebviewControllerFactory';
@@ -149,7 +148,7 @@ export class SingleWebview<FD, R> implements ReactWebview<FD> {
     private async fireFeatureGates(features: Features[]) {
         if (features.length) {
             const featureFlags = {} as FeatureGateValues;
-            features.forEach((x) => (featureFlags[x] = FeatureFlagClient.checkGate(x)));
+            features.forEach((x) => (featureFlags[x] = Container.featureFlagClient.checkGate(x)));
             this.postMessage({ command: CommonMessageType.UpdateFeatureFlags, featureFlags });
         }
     }
@@ -157,7 +156,7 @@ export class SingleWebview<FD, R> implements ReactWebview<FD> {
     private async fireExperimentGates(experiments: Experiments[]) {
         if (experiments.length) {
             const experimentValues = {} as ExperimentGateValues;
-            experiments.forEach((x) => (experimentValues[x] = FeatureFlagClient.checkExperimentValue(x)));
+            experiments.forEach((x) => (experimentValues[x] = Container.featureFlagClient.checkExperimentValue(x)));
             this.postMessage({ command: CommonMessageType.UpdateExperimentValues, experimentValues });
         }
     }

--- a/src/webview/startwork/vscStartWorkActionApi.test.ts
+++ b/src/webview/startwork/vscStartWorkActionApi.test.ts
@@ -7,7 +7,6 @@ import { Container } from '../../container';
 import { ConfigSection, ConfigSubSection } from '../../lib/ipc/models/config';
 import { Logger } from '../../logger';
 import { Branch, RefType } from '../../typings/git';
-import { FeatureFlagClient } from '../../util/featureFlags';
 import { VSCStartWorkActionApi } from './vscStartWorkActionApi';
 
 // Mock external dependencies
@@ -184,7 +183,9 @@ describe('VSCStartWorkActionApi', () => {
         // Mock clientForSite
         (clientForSite as jest.Mock).mockResolvedValue(mockBbClient);
 
-        (FeatureFlagClient.checkGate as jest.Mock).mockReturnValue(false);
+        (Container.featureFlagClient as any) = {
+            checkGate: jest.fn().mockReturnValue(false),
+        };
 
         api = new VSCStartWorkActionApi();
     });

--- a/src/webview/startwork/vscStartWorkActionApi.ts
+++ b/src/webview/startwork/vscStartWorkActionApi.ts
@@ -9,7 +9,7 @@ import { ConfigSection, ConfigSubSection } from '../../lib/ipc/models/config';
 import { StartWorkActionApi } from '../../lib/webview/controller/startwork/startWorkActionApi';
 import { Logger } from '../../logger';
 import { Branch, RefType } from '../../typings/git';
-import { FeatureFlagClient, Features } from '../../util/featureFlags';
+import { Features } from '../../util/featureFlags';
 
 export class VSCStartWorkActionApi implements StartWorkActionApi {
     getWorkspaceRepos(): WorkspaceRepo[] {
@@ -103,7 +103,7 @@ export class VSCStartWorkActionApi implements StartWorkActionApi {
     }
 
     closePage() {
-        const factory = FeatureFlagClient.checkGate(Features.StartWorkV3)
+        const factory = Container.featureFlagClient.checkGate(Features.StartWorkV3)
             ? Container.startWorkV3WebviewFactory
             : Container.startWorkWebviewFactory;
         factory.hide();

--- a/src/webviews/abstractWebview.test.ts
+++ b/src/webviews/abstractWebview.test.ts
@@ -25,6 +25,10 @@ jest.mock('../container', () => ({
             sendScreenEvent: jest.fn(),
             sendTrackEvent: jest.fn(),
         },
+        featureFlagClient: {
+            checkGate: jest.fn().mockReturnValue(false),
+            checkExperimentValue: jest.fn().mockReturnValue(undefined),
+        },
         analyticsApi: {
             fireUIErrorEvent: jest.fn(),
         },
@@ -81,13 +85,6 @@ class TestReactWebview extends AbstractReactWebview {
         return undefined;
     }
 }
-
-jest.mock('../util/featureFlags', () => ({
-    FeatureFlagClient: {
-        checkGate: jest.fn().mockReturnValue(false),
-        checkExperimentValue: jest.fn().mockReturnValue(undefined),
-    },
-}));
 
 // Test implementation of InitializingWebview
 class TestInitializingWebview implements InitializingWebview<string> {

--- a/src/webviews/abstractWebview.ts
+++ b/src/webviews/abstractWebview.ts
@@ -21,7 +21,7 @@ import { isAction, isAlertable, isPMFSubmitAction } from '../ipc/messaging';
 import { CommonActionType } from '../lib/ipc/fromUI/common';
 import { AdditionalSettings, CommonMessageType } from '../lib/ipc/toUI/common';
 import { iconSet, Resources } from '../resources';
-import { Experiments, FeatureFlagClient, Features } from '../util/featureFlags';
+import { Experiments, Features } from '../util/featureFlags';
 import { ExperimentGateValues, FeatureGateValues } from '../util/featureFlags/features';
 import { UIWebsocket } from '../ws';
 
@@ -149,7 +149,7 @@ export abstract class AbstractReactWebview implements ReactWebview {
     private fireFeatureGates(features: Features[]) {
         if (features.length) {
             const featureFlags = {} as FeatureGateValues;
-            features.forEach((x) => (featureFlags[x] = FeatureFlagClient.checkGate(x)));
+            features.forEach((x) => (featureFlags[x] = Container.featureFlagClient.checkGate(x)));
             this.postMessage({ type: CommonMessageType.UpdateFeatureFlags, featureFlags });
         }
     }
@@ -157,7 +157,7 @@ export abstract class AbstractReactWebview implements ReactWebview {
     private fireExperimentGates(experiments: Experiments[]) {
         if (experiments.length) {
             const experimentValues = {} as ExperimentGateValues;
-            experiments.forEach((x) => (experimentValues[x] = FeatureFlagClient.checkExperimentValue(x)));
+            experiments.forEach((x) => (experimentValues[x] = Container.featureFlagClient.checkExperimentValue(x)));
             this.postMessage({ type: CommonMessageType.UpdateExperimentValues, experimentValues });
         }
     }

--- a/src/webviews/createIssueWebview.test.ts
+++ b/src/webviews/createIssueWebview.test.ts
@@ -1,6 +1,5 @@
 import { IssueType, MinimalORIssueLink, Project } from '@atlassianlabs/jira-pi-common-models';
 import { CreateMetaTransformerResult, FieldUI, IssueTypeUI, ValueType } from '@atlassianlabs/jira-pi-meta-models';
-import { FeatureFlagClient } from 'src/util/featureFlags';
 import { expansionCastTo } from 'testsutil';
 import { Position, Uri, window } from 'vscode';
 
@@ -163,7 +162,9 @@ describe('CreateIssueWebview', () => {
         jest.clearAllMocks();
 
         // Mock FeatureFlagClient to return false by default (performance disabled)
-        (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(false);
+        (Container.featureFlagClient as any) = {
+            checkExperimentValue: jest.fn().mockReturnValue(false),
+        };
 
         // Setup mocks
         Container.siteManager.getSiteForId = jest.fn().mockReturnValue(mockSiteDetails);
@@ -371,7 +372,7 @@ describe('CreateIssueWebview', () => {
 
         it('should use performance-enabled path when feature flag is enabled', async () => {
             // Enable performance feature flag
-            (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
+            (Container.featureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
 
             await webview.forceUpdateFields();
 
@@ -390,7 +391,7 @@ describe('CreateIssueWebview', () => {
 
         it('should handle project without permission in performance mode', async () => {
             // Enable performance feature flag
-            (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
+            (Container.featureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
 
             // Mock project without permission
             const projectWithoutPermission = { ...mockProject, id: 'different-id' };
@@ -420,7 +421,7 @@ describe('CreateIssueWebview', () => {
 
         it('should handle partial issue in performance mode', async () => {
             // Enable performance feature flag
-            (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
+            (Container.featureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(true);
 
             const partialIssue: PartialIssue = {
                 summary: 'Partial Summary',

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -3,7 +3,7 @@ import { CreateMetaTransformerResult, FieldValues, IssueTypeUI, ValueType } from
 import { decode } from 'base64-arraybuffer-es6';
 import { format } from 'date-fns';
 import FormData from 'form-data';
-import { Experiments, FeatureFlagClient } from 'src/util/featureFlags';
+import { Experiments } from 'src/util/featureFlags';
 import timer from 'src/util/perf';
 import { commands, Position, Uri, ViewColumn, window } from 'vscode';
 
@@ -289,7 +289,7 @@ export class CreateIssueWebview
         this.isRefeshing = true;
         try {
             const availableSites = Container.siteManager.getSitesAvailable(ProductJira);
-            const performanceEnabled = FeatureFlagClient.checkExperimentValue(
+            const performanceEnabled = Container.featureFlagClient.checkExperimentValue(
                 Experiments.AtlascodePerformanceExperiment,
             );
             timer.mark(CreateJiraIssueRenderEventName);

--- a/src/webviews/jiraIssueWebview.test.ts
+++ b/src/webviews/jiraIssueWebview.test.ts
@@ -1,5 +1,4 @@
 import { createEmptyMinimalIssue, emptyUser, MinimalIssue, User } from '@atlassianlabs/jira-pi-common-models';
-import { FeatureFlagClient } from 'src/util/featureFlags';
 import { expansionCastTo } from 'testsutil/miscFunctions';
 import { commands, env, WebviewPanel } from 'vscode';
 
@@ -166,7 +165,9 @@ describe('JiraIssueWebview', () => {
         jest.clearAllMocks();
 
         // Defaulted value for AtlascodePerformanceExperiment should be false
-        (FeatureFlagClient.checkExperimentValue as jest.Mock).mockReturnValue(false);
+        (Container.featureFlagClient as any) = {
+            checkExperimentValue: jest.fn().mockReturnValue(false),
+        };
 
         mockJiraClient = {
             editIssue: jest.fn(),

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -13,7 +13,7 @@ import {
 import { FieldValues, ValueType } from '@atlassianlabs/jira-pi-meta-models';
 import { decode } from 'base64-arraybuffer-es6';
 import FormData from 'form-data';
-import { Experiments, FeatureFlagClient } from 'src/util/featureFlags';
+import { Experiments } from 'src/util/featureFlags';
 import timer from 'src/util/perf';
 import { commands, env } from 'vscode';
 
@@ -191,7 +191,7 @@ export class JiraIssueWebview
     async updateEpicChildren() {
         if (this._issue.isEpic) {
             const site = this._issue.siteDetails;
-            const performanceEnabled = FeatureFlagClient.checkExperimentValue(
+            const performanceEnabled = Container.featureFlagClient.checkExperimentValue(
                 Experiments.AtlascodePerformanceExperiment,
             );
             if (performanceEnabled) {


### PR DESCRIPTION
### What Is This Change?

This code introduces a "double feature flag client" used this way:
- a constant base client that references the user anonymously, without the tenant id
- a variable (possibly undefined) tenant client that references the user with the tenant id

When the user logs out / logs in, only the tenant client gets updated, or removed if the user doesn't have a tenant id correlation anymore.

When the tenant client is undefined, we fallback using the base client.
In case updating the tenant client fails (we attempt 5 times), we fallback using the base client.

In addition to the above changes, this change also refactor the FeatureFlagClient from a static class to a singleton class.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`