### PR TITLE
chore: ignore css chunk order warnings in devcompile

### DIFF
--- a/webpack.react.dev.js
+++ b/webpack.react.dev.js
@@ -21,6 +21,7 @@ module.exports = {
         mui: resolveApp('./src/react/index.tsx'),
     },
     devtool: 'cheap-module-source-map',
+
     output: {
         publicPath: '',
         pathinfo: true,
@@ -41,6 +42,7 @@ module.exports = {
     plugins: [
         new MiniCssExtractPlugin({
             filename: '[name].css',
+            ignoreOrder: true,
         }),
         new WebpackManifestPlugin({
             fileName: 'asset-manifest.json',


### PR DESCRIPTION
### What Is This Change?

We've just caught a situation where `npm run compile` succeeds, but `npm run devcompile` fails on css chunk ordering warnings:
<img width="1864" height="1249" alt="image" src="https://github.com/user-attachments/assets/0b166bc1-415f-48f8-8efe-9af537c97157" />


Arguably, this is _very_ undesirable - if the regular build succeeds, the `devcompile` should succeed as well.

To prevent this in the future, let's prevent css ordering warnings when webviews are being compiled

### How Has This Been Tested?

Did a before-and-after on a broken `main`

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`