### PR TITLE
[AXON-934] add copy command

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -253,6 +253,28 @@ body {
     padding: 10px 16px 0 16px;
 }
 
+.chat-message-actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0;
+    margin-bottom: 8px;
+}
+
+.chat-message-action {
+    display: flex;
+    align-items: center;
+    background: transparent;
+    border: none;
+    color: var(--vscode-editor-foreground);
+    cursor: pointer;
+    border-radius: 2px;
+}
+
+.chat-message-action:hover {
+    background: var(--vscode-button-secondaryHoverBackground);
+}
+
 .message-drawer {
     width: 100%;
     display: flex;

--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -46,14 +46,13 @@ export const renderChatHistory = (
             const parsedMessages = parseToolReturnMessage(msg);
             return parsedMessages.map((message) => {
                 if (message.technicalPlan) {
-                    return <TechnicalPlanComponent key={index} content={message.technicalPlan} openFile={openFile} />;
+                    return <TechnicalPlanComponent content={message.technicalPlan} openFile={openFile} />;
                 }
-                return <ToolReturnParsedItem key={index} msg={message} openFile={openFile} />;
+                return <ToolReturnParsedItem msg={message} openFile={openFile} />;
             });
         case 'RovoDevError':
             return (
                 <ErrorMessageItem
-                    index={index}
                     msg={msg}
                     isRetryAfterErrorButtonEnabled={isRetryAfterErrorButtonEnabled}
                     retryAfterError={retryAfterError}
@@ -61,7 +60,7 @@ export const renderChatHistory = (
             );
         case 'RovoDev':
         case 'User':
-            return <ChatMessageItem index={index} msg={msg} />;
+            return <ChatMessageItem msg={msg} />;
         case 'RovoDevRetry':
             const retryMsg: DefaultMessage = {
                 text: 'Unable to process the request ' + '`' + msg.tool_name + '`',
@@ -69,13 +68,12 @@ export const renderChatHistory = (
             };
             return (
                 <ChatMessageItem
-                    index={index}
                     msg={retryMsg}
                     icon={<StatusErrorIcon color="var(--ds-icon-danger)" label="error-icon" spacing="none" />}
                 />
             );
         default:
-            return <div key={index}>Unknown message type</div>;
+            return <div>Unknown message type</div>;
     }
 };
 

--- a/src/react/atlascode/rovo-dev/common/errorMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/errorMessage.tsx
@@ -8,10 +8,9 @@ import { ErrorMessage } from '../utils';
 
 export const ErrorMessageItem: React.FC<{
     msg: ErrorMessage;
-    index: number;
     isRetryAfterErrorButtonEnabled: (uid: string) => boolean;
     retryAfterError: () => void;
-}> = ({ msg, index, isRetryAfterErrorButtonEnabled, retryAfterError }) => {
+}> = ({ msg, isRetryAfterErrorButtonEnabled, retryAfterError }) => {
     const getColor = useCallback(() => {
         switch (msg.type) {
             case 'error':
@@ -35,7 +34,7 @@ export const ErrorMessageItem: React.FC<{
     }, [msg.type, msg.title]);
 
     return (
-        <div key={index} style={{ ...chatMessageStyles, ...errorMessageStyles }}>
+        <div style={{ ...chatMessageStyles, ...errorMessageStyles }}>
             <div style={{ display: 'flex', flexDirection: 'row' }}>
                 <div style={{ padding: '4px', color: getColor() }}>
                     {msg.type === 'error' && <StatusErrorIcon label={getTitle()} />}

--- a/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.test.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.test.tsx
@@ -16,7 +16,7 @@ describe('ChatMessageItem', () => {
     });
 
     it('renders user message correctly', () => {
-        render(<ChatMessageItem msg={defaultMessage} index={0} />);
+        render(<ChatMessageItem msg={defaultMessage} />);
 
         expect(screen.getByText('Test message')).toBeTruthy();
     });
@@ -27,7 +27,7 @@ describe('ChatMessageItem', () => {
             source: 'RovoDev',
         });
 
-        render(<ChatMessageItem msg={assistantMessage} index={0} />);
+        render(<ChatMessageItem msg={assistantMessage} />);
 
         expect(screen.getByText('Test message')).toBeTruthy();
     });
@@ -38,7 +38,7 @@ describe('ChatMessageItem', () => {
             source: 'RovoDev',
         });
 
-        render(<ChatMessageItem msg={assistantMessage} index={0} />);
+        render(<ChatMessageItem msg={assistantMessage} />);
         expect(screen.getByText('Bold text')).toBeTruthy();
     });
 });

--- a/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
@@ -1,3 +1,6 @@
+import CopyIcon from '@atlaskit/icon/core/copy';
+import ThumbsDownIcon from '@atlaskit/icon/core/thumbs-down';
+import ThumbsUpIcon from '@atlaskit/icon/core/thumbs-up';
 import React from 'react';
 
 import { mdParser } from '../common/common';
@@ -6,14 +9,14 @@ import { DefaultMessage } from '../utils';
 
 export const ChatMessageItem: React.FC<{
     msg: DefaultMessage;
-    index?: number;
     icon?: React.ReactNode;
-}> = ({ msg, index, icon }) => {
+    enableActions?: boolean;
+    onCopy?: (text: string) => void;
+}> = ({ msg, icon, enableActions, onCopy }) => {
     const messageTypeStyles = msg.source === 'User' ? 'user-message' : 'agent-message';
     const content = (
         <div
             style={{ display: 'flex', flexDirection: 'column' }}
-            key="parsed-content"
             dangerouslySetInnerHTML={{ __html: mdParser.render(msg.text || '') }}
         />
     );
@@ -21,7 +24,6 @@ export const ChatMessageItem: React.FC<{
     return (
         <>
             <div
-                key={index}
                 className={`chat-message ${messageTypeStyles}`}
                 style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '8px' }}
             >
@@ -31,6 +33,26 @@ export const ChatMessageItem: React.FC<{
             {msg.source === 'User' && msg.context && (
                 <div className="message-context">
                     <PromptContextCollection content={msg.context} direction="column" align="right" inChat={true} />
+                </div>
+            )}
+            {msg.source === 'RovoDev' && enableActions && (
+                <div className="chat-message-actions">
+                    <button aria-label="like-response-button" title="Helpful" className="chat-message-action">
+                        <ThumbsUpIcon label="thumbs-up" />
+                    </button>
+                    <button aria-label="dislike-response-button" title="Unhelpful" className="chat-message-action">
+                        <ThumbsDownIcon label="thumbs-down" />
+                    </button>
+                    <button
+                        aria-label="copy-button"
+                        title="Copy response"
+                        className="chat-message-action"
+                        onClick={() => {
+                            onCopy && onCopy(msg.text || '');
+                        }}
+                    >
+                        <CopyIcon label="Copy button" />
+                    </button>
                 </div>
             )}
         </>

--- a/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
@@ -186,6 +186,14 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
         }
     }, [state, chatHistory, currentThinking, currentMessage, isFormVisible, pendingToolCall, checkGitChanges]);
 
+    const handleCopyResponse = React.useCallback((text: string) => {
+        if (!navigator.clipboard) {
+            console.warn('Clipboard API not supported');
+            return;
+        }
+        navigator.clipboard.writeText(text);
+    }, []);
+
     return (
         <div ref={chatEndRef} className="chat-message-container">
             <RovoDevLanding />
@@ -202,7 +210,13 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                                 />
                             );
                         } else if (block.source === 'User' || block.source === 'RovoDev') {
-                            return <ChatMessageItem msg={block} />;
+                            return (
+                                <ChatMessageItem
+                                    msg={block}
+                                    enableActions={block.source === 'RovoDev'}
+                                    onCopy={handleCopyResponse}
+                                />
+                            );
                         } else if (block.source === 'ToolReturn') {
                             const parsedMessages = parseToolReturnMessage(block);
 
@@ -221,7 +235,6 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                             return (
                                 <ErrorMessageItem
                                     msg={block}
-                                    index={idx}
                                     isRetryAfterErrorButtonEnabled={renderProps.isRetryAfterErrorButtonEnabled}
                                     retryAfterError={renderProps.retryPromptAfterError}
                                 />

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.test.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.test.tsx
@@ -48,6 +48,7 @@ describe('PromptInputBox', () => {
         onCancel: jest.fn(),
         sendButtonDisabled: false,
         onAddContext: jest.fn(),
+        onCopy: jest.fn(),
     };
 
     beforeEach(() => {

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
@@ -25,6 +25,7 @@ interface PromptInputBoxProps {
     onCancel: () => void;
     sendButtonDisabled?: boolean;
     onAddContext: () => void;
+    onCopy: () => void;
 }
 
 const TextAreaMessages: Record<State, string> = {
@@ -53,10 +54,15 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
     onCancel,
     sendButtonDisabled = false,
     onAddContext,
+    onCopy,
 }) => {
     const [editor, setEditor] = React.useState<monaco.editor.IStandaloneCodeEditor | null>(null);
 
-    const setupCommands = (editor: monaco.editor.IStandaloneCodeEditor, onSend: (text: string) => void) => {
+    const setupCommands = (
+        editor: monaco.editor.IStandaloneCodeEditor,
+        onSend: (text: string) => void,
+        onCopy: () => void,
+    ) => {
         monaco.editor.registerCommand('rovo-dev.clearChat', () => {
             editor.setValue('');
 
@@ -67,6 +73,11 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
             editor.setValue('');
 
             onSend(`/prune`);
+        });
+
+        monaco.editor.registerCommand('rovo-dev.copyResponse', () => {
+            editor.setValue('');
+            onCopy();
         });
     };
 
@@ -114,7 +125,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
             const editor = createMonacoPromptEditor(container);
             setupPromptKeyBindings(editor, onSend);
             setupAutoResize(editor);
-            setupCommands(editor, onSend);
+            setupCommands(editor, onSend, onCopy);
 
             editor.setValue(promptText);
 
@@ -126,7 +137,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
             };
         }
         return () => {};
-    }, [onSend, promptText]);
+    }, [onCopy, onSend, promptText]);
 
     React.useEffect(() => {
         if (!editor) {

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/utils.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/utils.tsx
@@ -73,6 +73,12 @@ export const SLASH_COMMANDS: SlashCommand[] = [
         description: 'Prune the chat',
         command: { title: 'Prune', id: 'rovo-dev.pruneChat', tooltip: 'Prune the chat' },
     },
+    {
+        label: '/copy',
+        insertText: '/copy',
+        description: 'Copy the last response to clipboard',
+        command: { title: 'Copy', id: 'rovo-dev.copyResponse', tooltip: 'Copy the last response to clipboard' },
+    },
 ];
 
 export const createSlashCommandProvider = (): monaco.languages.CompletionItemProvider => {
@@ -112,6 +118,7 @@ export const createSlashCommandProvider = (): monaco.languages.CompletionItemPro
                 command: command.command,
                 sortText: `0${index}`,
                 filterText: command.label,
+                detail: command.description,
             }));
 
             return { suggestions };

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -640,6 +640,26 @@ const RovoDevView: React.FC = () => {
         });
     }, [postMessage]);
 
+    // Copy the last response to clipboard
+    // This is for PromptInputBox because it cannot access the chat stream directly
+    const handleCopyResponse = useCallback(() => {
+        const lastMessage = chatStream.at(-1);
+        if (currentState !== State.WaitingForPrompt || !lastMessage || Array.isArray(lastMessage)) {
+            return;
+        }
+
+        if (lastMessage.source !== 'RovoDev' || !lastMessage.text) {
+            return;
+        }
+
+        if (!navigator.clipboard) {
+            console.warn('Clipboard API not available');
+            return;
+        }
+
+        navigator.clipboard.writeText(lastMessage.text);
+    }, [chatStream, currentState]);
+
     return (
         <div className="rovoDevChat">
             <ChatStream
@@ -723,6 +743,7 @@ const RovoDevView: React.FC = () => {
                                 currentContext: promptContextCollection,
                             });
                         }}
+                        onCopy={handleCopyResponse}
                     />
                 </div>
                 <div className="ai-disclaimer">Uses AI. Verify results.</div>

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -17,6 +17,7 @@ export const enum RovoDevViewResponseType {
     ReportThinkingDrawerExpanded = 'reportThinkingDrawerExpanded',
     CheckGitChanges = 'checkGitChanges',
     WebviewReady = 'webviewReady',
+    CopyResponse = 'copyResponse',
 }
 
 export interface ModifiedFile {
@@ -39,4 +40,5 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.ReportChangesGitPushed, { pullRequestCreated: boolean }>
     | ReducerAction<RovoDevViewResponseType.ReportThinkingDrawerExpanded>
     | ReducerAction<RovoDevViewResponseType.CheckGitChanges>
-    | ReducerAction<RovoDevViewResponseType.WebviewReady>;
+    | ReducerAction<RovoDevViewResponseType.WebviewReady>
+    | ReducerAction<RovoDevViewResponseType.CopyResponse, { text: string }>;

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -268,6 +268,10 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                             this._processState = RovoDevProcessState.Starting;
                             RovoDevProcessManager.initializeRovoDevProcessManager(this._context);
                         }
+                        break;
+                    case RovoDevViewResponseType.CopyResponse:
+                        await navigator.clipboard.writeText(e.text);
+                        break;
                 }
             } catch (error) {
                 this.processError(error, false);


### PR DESCRIPTION
### What Is This Change?

Added `/copy` command which copies the last agent response in line with CLI

Added message buttons

Added functionality for copy button which copies the respective agent response

Demo: https://www.loom.com/share/77c6964b415b4dbaa123ddbdfd682cee

### How Has This Been Tested?

manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`