### PR TITLE
AXON-936: Upgrade dropdown-menu to 13.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@atlaskit/checkbox": "^17.1.10",
                 "@atlaskit/comment": "^13.0.19",
                 "@atlaskit/datetime-picker": "^17.0.13",
-                "@atlaskit/dropdown-menu": "^12.26.5",
+                "@atlaskit/dropdown-menu": "^13.1.0",
                 "@atlaskit/feature-gate-js-client": "^5.5.5",
                 "@atlaskit/form": "^12.2.0",
                 "@atlaskit/icon": "^27.12.0",
@@ -1967,61 +1967,741 @@
             }
         },
         "node_modules/@atlaskit/dropdown-menu": {
-            "version": "12.26.5",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/dropdown-menu/-/dropdown-menu-12.26.5.tgz",
-            "integrity": "sha512-/LrzBMxx/+sTcXOd26Tt40fY7vdJhABcU5AkGWH7/QKyv7YcMidw5OaMHbhJfFbXn39MGeAwLp9e4jKX0YcK6w==",
+            "version": "13.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/dropdown-menu/-/dropdown-menu-13.1.0.tgz",
+            "integrity": "sha512-1WIrF2u6smYOKw0B6bVpYPrdz/EQUDmnblRYFJDG+A+omV0zRGCGW1eSAq3f34Bqx1CLUEHfmkdphRfszU7NuQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/button": "^20.5.0",
+                "@atlaskit/button": "^22.0.0",
                 "@atlaskit/codemod-utils": "^4.2.0",
-                "@atlaskit/ds-lib": "^3.5.0",
-                "@atlaskit/icon": "^23.9.0",
-                "@atlaskit/layering": "^1.1.0",
-                "@atlaskit/menu": "^2.14.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/icon": "^25.3.0",
+                "@atlaskit/layering": "^2.0.0",
+                "@atlaskit/menu": "^3.2.0",
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/popup": "^1.31.0",
-                "@atlaskit/primitives": "^13.5.0",
-                "@atlaskit/spinner": "^17.1.0",
-                "@atlaskit/theme": "^16.0.0",
-                "@atlaskit/tokens": "^3.3.0",
+                "@atlaskit/popup": "^3.0.0",
+                "@atlaskit/primitives": "^14.2.0",
+                "@atlaskit/spinner": "^18.0.0",
+                "@atlaskit/theme": "^18.0.0",
+                "@atlaskit/tokens": "^4.5.0",
                 "@babel/runtime": "^7.0.0",
                 "@emotion/react": "^11.7.1",
                 "bind-event-listener": "^3.0.0"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
             }
         },
-        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/icon": {
-            "version": "23.11.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-23.11.0.tgz",
-            "integrity": "sha512-GIRqNs3bo93KBuaRSGaV8vXeLQKJmoYcE+FPUtTbrnWo6HL0+A3ASRDazNlo18Nojax8lsmd6+tgTpU7QHhv9Q==",
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/app-provider": {
+            "version": "3.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-3.1.0.tgz",
+            "integrity": "sha512-IkjM02XyVmn53pST8lx5bp0ahevbfYki9ax0U0b3zXqQut+0C97WbwoDvdhmlvtIhMmS6e0ET8dL5s+fNTYssg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/app-provider/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/tokens": "^3.3.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/app-provider/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button": {
+            "version": "22.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/button/-/button-22.0.5.tgz",
+            "integrity": "sha512-/41NgyT5037uWZIZMM+YHVtRCwu8iJwG8vV+9M49t6A4aWUU4ZcmCLGTqwsMa93816eumTJfl2yFxd5Q2E5cIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.0.0",
+                "@atlaskit/css": "0.10.4",
+                "@atlaskit/ds-lib": "4.0.0",
+                "@atlaskit/focus-ring": "3.0.0",
+                "@atlaskit/icon": "25.4.0",
+                "@atlaskit/interaction-context": "3.0.0",
+                "@atlaskit/platform-feature-flags": "1.1.1",
+                "@atlaskit/primitives": "14.2.3",
+                "@atlaskit/spinner": "18.0.3",
+                "@atlaskit/theme": "18.0.1",
+                "@atlaskit/tokens": "4.5.2",
+                "@atlaskit/tooltip": "20.0.5",
+                "@atlaskit/visually-hidden": "3.0.2",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/app-provider": {
+            "version": "2.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-2.3.0.tgz",
+            "integrity": "sha512-YouUNVDSl7bZy2wBiPUdRAkheZli+K1djg3s5nd24S7c8CobPXbPbirIU+WG9X3SvEY1t60O/trHuy447QE0+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^5.6.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/app-provider/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/app-provider/node_modules/@atlaskit/tokens": {
+            "version": "5.6.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-5.6.3.tgz",
+            "integrity": "sha512-oRYrJtzWFzA7ExUHXhFI2h5pM70eXKkOZVj29Ase1ZSCSqN54Ii2KrE69U43pkQzVT05KTq0kV3Uoq3MM6HP3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/ds-lib": {
+            "version": "4.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-4.0.0.tgz",
+            "integrity": "sha512-nM0wAo8bm7FyAYuId6Ba2MFnLSVzlsZpyfRxPJ7dMFqEhJ4R53/CoT8v18mvi2Hu1Y4+d1t97lOyybHfgFyb+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/icon": {
+            "version": "25.4.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-25.4.0.tgz",
+            "integrity": "sha512-9DyoRKg44sJ/M2hfB9HB7YDzHMRTRZQaskUpSct2JAuNgRIUX2pd9lw3o71qmpleRbCDPYZVJdtoEjVZxNgu2g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^4.5.0",
                 "@babel/register": "^7.25.9",
                 "@babel/runtime": "^7.0.0",
                 "@emotion/react": "^11.7.1"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/primitives": {
+            "version": "14.2.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-14.2.3.tgz",
+            "integrity": "sha512-8/XH2gRsCR3pz3zd6pglFNOWkIunETQaLSCampKdE14GewzPHUX/zMwLJZHSNNs/gjVJLdRcSHhDPvaU+ZQvgw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.0.0",
+                "@atlaskit/app-provider": "^2.0.0",
+                "@atlaskit/css": "^0.10.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/interaction-context": "^3.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^4.5.0",
+                "@atlaskit/visually-hidden": "^3.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/spinner": {
+            "version": "18.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/spinner/-/spinner-18.0.3.tgz",
+            "integrity": "sha512-3xGxG4LDk0yWnUleSRLNsIgGwzedSyMOD3i7nRTmXr2E/WlP5ZMwE+rcnvdCo1DJs5JkBsAU6otECz+aPu+T4w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/interaction-context": "^3.0.0",
+                "@atlaskit/theme": "^18.0.0",
+                "@atlaskit/tokens": "^4.5.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/theme": {
+            "version": "18.0.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-18.0.1.tgz",
+            "integrity": "sha512-1pVWT7zlREp1ivU/e43tO/gN+WQyqdYKgJyoSEGJpwZwVJTJ7FULMJIhaWqdqxbpkTXDEPzpMHDNE4MUx+Q5Vw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/tokens": "^4.5.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/button/node_modules/@atlaskit/tokens": {
+            "version": "4.5.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-4.5.2.tgz",
+            "integrity": "sha512-9tirpHkAl3yJAWEmiWHyG1I+z6ghKQdPfmtJYY4/FppbLI+XjxL6Tvr9/GZDmx6twsKi0lLBwsuX1v51USIh1g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/css": {
+            "version": "0.10.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.10.4.tgz",
+            "integrity": "sha512-Xt0LFlLfBUXGzrva3bG3/MrhEQkO5ipvBOjiUorGVVa6S9GQ4NLedOa42vJuK5Vy7j3fKLah5PlyPm8j4taxeA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^4.5.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/ds-lib": {
+            "version": "4.2.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-4.2.0.tgz",
+            "integrity": "sha512-+vNqDxmXWNpjrBxqnZHIFjjaZ4bYlbIR1UBJ4JfEoTlwCnJZdFUPhfq/XFOqSI+nIh54Q5hqT/7vreZobnhG5g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/focus-ring": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/focus-ring/-/focus-ring-3.0.0.tgz",
+            "integrity": "sha512-6wl45BRPBLUkO6W5tf7Yd03eqAJdwtHq7W00v1EWJ/zd3xZqmmjBGBbUUkBgLGZbUFKJMbYDFqfUKFZHcJWFtw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^4.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/icon": {
+            "version": "25.8.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-25.8.0.tgz",
+            "integrity": "sha512-f/lXX0vMX/sNXPDDjcFa0meJr5+Y3dNnvalf5Z/DAoMQC1zLpKr/jzb6OdV/4R7psK2itIVwLPV5aSxn9I9U2A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^4.8.0",
+                "@babel/register": "^7.25.9",
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/interaction-context": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/interaction-context/-/interaction-context-3.0.0.tgz",
+            "integrity": "sha512-s2OvErvOWlDxw75kvANbsiosC8dxyXg+3A2CORYa3HigUnDg5unaM5oDNig8em0/2m9d9TYvrRuamjY0tHFnPQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/layering": {
+            "version": "2.2.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/layering/-/layering-2.2.1.tgz",
+            "integrity": "sha512-jnOPwolq+/pUy2SA2ksZocRujRxxwkZnVoIHG842JCCmA3G7ajrwuXcv0Sa2Vdfl22BvEBk9iKqhIKkEIv3AGA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/motion": {
+            "version": "5.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/motion/-/motion-5.3.0.tgz",
+            "integrity": "sha512-gCRs7DCc2LVFMDVkQfmvBCd7j4EIq2wJV5brGkKyJ2EeOUeB2GKVktBVecsfYh2WPEF5XbFw1Wt+QG27r31fTw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/css": "^0.12.0",
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/motion/node_modules/@atlaskit/css": {
+            "version": "0.12.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.12.2.tgz",
+            "integrity": "sha512-9JCMv+eS9wKupeqtSnNmiOXPV92torqNZVjd3XInyX867dvqksbgAkg74GgKxRrflw2hjsZuOhG57ffdJQ1F/g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/motion/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/motion/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/popper": {
+            "version": "7.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/popper/-/popper-7.1.1.tgz",
+            "integrity": "sha512-yNib4QhSIZPYw1VqC8y3/ezJV3w3Do7xIG+4xfEt/8+bZ9BEAf5MXVxgQXpfOQO1CCSYfamyW4za42v5KL6lKw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "@popperjs/core": "^2.11.8",
+                "react-popper": "^2.3.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/portal": {
+            "version": "5.1.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/portal/-/portal-5.1.3.tgz",
+            "integrity": "sha512-f7yaYZlSuP86gEPbK68ySsdC9wxetsaWiTdiC1WbxbKuAKfan2GKolqQvrYYurTufXa9A9RkuT7xU8jp4QjHfg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/theme": "^19.0.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/portal/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/portal/node_modules/@atlaskit/theme": {
+            "version": "19.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-19.0.2.tgz",
+            "integrity": "sha512-sIFwGr6jmcnFwobys+85nts2v5KF/lbis+jhU5D09nLsscRC7t/TqxRyrE6q7Ewd3cnyXwFG0vQsTDSCRsqgVg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/portal/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/primitives": {
+            "version": "14.11.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-14.11.4.tgz",
+            "integrity": "sha512-BrXo6I0VlWF2Flzi+mvYWEoYEklk09ANQNZnvZYLk3isxy2VXqFSyRgjupTX5t+rAZCNfSh99JdP/5uVTgSGGA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.1.0",
+                "@atlaskit/app-provider": "^3.1.0",
+                "@atlaskit/css": "^0.12.0",
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/interaction-context": "^3.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^6.0.0",
+                "@atlaskit/visually-hidden": "^3.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/primitives/node_modules/@atlaskit/css": {
+            "version": "0.12.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.12.2.tgz",
+            "integrity": "sha512-9JCMv+eS9wKupeqtSnNmiOXPV92torqNZVjd3XInyX867dvqksbgAkg74GgKxRrflw2hjsZuOhG57ffdJQ1F/g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/primitives/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/primitives/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
             }
         },
         "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/spinner": {
-            "version": "17.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/spinner/-/spinner-17.2.0.tgz",
-            "integrity": "sha512-m34zRXGPz7WUeI5kjhPAzAPZEnEBXdwqeCww28wtlWEqQJACrVhdI/1QIYqFBj+/bZMmc21DSsvjP0Nbty7scg==",
+            "version": "18.0.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/spinner/-/spinner-18.0.6.tgz",
+            "integrity": "sha512-U0G0tRxHE4Gm8gNylU0ffoAGq+BtkXF7EzpHmIBiEOFjGgS3TSW85Z0tty0x7fdcntpYi37+neKa13xN6xnoyA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/interaction-context": "^2.6.0",
-                "@atlaskit/theme": "^16.0.0",
-                "@atlaskit/tokens": "^3.3.0",
+                "@atlaskit/interaction-context": "^3.0.0",
+                "@atlaskit/theme": "^19.0.0",
+                "@atlaskit/tokens": "^5.4.0",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.2"
+                "@compiled/react": "^0.18.3"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/spinner/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/spinner/node_modules/@atlaskit/theme": {
+            "version": "19.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-19.0.2.tgz",
+            "integrity": "sha512-sIFwGr6jmcnFwobys+85nts2v5KF/lbis+jhU5D09nLsscRC7t/TqxRyrE6q7Ewd3cnyXwFG0vQsTDSCRsqgVg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/spinner/node_modules/@atlaskit/theme/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/spinner/node_modules/@atlaskit/tokens": {
+            "version": "5.6.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-5.6.3.tgz",
+            "integrity": "sha512-oRYrJtzWFzA7ExUHXhFI2h5pM70eXKkOZVj29Ase1ZSCSqN54Ii2KrE69U43pkQzVT05KTq0kV3Uoq3MM6HP3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/theme": {
+            "version": "18.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-18.0.3.tgz",
+            "integrity": "sha512-BdAudMIs7XT9UnJzrof4QymxpkLCJl8Wx2EslZZjWr9SXocSR1fJyNRNo1f4d+y8xaY9L9RplwCuryUPztuCkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/tokens": "^5.4.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/theme/node_modules/@atlaskit/tokens": {
+            "version": "5.6.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-5.6.3.tgz",
+            "integrity": "sha512-oRYrJtzWFzA7ExUHXhFI2h5pM70eXKkOZVj29Ase1ZSCSqN54Ii2KrE69U43pkQzVT05KTq0kV3Uoq3MM6HP3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/theme/node_modules/@atlaskit/tokens/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/tokens": {
+            "version": "4.9.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-4.9.1.tgz",
+            "integrity": "sha512-f8BvV+ZAi+0NV7xZzO12Fe4C/sPSXKaalwYOuO9tIjOeaR3ot6vY//rDGP/rKCC+HBsY6GoLcIsBs3UnERxyGQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/tooltip": {
+            "version": "20.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tooltip/-/tooltip-20.0.5.tgz",
+            "integrity": "sha512-gaBuZbZkGB65PoU0X3tOYTaTdGJAuSP46FGavB8hRar6JOHcFcNL6CKR6ACVNwDEX8TNAJHm7lSQ+TyzD7VM7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.0.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/layering": "^2.1.0",
+                "@atlaskit/motion": "^5.1.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/popper": "^7.0.0",
+                "@atlaskit/portal": "^5.1.0",
+                "@atlaskit/theme": "^18.0.0",
+                "@atlaskit/tokens": "^4.5.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3",
+                "@emotion/react": "^11.7.1",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/dropdown-menu/node_modules/@atlaskit/visually-hidden": {
+            "version": "3.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-3.0.2.tgz",
+            "integrity": "sha512-xYF/fGIKqB8s2sAOXGWwzcke9wO/fSdjWNzeZtNSJdv0J9f3OCjDxHbxTC4c0TKhIMHmXpTsD6fCU6+79J1usg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
             }
         },
         "node_modules/@atlaskit/ds-lib": {
@@ -2869,24 +3549,345 @@
             }
         },
         "node_modules/@atlaskit/menu": {
-            "version": "2.14.4",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/menu/-/menu-2.14.4.tgz",
-            "integrity": "sha512-/b/etU4MsaeTW9+sRsSMI8O7Ez/nU+htLqc2nZVynONahhXeyfnL1PRohBgOx3f8DDvliuqTqZlAZfPJLV0fEQ==",
+            "version": "3.2.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/menu/-/menu-3.2.0.tgz",
+            "integrity": "sha512-JnX8jLVVRyijZPiTRsVRcVxC0c9WT6rriL0N6y7gc1aXWjLOjLCk07XC7ZSbgIsGAfKggev2oeromvFWHAYSQg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/app-provider": "^1.8.0",
-                "@atlaskit/ds-lib": "^3.5.0",
-                "@atlaskit/focus-ring": "^2.1.0",
-                "@atlaskit/interaction-context": "^2.6.0",
+                "@atlaskit/app-provider": "^2.0.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/focus-ring": "^3.0.0",
+                "@atlaskit/interaction-context": "^3.0.0",
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/primitives": "^13.5.0",
-                "@atlaskit/theme": "^16.0.0",
-                "@atlaskit/tokens": "^3.3.0",
+                "@atlaskit/primitives": "^14.2.0",
+                "@atlaskit/theme": "^18.0.0",
+                "@atlaskit/tokens": "^4.5.0",
                 "@babel/runtime": "^7.0.0",
                 "@emotion/react": "^11.7.1"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/app-provider": {
+            "version": "2.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-2.3.0.tgz",
+            "integrity": "sha512-YouUNVDSl7bZy2wBiPUdRAkheZli+K1djg3s5nd24S7c8CobPXbPbirIU+WG9X3SvEY1t60O/trHuy447QE0+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^5.6.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/app-provider/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/app-provider/node_modules/@atlaskit/tokens": {
+            "version": "5.6.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-5.6.3.tgz",
+            "integrity": "sha512-oRYrJtzWFzA7ExUHXhFI2h5pM70eXKkOZVj29Ase1ZSCSqN54Ii2KrE69U43pkQzVT05KTq0kV3Uoq3MM6HP3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/css": {
+            "version": "0.12.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.12.2.tgz",
+            "integrity": "sha512-9JCMv+eS9wKupeqtSnNmiOXPV92torqNZVjd3XInyX867dvqksbgAkg74GgKxRrflw2hjsZuOhG57ffdJQ1F/g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/css/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/css/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/ds-lib": {
+            "version": "4.2.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-4.2.0.tgz",
+            "integrity": "sha512-+vNqDxmXWNpjrBxqnZHIFjjaZ4bYlbIR1UBJ4JfEoTlwCnJZdFUPhfq/XFOqSI+nIh54Q5hqT/7vreZobnhG5g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/focus-ring": {
+            "version": "3.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/focus-ring/-/focus-ring-3.0.2.tgz",
+            "integrity": "sha512-QPmuHNZhvBbF0tStPXYuypthDsUy0rdzkBegArrZMzrW8YLsOpHW9FOQRDdJEmXGJeKKTyE68h3/8tEcbsSEMg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/focus-ring/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/focus-ring/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/interaction-context": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/interaction-context/-/interaction-context-3.0.0.tgz",
+            "integrity": "sha512-s2OvErvOWlDxw75kvANbsiosC8dxyXg+3A2CORYa3HigUnDg5unaM5oDNig8em0/2m9d9TYvrRuamjY0tHFnPQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/primitives": {
+            "version": "14.11.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-14.11.4.tgz",
+            "integrity": "sha512-BrXo6I0VlWF2Flzi+mvYWEoYEklk09ANQNZnvZYLk3isxy2VXqFSyRgjupTX5t+rAZCNfSh99JdP/5uVTgSGGA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.1.0",
+                "@atlaskit/app-provider": "^3.1.0",
+                "@atlaskit/css": "^0.12.0",
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/interaction-context": "^3.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^6.0.0",
+                "@atlaskit/visually-hidden": "^3.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/primitives/node_modules/@atlaskit/app-provider": {
+            "version": "3.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-3.1.0.tgz",
+            "integrity": "sha512-IkjM02XyVmn53pST8lx5bp0ahevbfYki9ax0U0b3zXqQut+0C97WbwoDvdhmlvtIhMmS6e0ET8dL5s+fNTYssg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/primitives/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/primitives/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/theme": {
+            "version": "18.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-18.0.3.tgz",
+            "integrity": "sha512-BdAudMIs7XT9UnJzrof4QymxpkLCJl8Wx2EslZZjWr9SXocSR1fJyNRNo1f4d+y8xaY9L9RplwCuryUPztuCkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/tokens": "^5.4.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/theme/node_modules/@atlaskit/tokens": {
+            "version": "5.6.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-5.6.3.tgz",
+            "integrity": "sha512-oRYrJtzWFzA7ExUHXhFI2h5pM70eXKkOZVj29Ase1ZSCSqN54Ii2KrE69U43pkQzVT05KTq0kV3Uoq3MM6HP3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/theme/node_modules/@atlaskit/tokens/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/tokens": {
+            "version": "4.9.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-4.9.1.tgz",
+            "integrity": "sha512-f8BvV+ZAi+0NV7xZzO12Fe4C/sPSXKaalwYOuO9tIjOeaR3ot6vY//rDGP/rKCC+HBsY6GoLcIsBs3UnERxyGQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/menu/node_modules/@atlaskit/visually-hidden": {
+            "version": "3.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-3.0.3.tgz",
+            "integrity": "sha512-tU2KX0Hdn4DTL0DejO5j27RuySBdWRQQNVEvmNs20F5YnVQla/wGt1a85Y0widuBOn3H/RgTRuHPsChk9fimHg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
             }
         },
         "node_modules/@atlaskit/modal-dialog": {
@@ -3228,20 +4229,21 @@
             }
         },
         "node_modules/@atlaskit/popup": {
-            "version": "1.32.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/popup/-/popup-1.32.0.tgz",
-            "integrity": "sha512-sarQ84k+0Ifc9ZnuaNvu2T14CUbcMfMMC2WivF1nQfjebdRr1NGdRD3THXt+U/+KhjUyrWh1Dl1giX0J1Ub9vg==",
+            "version": "3.0.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/popup/-/popup-3.0.1.tgz",
+            "integrity": "sha512-ZEGbPfdkTiy77Ipd1eRM/sLrw2cZpbUlfuE8smddmdSQ6w9GuhUMDT72IYlaVOXP0c8NArcF37BBjLCDf5n/Aw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/css": "^0.9.0",
-                "@atlaskit/ds-lib": "^3.5.0",
-                "@atlaskit/focus-ring": "^2.1.0",
-                "@atlaskit/layering": "^1.1.0",
+                "@atlaskit/css": "^0.10.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/focus-ring": "^3.0.0",
+                "@atlaskit/layering": "^2.1.0",
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/popper": "^6.4.0",
-                "@atlaskit/portal": "^4.11.0",
-                "@atlaskit/primitives": "^13.6.0",
-                "@atlaskit/theme": "^16.0.0",
-                "@atlaskit/tokens": "^3.3.0",
+                "@atlaskit/popper": "^7.0.0",
+                "@atlaskit/portal": "^5.1.0",
+                "@atlaskit/primitives": "^14.2.0",
+                "@atlaskit/theme": "^18.0.0",
+                "@atlaskit/tokens": "^4.5.0",
                 "@babel/runtime": "^7.0.0",
                 "@emotion/react": "^11.7.1",
                 "bind-event-listener": "^3.0.0",
@@ -3250,8 +4252,420 @@
                 "tiny-invariant": "^1.2.0"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/app-provider": {
+            "version": "3.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-3.1.0.tgz",
+            "integrity": "sha512-IkjM02XyVmn53pST8lx5bp0ahevbfYki9ax0U0b3zXqQut+0C97WbwoDvdhmlvtIhMmS6e0ET8dL5s+fNTYssg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/app-provider/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/app-provider/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/css": {
+            "version": "0.10.7",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.10.7.tgz",
+            "integrity": "sha512-UtHum6QMV5/1Bor1z/kHylnKgQgz+yJjQXhwcM6/6SeNOdL1jcT9VFJt6l99HbfPVWn4DJuKHqgU3wnf3acZCw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^5.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/css/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/css/node_modules/@atlaskit/tokens": {
+            "version": "5.6.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-5.6.3.tgz",
+            "integrity": "sha512-oRYrJtzWFzA7ExUHXhFI2h5pM70eXKkOZVj29Ase1ZSCSqN54Ii2KrE69U43pkQzVT05KTq0kV3Uoq3MM6HP3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/ds-lib": {
+            "version": "4.2.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-4.2.0.tgz",
+            "integrity": "sha512-+vNqDxmXWNpjrBxqnZHIFjjaZ4bYlbIR1UBJ4JfEoTlwCnJZdFUPhfq/XFOqSI+nIh54Q5hqT/7vreZobnhG5g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/focus-ring": {
+            "version": "3.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/focus-ring/-/focus-ring-3.0.2.tgz",
+            "integrity": "sha512-QPmuHNZhvBbF0tStPXYuypthDsUy0rdzkBegArrZMzrW8YLsOpHW9FOQRDdJEmXGJeKKTyE68h3/8tEcbsSEMg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/focus-ring/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/focus-ring/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/interaction-context": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/interaction-context/-/interaction-context-3.0.0.tgz",
+            "integrity": "sha512-s2OvErvOWlDxw75kvANbsiosC8dxyXg+3A2CORYa3HigUnDg5unaM5oDNig8em0/2m9d9TYvrRuamjY0tHFnPQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/layering": {
+            "version": "2.2.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/layering/-/layering-2.2.1.tgz",
+            "integrity": "sha512-jnOPwolq+/pUy2SA2ksZocRujRxxwkZnVoIHG842JCCmA3G7ajrwuXcv0Sa2Vdfl22BvEBk9iKqhIKkEIv3AGA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/popper": {
+            "version": "7.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/popper/-/popper-7.1.1.tgz",
+            "integrity": "sha512-yNib4QhSIZPYw1VqC8y3/ezJV3w3Do7xIG+4xfEt/8+bZ9BEAf5MXVxgQXpfOQO1CCSYfamyW4za42v5KL6lKw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "@popperjs/core": "^2.11.8",
+                "react-popper": "^2.3.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/portal": {
+            "version": "5.1.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/portal/-/portal-5.1.3.tgz",
+            "integrity": "sha512-f7yaYZlSuP86gEPbK68ySsdC9wxetsaWiTdiC1WbxbKuAKfan2GKolqQvrYYurTufXa9A9RkuT7xU8jp4QjHfg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/theme": "^19.0.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/portal/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/portal/node_modules/@atlaskit/theme": {
+            "version": "19.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-19.0.2.tgz",
+            "integrity": "sha512-sIFwGr6jmcnFwobys+85nts2v5KF/lbis+jhU5D09nLsscRC7t/TqxRyrE6q7Ewd3cnyXwFG0vQsTDSCRsqgVg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/portal/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/primitives": {
+            "version": "14.11.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-14.11.4.tgz",
+            "integrity": "sha512-BrXo6I0VlWF2Flzi+mvYWEoYEklk09ANQNZnvZYLk3isxy2VXqFSyRgjupTX5t+rAZCNfSh99JdP/5uVTgSGGA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.1.0",
+                "@atlaskit/app-provider": "^3.1.0",
+                "@atlaskit/css": "^0.12.0",
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/interaction-context": "^3.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^6.0.0",
+                "@atlaskit/visually-hidden": "^3.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/primitives/node_modules/@atlaskit/css": {
+            "version": "0.12.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.12.2.tgz",
+            "integrity": "sha512-9JCMv+eS9wKupeqtSnNmiOXPV92torqNZVjd3XInyX867dvqksbgAkg74GgKxRrflw2hjsZuOhG57ffdJQ1F/g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^6.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/primitives/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/primitives/node_modules/@atlaskit/tokens": {
+            "version": "6.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-6.0.0.tgz",
+            "integrity": "sha512-KofyBwF86HsQPoldfihaukihE9tPqe4cbjgYDmSl8KOXDdAQDpGg9TnUAGknxu3p8EsLZpViG53HfwWvLjs+pQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/theme": {
+            "version": "18.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/theme/-/theme-18.0.3.tgz",
+            "integrity": "sha512-BdAudMIs7XT9UnJzrof4QymxpkLCJl8Wx2EslZZjWr9SXocSR1fJyNRNo1f4d+y8xaY9L9RplwCuryUPztuCkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/codemod-utils": "^4.2.0",
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/tokens": "^5.4.0",
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/theme/node_modules/@atlaskit/tokens": {
+            "version": "5.6.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-5.6.3.tgz",
+            "integrity": "sha512-oRYrJtzWFzA7ExUHXhFI2h5pM70eXKkOZVj29Ase1ZSCSqN54Ii2KrE69U43pkQzVT05KTq0kV3Uoq3MM6HP3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/theme/node_modules/@atlaskit/tokens/node_modules/@atlaskit/ds-lib": {
+            "version": "5.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.0.0.tgz",
+            "integrity": "sha512-Bd0/D5Q2Sg/Z1kg/Qst+2VfiVoVuGwEvrWKSt63QgDaCizl30j2EtqLLF9U978mzl1JHMmi3KQeYf3ROjhoACA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "react-uid": "^2.2.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/tokens": {
+            "version": "4.9.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-4.9.1.tgz",
+            "integrity": "sha512-f8BvV+ZAi+0NV7xZzO12Fe4C/sPSXKaalwYOuO9tIjOeaR3ot6vY//rDGP/rKCC+HBsY6GoLcIsBs3UnERxyGQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^4.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/popup/node_modules/@atlaskit/visually-hidden": {
+            "version": "3.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-3.0.3.tgz",
+            "integrity": "sha512-tU2KX0Hdn4DTL0DejO5j27RuySBdWRQQNVEvmNs20F5YnVQla/wGt1a85Y0widuBOn3H/RgTRuHPsChk9fimHg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.3"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
             }
         },
         "node_modules/@atlaskit/portal": {

--- a/package.json
+++ b/package.json
@@ -1384,7 +1384,7 @@
         "@atlaskit/checkbox": "^17.1.10",
         "@atlaskit/comment": "^13.0.19",
         "@atlaskit/datetime-picker": "^17.0.13",
-        "@atlaskit/dropdown-menu": "^12.26.5",
+        "@atlaskit/dropdown-menu": "^13.1.0",
         "@atlaskit/feature-gate-js-client": "^5.5.5",
         "@atlaskit/form": "^12.2.0",
         "@atlaskit/icon": "^27.12.0",


### PR DESCRIPTION
### What Is This Change?

Initially, I wanted to update the package to the latest version, but I realized they changed something in version 14, and the `dropdown-menu` looked strange in dark theme. 

<img width="183" height="278" alt="Screenshot 2025-08-21 at 15 26 01" src="https://github.com/user-attachments/assets/c1c74c65-8d06-4373-bfa6-a9d0e9189cd1" />

So I only updated it to 13.1.0. It looks fine

<img width="185" height="283" alt="Screenshot 2025-08-21 at 15 29 04" src="https://github.com/user-attachments/assets/3b167704-ab82-4dac-9ff0-e5a528ac6cbd" />

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change