### PR TITLE
Fixed issue with create and epics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - Fixed issue when project value was not updating in create issue page
+- Fixed issue when trying to create children issues on epic that had no children to begin with.
 
 ## What's new in 3.8.10
 

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/ChildIssuesComponent.test.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/ChildIssuesComponent.test.tsx
@@ -7,19 +7,23 @@ import { ChildIssuesComponent } from './ChildIssuesComponent';
 describe('ChildIssuesComponent', () => {
     const mockOnSave = jest.fn();
     const mockSetEnableSubtasks = jest.fn();
+    const mockSetEnableEpicChildren = jest.fn();
     const mockHandleOpenIssue = jest.fn();
 
     const defaultProps = {
-        subtaskTypes: [
+        childTypes: [
             { id: '1', name: 'Task', iconUrl: 'task-icon.png' },
             { id: '2', name: 'Bug', iconUrl: 'bug-icon.png' },
         ] as IssueType[],
         label: 'Subtasks',
         onSave: mockOnSave,
         loading: false,
-        enableSubtasks: { enable: false, setEnableSubtasks: mockSetEnableSubtasks },
+        enable: false,
         handleOpenIssue: mockHandleOpenIssue,
         issues: [],
+        isEpic: false,
+        setEnableEpicChildren: mockSetEnableEpicChildren,
+        setEnableSubtasks: mockSetEnableSubtasks,
     };
 
     beforeEach(() => {

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/ChildIssuesComponent.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/ChildIssuesComponent.tsx
@@ -15,13 +15,16 @@ export type SummaryAndIssueType = {
     issuetype: { id: string };
 };
 type Props = {
-    subtaskTypes: IssueType[];
+    childTypes: IssueType[];
     label: string;
     onSave: (val: SummaryAndIssueType) => void;
     loading: boolean;
-    enableSubtasks: { enable: boolean; setEnableSubtasks: (enable: boolean) => void };
+    enable: boolean;
+    setEnableSubtasks: (enable: boolean) => void;
+    setEnableEpicChildren: (enable: boolean) => void;
     handleOpenIssue: (issueOrKey: MinimalIssueOrKeyAndSite<DetailedSiteInfo>) => void;
     issues: any[];
+    isEpic: boolean;
 };
 
 const { Option, SingleValue } = components;
@@ -44,20 +47,22 @@ const IconValue = (props: any) => (
 );
 
 export const ChildIssuesComponent: React.FC<Props> = ({
-    subtaskTypes,
+    childTypes,
     label,
     onSave,
     loading,
-    enableSubtasks,
+    enable,
+    setEnableSubtasks,
+    setEnableEpicChildren,
     handleOpenIssue,
     issues,
+    isEpic,
 }) => {
     const [isEditing, setIsEditing] = React.useState(false);
     const [inputValue, setInputValue] = React.useState('');
     const [selectedIssueType, setSelectedIssueType] = React.useState<IssueType>(
-        subtaskTypes.length > 0 ? subtaskTypes[0] : emptyIssueType,
+        childTypes.length > 0 ? childTypes[0] : emptyIssueType,
     );
-    const { enable, setEnableSubtasks } = enableSubtasks;
     React.useEffect(() => {
         if (enable) {
             setIsEditing(true);
@@ -76,8 +81,12 @@ export const ChildIssuesComponent: React.FC<Props> = ({
     const handleCancel = () => {
         setInputValue('');
         setIsEditing(false);
-        setSelectedIssueType(subtaskTypes.length > 0 ? subtaskTypes[0] : emptyIssueType);
-        setEnableSubtasks(false);
+        setSelectedIssueType(childTypes.length > 0 ? childTypes[0] : emptyIssueType);
+        if (isEpic) {
+            setEnableEpicChildren(false);
+        } else {
+            setEnableSubtasks(false);
+        }
     };
     return (
         <Box>
@@ -100,7 +109,7 @@ export const ChildIssuesComponent: React.FC<Props> = ({
                             <Select
                                 className="ac-select-container"
                                 classNamePrefix="ac-select"
-                                options={subtaskTypes}
+                                options={childTypes}
                                 defaultValue={selectedIssueType}
                                 components={{ Option: IconOption, SingleValue: IconValue }}
                                 getOptionLabel={(option: IssueType) => option.name}

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/IssueMainPanel.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/IssueMainPanel.tsx
@@ -71,6 +71,7 @@ const IssueMainPanel: React.FC<Props> = ({
 
     //states
     const [enableSubtasks, setEnableSubtasks] = React.useState(false);
+    const [enableEpicChildren, setEnableEpicChildren] = React.useState(false);
     const [enableLinkedIssues, setEnableLinkedIssues] = React.useState(false);
     const [isModalOpen, setIsModalOpen] = React.useState(false);
     const [isInlineDialogOpen, setIsInlineDialogOpen] = React.useState(false);
@@ -81,9 +82,15 @@ const IssueMainPanel: React.FC<Props> = ({
         <Tooltip content="Add content">
             <AddContentDropdown
                 handleAttachmentClick={() => setIsModalOpen(true)}
-                handleChildIssueClick={() => {
-                    setEnableSubtasks(true);
-                }}
+                handleChildIssueClick={
+                    isEpic
+                        ? () => {
+                              setEnableEpicChildren(true);
+                          }
+                        : () => {
+                              setEnableSubtasks(true);
+                          }
+                }
                 handleLinkedIssueClick={() => {
                     setEnableLinkedIssues(true);
                 }}
@@ -202,26 +209,32 @@ const IssueMainPanel: React.FC<Props> = ({
             {subtasks && (subtasks.length > 0 || enableSubtasks) && (
                 <div>
                     <ChildIssuesComponent
-                        subtaskTypes={subtaskTypes}
+                        childTypes={subtaskTypes}
                         label="Child issues"
                         loading={loadingField === 'subtasks'}
                         onSave={(e: any) => handleInlineEdit(fields['subtasks'], e)}
-                        enableSubtasks={{ enable: enableSubtasks, setEnableSubtasks }}
+                        enable={enableSubtasks}
+                        setEnableEpicChildren={setEnableEpicChildren}
+                        setEnableSubtasks={setEnableSubtasks}
                         handleOpenIssue={handleOpenIssue}
                         issues={subtasks}
+                        isEpic={isEpic}
                     />
                 </div>
             )}
-            {isEpic && epicChildren && epicChildren.length > 0 && (
+            {isEpic && epicChildren && (epicChildren.length > 0 || enableEpicChildren) && (
                 <div>
                     <ChildIssuesComponent
-                        subtaskTypes={!epicChildrenTypes ? [] : epicChildrenTypes} // This are not "subtasks" for epics but full issues
+                        childTypes={!epicChildrenTypes ? [] : epicChildrenTypes}
                         label="Epic Child issues"
-                        loading={loadingField === 'subtasks'}
-                        onSave={(e: any) => handleInlineEdit(fields['subtasks'], e)}
-                        enableSubtasks={{ enable: enableSubtasks, setEnableSubtasks }} // Change this for epics
+                        loading={loadingField === 'subtasks'} // Handles loading state the same as subtasks
+                        onSave={(e: any) => handleInlineEdit(fields['subtasks'], e)} // Creates an issue in the same way for standardIssues and subtasks
+                        enable={enableEpicChildren}
+                        setEnableEpicChildren={setEnableEpicChildren}
+                        setEnableSubtasks={setEnableSubtasks}
                         handleOpenIssue={handleOpenIssue}
                         issues={epicChildren}
+                        isEpic={isEpic}
                     />
                 </div>
             )}


### PR DESCRIPTION
Fixed the issue but still need to test with server

### What Is This Change?

- Fixed the bug where we created an epic from the create issue page and could not see the epic children nor create any.
- Also made the React components easier to read and more general for child-parent types in Cloud and DC.

### How Has This Been Tested?

- Tested via Cloud on Jira instance. 

- Testing still needed on cloud
Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change