### PR TITLE
NO ISSUE: Do not keep files on clear chat if no files to keeP

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -172,6 +172,9 @@ const RovoDevView: React.FC = () => {
 
     const keepFiles = useCallback(
         (files: ToolReturnParseResult[]) => {
+            if (files.length === 0) {
+                return;
+            }
             dispatch({
                 type: RovoDevViewResponseType.KeepFileChanges,
                 files: files.map(


### PR DESCRIPTION
### What Is This Change?

Check to see if there are any modified files before calling 'Keep Files' message. This is to prevent bug where calling new session command before chatSessionID is init breaks telemetry

<img width="439" height="719" alt="image" src="https://github.com/user-attachments/assets/6953d79a-9668-4246-862d-411cb31e1200" />

### How Has This Been Tested?

maunal
Basic checks:

- [x] `npm run lint`
- [x] `npm run test`