### PR TITLE
[AXON-884] add new authentication command

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -61,10 +61,10 @@ export const baseConfigFor = (project: string, testExtension: string): Config =>
         global:
             testExtension === 'ts'
                 ? {
-                      statements: 70,
-                      branches: 62,
-                      functions: 62,
-                      lines: 70,
+                      statements: 68,
+                      branches: 60,
+                      functions: 60,
+                      lines: 68,
                   }
                 : /* tsx */ {
                       statements: 7,

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
         ],
         "commands": [
             {
+                "command": "atlascode.rovodev.quickAuth",
+                "title": "Authenticate",
+                "category": "Jira"
+            },
+            {
                 "command": "atlascode.rovodev.askInteractive",
                 "title": "Ask & Open",
                 "enablement": "atlascode:rovoDevEnabled",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -93,6 +93,7 @@ export const enum Commands {
     OpenRovoDevMcpJson = 'atlascode.openRovoDevMcpJson',
     OpenRovoDevGlobalMemory = 'atlascode.openRovoDevGlobalMemory',
     OpenNativeSettings = 'atlascode.openNativeSettings',
+    QuickAuth = 'atlascode.rovodev.quickAuth',
 
     // Debug mode-only commands
     DebugQuickCommand = 'atlascode.debug.quickCommand',

--- a/src/container.ts
+++ b/src/container.ts
@@ -31,6 +31,7 @@ import { StartWorkIssueMessage } from './lib/ipc/toUI/startWork';
 import { CommonActionMessageHandler } from './lib/webview/controller/common/commonActionMessageHandler';
 import { Logger } from './logger';
 import OnboardingProvider from './onboarding/onboardingProvider';
+import { registerQuickAuthCommand } from './onboarding/quickFlow';
 import { Pipeline } from './pipelines/model';
 import { RovoDevCodeActionProvider } from './rovo-dev/rovoDevCodeActionProvider';
 import { RovoDevDecorator } from './rovo-dev/rovoDevDecorator';
@@ -194,6 +195,9 @@ export class Container {
         context.subscriptions.push(new HelpExplorer());
 
         this._featureFlagClient = FeatureFlagClient.getInstance();
+
+        // TODO: add a guard rail feature flag
+        context.subscriptions.push(registerQuickAuthCommand());
         try {
             await this._featureFlagClient.initialize({
                 analyticsAnonymousId: this.machineId,

--- a/src/onboarding/quickFlow/authentication/authFlowUI.ts
+++ b/src/onboarding/quickFlow/authentication/authFlowUI.ts
@@ -1,0 +1,333 @@
+import { ProductJira } from 'src/atlclients/authInfo';
+import { Container } from 'src/container';
+import {
+    env,
+    InputBoxOptions,
+    QuickInputButton,
+    QuickInputButtons,
+    QuickPickItem,
+    QuickPickItemKind,
+    ThemeIcon,
+    Uri,
+} from 'vscode';
+
+import { BaseUI, UiResponse } from '../baseUI';
+import {
+    AuthenticationType,
+    AuthFlowData,
+    ServerCredentialType,
+    SpecialSiteOptions,
+    SSLConfigurationType,
+} from './types';
+
+export type ExtraOptions = {
+    step?: number;
+    totalSteps?: number;
+    buttons?: QuickInputButton[];
+    buttonHandler?: (e: QuickInputButton) => void;
+    value?: string;
+    prompt?: string;
+};
+
+type PartialData = Partial<AuthFlowData>;
+
+export class AuthFlowUI {
+    constructor(private readonly baseUI: BaseUI = new BaseUI('Authenticate with Jira')) {}
+
+    // QuickPicks
+
+    public pickServerCredentialType(state: PartialData): Promise<UiResponse<ServerCredentialType>> {
+        return this.baseUI.showQuickPick(
+            [
+                {
+                    label: ServerCredentialType.Basic,
+                    detail: 'Simple and secure username/password authentication, applicable in most cases',
+                },
+                {
+                    label: ServerCredentialType.PAT,
+                    detail: "Choose this if you already have a Personal Access Token you'd like to use instead",
+                },
+            ],
+            {
+                placeHolder: 'How would you like to authenticate?',
+                value: state.serverCredentialType || '',
+            },
+        );
+    }
+
+    public pickSite(state: PartialData): Promise<UiResponse<SpecialSiteOptions | string>> {
+        const sites: QuickPickItem[] = Container.siteManager
+            .getSitesAvailable(ProductJira)
+            .filter((site) => site.isCloud === (state.authenticationType !== AuthenticationType.Server))
+            .map((site) => ({
+                label: site.host,
+                iconPath: site.isCloud ? new ThemeIcon('cloud') : new ThemeIcon('server'),
+            }))
+            .sort((a, b) => a.label.localeCompare(b.label));
+
+        if (sites.length === 0 && state.authenticationType === AuthenticationType.ApiToken) {
+            sites.push({
+                label: SpecialSiteOptions.OAuth,
+                // TODO: actually trigger OAuth here once we can await on flows
+                detail: 'You can run OAuth from the previous step',
+                iconPath: new ThemeIcon('info'),
+            });
+        }
+        const choices = [
+            {
+                label: SpecialSiteOptions.NewSite,
+                iconPath: new ThemeIcon('add'),
+            },
+            {
+                label: '',
+                kind: QuickPickItemKind.Separator,
+            },
+            ...sites,
+        ];
+        return this.baseUI.showQuickPick(choices, {
+            placeHolder: 'Select a site to authenticate with',
+            validateSelection: (items) =>
+                items.length > 0 && !items.some((item) => item.label.includes('Login with OAuth')),
+        });
+    }
+
+    public pickAuthenticationType(state: PartialData): Promise<UiResponse<AuthenticationType>> {
+        return this.baseUI.showQuickPick(
+            [
+                {
+                    iconPath: new ThemeIcon('cloud'),
+                    label: AuthenticationType.OAuth,
+                    description: 'Authenticate using OAuth',
+                    detail: 'Get basic access to your Atlassian work items',
+                },
+                {
+                    iconPath: new ThemeIcon('key'),
+                    label: AuthenticationType.ApiToken,
+                    description: 'Authenticate via an API token',
+                    detail: 'Get the full power of Atlassian integration, including experimental and AI features',
+                },
+                {
+                    iconPath: new ThemeIcon('server'),
+                    label: AuthenticationType.Server,
+                    description: 'Authenticate with Jira Server or Datacenter',
+                    detail: 'Use this if you have a self-hosted Jira instance or Jira DC',
+                },
+            ],
+            {
+                placeHolder: 'How would you like to authenticate?',
+                value: state.authenticationType || '',
+            },
+        );
+    }
+
+    public pickContextPathNeeded(state: PartialData): Promise<UiResponse<'Yes' | 'No'>> {
+        const site = state.site;
+        return this.baseUI.showQuickPick(
+            [
+                {
+                    label: 'Yes',
+                    description: 'Your Jira server has a path',
+                    detail: `For example: https://${site}/path/to/jira`,
+                },
+                {
+                    label: 'No',
+                    description: 'Your Jira server is running at the root',
+                    detail: `For example: https://${site}/`,
+                },
+            ],
+            {
+                placeHolder: 'Does your server have a context path?',
+                value: state.isContextPathNeeded === undefined ? '' : state.isContextPathNeeded ? 'Yes' : 'No',
+                buttons: [
+                    QuickInputButtons.Back,
+                    { iconPath: new ThemeIcon('info'), tooltip: 'Learn more about context paths' },
+                ],
+                buttonHandler: (button) => {
+                    if (button.tooltip === 'Learn more about context paths') {
+                        // Open the documentation link
+                        env.openExternal(
+                            Uri.parse(
+                                'https://confluence.atlassian.com/kb/set-a-context-path-for-atlassian-applications-836601189.html',
+                            ),
+                        );
+                    }
+                },
+            },
+        );
+    }
+
+    pickSslConfigurationType(state: PartialData): Promise<UiResponse<SSLConfigurationType>> {
+        return this.baseUI.showQuickPick(
+            [
+                {
+                    label: SSLConfigurationType.Default,
+                    detail: 'Applicable for most cases',
+                },
+                {
+                    kind: QuickPickItemKind.Separator,
+                    label: '',
+                },
+                {
+                    label: SSLConfigurationType.CustomCA,
+                    detail: 'Choose this to provide paths to your custom CA certificates',
+                },
+                {
+                    label: SSLConfigurationType.CustomClientSideCerts,
+                    detail: 'Choose this to specify a PFX file and its passphrase, if necessary',
+                },
+            ],
+            {
+                placeHolder: 'Select SSL Configuration Type',
+                value: state.sslConfigurationType || '',
+            },
+        );
+    }
+
+    public pickCreateTokenNeeded(state: PartialData): Promise<UiResponse<'Yes' | 'No'>> {
+        return this.baseUI.showQuickPick(
+            [
+                {
+                    label: 'Yes',
+                    description: 'Create a new API token',
+                    detail: 'Choose this to open the API token management page in your browser',
+                },
+                {
+                    label: 'No',
+                    description: 'Use an existing API token',
+                    detail: 'Choose this if you already have an API token ready to use',
+                },
+            ],
+            {
+                placeHolder: 'Would you like to open the API token management page?',
+            },
+        );
+    }
+
+    // Text boxes
+
+    public inputNewSite(state: PartialData): Promise<UiResponse> {
+        const defaults: Partial<InputBoxOptions> = {
+            value: state.site || '',
+            valueSelection: state.site ? [0, state.site.length] : undefined,
+        };
+
+        if (state.authenticationType !== AuthenticationType.Server) {
+            // We expect an `atlassian.net` hostname
+            defaults.value = defaults.value || 'your-site.atlassian.net';
+            defaults.valueSelection = [0, defaults.value.indexOf('.atlassian.net')];
+            defaults.validateInput = (value) => {
+                const isValid = /^[a-z0-9]+([-.][a-z0-9]+)*\.atlassian\.net$/.test(value);
+                return isValid
+                    ? null
+                    : 'Cloud sites typically look like `your-site.atlassian.net`. Do you have a Jira Server instance?';
+            };
+        } else {
+            // Not an .atlassian.net domain
+            defaults.validateInput = (value) => {
+                const isCloud = /^[a-z0-9]+([-.][a-z0-9]+)*\.atlassian\.net$/.test(value);
+                return !isCloud ? null : 'This looks like a cloud site. Do you have a Jira Cloud instance?';
+            };
+        }
+
+        return this.baseUI.showInputBox({
+            placeHolder: 'Enter your new site name',
+            ...defaults,
+        });
+    }
+
+    public inputContextPath(state: PartialData): Promise<UiResponse> {
+        return this.baseUI.showInputBox({
+            placeHolder: 'Does your server have a context path?',
+            value: state.contextPath || '',
+            buttons: [
+                QuickInputButtons.Back,
+                { iconPath: new ThemeIcon('info'), tooltip: 'Learn more about context paths' },
+            ],
+            buttonHandler: (button) => {
+                if (button.tooltip === 'Learn more about context paths') {
+                    // Open the documentation link
+                    env.openExternal(
+                        Uri.parse(
+                            'https://confluence.atlassian.com/kb/set-a-context-path-for-atlassian-applications-836601189.html',
+                        ),
+                    );
+                }
+            },
+        });
+    }
+
+    inputSslCertsPath(state: PartialData): Promise<UiResponse> {
+        return this.baseUI.showInputBox({
+            placeHolder: 'Enter the path to your SSL certificates',
+            prompt: 'Use comma if you have multiple paths',
+            value: state.sslCertsPath || '',
+        });
+    }
+
+    inputPfxPath(state: PartialData): Promise<UiResponse> {
+        return this.baseUI.showInputBox({
+            placeHolder: 'Enter the path to your PFX file',
+            value: state.pfxPath || '',
+        });
+    }
+
+    inputPfxPassphrase(state: PartialData): Promise<UiResponse> {
+        return this.baseUI.showInputBox({
+            placeHolder: 'Enter the passphrase for your PFX file',
+            value: state.pfxPassphrase || '',
+        });
+    }
+
+    public async inputUsername(state: PartialData): Promise<UiResponse> {
+        const inferredUsername = await this.getDefaultUsername(state);
+        const defaultUsername = state.username || inferredUsername;
+
+        const credName = state.authenticationType === AuthenticationType.ApiToken ? 'email address' : 'username';
+
+        return this.baseUI.showInputBox({
+            placeHolder: `Enter your ${credName}`,
+            value: defaultUsername,
+            prompt:
+                inferredUsername && inferredUsername === defaultUsername
+                    ? `This ${credName} was inferred from your existing credentials`
+                    : undefined,
+            valueSelection: defaultUsername ? [0, defaultUsername.length] : undefined,
+        });
+    }
+
+    public inputPassword(state: PartialData, passwordName: string): Promise<UiResponse> {
+        return this.baseUI.showInputBox({
+            placeHolder: `Enter your ${passwordName}`,
+            password: true,
+            value: state.password || '',
+            valueSelection: state.password ? [0, state.password.length] : undefined,
+        });
+    }
+
+    // Helpers
+
+    private async getDefaultUsername(state: PartialData): Promise<string> {
+        if (state.authenticationType !== AuthenticationType.ApiToken) {
+            return '';
+        }
+
+        const sites = Container.siteManager.getSitesAvailable(ProductJira);
+        const site = sites.find((s) => s.host === state.site);
+        if (!site) {
+            return '';
+        }
+
+        const credentials = await Container.credentialManager.getAuthInfo(site);
+        if (!credentials) {
+            return '';
+        }
+
+        return credentials.user.email;
+    }
+
+    public openApiManagementPage(): void {
+        // Open the API token management page in the user's browser
+        const url = 'https://id.atlassian.com/manage-profile/security/api-tokens';
+        env.openExternal(Uri.parse(url));
+    }
+}

--- a/src/onboarding/quickFlow/authentication/index.ts
+++ b/src/onboarding/quickFlow/authentication/index.ts
@@ -1,0 +1,23 @@
+import { QuickFlow } from '../quickFlow';
+import { AuthFlowUI } from './authFlowUI';
+import { CommonAuthStates } from './states/common';
+import { AuthFlowData, AuthState } from './types';
+
+export { AuthFlowData };
+
+export class AuthFlow extends QuickFlow<AuthFlowUI, AuthFlowData> {
+    static FlowDataType: AuthFlowData;
+    static UIType: AuthFlowUI;
+
+    constructor(private readonly _ui: AuthFlowUI = new AuthFlowUI()) {
+        super();
+    }
+
+    initialState(): AuthState {
+        return CommonAuthStates.initialState;
+    }
+
+    ui() {
+        return this._ui;
+    }
+}

--- a/src/onboarding/quickFlow/authentication/states/common.ts
+++ b/src/onboarding/quickFlow/authentication/states/common.ts
@@ -1,0 +1,151 @@
+import { UiAction } from '../../baseUI';
+import { Transition } from '../../types';
+import { AuthFlowUI } from '../authFlowUI';
+import { AuthenticationType, AuthState, PartialAuthData } from '../types';
+import { ServerAuthStates } from './server';
+import { TerminalAuthStates } from './terminal';
+
+export class CommonAuthStates {
+    public static initialState: AuthState = {
+        name: 'initial',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            return Transition.forward(CommonAuthStates.selectAuthType);
+        },
+    };
+
+    public static selectAuthType: AuthState = {
+        name: 'selectAuthType',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            const transitions = {
+                [AuthenticationType.OAuth]: TerminalAuthStates.runOauth,
+                [AuthenticationType.ApiToken]: CommonAuthStates.selectSiteFromDropdown,
+                [AuthenticationType.Server]: CommonAuthStates.selectSiteFromDropdown,
+            };
+
+            if (data.skipAllowed && data.authenticationType !== undefined) {
+                return Transition.forward(transitions[data.authenticationType]);
+            }
+
+            const { value, action } = await ui.pickAuthenticationType(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            const targetStep = transitions[value as AuthenticationType];
+            if (!targetStep) {
+                throw new Error(`Unknown authentication type: ${value}`);
+            }
+
+            return Transition.forward(targetStep, { authenticationType: value as AuthenticationType });
+        },
+    };
+
+    public static selectSiteFromDropdown: AuthState = {
+        name: 'selectSiteFromDropdown',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            const transitions = {
+                [AuthenticationType.OAuth]: CommonAuthStates.inputUsername,
+                [AuthenticationType.ApiToken]: CommonAuthStates.inputUsername,
+                [AuthenticationType.Server]: ServerAuthStates.chooseServerAuthType,
+            };
+
+            if (data.skipAllowed && data.site !== undefined) {
+                return Transition.forward(transitions[data.authenticationType!]);
+            }
+
+            const { value, action } = await ui.pickSite(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            if (value === 'Log in to a new site...') {
+                return Transition.forward(CommonAuthStates.inputNewSite, { isNewSite: true });
+            }
+            return Transition.forward(transitions[data.authenticationType!], { site: value });
+        },
+    };
+
+    public static inputNewSite: AuthState = {
+        name: 'inputNewSite',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            const transitions = {
+                [AuthenticationType.OAuth]: CommonAuthStates.inputUsername,
+                [AuthenticationType.ApiToken]: CommonAuthStates.inputUsername,
+                [AuthenticationType.Server]: ServerAuthStates.chooseServerAuthType,
+            };
+
+            const { value, action } = await ui.inputNewSite(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(transitions[data.authenticationType!], { site: value, isNewSite: true });
+        },
+    };
+
+    public static inputUsername: AuthState = {
+        name: 'inputUsername',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            const nextStep =
+                data.authenticationType !== AuthenticationType.Server
+                    ? CommonAuthStates.showCreateTokenPrompt
+                    : CommonAuthStates.inputPassword;
+
+            if (data.skipAllowed && data.username !== undefined) {
+                return Transition.forward(nextStep);
+            }
+
+            const { value, action } = await ui.inputUsername(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(nextStep, { username: value });
+        },
+    };
+
+    public static showCreateTokenPrompt: AuthState = {
+        name: 'showCreateTokenPrompt',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (data.skipAllowed && data.willOpenTokenManagementPage === false) {
+                // Only skip this step if we are explicitly told not to open the page
+                return Transition.forward(CommonAuthStates.inputPassword);
+            }
+
+            const { value, action } = await ui.pickCreateTokenNeeded(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            if (value === 'Yes') {
+                ui.openApiManagementPage();
+            }
+
+            return Transition.forward(CommonAuthStates.inputPassword, { willOpenTokenManagementPage: value === 'Yes' });
+        },
+    };
+
+    public static inputPassword: AuthState = {
+        name: 'inputPassword',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            const transitions = {
+                [AuthenticationType.ApiToken]: TerminalAuthStates.addAPIToken,
+                [AuthenticationType.Server]: ServerAuthStates.showContextPathPrompt,
+                // Should be unreachable
+                [AuthenticationType.OAuth]: TerminalAuthStates.runOauth,
+            };
+
+            if (data.skipAllowed && data.password !== undefined) {
+                return Transition.forward(transitions[data.authenticationType!]);
+            }
+
+            const passwordType = data.authenticationType === AuthenticationType.ApiToken ? 'API Token' : 'Password';
+            const { value, action } = await ui.inputPassword(data, passwordType);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(transitions[data.authenticationType!], { password: value });
+        },
+    };
+}

--- a/src/onboarding/quickFlow/authentication/states/server.ts
+++ b/src/onboarding/quickFlow/authentication/states/server.ts
@@ -1,0 +1,157 @@
+import { UiAction } from '../../baseUI';
+import { Transition } from '../../types';
+import { AuthFlowUI } from '../authFlowUI';
+import { AuthState, PartialAuthData, ServerCredentialType, SSLConfigurationType } from '../types';
+import { CommonAuthStates } from './common';
+import { TerminalAuthStates } from './terminal';
+
+export class ServerAuthStates {
+    public static chooseServerAuthType: AuthState = {
+        name: 'chooseServerAuthType',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            const transitions = {
+                [ServerCredentialType.Basic]: CommonAuthStates.inputUsername,
+                [ServerCredentialType.PAT]: ServerAuthStates.inputPAT,
+            };
+
+            if (data.skipAllowed && data.serverCredentialType !== undefined) {
+                return Transition.forward(transitions[data.serverCredentialType]);
+            }
+
+            const { value, action } = await ui.pickServerCredentialType(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(transitions[value as ServerCredentialType], {
+                serverCredentialType: value as ServerCredentialType,
+            });
+        },
+    };
+
+    public static inputPAT: AuthState = {
+        name: 'inputPAT',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (data.skipAllowed && data.personalAccessToken !== undefined) {
+                return Transition.forward(ServerAuthStates.showContextPathPrompt);
+            }
+
+            const { value, action } = await ui.inputPassword(data, 'Personal Access Token');
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(ServerAuthStates.showContextPathPrompt, { personalAccessToken: value });
+        },
+    };
+
+    public static showContextPathPrompt: AuthState = {
+        name: 'showContextPathPrompt',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (data.skipAllowed && data.isContextPathNeeded !== undefined) {
+                return Transition.forward(ServerAuthStates.inputContextPath);
+            }
+
+            const { value, action } = await ui.pickContextPathNeeded(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            const isNeeded = value === 'Yes';
+            return Transition.forward(
+                isNeeded ? ServerAuthStates.inputContextPath : ServerAuthStates.chooseSslConfigurationType,
+                {
+                    isContextPathNeeded: isNeeded,
+                },
+            );
+        },
+    };
+
+    public static inputContextPath: AuthState = {
+        name: 'inputContextPath',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (data.skipAllowed && data.contextPath !== undefined) {
+                return Transition.forward(ServerAuthStates.chooseSslConfigurationType);
+            }
+
+            const { value, action } = await ui.inputContextPath(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(ServerAuthStates.chooseSslConfigurationType, { contextPath: value });
+        },
+    };
+
+    public static chooseSslConfigurationType: AuthState = {
+        name: 'chooseSslConfigurationType',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            const transitions = {
+                [SSLConfigurationType.Default]: TerminalAuthStates.finishServerAuth,
+                [SSLConfigurationType.CustomCA]: ServerAuthStates.inputSslCertsPath,
+                [SSLConfigurationType.CustomClientSideCerts]: ServerAuthStates.inputPfxPath,
+            };
+
+            if (data.skipAllowed && data.sslConfigurationType !== undefined) {
+                return Transition.forward(transitions[data.sslConfigurationType]);
+            }
+
+            const { value, action } = await ui.pickSslConfigurationType(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(transitions[value as SSLConfigurationType], {
+                sslConfigurationType: value as SSLConfigurationType,
+            });
+        },
+    };
+
+    public static inputSslCertsPath: AuthState = {
+        name: 'inputSslCertsPath',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (data.skipAllowed && data.sslCertsPath !== undefined) {
+                return Transition.forward(TerminalAuthStates.finishServerAuth);
+            }
+
+            const { value, action } = await ui.inputSslCertsPath(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(TerminalAuthStates.finishServerAuth, { sslCertsPath: value });
+        },
+    };
+
+    public static inputPfxPath: AuthState = {
+        name: 'inputPfxPath',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (data.skipAllowed && data.pfxPath !== undefined) {
+                return Transition.forward(ServerAuthStates.inputPfxPassphrase);
+            }
+
+            const { value, action } = await ui.inputPfxPath(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(ServerAuthStates.inputPfxPassphrase, { pfxPath: value });
+        },
+    };
+
+    public static inputPfxPassphrase: AuthState = {
+        name: 'inputPfxPassphrase',
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (data.skipAllowed && data.pfxPassphrase !== undefined) {
+                return Transition.forward(TerminalAuthStates.finishServerAuth);
+            }
+
+            const { value, action } = await ui.inputPfxPassphrase(data);
+            if (action === UiAction.Back) {
+                return Transition.back();
+            }
+
+            return Transition.forward(TerminalAuthStates.finishServerAuth, { pfxPassphrase: value });
+        },
+    };
+}

--- a/src/onboarding/quickFlow/authentication/states/terminal.ts
+++ b/src/onboarding/quickFlow/authentication/states/terminal.ts
@@ -1,0 +1,82 @@
+import { BasicAuthInfo, PATAuthInfo, ProductJira } from 'src/atlclients/authInfo';
+import { Container } from 'src/container';
+import { SETTINGS_URL } from 'src/uriHandler';
+
+import { Transition } from '../../types';
+import { AuthFlowUI } from '../authFlowUI';
+import { AuthenticationType, AuthState, PartialAuthData, ServerCredentialType } from '../types';
+
+export class TerminalAuthStates {
+    public static runOauth: AuthState = {
+        name: 'runOauth',
+        isTerminal: true,
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (!data.authenticationType || data.authenticationType !== AuthenticationType.OAuth) {
+                throw new Error('Authentication type must be OAuth to run OAuth flow');
+            }
+
+            await Container.loginManager.userInitiatedOAuthLogin(
+                { host: 'atlassian.net', product: ProductJira },
+                SETTINGS_URL,
+            );
+            return Transition.done();
+        },
+    };
+
+    public static addAPIToken: AuthState = {
+        name: 'addAPIToken',
+        isTerminal: true,
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (!data.site || !data.username || !data.password) {
+                throw new Error('Missing required fields for API Token authentication');
+            }
+
+            Container.loginManager.userInitiatedServerLogin(
+                {
+                    host: data.site,
+                    product: ProductJira,
+                },
+                {
+                    username: data.username,
+                    password: data.password,
+                } as BasicAuthInfo,
+            );
+
+            return Transition.done();
+        },
+    };
+
+    public static finishServerAuth: AuthState = {
+        name: 'serverAuth',
+        isTerminal: true,
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            if (!data.site) {
+                throw new Error('Missing required fields for Server authentication');
+            }
+
+            const authInfo =
+                data.serverCredentialType === ServerCredentialType.PAT
+                    ? ({
+                          token: data.personalAccessToken,
+                      } as PATAuthInfo)
+                    : ({
+                          username: data.username,
+                          password: data.password,
+                      } as BasicAuthInfo);
+
+            Container.loginManager.userInitiatedServerLogin(
+                {
+                    host: data.site,
+                    product: ProductJira,
+                    contextPath: data.contextPath,
+                    customSSLCertPaths: data.sslCertsPath,
+                    pfxPath: data.pfxPath,
+                    pfxPassphrase: data.pfxPassphrase,
+                },
+                authInfo,
+            );
+
+            return Transition.done();
+        },
+    };
+}

--- a/src/onboarding/quickFlow/authentication/types.ts
+++ b/src/onboarding/quickFlow/authentication/types.ts
@@ -1,0 +1,54 @@
+import { Product } from 'src/atlclients/authInfo';
+
+import { State } from '../types';
+import { AuthFlowUI } from './authFlowUI';
+
+export enum SpecialSiteOptions {
+    NewSite = 'Log in to a new site...',
+    OAuth = 'Login with OAuth to see available cloud sites',
+}
+
+export enum AuthenticationType {
+    OAuth = 'OAuth',
+    ApiToken = 'API Token',
+    Server = 'Server',
+}
+
+export enum ServerCredentialType {
+    Basic = 'Username & Password',
+    PAT = 'Personal Access Token',
+}
+
+export enum SSLConfigurationType {
+    Default = 'Default settings',
+    CustomCA = 'Custom CA certificates',
+    CustomClientSideCerts = 'Custom client-side certificates',
+}
+
+export type AuthFlowData = {
+    // Product is assumed to be Jira, for now
+    product: Product;
+
+    skipAllowed: boolean;
+
+    isNewSite: boolean;
+    site: string;
+    authenticationType: AuthenticationType;
+    username: string;
+    password: string;
+    willOpenTokenManagementPage: boolean;
+
+    // Server-specific stuff
+    serverCredentialType: ServerCredentialType;
+    personalAccessToken: string;
+    isContextPathNeeded: boolean;
+    contextPath: string;
+    sslConfigurationType: SSLConfigurationType;
+    sslCertsPath: string;
+    pfxPath: string;
+    pfxPassphrase: string;
+};
+
+export type PartialAuthData = Partial<AuthFlowData>;
+
+export type AuthState = State<AuthFlowUI, PartialAuthData>;

--- a/src/onboarding/quickFlow/baseUI.ts
+++ b/src/onboarding/quickFlow/baseUI.ts
@@ -1,0 +1,186 @@
+import {
+    InputBox,
+    InputBoxOptions,
+    InputBoxValidationSeverity,
+    QuickInput,
+    QuickInputButton,
+    QuickInputButtons,
+    QuickPickItem,
+    QuickPickOptions,
+    window,
+} from 'vscode';
+
+export enum UiAction {
+    Next,
+    Back,
+}
+
+export type UiResponse<T = string> = { value?: T; action: UiAction };
+
+export type ExtraOptions = {
+    step?: number;
+    totalSteps?: number;
+    buttons?: QuickInputButton[];
+    buttonHandler?: (e: QuickInputButton) => void;
+    value?: string;
+    prompt?: string;
+    debounceValidationMs?: number;
+};
+
+export class BaseUI {
+    constructor(
+        private readonly title: string,
+        private readonly ignoreFocusOut: boolean = true,
+    ) {}
+
+    isInputValid(input: InputBox) {
+        if (!input.validationMessage) {
+            return true;
+        }
+
+        if (typeof input.validationMessage === 'string') {
+            return false;
+        }
+
+        return input.validationMessage.severity !== InputBoxValidationSeverity.Error;
+    }
+
+    showInputBox(props: InputBoxOptions & ExtraOptions): Promise<UiResponse> {
+        const input = window.createInputBox();
+
+        // Common properties
+        input.title = this.title;
+        input.ignoreFocusOut = this.ignoreFocusOut;
+
+        // Special properties
+        input.placeholder = props.placeHolder;
+        input.step = props.step;
+        input.totalSteps = props.totalSteps;
+        input.value = props.value || '';
+        input.valueSelection = props.valueSelection;
+        input.password = props.password || false;
+        input.prompt = props.prompt;
+
+        input.buttons = [QuickInputButtons.Back, ...(props.buttons || [])];
+
+        return new Promise((resolve, reject) => {
+            if (props.validateInput !== undefined) {
+                if (props.debounceValidationMs) {
+                    const debouncer = new Debouncer(input, props.validateInput, props.debounceValidationMs);
+                    input.onDidChangeValue(async (value) => {
+                        if (props.validateInput !== undefined) {
+                            const result = await debouncer.run(value);
+                            input.validationMessage = result === null ? undefined : result;
+                        }
+                    });
+                } else {
+                    input.onDidChangeValue(async (value) => {
+                        const errorMessage = await props.validateInput?.(value);
+                        input.validationMessage = errorMessage || undefined;
+                    });
+                }
+            }
+
+            input.onDidAccept(() => {
+                // According to the docs, `string` validation errors should in
+                // theory prevent accepting the form, but somehow they don't
+                if (!this.isInputValid(input)) {
+                    return;
+                }
+                resolve({ value: input.value, action: UiAction.Next });
+                input.hide();
+            });
+
+            input.onDidTriggerButton((e) => {
+                if (e === QuickInputButtons.Back) {
+                    resolve({ value: input.value, action: UiAction.Back });
+                    input.hide();
+                } else {
+                    props.buttonHandler?.(e);
+                }
+            });
+
+            input.onDidHide(() => {
+                input.dispose();
+                resolve({ value: '', action: UiAction.Back });
+            });
+
+            input.show();
+        });
+    }
+
+    public showQuickPick<T = string>(
+        items: QuickPickItem[],
+        props: QuickPickOptions & ExtraOptions & { validateSelection?: (items: readonly QuickPickItem[]) => boolean },
+    ): Promise<UiResponse<T>> {
+        const input = window.createQuickPick();
+
+        // Common properties
+        input.title = this.title;
+        input.ignoreFocusOut = this.ignoreFocusOut;
+
+        // Special properties
+        input.placeholder = props.placeHolder;
+        input.items = items;
+        input.value = props.value || '';
+        input.activeItems = [items[0]];
+        input.totalSteps = props.step;
+        input.ignoreFocusOut = props.ignoreFocusOut || true;
+
+        input.buttons = [QuickInputButtons.Back, ...(props.buttons || [])];
+        if (props.buttonHandler !== undefined) {
+            input.onDidTriggerButton((e) => {
+                props.buttonHandler?.(e);
+            });
+        }
+
+        return new Promise((resolve, reject) => {
+            input.onDidAccept(() => {
+                const selection = input.selectedItems;
+                if (props.validateSelection?.(selection) === false) {
+                    return;
+                }
+
+                resolve({ value: selection[0].label as T, action: UiAction.Next });
+                input.hide();
+            });
+            input.onDidHide(() => {
+                input.dispose();
+                resolve({ value: undefined, action: UiAction.Back });
+            });
+            input.show();
+        });
+    }
+}
+
+class Debouncer<T> {
+    timeout: NodeJS.Timeout | null = null;
+    lastPromise: Promise<T | undefined> = Promise.resolve(undefined);
+
+    constructor(
+        private input: QuickInput,
+        private validator: (value: string) => T,
+        private delay: number = 1000,
+    ) {}
+
+    get run(): (value: string) => Promise<T | undefined> {
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+        }
+
+        // Return a function that will return a promise
+        return (value: string) => {
+            this.input.busy = true;
+            if (this.timeout) {
+                clearTimeout(this.timeout);
+            }
+            this.lastPromise = new Promise((resolve) => {
+                this.timeout = setTimeout(async () => {
+                    resolve(await this.validator(value));
+                    this.input.busy = false;
+                }, this.delay);
+            });
+            return this.lastPromise;
+        };
+    }
+}

--- a/src/onboarding/quickFlow/index.ts
+++ b/src/onboarding/quickFlow/index.ts
@@ -1,0 +1,23 @@
+import { ProductBitbucket, ProductJira } from 'src/atlclients/authInfo';
+import { Commands } from 'src/constants';
+import { commands, Disposable, window } from 'vscode';
+
+import { AuthFlow, AuthFlowData } from './authentication';
+
+export function registerQuickAuthCommand(): Disposable {
+    return Disposable.from(
+        commands.registerCommand(Commands.QuickAuth, async (initialState: Partial<AuthFlowData>) => {
+            if (initialState?.product === ProductBitbucket) {
+                // Unsupported for now, shouldn't ever end up here
+                window.showErrorMessage('Quick Auth is only supported for Jira at the moment.');
+                return;
+            }
+
+            const flow = new AuthFlow();
+            await flow.run({
+                ...initialState,
+                product: ProductJira,
+            });
+        }),
+    );
+}

--- a/src/onboarding/quickFlow/quickFlow.test.ts
+++ b/src/onboarding/quickFlow/quickFlow.test.ts
@@ -1,0 +1,91 @@
+import { window } from 'vscode';
+
+import { QuickFlow } from './quickFlow';
+
+jest.mock('vscode', () => ({
+    window: {
+        showErrorMessage: jest.fn(),
+    },
+}));
+
+type UIType = {};
+type DataType = { foo?: string; bar?: number };
+
+class TestQuickFlow extends QuickFlow<UIType, DataType> {
+    private _ui: UIType = {};
+    private _initialState: any;
+
+    constructor(initialState: any) {
+        super();
+        this._initialState = initialState;
+    }
+
+    initialState() {
+        return this._initialState;
+    }
+
+    ui() {
+        return this._ui;
+    }
+}
+
+function createState(isTerminal: boolean, actionImpl: any) {
+    return {
+        isTerminal,
+        action: actionImpl,
+    };
+}
+
+describe('QuickFlow.run', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should run through states and call terminal action', async () => {
+        const terminalAction = jest.fn().mockResolvedValue([null, undefined]);
+        const terminalState = createState(true, terminalAction);
+
+        const nonTerminalAction = jest.fn().mockResolvedValue([{ foo: 'bar' }, terminalState]);
+        const nonTerminalState = createState(false, nonTerminalAction);
+
+        const flow = new TestQuickFlow(nonTerminalState);
+
+        await flow.run({ foo: 'start' });
+
+        expect(nonTerminalAction).toHaveBeenCalledWith({ foo: 'start' }, flow.ui());
+        expect(terminalAction).toHaveBeenCalledWith({ foo: 'bar' }, flow.ui());
+        expect(window.showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it('should accumulate data correctly', async () => {
+        const terminalAction = jest.fn().mockResolvedValue([null, undefined]);
+        const terminalState = createState(true, terminalAction);
+
+        const nonTerminalAction = jest.fn().mockResolvedValue([{ foo: 'bar' }, terminalState]);
+        const nonTerminalState = createState(false, nonTerminalAction);
+
+        const flow = new TestQuickFlow(nonTerminalState);
+
+        await flow.run({ bar: 42 });
+
+        // Data should be merged: { bar: 42 } + { foo: 'bar' } = { bar: 42, foo: 'bar' }
+        expect(nonTerminalAction).toHaveBeenCalledWith({ bar: 42 }, flow.ui());
+        expect(terminalAction).toHaveBeenCalledWith({ bar: 42, foo: 'bar' }, flow.ui());
+    });
+
+    it('should call ui() method', async () => {
+        const terminalAction = jest.fn().mockResolvedValue([null, undefined]);
+        const terminalState = createState(true, terminalAction);
+
+        const nonTerminalAction = jest.fn().mockResolvedValue([null, terminalState]);
+        const nonTerminalState = createState(false, nonTerminalAction);
+
+        const flow = new TestQuickFlow(nonTerminalState);
+
+        const uiSpy = jest.spyOn(flow, 'ui');
+
+        await flow.run();
+
+        expect(uiSpy).toHaveBeenCalled();
+    });
+});

--- a/src/onboarding/quickFlow/quickFlow.ts
+++ b/src/onboarding/quickFlow/quickFlow.ts
@@ -1,0 +1,55 @@
+import { State } from './types';
+
+type FlowAction<UIType, DataType> = {
+    data: Partial<DataType>;
+    state?: State<UIType, Partial<DataType>>;
+};
+
+export abstract class QuickFlow<UIType, DataType> {
+    private evalData(stack: FlowAction<UIType, DataType>[]): Partial<DataType> {
+        return stack.reduce((acc, curr) => {
+            return { ...acc, ...curr.data };
+        }, {});
+    }
+
+    public abstract initialState(): State<UIType, Partial<DataType>>;
+
+    public abstract ui(): UIType;
+
+    public async run(initialData?: Partial<DataType>) {
+        let state = this.initialState();
+        const ui = this.ui();
+
+        const actionStack = [{ data: initialData || {}, state }];
+
+        while (actionStack.length > 0 && !state.isTerminal) {
+            const data = this.evalData(actionStack);
+            const [newData, nextState] = await state.action(data, ui);
+
+            if (nextState === undefined) {
+                // go back
+                const old = actionStack.pop();
+
+                if (!old?.state) {
+                    // nothing to go back to, exit
+                    break;
+                }
+
+                state = old.state;
+                continue;
+            }
+
+            if (newData) {
+                actionStack.push({ data: newData, state: state });
+            }
+
+            state = nextState;
+        }
+
+        if (actionStack.length > 0 && state.isTerminal) {
+            state.action(this.evalData(actionStack), ui);
+        }
+
+        // If the flow is cancelled, do nothing
+    }
+}

--- a/src/onboarding/quickFlow/types.ts
+++ b/src/onboarding/quickFlow/types.ts
@@ -1,0 +1,35 @@
+export type State<UIType, DataType> = {
+    /** Name of the state - for debug only */
+    name: string;
+
+    /**
+     * Action handler of the state.
+     *
+     * @param data The current data for the flow.
+     * @param ui The UI instance for showing input boxes.
+     * @returns The new data and the next state. To go back, return `undefined` as the next state
+     */
+    action: (data: Partial<DataType>, ui: UIType) => Promise<TransitionInfo<UIType, DataType>>;
+
+    /** Is this state terminal? */
+    isTerminal?: boolean;
+};
+
+type TransitionInfo<UIType, DataType> = [DataType | undefined, State<UIType, DataType> | undefined];
+
+export class Transition {
+    static forward<UIType, DataType>(
+        state: State<UIType, DataType>,
+        data?: DataType,
+    ): TransitionInfo<UIType, DataType> {
+        return [data, state];
+    }
+
+    static back<UIType, DataType>(): TransitionInfo<UIType, DataType> {
+        return [undefined, undefined];
+    }
+
+    static done<UIType, DataType>(): TransitionInfo<UIType, DataType> {
+        return [undefined, undefined];
+    }
+}


### PR DESCRIPTION
### What Is This Change?

First in a number of PRs intended to overhaul our authentication UI

<img width="745" height="259" alt="image" src="https://github.com/user-attachments/assets/eccfeb6c-d9ab-473d-a9f9-73c2a7a8ba1e" />

This PR:
 * Implements a QuickInput-based vscode-native authentication flow, iterating on the existing onboarding
 * Hooks it up to the extension to be executable via a command

Not in this PR:
 * Lots of things - it's pretty big already and making it bigger felt wrong :D
 * Hooking this flow into other authentication entrypoints (settings, welcome pages, etc)
 * A bunch of visual refinements (validation, flow iteration, etc)
 * Instrumentation
 * Unit tests - the autogenerated ones were really close to implementation, and not very useful

### How Has This Been Tested?

Manually - but testing and iteration is very much ongoing.
This should be safe to push since it's currently decoupled from all the "normal" auth flows

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] ~Update the CHANGELOG if making a user facing change~