### PR TITLE
Fixed font-size in Rovo Dev prompt box

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -15,6 +15,10 @@ body {
     max-width: 800px;
 }
 
+#prompt-editor-container * {
+    font-size: var(--vscode-font-size) !important;
+}
+
 .rovoDevChat button {
     cursor: pointer;
 }

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/utils.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/utils.tsx
@@ -47,7 +47,6 @@ export const createMonacoPromptEditor = (container: HTMLElement) => {
             autoFindInSelection: 'never',
         },
 
-        fontSize: 14,
         lineHeight: 20,
         fontFamily: 'var(--vscode-font-family)',
     });


### PR DESCRIPTION
### What Is This Change?

Was set to 12px for some reason, now fixed to 13px.

### How Has This Been Tested?

- [x] `npm run lint`
- [x] `npm run test`
- [x] `manual tests`
