### PR TITLE
Asserts that nightly version does not exist before building it

### DIFF
--- a/scripts/version/assert-nightly.sh
+++ b/scripts/version/assert-nightly.sh
@@ -5,8 +5,15 @@ version=$1
 
 if [[ $version =~ ^[0-9]+\.[0-9]*[13579]\.[0-9]+.*$ ]]; then
     echo "Version $version is a valid pre-release (odd minor version)"
-    exit 0
 else
     echo "Version $version is not a valid pre-release (even minor version or invalid format)"
     exit 1
 fi
+
+tag="v$version-nightly"
+if git rev-parse "$tag" >/dev/null 2>&1; then
+    echo "Version $version already exists!"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
### What Is This Change?

This change checks if the nightly version already exists before kicking off a build for it.
It's going to save ~ 15 minutes or more for nightly builds that, because of a bug, they end up choosing a version that already exists.

### How Has This Been Tested?

- [X] `manual tests`