### PR TITLE
AXON-965: Configure webpack to support Compiled CSS-in-JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,7 @@
                 "websocket": "^1.0.35"
             },
             "devDependencies": {
+                "@compiled/webpack-loader": "^0.19.6",
                 "@jest/globals": "^30.0.2",
                 "@playwright/test": "1.53.0",
                 "@testing-library/dom": "^10.4.1",
@@ -160,7 +161,7 @@
                 "autoprefixer": "^10.4.20",
                 "concurrently": "^9.1.2",
                 "css-loader": "^7.1.2",
-                "css-minimizer-webpack-plugin": "^7.0.0",
+                "css-minimizer-webpack-plugin": "^7.0.2",
                 "eslint": "^9.27.0",
                 "eslint-import-resolver-typescript": "^4.4.1",
                 "eslint-plugin-import": "^2.30.0",
@@ -175,7 +176,7 @@
                 "jest-css-modules-transform": "^4.4.2",
                 "jest-environment-jsdom": "^30.0.0-beta.3",
                 "jest-mock-vscode": "^4.4.0",
-                "mini-css-extract-plugin": "^2.9.1",
+                "mini-css-extract-plugin": "^2.9.4",
                 "nyc": "^17.1.0",
                 "ovsx": "^0.10.5",
                 "path-browserify": "^1.0.1",
@@ -3545,6 +3546,22 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/plugin-syntax-flow": {
+            "version": "7.27.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
+            "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/plugin-syntax-import-attributes": {
             "version": "7.27.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
@@ -3708,6 +3725,23 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-flow-strip-types": {
+            "version": "7.27.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
+            "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/plugin-syntax-flow": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3915,6 +3949,757 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "node_modules/@compiled/babel-plugin": {
+            "version": "0.38.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@compiled/babel-plugin/-/babel-plugin-0.38.1.tgz",
+            "integrity": "sha512-ZWAxfiY3c7wQphuhmdqrL/I5CHjP6/nSIf1Zo76Xkd+X0CqjuKB6YQp1eoACeJmzAVcZpL/1X2MPvR3RNJFktw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/core": "^7.26.10",
+                "@babel/generator": "^7.26.10",
+                "@babel/helper-plugin-utils": "^7.26.5",
+                "@babel/parser": "^7.26.10",
+                "@babel/plugin-syntax-jsx": "^7.25.9",
+                "@babel/plugin-transform-flow-strip-types": "^7.26.5",
+                "@babel/template": "^7.26.9",
+                "@babel/traverse": "^7.26.10",
+                "@babel/types": "^7.26.10",
+                "@compiled/css": "^0.21.0",
+                "@compiled/utils": "^0.13.1",
+                "@emotion/is-prop-valid": "^1.3.1",
+                "resolve": "^1.22.10"
+            }
+        },
+        "node_modules/@compiled/babel-plugin-strip-runtime": {
+            "version": "0.38.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@compiled/babel-plugin-strip-runtime/-/babel-plugin-strip-runtime-0.38.0.tgz",
+            "integrity": "sha512-I+SazUOFjQ7wCNom4ZgtQ/Roy6iESW/kG4ucNwcJt0/AYqEN/nOcC+vDWkEdaZtoREbblYEz6kG3yS8Pz5sAdw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/core": "^7.26.10",
+                "@babel/helper-plugin-utils": "^7.26.5",
+                "@babel/template": "^7.26.9",
+                "@babel/traverse": "^7.26.10",
+                "@babel/types": "^7.26.10",
+                "@compiled/css": "^0.21.0",
+                "@compiled/utils": "^0.13.1"
+            }
+        },
+        "node_modules/@compiled/css": {
+            "version": "0.21.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@compiled/css/-/css-0.21.0.tgz",
+            "integrity": "sha512-6eMEozYy62tTjRYgGs3XgwUDwbkbXhLbaX7ZEgwzZXzEWdQS9CmRzfsz1Tzw+92PGaa5cswDW0UThF8cCfpOjQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@compiled/utils": "^0.13.1",
+                "autoprefixer": "^10.4.14",
+                "cssnano-preset-default": "^5.2.14",
+                "postcss": "^8.4.31",
+                "postcss-discard-duplicates": "^6.0.0",
+                "postcss-nested": "^5.0.6",
+                "postcss-normalize-whitespace": "^5.1.1",
+                "postcss-selector-parser": "^6.0.13",
+                "postcss-values-parser": "^6.0.2"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/css-declaration-sorter": {
+            "version": "6.4.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
+            "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.0.9"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/css-select": {
+            "version": "4.3.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/css-tree": {
+            "version": "1.1.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/css-tree/-/css-tree-1.1.3.tgz",
+            "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.14",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/cssnano-preset-default": {
+            "version": "5.2.14",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
+            "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-declaration-sorter": "^6.3.1",
+                "cssnano-utils": "^3.1.0",
+                "postcss-calc": "^8.2.3",
+                "postcss-colormin": "^5.3.1",
+                "postcss-convert-values": "^5.1.3",
+                "postcss-discard-comments": "^5.1.2",
+                "postcss-discard-duplicates": "^5.1.0",
+                "postcss-discard-empty": "^5.1.1",
+                "postcss-discard-overridden": "^5.1.0",
+                "postcss-merge-longhand": "^5.1.7",
+                "postcss-merge-rules": "^5.1.4",
+                "postcss-minify-font-values": "^5.1.0",
+                "postcss-minify-gradients": "^5.1.1",
+                "postcss-minify-params": "^5.1.4",
+                "postcss-minify-selectors": "^5.2.1",
+                "postcss-normalize-charset": "^5.1.0",
+                "postcss-normalize-display-values": "^5.1.0",
+                "postcss-normalize-positions": "^5.1.1",
+                "postcss-normalize-repeat-style": "^5.1.1",
+                "postcss-normalize-string": "^5.1.0",
+                "postcss-normalize-timing-functions": "^5.1.0",
+                "postcss-normalize-unicode": "^5.1.1",
+                "postcss-normalize-url": "^5.1.0",
+                "postcss-normalize-whitespace": "^5.1.1",
+                "postcss-ordered-values": "^5.1.3",
+                "postcss-reduce-initial": "^5.1.2",
+                "postcss-reduce-transforms": "^5.1.0",
+                "postcss-svgo": "^5.1.0",
+                "postcss-unique-selectors": "^5.1.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/cssnano-preset-default/node_modules/postcss-discard-duplicates": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+            "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/cssnano-utils": {
+            "version": "3.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+            "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/csso": {
+            "version": "4.2.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/csso/-/csso-4.2.0.tgz",
+            "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/mdn-data": {
+            "version": "2.0.14",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mdn-data/-/mdn-data-2.0.14.tgz",
+            "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/@compiled/css/node_modules/postcss-calc": {
+            "version": "8.2.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-calc/-/postcss-calc-8.2.4.tgz",
+            "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^6.0.9",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.2"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-colormin": {
+            "version": "5.3.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
+            "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.21.4",
+                "caniuse-api": "^3.0.0",
+                "colord": "^2.9.1",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-convert-values": {
+            "version": "5.1.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+            "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.21.4",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-discard-comments": {
+            "version": "5.1.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+            "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-discard-duplicates": {
+            "version": "6.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
+            "integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14 || ^16 || >=18.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4.31"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-discard-empty": {
+            "version": "5.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
+            "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-discard-overridden": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+            "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-merge-longhand": {
+            "version": "5.1.7",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+            "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0",
+                "stylehacks": "^5.1.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-merge-rules": {
+            "version": "5.1.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
+            "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.21.4",
+                "caniuse-api": "^3.0.0",
+                "cssnano-utils": "^3.1.0",
+                "postcss-selector-parser": "^6.0.5"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-minify-font-values": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+            "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-minify-gradients": {
+            "version": "5.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
+            "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "colord": "^2.9.1",
+                "cssnano-utils": "^3.1.0",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-minify-params": {
+            "version": "5.1.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+            "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.21.4",
+                "cssnano-utils": "^3.1.0",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-minify-selectors": {
+            "version": "5.2.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+            "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^6.0.5"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-charset": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+            "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-display-values": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+            "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-positions": {
+            "version": "5.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+            "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-repeat-style": {
+            "version": "5.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+            "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-string": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+            "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-timing-functions": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+            "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-unicode": {
+            "version": "5.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+            "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.21.4",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-url": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+            "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "normalize-url": "^6.0.1",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-normalize-whitespace": {
+            "version": "5.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
+            "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-ordered-values": {
+            "version": "5.1.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+            "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssnano-utils": "^3.1.0",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-reduce-initial": {
+            "version": "5.1.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
+            "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.21.4",
+                "caniuse-api": "^3.0.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-reduce-transforms": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+            "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-selector-parser": {
+            "version": "6.1.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-svgo": {
+            "version": "5.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+            "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0",
+                "svgo": "^2.7.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/postcss-unique-selectors": {
+            "version": "5.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
+            "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^6.0.5"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/stylehacks": {
+            "version": "5.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/stylehacks/-/stylehacks-5.1.1.tgz",
+            "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.21.4",
+                "postcss-selector-parser": "^6.0.4"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.15"
+            }
+        },
+        "node_modules/@compiled/css/node_modules/svgo": {
+            "version": "2.8.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/svgo/-/svgo-2.8.0.tgz",
+            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@trysound/sax": "0.2.0",
+                "commander": "^7.2.0",
+                "css-select": "^4.1.3",
+                "css-tree": "^1.1.3",
+                "csso": "^4.2.0",
+                "picocolors": "^1.0.0",
+                "stable": "^0.1.8"
+            },
+            "bin": {
+                "svgo": "bin/svgo"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/@compiled/react": {
             "version": "0.18.4",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@compiled/react/-/react-0.18.4.tgz",
@@ -3924,6 +4709,48 @@
             },
             "peerDependencies": {
                 "react": ">= 16.12.0"
+            }
+        },
+        "node_modules/@compiled/utils": {
+            "version": "0.13.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@compiled/utils/-/utils-0.13.2.tgz",
+            "integrity": "sha512-UZZv/P+pKN78BSvyu8lHO18sYS2XC1qB/Afi9ggol0wAJFY8eWrAoLvWzXDC6Pt495KOLqUX6HpWXQPyGF9ojA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "convert-source-map": "^2.0.0",
+                "source-map": "^0.7.4"
+            }
+        },
+        "node_modules/@compiled/utils/node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@compiled/webpack-loader": {
+            "version": "0.19.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@compiled/webpack-loader/-/webpack-loader-0.19.6.tgz",
+            "integrity": "sha512-8FEF/qC4LzPJSzZsh7jid3iwlWnN8ms1ETFcr4beDn3L8m90r2N7rn0Ms8/MVogcsRdAGn9RPYjlsbuCmVbA6Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/core": "^7.26.10",
+                "@babel/parser": "^7.26.10",
+                "@compiled/babel-plugin": "^0.38.0",
+                "@compiled/babel-plugin-strip-runtime": "^0.38.0",
+                "@compiled/css": "^0.21.0",
+                "@compiled/utils": "^0.13.1",
+                "enhanced-resolve": "^5.18.1",
+                "loader-utils": "^2.0.4",
+                "webpack-sources": "^3.2.3"
+            },
+            "peerDependencies": {
+                "webpack": ">= 4.46.0"
             }
         },
         "node_modules/@coolaj86/urequest": {
@@ -10185,6 +11012,16 @@
                 }
             ]
         },
+        "node_modules/big.js": {
+            "version": "5.2.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/binaryextensions": {
             "version": "6.11.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/binaryextensions/-/binaryextensions-6.11.0.tgz",
@@ -11879,6 +12716,16 @@
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true
+        },
+        "node_modules/emojis-list": {
+            "version": "3.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/emojis-list/-/emojis-list-3.0.0.tgz",
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
@@ -14888,6 +15735,19 @@
             "version": "1.0.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+        },
+        "node_modules/is-url-superb": {
+            "version": "4.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-url-superb/-/is-url-superb-4.0.0.tgz",
+            "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
@@ -19102,6 +19962,21 @@
                 "node": ">=6.11.5"
             }
         },
+        "node_modules/loader-utils": {
+            "version": "2.0.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/locate-path/-/locate-path-6.0.0.tgz",
@@ -19431,10 +20306,11 @@
             }
         },
         "node_modules/mini-css-extract-plugin": {
-            "version": "2.9.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.2.tgz",
-            "integrity": "sha512-GJuACcS//jtq4kCtd5ii/M0SZf7OZRH+BxdqXZHaJfb8TJiVl+NgQRPwiYt2EuqeSkNydn/7vP+bcE27C5mb9w==",
+            "version": "2.9.4",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
+            "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "schema-utils": "^4.0.0",
                 "tapable": "^2.2.1"
@@ -19795,6 +20671,19 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/normalize-url": {
+            "version": "6.1.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/normalize-url/-/normalize-url-6.1.0.tgz",
+            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/npm-run-path": {
@@ -22140,6 +23029,24 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
+        "node_modules/postcss-values-parser": {
+            "version": "6.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+            "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "color-name": "^1.1.4",
+                "is-url-superb": "^4.0.0",
+                "quote-unquote": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.9"
+            }
+        },
         "node_modules/prebuild-install": {
             "version": "7.1.3",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -22503,6 +23410,13 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/quote-unquote": {
+            "version": "1.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/quote-unquote/-/quote-unquote-1.0.0.tgz",
+            "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/raf-schd": {
             "version": "4.0.3",
@@ -23834,6 +24748,14 @@
             "dependencies": {
                 "@coolaj86/urequest": "^1.3.6"
             }
+        },
+        "node_modules/stable": {
+            "version": "0.1.8",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/stable/-/stable-0.1.8.tgz",
+            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+            "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stable-hash": {
             "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -1517,6 +1517,7 @@
         "websocket": "^1.0.35"
     },
     "devDependencies": {
+        "@compiled/webpack-loader": "^0.19.6",
         "@jest/globals": "^30.0.2",
         "@playwright/test": "1.53.0",
         "@testing-library/dom": "^10.4.1",
@@ -1548,7 +1549,7 @@
         "autoprefixer": "^10.4.20",
         "concurrently": "^9.1.2",
         "css-loader": "^7.1.2",
-        "css-minimizer-webpack-plugin": "^7.0.0",
+        "css-minimizer-webpack-plugin": "^7.0.2",
         "eslint": "^9.27.0",
         "eslint-import-resolver-typescript": "^4.4.1",
         "eslint-plugin-import": "^2.30.0",
@@ -1563,7 +1564,7 @@
         "jest-css-modules-transform": "^4.4.2",
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "jest-mock-vscode": "^4.4.0",
-        "mini-css-extract-plugin": "^2.9.1",
+        "mini-css-extract-plugin": "^2.9.4",
         "nyc": "^17.1.0",
         "ovsx": "^0.10.5",
         "path-browserify": "^1.0.1",

--- a/webpack.react.dev.js
+++ b/webpack.react.dev.js
@@ -8,6 +8,7 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const autoprefixer = require('autoprefixer');
+const { CompiledExtractPlugin } = require('@compiled/webpack-loader');
 
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
@@ -43,6 +44,9 @@ module.exports = {
         new MiniCssExtractPlugin({
             filename: '[name].css',
             ignoreOrder: true,
+        }),
+        new CompiledExtractPlugin({
+            sortShorthand: true,
         }),
         new WebpackManifestPlugin({
             fileName: 'asset-manifest.json',
@@ -82,10 +86,25 @@ module.exports = {
                 // Include ts, tsx, js, and jsx files.
                 test: /\.(ts|js)x?$/,
                 exclude: [/node_modules/, /\.test\.ts$/, /\.spec\.ts$/],
-                use: [{ loader: 'ts-loader', options: { transpileOnly: true, onlyCompileBundledFiles: true } }],
+                use: [
+                    {
+                        loader: '@compiled/webpack-loader',
+                        options: {
+                            transformerBabelPlugins: ['@atlaskit/tokens/babel-plugin'],
+                            extract: true,
+                            inlineCss: true,
+                        },
+                    },
+                    { loader: 'ts-loader', options: { transpileOnly: true, onlyCompileBundledFiles: true } },
+                ],
+            },
+
+            {
+                test: /compiled(-css)?\.css$/i,
+                use: [MiniCssExtractPlugin.loader, 'css-loader'],
             },
             {
-                test: /\.css$/,
+                test: /(?<!compiled-css)(?<!\.compiled)\.css$/i,
                 use: [
                     {
                         loader: MiniCssExtractPlugin.loader,

--- a/webpack.react.dev.js
+++ b/webpack.react.dev.js
@@ -87,6 +87,7 @@ module.exports = {
                 test: /\.(ts|js)x?$/,
                 exclude: [/node_modules/, /\.test\.ts$/, /\.spec\.ts$/],
                 use: [
+                    { loader: 'ts-loader', options: { transpileOnly: true, onlyCompileBundledFiles: true } },
                     {
                         loader: '@compiled/webpack-loader',
                         options: {
@@ -95,7 +96,6 @@ module.exports = {
                             inlineCss: true,
                         },
                     },
-                    { loader: 'ts-loader', options: { transpileOnly: true, onlyCompileBundledFiles: true } },
                 ],
             },
 

--- a/webpack.react.prod.js
+++ b/webpack.react.prod.js
@@ -131,6 +131,7 @@ module.exports = {
                 test: /\.(ts|js)x?$/,
                 exclude: [/node_modules/, /\.test\.ts$/, /\.spec\.ts$/],
                 use: [
+                    { loader: 'ts-loader', options: { transpileOnly: true, onlyCompileBundledFiles: true } },
                     {
                         loader: '@compiled/webpack-loader',
                         options: {
@@ -139,7 +140,6 @@ module.exports = {
                             inlineCss: true,
                         },
                     },
-                    { loader: 'ts-loader', options: { transpileOnly: true, onlyCompileBundledFiles: true } },
                 ],
             },
 

--- a/webpack.react.prod.js
+++ b/webpack.react.prod.js
@@ -10,6 +10,7 @@ const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const CSSMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const autoprefixer = require('autoprefixer');
+const { CompiledExtractPlugin } = require('@compiled/webpack-loader');
 
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
@@ -73,8 +74,11 @@ module.exports = {
     },
     plugins: [
         new MiniCssExtractPlugin({
-            filename: '[name].css',
+            filename: '[name].[contenthash].css',
             ignoreOrder: true,
+        }),
+        new CompiledExtractPlugin({
+            sortShorthand: true,
         }),
         new WebpackManifestPlugin({
             fileName: 'asset-manifest.json',
@@ -126,10 +130,26 @@ module.exports = {
                 // Include ts, tsx, js, and jsx files.
                 test: /\.(ts|js)x?$/,
                 exclude: [/node_modules/, /\.test\.ts$/, /\.spec\.ts$/],
-                use: [{ loader: 'ts-loader', options: { transpileOnly: true, onlyCompileBundledFiles: true } }],
+                use: [
+                    {
+                        loader: '@compiled/webpack-loader',
+                        options: {
+                            transformerBabelPlugins: ['@atlaskit/tokens/babel-plugin'],
+                            extract: true,
+                            inlineCss: true,
+                        },
+                    },
+                    { loader: 'ts-loader', options: { transpileOnly: true, onlyCompileBundledFiles: true } },
+                ],
             },
+
             {
-                test: /\.css$/,
+                test: /compiled(-css)?\.css$/i,
+                use: [MiniCssExtractPlugin.loader, 'css-loader'],
+            },
+
+            {
+                test: /(?<!compiled-css)(?<!\.compiled)\.css$/i,
                 use: [
                     {
                         loader: MiniCssExtractPlugin.loader,


### PR DESCRIPTION
### What Is This Change?

This PR adds proper support for Compiled CSS-in-JS to handle Atlaskit component styles correctly in our webpack configuration.

## Changes
- Added `@compiled/webpack-loader` with proper configuration for CSS-in-JS extraction
- Configured `CompiledExtractPlugin` with `sortShorthand: true` for optimal style processing
- Added specific CSS rules to handle `.compiled.css` files generated by Atlaskit components
- Updated babel configuration with necessary presets and plugins for Compiled
- Keep `ignoreOrder: true` in `MiniCssExtractPlugin` to handle CSS ordering warnings - [details](https://github.com/atlassian/atlascode/pull/830/files#r2305607088)

## Why
Atlaskit components use Compiled CSS-in-JS (since October 2024) which requires specific webpack configuration to:
- Properly extract and bundle CSS styles
- Handle style dependencies between components
- Ensure consistent styling across different pages
- Optimize bundle size and performance

Source:
https://atlassian.design/get-started/develop/atlassians
https://community.developer.atlassian.com/t/rfc-73-migrating-our-components-to-compiled-css-in-js/85953
https://compiledcssinjs.com/

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change