### PR TITLE
chore: make nightly version resolution more verbose

### DIFF
--- a/scripts/version/get-next-nightly.sh
+++ b/scripts/version/get-next-nightly.sh
@@ -5,17 +5,37 @@
 # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
 
 git fetch --tags -q
+
+echo "Evaluating next nightly version..." >&2
+
 latest_stable_version=$(./scripts/version/get-latest-stable.sh)
 latest_nightly_version=$(./scripts/version/get-latest-nightly.sh)
+cat <<EOF >&2
+----- available versions ------
+Stable: $latest_stable_version
+Nightly: $latest_nightly_version
+EOF
 
 # Major version is the same as the latest stable version
 stable_major=$(echo $latest_stable_version | cut -d '.' -f 1)
 nightly_major=$(echo $latest_nightly_version | cut -d '.' -f 1)
 
+cat <<EOF >&2
+----- major versions ------
+Stable: $stable_major
+Nightly: $nightly_major
+EOF
+
 # Minor version is always "latest stable + 1"
 stable_minor=$(echo $latest_stable_version | cut -d '.' -f 2)
 nightly_minor=$(echo $latest_nightly_version | cut -d '.' -f 2)
 next_minor=$((stable_minor + 1))
+cat <<EOF >&2
+----- minor versions ------
+Stable: $stable_minor
+Nightly: $nightly_minor
+Next nightly minor version: $next_minor
+EOF
 
 # Patch is incrementing, unless we're on a new minor
 if [[ $nightly_major -eq $stable_major && $next_minor -eq $nightly_minor ]]; then
@@ -26,4 +46,8 @@ else
     next_patch=0
 fi
 
+cat <<EOF >&2
+----- next nightly version ------
+Nightly: $stable_major.$next_minor.$next_patch
+EOF
 echo "$stable_major.$next_minor.$next_patch"


### PR DESCRIPTION
### What Is This Change?

Tiny change to make the version resolution logic that happens on builds a bit more verbose, to debug the odd discrepancy between `release` and `release-nightly`

<img width="353" height="283" alt="image" src="https://github.com/user-attachments/assets/fedf3689-992d-4a15-af52-2c36b1933faa" />

### How Has This Been Tested?

See picture above ;)