### PR TITLE
Added Product Toggle for new config page

### DIFF
--- a/src/react/atlascode/config/ConfigPageV3.tsx
+++ b/src/react/atlascode/config/ConfigPageV3.tsx
@@ -112,6 +112,18 @@ const ConfigPageV3: React.FunctionComponent = () => {
         }
     }, []);
 
+    const handleJiraToggle = useCallback((enabled: boolean): void => {
+        const changes = Object.create(null);
+        changes['jira.enabled'] = enabled;
+        setChanges(changes);
+    }, []);
+
+    const handleBitbucketToggle = useCallback((enabled: boolean): void => {
+        const changes = Object.create(null);
+        changes['bitbucket.enabled'] = enabled;
+        setChanges(changes);
+    }, []);
+
     useEffect(() => {
         if (Object.keys(changes).length > 0) {
             controller.updateConfig(changes);
@@ -236,6 +248,9 @@ const ConfigPageV3: React.FunctionComponent = () => {
                                             jiraSites={state.jiraSites}
                                             bitbucketSites={state.bitbucketSites}
                                             isRemote={state.isRemote}
+                                            config={state.config}
+                                            jiraToggle={handleJiraToggle}
+                                            bbToggle={handleBitbucketToggle}
                                         />
                                         <AdvancedConfigsPanel
                                             visible={openSection === ConfigV3Section.AdvancedConfig}

--- a/src/react/atlascode/config/generalAuth/AuthPanel.tsx
+++ b/src/react/atlascode/config/generalAuth/AuthPanel.tsx
@@ -11,6 +11,7 @@ import { SiteWithAuthInfo } from '../../../../lib/ipc/toUI/config';
 import { PanelSubtitle } from '../../common/PanelSubtitle';
 import { PanelTitle } from '../../common/PanelTitle';
 import { SiteAuthenticator } from './../auth/SiteAuthenticator';
+import { ProductEnabler } from './../ProductEnabler';
 
 const useStyles = makeStyles(
     (theme: Theme) =>
@@ -19,6 +20,17 @@ const useStyles = makeStyles(
                 '&:hover': {
                     cursor: 'default !important',
                 },
+                display: 'flex',
+                alignItems: 'center',
+                '& .MuiAccordionSummary-content': {
+                    display: 'flex',
+                    alignItems: 'center',
+                },
+            },
+            alignedSubtitle: {
+                alignSelf: 'center',
+                display: 'flex',
+                alignItems: 'center',
             },
         }) as const,
 );
@@ -28,25 +40,41 @@ type AuthPanelProps = {
     sites: SiteWithAuthInfo[];
     product: Product;
     section: ConfigV3Section;
+    config: { [key: string]: any };
+    productToggle: (enabled: boolean) => void;
 };
 
-export const AuthPanel: React.FunctionComponent<AuthPanelProps> = memo(({ isRemote, sites, product, section }) => {
-    const currentAuthSubSection = product.key === 'jira' ? ConfigV3SubSection.JiraAuth : ConfigV3SubSection.BbAuth;
-    const classes = useStyles();
+export const AuthPanel: React.FunctionComponent<AuthPanelProps> = memo(
+    ({ isRemote, sites, product, section, config, productToggle }) => {
+        const currentAuthSubSection = product.key === 'jira' ? ConfigV3SubSection.JiraAuth : ConfigV3SubSection.BbAuth;
+        const classes = useStyles();
 
-    return (
-        <Accordion hidden={false} square={false} expanded={true}>
-            <AccordionSummary
-                className={classes.panelStyles}
-                aria-controls={`${section}-${currentAuthSubSection}-content`}
-                id={`${section}-${currentAuthSubSection}-header`}
-            >
-                <PanelTitle>{product.name}</PanelTitle>
-                <PanelSubtitle>authenticate with {product.name} instances</PanelSubtitle>
-            </AccordionSummary>
-            <AccordionDetails>
-                <SiteAuthenticator product={product} isRemote={isRemote} sites={sites} />
-            </AccordionDetails>
-        </Accordion>
-    );
-});
+        return (
+            <Accordion hidden={false} square={false} expanded={true}>
+                <AccordionSummary
+                    className={classes.panelStyles}
+                    aria-controls={`${section}-${currentAuthSubSection}-content`}
+                    id={`${section}-${currentAuthSubSection}-header`}
+                >
+                    <PanelTitle>
+                        {
+                            <ProductEnabler
+                                label={product.name}
+                                enabled={config[`${product.key}.enabled`]}
+                                onToggle={productToggle}
+                            />
+                        }
+                    </PanelTitle>
+                    <PanelSubtitle className={classes.alignedSubtitle}>
+                        authenticate with {product.name} instances
+                    </PanelSubtitle>
+                </AccordionSummary>
+                {config[`${product.key}.enabled`] && (
+                    <AccordionDetails>
+                        <SiteAuthenticator product={product} isRemote={isRemote} sites={sites} />
+                    </AccordionDetails>
+                )}
+            </Accordion>
+        );
+    },
+);

--- a/src/react/atlascode/config/generalAuth/AuthenticationPanel.tsx
+++ b/src/react/atlascode/config/generalAuth/AuthenticationPanel.tsx
@@ -11,6 +11,9 @@ type AuthenicationPanelProps = {
     jiraSites: SiteWithAuthInfo[];
     bitbucketSites: SiteWithAuthInfo[];
     isRemote: boolean;
+    config: { [key: string]: any };
+    jiraToggle: (enabled: boolean) => void;
+    bbToggle: (enabled: boolean) => void;
 };
 
 export const AuthenticationPanel: React.FunctionComponent<AuthenicationPanelProps> = ({
@@ -18,6 +21,9 @@ export const AuthenticationPanel: React.FunctionComponent<AuthenicationPanelProp
     jiraSites,
     bitbucketSites,
     isRemote,
+    config,
+    jiraToggle,
+    bbToggle,
 }) => {
     return (
         <>
@@ -30,6 +36,8 @@ export const AuthenticationPanel: React.FunctionComponent<AuthenicationPanelProp
                                 sites={jiraSites}
                                 product={ProductJira}
                                 section={ConfigV3Section.Auth}
+                                config={config}
+                                productToggle={jiraToggle}
                             />
                         </Grid>
                         <Grid item>
@@ -38,6 +46,8 @@ export const AuthenticationPanel: React.FunctionComponent<AuthenicationPanelProp
                                 sites={bitbucketSites}
                                 product={ProductBitbucket}
                                 section={ConfigV3Section.Auth}
+                                config={config}
+                                productToggle={bbToggle}
                             />
                         </Grid>
                     </Grid>

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -12,7 +12,7 @@ export const enum Experiments {
 
 export const ExperimentGates: Record<Experiments, ExperimentPayload> = {
     [Experiments.AtlascodeNewSettingsExperiment]: {
-        parameter: 'enabled',
+        parameter: 'enabled2',
         defaultValue: false,
     },
 };


### PR DESCRIPTION
### What Is This Change?
Added a Product Toggle for the new config page. 
<img width="1571" height="945" alt="Screenshot 2025-08-27 at 2 20 41 PM" src="https://github.com/user-attachments/assets/774efd4e-f9b4-4329-b2ff-306953633f29" />


### How Has This Been Tested?

- Manual Testing

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change