### PR TITLE
[AXON-971] show machine id in advanced settings

### DIFF
--- a/src/lib/ipc/toUI/config.ts
+++ b/src/lib/ipc/toUI/config.ts
@@ -58,6 +58,7 @@ export interface ConfigInitMessage {
     target: ConfigTarget;
     section?: ConfigSection;
     subSection?: ConfigSubSection;
+    machineId?: string;
 }
 export interface ConfigV3InitMessage {
     config: FlattenedConfig;
@@ -69,6 +70,7 @@ export interface ConfigV3InitMessage {
     target: ConfigTarget;
     section?: ConfigV3Section;
     subSection?: ConfigV3SubSection;
+    machineId?: string;
 }
 
 export const emptyConfigInitMessage: ConfigInitMessage = {

--- a/src/lib/webview/controller/config/configV3WebviewController.ts
+++ b/src/lib/webview/controller/config/configV3WebviewController.ts
@@ -97,6 +97,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                 isRemote: this._api.getIsRemote(),
                 target: target,
                 showTunnelOption: this._api.shouldShowTunnelOption(),
+                machineId: vscode.env.machineId,
                 config: cfg,
                 ...section,
             });

--- a/src/lib/webview/controller/config/configWebviewController.ts
+++ b/src/lib/webview/controller/config/configWebviewController.ts
@@ -97,6 +97,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                 target: target,
                 showTunnelOption: this._api.shouldShowTunnelOption(),
                 config: cfg,
+                machineId: vscode.env.machineId,
                 ...section,
             });
 

--- a/src/react/atlascode/config/ConfigPage.tsx
+++ b/src/react/atlascode/config/ConfigPage.tsx
@@ -301,6 +301,7 @@ const ConfigPage: React.FunctionComponent = () => {
                                             selectedSubSections={openSubsections[ConfigSection.General]}
                                             onSubsectionChange={handleSubsectionChange}
                                             config={state.config!}
+                                            machineId={state.machineId}
                                         />
                                         <ExplorePanel
                                             visible={openSection === ConfigSection.Explore}

--- a/src/react/atlascode/config/ConfigPageV3.tsx
+++ b/src/react/atlascode/config/ConfigPageV3.tsx
@@ -244,6 +244,7 @@ const ConfigPageV3: React.FunctionComponent = () => {
                                             config={state.config!}
                                             sites={state.jiraSites}
                                             isRemote={state.isRemote}
+                                            machineId={state.machineId}
                                         />
                                     </Box>
                                 </Paper>

--- a/src/react/atlascode/config/advancedConfigs/advancedConfigsPanel.tsx
+++ b/src/react/atlascode/config/advancedConfigs/advancedConfigsPanel.tsx
@@ -15,6 +15,7 @@ type AdvancedConfigsProps = CommonPanelProps & {
     sites: SiteWithAuthInfo[];
     isRemote: boolean;
     onSubsectionChange: (subSection: ConfigV3SubSection, expanded: boolean) => void;
+    machineId?: string;
 };
 
 const useStyles = makeStyles(
@@ -34,6 +35,7 @@ export const AdvancedConfigsPanel: React.FunctionComponent<AdvancedConfigsProps>
     config,
     sites,
     isRemote,
+    machineId,
 }) => {
     const siteInfos = React.useMemo(() => {
         return sites.map((swa) => {
@@ -109,6 +111,11 @@ export const AdvancedConfigsPanel: React.FunctionComponent<AdvancedConfigsProps>
                                     If you don't wish to send usage data to Atlassian, you can set the
                                     telemetry.enableTelemetry user setting to false, and restart VS Code.
                                 </Typography>
+                                {machineId && (
+                                    <Typography variant="subtitle1" className={classes.root}>
+                                        VSCode unique ID: {machineId}
+                                    </Typography>
+                                )}
                             </Box>
                         </Grid>
                     </Grid>

--- a/src/react/atlascode/config/configController.ts
+++ b/src/react/atlascode/config/configController.ts
@@ -220,6 +220,7 @@ function configReducerV3(state: ConfigV3State, action: ConfigV3UIAction): Config
                 openSubSections: action.data.subSection ? [action.data.subSection] : [],
                 isSomethingLoading: false,
                 isErrorBannerOpen: false,
+                machineId: action.data.machineId,
                 errorDetails: undefined,
             };
             return newstate;
@@ -284,6 +285,7 @@ function configReducer(state: ConfigState, action: ConfigUIAction): ConfigState 
                 openSubSections: action.data.subSection ? [action.data.subSection] : [],
                 isSomethingLoading: false,
                 isErrorBannerOpen: false,
+                machineId: action.data.machineId,
                 errorDetails: undefined,
             };
             return newstate;

--- a/src/react/atlascode/config/general/GeneralPanel.tsx
+++ b/src/react/atlascode/config/general/GeneralPanel.tsx
@@ -11,6 +11,7 @@ import { GenMiscPanel } from './subpanels/GenMiscPanel';
 type GeneralPanelProps = CommonPanelProps & {
     config: { [key: string]: any };
     onSubsectionChange: (subSection: ConfigSubSection, expanded: boolean) => void;
+    machineId?: string;
 };
 
 const useStyles = makeStyles(
@@ -28,6 +29,7 @@ export const GeneralPanel: React.FunctionComponent<GeneralPanelProps> = ({
     selectedSubSections,
     onSubsectionChange,
     config,
+    machineId,
 }) => {
     const classes = useStyles();
 
@@ -78,6 +80,11 @@ export const GeneralPanel: React.FunctionComponent<GeneralPanelProps> = ({
                                     If you don't wish to send usage data to Atlassian, you can set the
                                     telemetry.enableTelemetry user setting to false, and restart VS Code.
                                 </Typography>
+                                {machineId && (
+                                    <Typography variant="subtitle1" className={classes.root}>
+                                        VSCode unique ID: {machineId}
+                                    </Typography>
+                                )}
                             </Box>
                         </Grid>
                         <Grid item></Grid>


### PR DESCRIPTION
### What Is This Change?

The unique ID from vscode used in experimentation is now shown at the bottom of advanced settings

Old settings page:
<img width="1553" height="467" alt="image" src="https://github.com/user-attachments/assets/0984d1d0-9a73-4eab-8688-e0f9e58bfe73" />

New settings page:
<img width="1540" height="517" alt="image" src="https://github.com/user-attachments/assets/8a4c8930-87cf-496d-824b-5afa6d66746b" />


### How Has This Been Tested?

See images above :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`