### PR TITLE
[AXON-971] add feature flag for the new auth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
             {
                 "command": "atlascode.rovodev.quickAuth",
                 "title": "Authenticate",
-                "category": "Jira"
+                "category": "Jira",
+                "when": "atlascode:useNewAuthFlow"
             },
             {
                 "command": "atlascode.rovodev.askInteractive",
@@ -804,6 +805,10 @@
                 }
             ],
             "commandPalette": [
+                {
+                    "command": "atlascode.rovodev.quickAuth",
+                    "when": "atlascode:useNewAuthFlow"
+                },
                 {
                     "command": "atlascode.rovodev.askRovoDev",
                     "when": "atlascode:rovoDevEnabled"

--- a/src/commandContext.ts
+++ b/src/commandContext.ts
@@ -15,6 +15,7 @@ export enum CommandContext {
     RovoDevTerminalEnabled = 'atlascode:rovoDevTerminalEnabled',
     BbyEnvironmentActive = 'atlascode:bbyEnvironmentActive',
     DebugMode = 'atlascode:debugMode',
+    UseNewAuthFlow = 'atlascode:useNewAuthFlow',
 }
 
 export function setCommandContext(key: CommandContext | string, value: any) {

--- a/src/container.ts
+++ b/src/container.ts
@@ -196,8 +196,6 @@ export class Container {
 
         this._featureFlagClient = FeatureFlagClient.getInstance();
 
-        // TODO: add a guard rail feature flag
-        context.subscriptions.push(registerQuickAuthCommand());
         try {
             await this._featureFlagClient.initialize({
                 analyticsAnonymousId: this.machineId,
@@ -218,6 +216,13 @@ export class Container {
             context.subscriptions.push((this._settingsWebviewFactory = settingsV3ViewFactory));
         } else {
             context.subscriptions.push((this._settingsWebviewFactory = settingsV2ViewFactory));
+        }
+
+        if (this._featureFlagClient.checkGate(Features.UseNewAuthFlow)) {
+            setCommandContext(CommandContext.UseNewAuthFlow, true);
+            context.subscriptions.push(registerQuickAuthCommand());
+        } else {
+            setCommandContext(CommandContext.UseNewAuthFlow, false);
         }
 
         if (!process.env.ROVODEV_BBY) {

--- a/src/util/featureFlags/features.ts
+++ b/src/util/featureFlags/features.ts
@@ -4,6 +4,7 @@ export const enum Features {
     AtlassianNotifications = 'atlascode-atlassian-notifications-v2',
     StartWorkV3 = 'atlascode-start-work-v3',
     RovoDevEnabled = 'rovo_dev_ff',
+    UseNewAuthFlow = 'atlascode-use-new-auth-flow',
 }
 
 export const enum Experiments {


### PR DESCRIPTION
### What Is This Change?

The new authentication flow is now under a feature flag, `atlascode-use-new-auth-flow`

| No feature flag | Yes feature flag |
|----|---|
| <img width="787" height="379" alt="image" src="https://github.com/user-attachments/assets/0368b671-697e-43ed-ad2d-cb53902bbd73" /> | <img width="757" height="160" alt="image" src="https://github.com/user-attachments/assets/0e2a19a5-4233-4395-ae06-65fa960eb13c" /> |

### How Has This Been Tested?

A bunch of override attempts + see images above :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`