### PR TITLE
[AXON-802, AXON-979] Rovo Dev gracefully stops and restart on auth change

### DIFF
--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
@@ -153,7 +153,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
         }
 
         editor.updateOptions({
-            readOnly: disabled || state !== State.WaitingForPrompt,
+            readOnly: disabled,
             placeholder: getTextAreaPlaceholder(state),
         });
     }, [state, editor, disabled]);

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -131,8 +131,9 @@ const RovoDevView: React.FC = () => {
                     setChatStream((prev) => [...prev, currentMessage]);
                     setCurrentMessage(null);
                 }
-                // If waiting for prompt, finalize response and append error message
-            } else {
+            }
+            // If waiting for prompt, finalize response and append error message
+            else if (currentState === State.WaitingForPrompt) {
                 finalizeResponse();
             }
             setChatStream((prev) => {
@@ -429,7 +430,7 @@ const RovoDevView: React.FC = () => {
                     setInitState(event.newState);
                     break;
 
-                case RovoDevProviderMessageType.WorkspaceChanged:
+                case RovoDevProviderMessageType.ProviderReady:
                     setWorkspaceCount(event.workspaceCount);
                     setCurrentState(event.workspaceCount ? State.WaitingForPrompt : State.NoWorkspaceOpen);
                     break;

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import net from 'net';
 import packageJson from 'package.json';
 import path from 'path';
+import { Logger } from 'src/logger';
 import { downloadAndUnzip } from 'src/util/downloadFile';
 import { getFsPromise } from 'src/util/fsPromises';
 import { Disposable, ExtensionContext, Terminal, Uri, window, workspace } from 'vscode';
@@ -13,7 +14,7 @@ import { rovodevInfo } from '../constants';
 import { Container } from '../container';
 import { RovoDevWebviewProvider } from './rovoDevWebviewProvider';
 
-export const MIN_SUPPORTED_ROVODEV_VERSION = packageJson.rovoDev.version;
+const MIN_SUPPORTED_ROVODEV_VERSION = packageJson.rovoDev.version;
 
 function GetRovoDevURIs(context: ExtensionContext) {
     const extensionPath = context.storageUri!.fsPath;
@@ -75,32 +76,39 @@ function isPortAvailable(port: number): Promise<boolean> {
  * Placeholder implementation for Rovo Dev CLI credential storage
  */
 async function getCloudCredentials(): Promise<{ username: string; key: string; host: string } | undefined> {
-    const sites = Container.siteManager.getSitesAvailable(ProductJira);
+    try {
+        const sites = Container.siteManager.getSitesAvailable(ProductJira);
 
-    const promises = sites.map(async (site) => {
-        if (!site.isCloud) {
-            return undefined;
-        }
+        const promises = sites.map(async (site) => {
+            if (!site.isCloud) {
+                return undefined;
+            }
 
-        if (!site.host.endsWith('.atlassian.net')) {
-            return undefined;
-        }
+            if (!site.host.endsWith('.atlassian.net')) {
+                return undefined;
+            }
 
-        const authInfo = await Container.credentialManager.getAuthInfo(site);
-        if (!isBasicAuthInfo(authInfo)) {
-            return undefined;
-        }
+            const authInfo = await Container.credentialManager.getAuthInfo(site);
+            if (!isBasicAuthInfo(authInfo)) {
+                return undefined;
+            }
 
-        return {
-            username: authInfo.username,
-            key: authInfo.password,
-            host: site.host,
-        };
-    });
+            return {
+                username: authInfo.username,
+                key: authInfo.password,
+                host: site.host,
+            };
+        });
 
-    const results = (await Promise.all(promises)).filter((result) => result !== undefined);
-    return results.length > 0 ? results[0] : undefined;
+        const results = (await Promise.all(promises)).filter((result) => result !== undefined);
+        return results.length > 0 ? results[0] : undefined;
+    } catch (error) {
+        Logger.error('RovoDev', error, 'Error fetching cloud credentials for Rovo Dev');
+        return undefined;
+    }
 }
+
+type CloudCredentials = NonNullable<Awaited<ReturnType<typeof getCloudCredentials>>>;
 
 export class RovoDevProcessManager {
     private static disposables: Disposable[] = [];
@@ -126,8 +134,8 @@ export class RovoDevProcessManager {
         const zipUrl = rovoDevURIs.RovoDevZipUrl;
 
         if (!zipUrl) {
-            this.rovoDevWebviewProvider.signalRovoDevDisabled();
-            this.rovoDevWebviewProvider.sendErrorToChat(
+            await this.rovoDevWebviewProvider.signalRovoDevDisabled();
+            await this.rovoDevWebviewProvider.sendErrorToChat(
                 `Rovo Dev is not supported for the following platform/architecture: ${process.platform}/${process.arch}`,
             );
             return;
@@ -149,41 +157,46 @@ export class RovoDevProcessManager {
             await getFsPromise((callback) => fs.mkdir(versionDir, { recursive: true }, callback));
         } catch (error) {
             const message = `Unable to update Rovo Dev:\n${error.message}\n\nTo try again, please close VS Code and reopen it.`;
-            this.rovoDevWebviewProvider.signalRovoDevDisabled();
-            this.rovoDevWebviewProvider.sendErrorToChat(message);
+            await this.rovoDevWebviewProvider.signalRovoDevDisabled();
+            await this.rovoDevWebviewProvider.sendErrorToChat(message);
             throw error;
         }
 
         this.rovoDevWebviewProvider.signalBinaryDownloadEnded();
-
-        await this.initializeRovoDevProcessManager(context);
     }
 
     public static async initializeRovoDevProcessManager(context: ExtensionContext) {
         const rovoDevURIs = GetRovoDevURIs(context);
 
-        this.rovoDevInstance?.dispose();
-        this.rovoDevInstance = undefined;
-
-        if (!fs.existsSync(rovoDevURIs.RovoDevBinPath)) {
-            this.rovoDevWebviewProvider.signalBinaryDownloadStarted();
-            await this.downloadBinaryThenInitialize(context, rovoDevURIs);
+        if (this.rovoDevInstance) {
+            this.sendErrorToChat(new Error('Rovo Dev is already initialized'));
             return;
         }
 
-        // Listen for workspace folder changes
-        const listener = workspace.onDidChangeWorkspaceFolders((event) => {
-            if (!this.rovoDevInstance && event.added.length > 0) {
-                this.startRovoDev(rovoDevURIs);
-            } else if (event.removed.length === workspace.workspaceFolders?.length) {
-                this.stopRovoDevInstance();
+        const credentials = await getCloudCredentials();
+        if (!credentials) {
+            this.sendErrorToChat(new Error('Please authenticate with an API token to enable Rovo Dev'));
+            return;
+        }
+
+        try {
+            if (!fs.existsSync(rovoDevURIs.RovoDevBinPath)) {
+                this.rovoDevWebviewProvider.signalBinaryDownloadStarted();
+                await this.downloadBinaryThenInitialize(context, rovoDevURIs);
             }
-        });
 
-        context.subscriptions.push(listener);
-        this.disposables.push(listener);
+            await this.startRovoDev(credentials, rovoDevURIs);
+        } catch (error) {
+            this.sendErrorToChat(error);
+        }
+    }
 
-        await this.startRovoDev(rovoDevURIs);
+    public static async refreshRovoDevCredentials(context: ExtensionContext) {
+        if (this.rovoDevInstance) {
+            this.rovoDevInstance.refreshCredentials();
+        } else {
+            this.initializeRovoDevProcessManager(context);
+        }
     }
 
     public static deactivateRovoDevProcessManager() {
@@ -209,81 +222,111 @@ export class RovoDevProcessManager {
         throw new Error('unable to find an available port.');
     }
 
-    private static async startRovoDev(rovoDevURIs: RovoDevURIs) {
+    private static async startRovoDev(credentials: CloudCredentials, rovoDevURIs: RovoDevURIs) {
         // skip there is no workspace folder open
         if (!workspace.workspaceFolders) {
             return;
         }
 
         const folder = workspace.workspaceFolders[0];
+        const port = await this.getOrAssignPortForWorkspace();
 
-        try {
-            const port = await this.getOrAssignPortForWorkspace();
-
-            if (Container.isDebugging) {
-                this.rovoDevInstance = new RovoDevTerminalInstance(
-                    this.rovoDevWebviewProvider,
-                    folder.uri.fsPath,
-                    port,
-                    rovoDevURIs.RovoDevBinPath,
-                    rovoDevURIs.RovoDevIconUri,
-                );
-            } else {
-                this.rovoDevInstance = new RovoDevProcessInstance(
-                    this.rovoDevWebviewProvider,
-                    folder.uri.fsPath,
-                    port,
-                    rovoDevURIs.RovoDevBinPath,
-                );
-            }
-        } catch (error) {
-            this.rovoDevWebviewProvider.signalRovoDevDisabled();
-            this.rovoDevWebviewProvider.sendErrorToChat(`Unable to start Rovo Dev:\n${error.message}`);
+        if (Container.isDebugging) {
+            this.rovoDevInstance = new RovoDevTerminalInstance(
+                this.rovoDevWebviewProvider,
+                credentials,
+                folder.uri.fsPath,
+                port,
+                rovoDevURIs.RovoDevBinPath,
+                rovoDevURIs.RovoDevIconUri,
+            );
+        } else {
+            this.rovoDevInstance = new RovoDevProcessInstance(
+                this.rovoDevWebviewProvider,
+                credentials,
+                folder.uri.fsPath,
+                port,
+                rovoDevURIs.RovoDevBinPath,
+            );
         }
+
+        await this.rovoDevInstance.start();
     }
 
     public static showTerminal() {
         this.rovoDevInstance?.showTerminal();
     }
+
+    private static async sendErrorToChat(error: Error) {
+        await this.rovoDevWebviewProvider.signalRovoDevDisabled();
+        await this.rovoDevWebviewProvider.sendErrorToChat(`Unable to start Rovo Dev:\n${error.message}`);
+    }
 }
 
-interface RovoDevInstance extends Disposable {
-    stop(): void;
-    showTerminal(): void;
+abstract class RovoDevInstance extends Disposable {
+    constructor(protected credentials: CloudCredentials | undefined) {
+        super(() => this.stop());
+    }
+
+    public abstract start(): Promise<void>;
+    public abstract stop(): void;
+    public abstract showTerminal(): void;
+    protected abstract restart(): void;
+
+    public async refreshCredentials(): Promise<void> {
+        const credentials = await getCloudCredentials();
+        if (!this.areEquals(credentials, this.credentials)) {
+            this.credentials = credentials;
+            this.restart();
+        }
+    }
+
+    private areEquals(cred1?: CloudCredentials, cred2?: CloudCredentials) {
+        if (cred1 === cred2) {
+            return true;
+        }
+
+        if (!cred1 || !cred2) {
+            return false;
+        }
+
+        return cred1.host === cred2.host && cred1.key === cred2.key && cred1.username === cred2.username;
+    }
 }
 
-class RovoDevProcessInstance extends Disposable implements RovoDevInstance {
+class RovoDevProcessInstance extends RovoDevInstance {
     private rovoDevProcess: ChildProcess | undefined;
+    private restarting: boolean = false;
 
     public get isRunning() {
         return !!this.rovoDevProcess;
     }
 
     constructor(
-        rovoDevWebviewProvider: RovoDevWebviewProvider,
-        workspacePath: string,
-        port: number,
-        rovoDevBinPath: string,
+        private rovoDevWebviewProvider: RovoDevWebviewProvider,
+        credentials: CloudCredentials | undefined,
+        private workspacePath: string,
+        private port: number,
+        private rovoDevBinPath: string,
     ) {
-        super(() => this.stop());
+        super(credentials);
+    }
 
-        this.stop();
+    public start(): Promise<void> {
+        const credentials = this.credentials;
 
-        access(rovoDevBinPath, constants.X_OK, (err) => {
-            if (err) {
-                throw new Error(`executable not found.`);
-            }
-
-            getCloudCredentials().then((creds) => {
-                if (!creds) {
-                    rovoDevWebviewProvider.signalRovoDevDisabled();
-                    rovoDevWebviewProvider.signalProcessTerminated(
-                        'Please authenticate with an API token to enable Rovo Dev',
-                    );
+        return new Promise<void>((resolve, reject) => {
+            access(this.rovoDevBinPath, constants.X_OK, (err) => {
+                if (err) {
+                    reject(new Error(`executable not found.`));
+                    return;
+                }
+                if (!credentials) {
+                    reject(new Error('Please authenticate with an API token to enable Rovo Dev'));
                     return;
                 }
 
-                const { username, key } = creds;
+                const { username, key } = credentials;
 
                 const env: NodeJS.ProcessEnv = {
                     USER: process.env.USER,
@@ -293,20 +336,26 @@ class RovoDevProcessInstance extends Disposable implements RovoDevInstance {
                 let stderrData = '';
 
                 this.rovoDevProcess = spawn(
-                    rovoDevBinPath,
-                    [`serve`, `${port}`, `--application-id`, `com.atlassian.vscode`],
+                    this.rovoDevBinPath,
+                    [`serve`, `${this.port}`, `--application-id`, `com.atlassian.vscode`],
                     {
-                        cwd: workspacePath,
+                        cwd: this.workspacePath,
                         stdio: ['ignore', 'pipe', 'pipe'],
                         detached: true,
                         env,
                     },
                 )
-                    .on('spawn', () => rovoDevWebviewProvider.signalProcessStarted(port))
+                    .on('spawn', () => this.rovoDevWebviewProvider.signalProcessStarted(this.port))
                     .on('exit', (code) => {
-                        this.rovoDevProcess = undefined;
+                        this.hasStopped();
 
-                        if (code !== 0) {
+                        if (this.restarting) {
+                            this.restarting = false;
+                            this.start().catch(async (error) => {
+                                await this.rovoDevWebviewProvider.signalRovoDevDisabled();
+                                await this.rovoDevWebviewProvider.sendErrorToChat(error.message);
+                            });
+                        } else if (code !== 0) {
                             let error: string;
                             if (stderrData.includes('auth token')) {
                                 error = `please login by providing an API Token. You can do this via Atlassian: Open Settings -> Authentication`;
@@ -315,8 +364,7 @@ class RovoDevProcessInstance extends Disposable implements RovoDevInstance {
                                 error = `process exited with code ${code}, see the log for details.`;
                             }
 
-                            rovoDevWebviewProvider.signalRovoDevDisabled();
-                            rovoDevWebviewProvider.signalProcessTerminated(error);
+                            this.rovoDevWebviewProvider.signalProcessTerminated(error);
                         }
                     });
 
@@ -325,6 +373,8 @@ class RovoDevProcessInstance extends Disposable implements RovoDevInstance {
                         stderrData += data.toString();
                     });
                 }
+
+                resolve();
             });
         });
     }
@@ -332,8 +382,17 @@ class RovoDevProcessInstance extends Disposable implements RovoDevInstance {
     public stop() {
         if (this.rovoDevProcess) {
             this.rovoDevProcess.kill();
-            this.rovoDevProcess = undefined;
+            this.hasStopped();
         }
+    }
+
+    private hasStopped() {
+        this.rovoDevProcess = undefined;
+    }
+
+    protected override restart(): void {
+        this.restarting = true;
+        this.stop();
     }
 
     public showTerminal() {
@@ -341,42 +400,46 @@ class RovoDevProcessInstance extends Disposable implements RovoDevInstance {
     }
 }
 
-class RovoDevTerminalInstance extends Disposable implements RovoDevInstance {
+class RovoDevTerminalInstance extends RovoDevInstance {
     private rovoDevTerminal: Terminal | undefined;
+    private disposables: Disposable[] = [];
 
     constructor(
-        rovoDevWebviewProvider: RovoDevWebviewProvider,
-        workspacePath: string,
-        port: number,
-        rovoDevBinPath: string,
-        rovoDevIconUri: Uri,
+        private rovoDevWebviewProvider: RovoDevWebviewProvider,
+        credentials: CloudCredentials | undefined,
+        private workspacePath: string,
+        private port: number,
+        private rovoDevBinPath: string,
+        private rovoDevIconUri: Uri,
     ) {
-        super(() => this.stop());
+        super(credentials);
+    }
 
-        access(rovoDevBinPath, constants.X_OK, (err) => {
-            if (err) {
-                throw new Error(`executable not found.`);
+    public start(): Promise<void> {
+        const credentials = this.credentials;
+
+        return new Promise<void>((resolve, reject) => {
+            if (!credentials) {
+                reject(new Error('Please authenticate with an API token to enable Rovo Dev'));
+                return;
             }
 
-            getCloudCredentials().then((creds) => {
-                if (!creds) {
-                    rovoDevWebviewProvider.signalRovoDevDisabled();
-                    rovoDevWebviewProvider.signalProcessTerminated(
-                        'Please authenticate with an API token to enable Rovo Dev',
-                    );
+            access(this.rovoDevBinPath, constants.X_OK, (err) => {
+                if (err) {
+                    reject(new Error(`executable not found.`));
                     return;
                 }
 
-                const { username, key } = creds || {};
+                const { username, key } = credentials;
 
                 this.rovoDevTerminal = window.createTerminal({
                     name: 'Rovo Dev',
-                    shellPath: rovoDevBinPath,
-                    shellArgs: [`serve`, `${port}`, `--application-id`, `com.atlassian.vscode`],
-                    cwd: workspacePath,
+                    shellPath: this.rovoDevBinPath,
+                    shellArgs: [`serve`, `${this.port}`, `--application-id`, `com.atlassian.vscode`],
+                    cwd: this.workspacePath,
                     hideFromUser: true,
                     isTransient: true,
-                    iconPath: rovoDevIconUri,
+                    iconPath: this.rovoDevIconUri,
                     env: {
                         USER: process.env.USER,
                         USER_EMAIL: username,
@@ -384,32 +447,49 @@ class RovoDevTerminalInstance extends Disposable implements RovoDevInstance {
                     },
                 });
 
-                window.onDidCloseTerminal((event) => {
+                const onDidCloseTerminal = window.onDidCloseTerminal((event) => {
                     if (event === this.rovoDevTerminal) {
+                        this.hasStopped();
+
                         const code = event.exitStatus?.code;
                         if (code) {
-                            rovoDevWebviewProvider.signalRovoDevDisabled();
-                            rovoDevWebviewProvider.signalProcessTerminated(
+                            this.rovoDevWebviewProvider.signalProcessTerminated(
                                 `Rovo Dev exited with code ${code}, see the log for details.`,
                             );
                         } else {
-                            rovoDevWebviewProvider.signalProcessTerminated();
+                            this.rovoDevWebviewProvider.signalProcessTerminated();
                         }
                     }
                 });
+                this.disposables.push(onDidCloseTerminal);
 
-                rovoDevWebviewProvider.signalProcessStarted(port, true);
+                this.rovoDevWebviewProvider.signalProcessStarted(this.port, true);
+                resolve();
             });
         });
     }
 
     public stop() {
         if (this.rovoDevTerminal) {
-            const terminal = this.rovoDevTerminal;
-            this.rovoDevTerminal = undefined;
             // sends a CTRL+C to the terminal
-            terminal.sendText('\u0003', true);
+            this.rovoDevTerminal.sendText('\u0003', true);
+            this.hasStopped();
         }
+    }
+
+    protected override restart(): void {
+        this.stop();
+        this.start().catch(async (error) => {
+            await this.rovoDevWebviewProvider.signalRovoDevDisabled();
+            await this.rovoDevWebviewProvider.sendErrorToChat(error.message);
+        });
+    }
+
+    private hasStopped() {
+        this.rovoDevTerminal?.dispose();
+        this.rovoDevTerminal = undefined;
+        this.disposables.forEach((x) => x.dispose());
+        this.disposables = [];
     }
 
     public showTerminal() {

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import path from 'path';
-import { gte as semver_gte } from 'semver';
 import { CommandContext, setCommandContext } from 'src/commandContext';
 import { getFsPromise } from 'src/util/fsPromises';
 import { setTimeout } from 'timers/promises';
@@ -47,7 +46,7 @@ import { getHtmlForView } from '../webview/common/getHtmlForView';
 import { PerformanceLogger } from './performanceLogger';
 import { RovoDevResponse, RovoDevResponseParser } from './responseParser';
 import { RovoDevApiClient, RovoDevHealthcheckResponse } from './rovoDevApiClient';
-import { MIN_SUPPORTED_ROVODEV_VERSION, RovoDevProcessManager } from './rovoDevProcessManager';
+import { RovoDevProcessManager } from './rovoDevProcessManager';
 import { RovoDevPullRequestHandler } from './rovoDevPullRequestHandler';
 import { RovoDevContext, RovoDevContextItem, RovoDevInitState, RovoDevPrompt, TechnicalPlan } from './rovoDevTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from './rovoDevWebviewProviderMessages';
@@ -253,14 +252,14 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                     case RovoDevViewResponseType.WebviewReady:
                         if (!this.isBoysenberry && !this.isDisabled) {
                             await webview.postMessage({
-                                type: RovoDevProviderMessageType.WorkspaceChanged,
+                                type: RovoDevProviderMessageType.ProviderReady,
                                 workspaceCount: workspace.workspaceFolders?.length || 0,
                             });
                         }
 
-                        const port = parseInt(process.env[rovodevInfo.envVars.port] || '0');
-                        if (port) {
-                            this.signalProcessStarted(port);
+                        const fixedPort = parseInt(process.env[rovodevInfo.envVars.port] || '0');
+                        if (fixedPort) {
+                            this.signalProcessStarted(fixedPort);
                         } else if (this.isBoysenberry) {
                             this.signalRovoDevDisabled();
                             throw new Error('Rovo Dev port not set');
@@ -277,17 +276,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                 this.processError(error, false);
             }
         });
-
-        if (!this.isBoysenberry) {
-            workspace.onDidChangeWorkspaceFolders(() => {
-                if (!this.isDisabled) {
-                    webview.postMessage({
-                        type: RovoDevProviderMessageType.WorkspaceChanged,
-                        workspaceCount: workspace.workspaceFolders?.length || 0,
-                    });
-                }
-            });
-        }
     }
 
     private beginNewSession(sessionId: string | null | undefined, manuallyCreated: boolean): void {
@@ -1148,13 +1136,13 @@ ${message}`;
      * Sends an error message to the chat history instead of showing a VS Code notification
      * @param errorMessage The error message to display in chat
      */
-    public sendErrorToChat(errorMessage: string): void {
-        this.processError(new Error(errorMessage), false);
+    public sendErrorToChat(errorMessage: string) {
+        return this.processError(new Error(errorMessage), false);
     }
 
     public signalBinaryDownloadStarted() {
         const webView = this._webView!;
-        webView.postMessage({
+        return webView.postMessage({
             type: RovoDevProviderMessageType.SetInitState,
             newState: RovoDevInitState.UpdatingBinaries,
         });
@@ -1162,7 +1150,7 @@ ${message}`;
 
     public signalBinaryDownloadEnded() {
         const webView = this._webView!;
-        webView.postMessage({
+        return webView.postMessage({
             type: RovoDevProviderMessageType.SetInitState,
             newState: RovoDevInitState.NotInitialized,
         });
@@ -1178,6 +1166,10 @@ ${message}`;
 
         const webView = this._webView!;
 
+        await webView.postMessage({
+            type: RovoDevProviderMessageType.ClearChat,
+        });
+
         // wait for Rovo Dev to be ready, for up to 10 seconds
         const result = await this.waitFor(() => this.executeHealthcheck(), 100000, 500);
 
@@ -1186,24 +1178,16 @@ ${message}`;
         try {
             if (result) {
                 const info = await this.executeHealthcheckInfo();
-                const version = (info || {}).version;
                 const sessionId = (info || {}).sessionId;
-                if (version && semver_gte(version, MIN_SUPPORTED_ROVODEV_VERSION)) {
-                    this.beginNewSession(sessionId, false);
-                    if (this.isBoysenberry) {
-                        await this.executeReplay();
-                    }
-                } else {
-                    throw new Error(
-                        `Rovo Dev version (${version}) is out of date. Please update Rovo Dev and try again.\nMin version compatible: ${MIN_SUPPORTED_ROVODEV_VERSION}`,
-                    );
+
+                this.beginNewSession(sessionId, false);
+                if (this.isBoysenberry) {
+                    await this.executeReplay();
                 }
             } else {
-                const errorMsg = this._rovoDevApiClient
-                    ? `Unable to initialize RovoDev at "${this._rovoDevApiClient.baseApiUrl}". Service wasn't ready within 10000ms`
-                    : `Unable to initialize RovoDev's client within 10000ms`;
-
-                throw new Error(errorMsg);
+                throw new Error(
+                    `Unable to initialize RovoDev at "${this._rovoDevApiClient.baseApiUrl}". Service wasn't ready within 10000ms`,
+                );
             }
         } catch (error) {
             thrownError = error;
@@ -1212,7 +1196,7 @@ ${message}`;
         this._initialized = true;
         this._processState = RovoDevProcessState.Started;
 
-        webView.postMessage({
+        await webView.postMessage({
             type: RovoDevProviderMessageType.SetInitState,
             newState: RovoDevInitState.Initialized,
         });
@@ -1234,27 +1218,30 @@ ${message}`;
         this._processState = RovoDevProcessState.Disabled;
 
         const webView = this._webView!;
-        webView.postMessage({
+        return webView.postMessage({
             type: RovoDevProviderMessageType.RovoDevDisabled,
         });
     }
 
     public signalDownloadProgress(downloadedBytes: number, totalBytes: number) {
         const webView = this._webView!;
-        webView.postMessage({
+        return webView.postMessage({
             type: RovoDevProviderMessageType.SetDownloadProgress,
             downloadedBytes,
             totalBytes,
         });
     }
 
-    public signalProcessTerminated(errorMessage?: string) {
+    public signalProcessTerminated(errorMessage?: string, canBeRestarted = true) {
         this._processState = RovoDevProcessState.Terminated;
         this._initialized = false;
+        this._rovoDevApiClient = undefined;
 
-        errorMessage = errorMessage
-            ? `Agent process terminated:\n${errorMessage}\n\nPlease start a new chat session to continue.`
-            : 'Agent process terminated.\nPlease start a new chat session to continue.';
+        errorMessage = errorMessage ? `Agent process terminated:\r\n${errorMessage}\r\n` : 'Agent process terminated.';
+
+        if (canBeRestarted) {
+            errorMessage += '\r\nPlease start a new chat session to continue.';
+        }
 
         const error = new Error(errorMessage);
         return this.processError(error, false, true);

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -15,7 +15,7 @@ export const enum RovoDevProviderMessageType {
     ErrorMessage = 'errorMessage',
     ClearChat = 'clearChat',
     SetInitState = 'setInitState',
-    WorkspaceChanged = 'workspaceChanged',
+    ProviderReady = 'providerReady',
     SetDownloadProgress = 'setDownloadProgress',
     CancelFailed = 'cancelFailed',
     CreatePRComplete = 'createPRComplete',
@@ -42,7 +42,7 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.ErrorMessage, { message: ErrorMessage }>
     | ReducerAction<RovoDevProviderMessageType.ClearChat>
     | ReducerAction<RovoDevProviderMessageType.SetInitState, { newState: RovoDevInitState }>
-    | ReducerAction<RovoDevProviderMessageType.WorkspaceChanged, { workspaceCount: number }>
+    | ReducerAction<RovoDevProviderMessageType.ProviderReady, { workspaceCount: number }>
     | ReducerAction<RovoDevProviderMessageType.SetDownloadProgress, { downloadedBytes: number; totalBytes: number }>
     | ReducerAction<RovoDevProviderMessageType.CancelFailed>
     | ReducerAction<RovoDevProviderMessageType.CreatePRComplete, { data: { url?: string; error?: string } }>


### PR DESCRIPTION
### What Is This Change?

This change implements the logic to stop and restart Rovo Dev on authentication change.

Specifically:
- when the API token in use is getting removed, Rovo Dev restarts
- when there are no available API tokens for Rovo Dev, Rovo Dev prints an error

This change also address the following Prompt Box issues:
1. Prompt Box doesn't get disabled on process terminated or rovo dev chat disabled
2. Prompt Box doesn't allow typing when the response is streaming back

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`