### PR TITLE
AXON-983 & AXON-984: Added new background color to better contrast

### DIFF
--- a/src/react/atlascode/config/explore/ExplorePanel.tsx
+++ b/src/react/atlascode/config/explore/ExplorePanel.tsx
@@ -13,14 +13,14 @@ const useStyles = makeStyles(
     (theme: Theme) =>
         ({
             code: {
-                backgroundColor: 'rgb(220, 220, 220)', //bright shade of gray
+                backgroundColor: 'var(--vscode-editorWidget-background)',
                 borderRadius: 5,
                 margin: theme.spacing(0, 1),
                 padding: theme.spacing(0, 1),
             },
             linkified: {
                 '&:hover': {
-                    backgroundColor: 'white',
+                    backgroundColor: 'var(--vscode-editor-selectionHighlightBackground)',
                 },
             },
         }) as const,


### PR DESCRIPTION
### What Is This Change?
**Added new background color to better contrast**
AXON-983:
Before:  
Dark
<img width="1056" height="620" alt="Screenshot 2025-08-28 at 12 22 37" src="https://github.com/user-attachments/assets/65040fc0-c974-4be1-a114-8215fe4b4a06" />
LIght
<img width="1191" height="564" alt="Screenshot 2025-08-28 at 16 59 06" src="https://github.com/user-attachments/assets/088b7e7b-5558-47fc-95f9-677833a661d2" />

After:
Dark
<img width="1191" height="746" alt="Screenshot 2025-08-28 at 16 57 05" src="https://github.com/user-attachments/assets/5bb9b4e1-06d2-4e00-8013-df7ff0e9d1e6" />
LIght
<img width="1191" height="746" alt="Screenshot 2025-08-28 at 16 58 21" src="https://github.com/user-attachments/assets/1e878381-a61a-43b6-8c4f-e552f88f8a51" />

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change