### PR TITLE
[AXON-972] Connect Jira auth flow to TreeNode login button

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,7 +25,7 @@ import { ConfigSection, ConfigSubSection, ConfigV3Section, ConfigV3SubSection } 
 import { Logger } from './logger';
 import { RovoDevProcessManager } from './rovo-dev/rovoDevProcessManager';
 import { RovoDevContext } from './rovo-dev/rovoDevTypes';
-import { Experiments } from './util/featureFlags';
+import { Experiments, Features } from './util/featureFlags';
 import { AbstractBaseNode } from './views/nodes/abstractBaseNode';
 import { IssueNode } from './views/nodes/issueNode';
 import { PipelineNode } from './views/pipelines/PipelinesTree';
@@ -406,6 +406,14 @@ export function registerCommands(vscodeContext: ExtensionContext) {
                 Container.openPullRequestHandler(data.pullRequestUrl);
             }),
             commands.registerCommand(Commands.ShowOnboardingFlow, () => Container.onboardingProvider.start()),
+            commands.registerCommand(Commands.JiraLogin, () => {
+                const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
+                if (useNewAuthFlow) {
+                    commands.executeCommand(Commands.QuickAuth, { product: ProductJira });
+                } else {
+                    commands.executeCommand(Commands.ShowConfigPage);
+                }
+            }),
         );
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,6 +94,7 @@ export const enum Commands {
     OpenRovoDevGlobalMemory = 'atlascode.openRovoDevGlobalMemory',
     OpenNativeSettings = 'atlascode.openNativeSettings',
     QuickAuth = 'atlascode.rovodev.quickAuth',
+    JiraLogin = 'atlascode.jira.login',
 
     // Debug mode-only commands
     DebugQuickCommand = 'atlascode.debug.quickCommand',

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -49,9 +49,8 @@ export function getJiraIssueUri(issue: MinimalIssue<DetailedSiteInfo>): Uri {
 }
 
 export const loginToJiraMessageNode = createLabelItem('Please login to Jira', {
-    command: Commands.ShowConfigPage,
+    command: Commands.JiraLogin,
     title: 'Login to Jira',
-    arguments: [ProductJira],
 });
 
 export class JiraIssueNode extends TreeItem implements AbstractBaseNode {


### PR DESCRIPTION
### What Is This Change?

With the feature flag turned on, this button now triggers the new authentication flow
<img width="391" height="115" alt="image" src="https://github.com/user-attachments/assets/47b045ed-d22d-48d3-9fd2-538da1ed07e2" />


[Loom on this](https://www.loom.com/share/9fe101db919e4c6d85fcc3ad21ea6b95)

### How Has This Been Tested?

Manually, with FF both on and off

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change