### PR TITLE
[AXON-973] Add featureflags to webview; new auth button

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -201,6 +201,7 @@ export class Container {
                 analyticsAnonymousId: this.machineId,
             });
 
+            this.pushFeatureUpdatesToUI();
             Logger.debug(`FeatureFlagClient: Succesfully initialized the client.`);
             featureFlagClientInitializedEvent(true).then((e) => {
                 this.analyticsClient.sendTrackEvent(e);
@@ -259,6 +260,7 @@ export class Container {
     static async updateFeatureFlagTenantId(tenantId: string | undefined): Promise<boolean> {
         try {
             await this._featureFlagClient.updateUser({ tenantId });
+            this.pushFeatureUpdatesToUI();
             return true;
         } catch (err) {
             Logger.error('RovoDev', err, "FeatureFlagClient: Failed to update user's tenantId");
@@ -325,6 +327,21 @@ export class Container {
         } catch (error) {
             Logger.error('RovoDev', error, 'Refreshing Jira issue views');
             return;
+        }
+    }
+
+    static pushFeatureUpdatesToUI() {
+        const factories = [
+            this.settingsWebviewFactory,
+            this.startWorkWebviewFactory,
+            this.startWorkV3WebviewFactory,
+            this.createPullRequestWebviewFactory,
+        ];
+
+        for (const factory of factories) {
+            if (typeof factory?.updateFeatureMetadata === 'function') {
+                factory.updateFeatureMetadata();
+            }
         }
     }
 

--- a/src/lib/ipc/fromUI/config.ts
+++ b/src/lib/ipc/fromUI/config.ts
@@ -20,6 +20,7 @@ export enum ConfigActionType {
     CreatePullRequest = 'createPullRequest',
     ViewPullRequest = 'viewPullRequest',
     OpenNativeSettings = 'openNativeSettings',
+    StartAuthFlow = 'StartAuthFlow',
 }
 
 export type ConfigAction =
@@ -38,6 +39,7 @@ export type ConfigAction =
     | ReducerAction<ConfigActionType.CreatePullRequest>
     | ReducerAction<ConfigActionType.ViewPullRequest>
     | ReducerAction<ConfigActionType.OpenNativeSettings>
+    | ReducerAction<ConfigActionType.StartAuthFlow>
     | CommonAction;
 
 export interface AuthAction {

--- a/src/lib/webview/controller/config/configV3WebviewController.test.ts
+++ b/src/lib/webview/controller/config/configV3WebviewController.test.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import * as vscode from 'vscode';
 
@@ -119,7 +120,7 @@ describe('ConfigV3WebviewController', () => {
         });
 
         test('should have required feature flags and experiments as empty arrays', () => {
-            expect(controller.requiredFeatureFlags).toEqual([]);
+            expect(controller.requiredFeatureFlags).toEqual([Features.UseNewAuthFlow]);
             expect(controller.requiredExperiments).toEqual([]);
         });
 

--- a/src/lib/webview/controller/config/configV3WebviewController.ts
+++ b/src/lib/webview/controller/config/configV3WebviewController.ts
@@ -1,12 +1,13 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import Axios from 'axios';
 import { ConfigV3Section } from 'src/lib/ipc/models/config';
+import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import { env } from 'vscode';
 import * as vscode from 'vscode';
 
 import { isBasicAuthInfo, isEmptySiteInfo, isPATAuthInfo } from '../../../../atlclients/authInfo';
-import { ExtensionId } from '../../../../constants';
+import { Commands, ExtensionId } from '../../../../constants';
 import { Container } from '../../../../container';
 import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
@@ -25,7 +26,7 @@ const AUTH_URI = `${env.uriScheme || 'vscode'}://${ExtensionId}/auth`;
 export const id: string = 'atlascodeSettingsV3';
 
 export class ConfigV3WebviewController implements WebviewController<SectionV3ChangeMessage> {
-    public readonly requiredFeatureFlags = [];
+    public readonly requiredFeatureFlags = [Features.UseNewAuthFlow];
     public readonly requiredExperiments = [];
 
     private _messagePoster: MessagePoster;
@@ -293,7 +294,10 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                 await this._api.openNativeSettings();
                 break;
             }
-
+            case ConfigActionType.StartAuthFlow: {
+                vscode.commands.executeCommand(Commands.JiraLogin);
+                break;
+            }
             case CommonActionType.SendAnalytics:
             case CommonActionType.CopyLink:
             case CommonActionType.OpenJiraIssue:

--- a/src/lib/webview/controller/config/configWebviewController.test.ts
+++ b/src/lib/webview/controller/config/configWebviewController.test.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import * as vscode from 'vscode';
 
@@ -119,7 +120,7 @@ describe('ConfigWebviewController', () => {
         });
 
         test('should have required feature flags and experiments as empty arrays', () => {
-            expect(controller.requiredFeatureFlags).toEqual([]);
+            expect(controller.requiredFeatureFlags).toEqual([Features.UseNewAuthFlow]);
             expect(controller.requiredExperiments).toEqual([]);
         });
 

--- a/src/lib/webview/controller/config/configWebviewController.ts
+++ b/src/lib/webview/controller/config/configWebviewController.ts
@@ -1,11 +1,12 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import Axios from 'axios';
+import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import { env } from 'vscode';
 import * as vscode from 'vscode';
 
 import { isBasicAuthInfo, isEmptySiteInfo, isPATAuthInfo } from '../../../../atlclients/authInfo';
-import { ExtensionId } from '../../../../constants';
+import { Commands, ExtensionId } from '../../../../constants';
 import { Container } from '../../../../container';
 import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
@@ -24,7 +25,7 @@ const AUTH_URI = `${env.uriScheme || 'vscode'}://${ExtensionId}/auth`;
 export const id: string = 'atlascodeSettingsV2'; // Need to change this to 'id_v2' to help with dif versions
 
 export class ConfigWebviewController implements WebviewController<SectionChangeMessage> {
-    public readonly requiredFeatureFlags = [];
+    public readonly requiredFeatureFlags = [Features.UseNewAuthFlow];
     public readonly requiredExperiments = [];
 
     private _messagePoster: MessagePoster;
@@ -298,6 +299,10 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
             }
             case ConfigActionType.OpenNativeSettings: {
                 await this._api.openNativeSettings();
+                break;
+            }
+            case ConfigActionType.StartAuthFlow: {
+                vscode.commands.executeCommand(Commands.JiraLogin);
                 break;
             }
 

--- a/src/react/atlascode/common/FeatureFlagContext.tsx
+++ b/src/react/atlascode/common/FeatureFlagContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, ReactNode, useContext, useState } from 'react';
+import { CommonMessageType } from 'src/lib/ipc/toUI/common';
+import { Features } from 'src/util/features';
+
+type FeatureFlags = Record<string, boolean>;
+
+interface FeatureFlagContextType {
+    flags: FeatureFlags;
+    setFlag: (key: string, value: boolean) => void;
+}
+
+const FeatureFlagContext = createContext<FeatureFlagContextType | undefined>(undefined);
+
+// re-export features for convenience
+export { Features };
+
+export const useFeatureFlags = (): FeatureFlagContextType => {
+    const context = useContext(FeatureFlagContext);
+    if (!context) {
+        throw new Error('useFeatureFlags must be used within a FeatureFlagProvider');
+    }
+    return context;
+};
+
+export const FeatureFlagProvider: React.FC<{ initialFlags?: FeatureFlags; children: ReactNode }> = ({
+    initialFlags = {},
+    children,
+}) => {
+    const [flags, setFlags] = useState<FeatureFlags>(initialFlags);
+
+    window.onmessage = (event) => {
+        const { command, featureFlags } = event.data;
+        if (command === CommonMessageType.UpdateFeatureFlags) {
+            setFlags(featureFlags);
+        }
+    };
+
+    const setFlag = (key: string, value: boolean) => {
+        setFlags((prev) => ({ ...prev, [key]: value }));
+    };
+
+    return <FeatureFlagContext.Provider value={{ flags, setFlag }}>{children}</FeatureFlagContext.Provider>;
+};

--- a/src/react/atlascode/config/ConfigPage.tsx
+++ b/src/react/atlascode/config/ConfigPage.tsx
@@ -25,6 +25,7 @@ import { AnalyticsView } from 'src/analyticsTypes';
 import { ConfigSection, ConfigSubSection, ConfigTarget } from '../../../lib/ipc/models/config';
 import { AtlascodeErrorBoundary } from '../common/ErrorBoundary';
 import { ErrorDisplay } from '../common/ErrorDisplay';
+import { FeatureFlagProvider } from '../common/FeatureFlagContext';
 import { PMFDisplay } from '../common/pmf/PMFDisplay';
 import { AuthDialog } from './auth/dialog/AuthDialog';
 import { AuthDialogControllerContext, useAuthDialog } from './auth/useAuthDialog';
@@ -170,166 +171,168 @@ const ConfigPage: React.FunctionComponent = () => {
 
     return (
         <ConfigControllerContext.Provider value={controller}>
-            <AuthDialogControllerContext.Provider value={authDialogController}>
-                <AtlascodeErrorBoundary
-                    context={{ view: AnalyticsView.SettingsPage }}
-                    postMessageFunc={controller.postMessage}
-                >
-                    <Container maxWidth="xl">
-                        <AppBar position="relative">
-                            <Toolbar>
-                                <Typography variant="h3" className={classes.title}>
-                                    Atlassian Settings
-                                </Typography>
-                                <Tabs
-                                    value={openSection}
-                                    onChange={handleTabChange}
-                                    aria-label="simple tabs example"
-                                    indicatorColor="primary"
-                                    variant="scrollable"
-                                    scrollButtons
-                                    allowScrollButtonsMobile
-                                >
-                                    <Tab
-                                        id="simple-tab-0"
-                                        aria-controls="simple-tabpanel-0"
-                                        value={ConfigSection.Jira}
-                                        label={
-                                            <ProductEnabler
-                                                label="Jira"
-                                                enabled={state.config['jira.enabled']}
-                                                onToggle={handleJiraToggle}
-                                            />
-                                        }
-                                    />
-                                    <Tab
-                                        id="simple-tab-1"
-                                        aria-controls="simple-tabpanel-1"
-                                        value={ConfigSection.Bitbucket}
-                                        label={
-                                            <ProductEnabler
-                                                label="Bitbucket"
-                                                enabled={state.config['bitbucket.enabled']}
-                                                onToggle={handleBitbucketToggle}
-                                            />
-                                        }
-                                    />
-                                    <Tab
-                                        id="simple-tab-2"
-                                        aria-controls="simple-tabpanel-2"
-                                        value={ConfigSection.General}
-                                        label="General"
-                                    />
-                                    <Tab
-                                        id="simple-tab-3"
-                                        aria-controls="simple-tabpanel-3"
-                                        value={ConfigSection.Explore}
-                                        label="Explore"
-                                    />
-                                </Tabs>
-                                <div className={classes.grow} />
-                                <Typography variant="subtitle1" classes={{ root: classes.targetSelectLabel }}>
-                                    Save settings to:{' '}
-                                </Typography>
-                                <ToggleButtonGroup
-                                    color="primary"
-                                    size="small"
-                                    value={internalTarget}
-                                    exclusive
-                                    onChange={handleTargetChange}
-                                >
-                                    <Tooltip title="User settings">
-                                        <ToggleButton
-                                            key={1}
-                                            value={ConfigTarget.User}
-                                            selected={internalTarget !== ConfigTarget.User}
-                                            disableRipple={internalTarget === ConfigTarget.User}
-                                        >
-                                            <Badge
-                                                color="primary"
-                                                variant="dot"
-                                                invisible={internalTarget !== ConfigTarget.User}
+            <FeatureFlagProvider>
+                <AuthDialogControllerContext.Provider value={authDialogController}>
+                    <AtlascodeErrorBoundary
+                        context={{ view: AnalyticsView.SettingsPage }}
+                        postMessageFunc={controller.postMessage}
+                    >
+                        <Container maxWidth="xl">
+                            <AppBar position="relative">
+                                <Toolbar>
+                                    <Typography variant="h3" className={classes.title}>
+                                        Atlassian Settings
+                                    </Typography>
+                                    <Tabs
+                                        value={openSection}
+                                        onChange={handleTabChange}
+                                        aria-label="simple tabs example"
+                                        indicatorColor="primary"
+                                        variant="scrollable"
+                                        scrollButtons
+                                        allowScrollButtonsMobile
+                                    >
+                                        <Tab
+                                            id="simple-tab-0"
+                                            aria-controls="simple-tabpanel-0"
+                                            value={ConfigSection.Jira}
+                                            label={
+                                                <ProductEnabler
+                                                    label="Jira"
+                                                    enabled={state.config['jira.enabled']}
+                                                    onToggle={handleJiraToggle}
+                                                />
+                                            }
+                                        />
+                                        <Tab
+                                            id="simple-tab-1"
+                                            aria-controls="simple-tabpanel-1"
+                                            value={ConfigSection.Bitbucket}
+                                            label={
+                                                <ProductEnabler
+                                                    label="Bitbucket"
+                                                    enabled={state.config['bitbucket.enabled']}
+                                                    onToggle={handleBitbucketToggle}
+                                                />
+                                            }
+                                        />
+                                        <Tab
+                                            id="simple-tab-2"
+                                            aria-controls="simple-tabpanel-2"
+                                            value={ConfigSection.General}
+                                            label="General"
+                                        />
+                                        <Tab
+                                            id="simple-tab-3"
+                                            aria-controls="simple-tabpanel-3"
+                                            value={ConfigSection.Explore}
+                                            label="Explore"
+                                        />
+                                    </Tabs>
+                                    <div className={classes.grow} />
+                                    <Typography variant="subtitle1" classes={{ root: classes.targetSelectLabel }}>
+                                        Save settings to:{' '}
+                                    </Typography>
+                                    <ToggleButtonGroup
+                                        color="primary"
+                                        size="small"
+                                        value={internalTarget}
+                                        exclusive
+                                        onChange={handleTargetChange}
+                                    >
+                                        <Tooltip title="User settings">
+                                            <ToggleButton
+                                                key={1}
+                                                value={ConfigTarget.User}
+                                                selected={internalTarget !== ConfigTarget.User}
+                                                disableRipple={internalTarget === ConfigTarget.User}
                                             >
-                                                <PersonIcon />
-                                            </Badge>
-                                        </ToggleButton>
-                                    </Tooltip>
-                                    <Tooltip title="Workspace settings">
-                                        <ToggleButton
-                                            key={2}
-                                            value={ConfigTarget.Workspace}
-                                            selected={internalTarget !== ConfigTarget.Workspace}
-                                            disableRipple={internalTarget === ConfigTarget.Workspace}
-                                        >
-                                            <Badge
-                                                color="primary"
-                                                variant="dot"
-                                                invisible={internalTarget !== ConfigTarget.Workspace}
+                                                <Badge
+                                                    color="primary"
+                                                    variant="dot"
+                                                    invisible={internalTarget !== ConfigTarget.User}
+                                                >
+                                                    <PersonIcon />
+                                                </Badge>
+                                            </ToggleButton>
+                                        </Tooltip>
+                                        <Tooltip title="Workspace settings">
+                                            <ToggleButton
+                                                key={2}
+                                                value={ConfigTarget.Workspace}
+                                                selected={internalTarget !== ConfigTarget.Workspace}
+                                                disableRipple={internalTarget === ConfigTarget.Workspace}
                                             >
-                                                <WorkIcon />
-                                            </Badge>
-                                        </ToggleButton>
-                                    </Tooltip>
-                                </ToggleButtonGroup>
-                                <RefreshButton loading={state.isSomethingLoading} onClick={controller.refresh} />
-                            </Toolbar>
-                        </AppBar>
-                        <Grid container spacing={1}>
-                            <Grid item xs={12} md={9} lg={10} xl={10}>
-                                <Paper className={classes.paper100}>
-                                    <ErrorDisplay />
-                                    <PMFDisplay postMessageFunc={controller.postMessage} />
-                                    <Box margin={2}>
-                                        <JiraPanel
-                                            visible={openSection === ConfigSection.Jira}
-                                            selectedSubSections={openSubsections[ConfigSection.Jira]}
-                                            onSubsectionChange={handleSubsectionChange}
-                                            config={state.config!}
-                                            sites={state.jiraSites}
-                                            isRemote={state.isRemote}
-                                        />
-                                        <BitbucketPanel
-                                            visible={openSection === ConfigSection.Bitbucket}
-                                            selectedSubSections={openSubsections[ConfigSection.Bitbucket]}
-                                            onSubsectionChange={handleSubsectionChange}
-                                            config={state.config!}
-                                            sites={state.bitbucketSites}
-                                            isRemote={state.isRemote}
-                                        />
-                                        <GeneralPanel
-                                            visible={openSection === ConfigSection.General}
-                                            selectedSubSections={openSubsections[ConfigSection.General]}
-                                            onSubsectionChange={handleSubsectionChange}
-                                            config={state.config!}
-                                            machineId={state.machineId}
-                                        />
-                                        <ExplorePanel
-                                            visible={openSection === ConfigSection.Explore}
-                                            config={state.config!}
-                                            sectionChanger={handleCompleteSectionChange}
-                                        />
-                                    </Box>
-                                </Paper>
+                                                <Badge
+                                                    color="primary"
+                                                    variant="dot"
+                                                    invisible={internalTarget !== ConfigTarget.Workspace}
+                                                >
+                                                    <WorkIcon />
+                                                </Badge>
+                                            </ToggleButton>
+                                        </Tooltip>
+                                    </ToggleButtonGroup>
+                                    <RefreshButton loading={state.isSomethingLoading} onClick={controller.refresh} />
+                                </Toolbar>
+                            </AppBar>
+                            <Grid container spacing={1}>
+                                <Grid item xs={12} md={9} lg={10} xl={10}>
+                                    <Paper className={classes.paper100}>
+                                        <ErrorDisplay />
+                                        <PMFDisplay postMessageFunc={controller.postMessage} />
+                                        <Box margin={2}>
+                                            <JiraPanel
+                                                visible={openSection === ConfigSection.Jira}
+                                                selectedSubSections={openSubsections[ConfigSection.Jira]}
+                                                onSubsectionChange={handleSubsectionChange}
+                                                config={state.config!}
+                                                sites={state.jiraSites}
+                                                isRemote={state.isRemote}
+                                            />
+                                            <BitbucketPanel
+                                                visible={openSection === ConfigSection.Bitbucket}
+                                                selectedSubSections={openSubsections[ConfigSection.Bitbucket]}
+                                                onSubsectionChange={handleSubsectionChange}
+                                                config={state.config!}
+                                                sites={state.bitbucketSites}
+                                                isRemote={state.isRemote}
+                                            />
+                                            <GeneralPanel
+                                                visible={openSection === ConfigSection.General}
+                                                selectedSubSections={openSubsections[ConfigSection.General]}
+                                                onSubsectionChange={handleSubsectionChange}
+                                                config={state.config!}
+                                                machineId={state.machineId}
+                                            />
+                                            <ExplorePanel
+                                                visible={openSection === ConfigSection.Explore}
+                                                config={state.config!}
+                                                sectionChanger={handleCompleteSectionChange}
+                                            />
+                                        </Box>
+                                    </Paper>
+                                </Grid>
+                                <Grid item xs={12} md={3} lg={2} xl={2}>
+                                    <Paper className={classes.paperOverflow}>
+                                        <Box margin={2}>
+                                            <SidebarButtons feedbackUser={state.feedbackUser} />
+                                        </Box>
+                                    </Paper>
+                                </Grid>
                             </Grid>
-                            <Grid item xs={12} md={3} lg={2} xl={2}>
-                                <Paper className={classes.paperOverflow}>
-                                    <Box margin={2}>
-                                        <SidebarButtons feedbackUser={state.feedbackUser} />
-                                    </Box>
-                                </Paper>
-                            </Grid>
-                        </Grid>
-                    </Container>
-                    <AuthDialog
-                        product={authDialogProduct}
-                        doClose={authDialogController.close}
-                        authEntry={authDialogEntry}
-                        open={authDialogOpen}
-                        save={controller.login}
-                        onExited={authDialogController.onExited}
-                    />
-                </AtlascodeErrorBoundary>
-            </AuthDialogControllerContext.Provider>
+                        </Container>
+                        <AuthDialog
+                            product={authDialogProduct}
+                            doClose={authDialogController.close}
+                            authEntry={authDialogEntry}
+                            open={authDialogOpen}
+                            save={controller.login}
+                            onExited={authDialogController.onExited}
+                        />
+                    </AtlascodeErrorBoundary>
+                </AuthDialogControllerContext.Provider>
+            </FeatureFlagProvider>
         </ConfigControllerContext.Provider>
     );
 };

--- a/src/react/atlascode/config/ConfigPageV3.tsx
+++ b/src/react/atlascode/config/ConfigPageV3.tsx
@@ -25,6 +25,7 @@ import { AnalyticsView } from 'src/analyticsTypes';
 import { ConfigTarget, ConfigV3Section, ConfigV3SubSection } from '../../../lib/ipc/models/config';
 import { AtlascodeErrorBoundary } from '../common/ErrorBoundary';
 import { ErrorDisplay } from '../common/ErrorDisplay';
+import { FeatureFlagProvider } from '../common/FeatureFlagContext';
 import { PMFDisplay } from '../common/pmf/PMFDisplay';
 import { AdvancedConfigsPanel } from './advancedConfigs/advancedConfigsPanel';
 import { AuthDialog } from './auth/dialog/AuthDialog';
@@ -157,132 +158,134 @@ const ConfigPageV3: React.FunctionComponent = () => {
 
     return (
         <ConfigControllerContext.Provider value={controller}>
-            <AuthDialogControllerContext.Provider value={authDialogController}>
-                <AtlascodeErrorBoundary
-                    context={{ view: AnalyticsView.SettingsPage }}
-                    postMessageFunc={controller.postMessage}
-                >
-                    <Container maxWidth="xl">
-                        <AppBar position="relative">
-                            <Toolbar>
-                                <Typography variant="h3" className={classes.title}>
-                                    Atlassian Settings
-                                </Typography>
-                                <Tabs
-                                    value={openSection}
-                                    onChange={handleTabChange}
-                                    aria-label="simple tabs example"
-                                    indicatorColor="primary"
-                                    variant="scrollable"
-                                    scrollButtons
-                                    allowScrollButtonsMobile
-                                >
-                                    <Tab
-                                        id="simple-tab-0"
-                                        aria-controls="simple-tabpanel-0"
-                                        value={ConfigV3Section.Auth}
-                                        label="Authentication"
-                                    />
-                                    <Tab
-                                        id="simple-tab-1"
-                                        aria-controls="simple-tabpanel-1"
-                                        value={ConfigV3Section.AdvancedConfig}
-                                        label="Advanced Settings"
-                                    />
-                                </Tabs>
-                                <div className={classes.grow} />
-                                <Typography variant="subtitle1" classes={{ root: classes.targetSelectLabel }}>
-                                    Save settings to:{' '}
-                                </Typography>
-                                <ToggleButtonGroup
-                                    color="primary"
-                                    size="small"
-                                    value={internalTarget}
-                                    exclusive
-                                    onChange={handleTargetChange}
-                                >
-                                    <Tooltip title="User settings">
-                                        <ToggleButton
-                                            key={1}
-                                            value={ConfigTarget.User}
-                                            selected={internalTarget !== ConfigTarget.User}
-                                            disableRipple={internalTarget === ConfigTarget.User}
-                                        >
-                                            <Badge
-                                                color="primary"
-                                                variant="dot"
-                                                invisible={internalTarget !== ConfigTarget.User}
-                                            >
-                                                <PersonIcon />
-                                            </Badge>
-                                        </ToggleButton>
-                                    </Tooltip>
-                                    <Tooltip title="Workspace settings">
-                                        <ToggleButton
-                                            key={2}
-                                            value={ConfigTarget.Workspace}
-                                            selected={internalTarget !== ConfigTarget.Workspace}
-                                            disableRipple={internalTarget === ConfigTarget.Workspace}
-                                        >
-                                            <Badge
-                                                color="primary"
-                                                variant="dot"
-                                                invisible={internalTarget !== ConfigTarget.Workspace}
-                                            >
-                                                <WorkIcon />
-                                            </Badge>
-                                        </ToggleButton>
-                                    </Tooltip>
-                                </ToggleButtonGroup>
-                                <RefreshButton loading={state.isSomethingLoading} onClick={controller.refresh} />
-                            </Toolbar>
-                        </AppBar>
-                        <Grid container spacing={1}>
-                            <Grid item xs={12} md={9} lg={10} xl={10}>
-                                <Paper className={classes.paper100}>
-                                    <ErrorDisplay />
-                                    <PMFDisplay postMessageFunc={controller.postMessage} />
-                                    <Box margin={2}>
-                                        <AuthenticationPanel
-                                            visible={openSection === ConfigV3Section.Auth}
-                                            jiraSites={state.jiraSites}
-                                            bitbucketSites={state.bitbucketSites}
-                                            isRemote={state.isRemote}
-                                            config={state.config}
-                                            jiraToggle={handleJiraToggle}
-                                            bbToggle={handleBitbucketToggle}
+            <FeatureFlagProvider>
+                <AuthDialogControllerContext.Provider value={authDialogController}>
+                    <AtlascodeErrorBoundary
+                        context={{ view: AnalyticsView.SettingsPage }}
+                        postMessageFunc={controller.postMessage}
+                    >
+                        <Container maxWidth="xl">
+                            <AppBar position="relative">
+                                <Toolbar>
+                                    <Typography variant="h3" className={classes.title}>
+                                        Atlassian Settings
+                                    </Typography>
+                                    <Tabs
+                                        value={openSection}
+                                        onChange={handleTabChange}
+                                        aria-label="simple tabs example"
+                                        indicatorColor="primary"
+                                        variant="scrollable"
+                                        scrollButtons
+                                        allowScrollButtonsMobile
+                                    >
+                                        <Tab
+                                            id="simple-tab-0"
+                                            aria-controls="simple-tabpanel-0"
+                                            value={ConfigV3Section.Auth}
+                                            label="Authentication"
                                         />
-                                        <AdvancedConfigsPanel
-                                            visible={openSection === ConfigV3Section.AdvancedConfig}
-                                            selectedSubSections={openSubsections[ConfigV3Section.AdvancedConfig]}
-                                            onSubsectionChange={handleSubsectionChange}
-                                            config={state.config!}
-                                            sites={state.jiraSites}
-                                            isRemote={state.isRemote}
-                                            machineId={state.machineId}
+                                        <Tab
+                                            id="simple-tab-1"
+                                            aria-controls="simple-tabpanel-1"
+                                            value={ConfigV3Section.AdvancedConfig}
+                                            label="Advanced Settings"
                                         />
-                                    </Box>
-                                </Paper>
+                                    </Tabs>
+                                    <div className={classes.grow} />
+                                    <Typography variant="subtitle1" classes={{ root: classes.targetSelectLabel }}>
+                                        Save settings to:{' '}
+                                    </Typography>
+                                    <ToggleButtonGroup
+                                        color="primary"
+                                        size="small"
+                                        value={internalTarget}
+                                        exclusive
+                                        onChange={handleTargetChange}
+                                    >
+                                        <Tooltip title="User settings">
+                                            <ToggleButton
+                                                key={1}
+                                                value={ConfigTarget.User}
+                                                selected={internalTarget !== ConfigTarget.User}
+                                                disableRipple={internalTarget === ConfigTarget.User}
+                                            >
+                                                <Badge
+                                                    color="primary"
+                                                    variant="dot"
+                                                    invisible={internalTarget !== ConfigTarget.User}
+                                                >
+                                                    <PersonIcon />
+                                                </Badge>
+                                            </ToggleButton>
+                                        </Tooltip>
+                                        <Tooltip title="Workspace settings">
+                                            <ToggleButton
+                                                key={2}
+                                                value={ConfigTarget.Workspace}
+                                                selected={internalTarget !== ConfigTarget.Workspace}
+                                                disableRipple={internalTarget === ConfigTarget.Workspace}
+                                            >
+                                                <Badge
+                                                    color="primary"
+                                                    variant="dot"
+                                                    invisible={internalTarget !== ConfigTarget.Workspace}
+                                                >
+                                                    <WorkIcon />
+                                                </Badge>
+                                            </ToggleButton>
+                                        </Tooltip>
+                                    </ToggleButtonGroup>
+                                    <RefreshButton loading={state.isSomethingLoading} onClick={controller.refresh} />
+                                </Toolbar>
+                            </AppBar>
+                            <Grid container spacing={1}>
+                                <Grid item xs={12} md={9} lg={10} xl={10}>
+                                    <Paper className={classes.paper100}>
+                                        <ErrorDisplay />
+                                        <PMFDisplay postMessageFunc={controller.postMessage} />
+                                        <Box margin={2}>
+                                            <AuthenticationPanel
+                                                visible={openSection === ConfigV3Section.Auth}
+                                                jiraSites={state.jiraSites}
+                                                bitbucketSites={state.bitbucketSites}
+                                                isRemote={state.isRemote}
+                                                config={state.config}
+                                                jiraToggle={handleJiraToggle}
+                                                bbToggle={handleBitbucketToggle}
+                                            />
+                                            <AdvancedConfigsPanel
+                                                visible={openSection === ConfigV3Section.AdvancedConfig}
+                                                selectedSubSections={openSubsections[ConfigV3Section.AdvancedConfig]}
+                                                onSubsectionChange={handleSubsectionChange}
+                                                config={state.config!}
+                                                sites={state.jiraSites}
+                                                isRemote={state.isRemote}
+                                                machineId={state.machineId}
+                                            />
+                                        </Box>
+                                    </Paper>
+                                </Grid>
+                                <Grid item xs={12} md={3} lg={2} xl={2}>
+                                    <Paper className={classes.paperOverflow}>
+                                        <Box margin={2}>
+                                            <SidebarButtons feedbackUser={state.feedbackUser} />
+                                        </Box>
+                                    </Paper>
+                                </Grid>
                             </Grid>
-                            <Grid item xs={12} md={3} lg={2} xl={2}>
-                                <Paper className={classes.paperOverflow}>
-                                    <Box margin={2}>
-                                        <SidebarButtons feedbackUser={state.feedbackUser} />
-                                    </Box>
-                                </Paper>
-                            </Grid>
-                        </Grid>
-                    </Container>
-                    <AuthDialog
-                        product={authDialogProduct}
-                        doClose={authDialogController.close}
-                        authEntry={authDialogEntry}
-                        open={authDialogOpen}
-                        save={controller.login}
-                        onExited={authDialogController.onExited}
-                    />
-                </AtlascodeErrorBoundary>
-            </AuthDialogControllerContext.Provider>
+                        </Container>
+                        <AuthDialog
+                            product={authDialogProduct}
+                            doClose={authDialogController.close}
+                            authEntry={authDialogEntry}
+                            open={authDialogOpen}
+                            save={controller.login}
+                            onExited={authDialogController.onExited}
+                        />
+                    </AtlascodeErrorBoundary>
+                </AuthDialogControllerContext.Provider>
+            </FeatureFlagProvider>
         </ConfigControllerContext.Provider>
     );
 };

--- a/src/react/atlascode/config/auth/SiteAuthenticator.tsx
+++ b/src/react/atlascode/config/auth/SiteAuthenticator.tsx
@@ -3,6 +3,7 @@ import React, { memo, useCallback, useContext } from 'react';
 
 import { Product } from '../../../../atlclients/authInfo';
 import { SiteWithAuthInfo } from '../../../../lib/ipc/toUI/config';
+import { Features, useFeatureFlags } from '../../common/FeatureFlagContext';
 import { ConfigControllerContext } from '../configController';
 import { CloudAuthButton } from './CloudAuthButton';
 import { SiteList } from './SiteList';
@@ -72,44 +73,59 @@ const AuthContainer = ({
     handleEdit,
     remoteAuth,
     isRemoteAuthButtonVisible,
-}: AuthContainerProps) => (
-    <React.Fragment>
-        <Grid item>
-            <Grid container direction="column" spacing={2}>
-                <Grid item>
-                    <Grid container spacing={2}>
-                        {!isRemote && (
-                            <React.Fragment>
+}: AuthContainerProps) => {
+    const { flags } = useFeatureFlags();
+    const configController = useContext(ConfigControllerContext);
+
+    return (
+        <React.Fragment>
+            <Grid item>
+                <Grid container direction="column" spacing={2}>
+                    <Grid item>
+                        <Grid container spacing={2}>
+                            {flags[Features.UseNewAuthFlow] && product.key === 'jira' ? (
+                                // Only enabled for jira for now
                                 <Grid item>
-                                    <CloudAuthButton product={product} />
-                                </Grid>
-                                <Grid item>
-                                    <Button color="primary" variant="contained" onClick={openProductAuth}>
-                                        {`Login with API Token`}
+                                    <Button
+                                        color="primary"
+                                        variant="contained"
+                                        onClick={configController.startAuthFlow}
+                                    >
+                                        Login to {product.name}
                                     </Button>
                                 </Grid>
-                                {isRemoteAuthButtonVisible && (
+                            ) : !isRemote ? (
+                                <React.Fragment>
                                     <Grid item>
-                                        <Button onClick={remoteAuth}>Remote Auth</Button>
+                                        <CloudAuthButton product={product} />
                                     </Grid>
-                                )}
-                            </React.Fragment>
-                        )}
-                        {isRemote && (
-                            <React.Fragment>
-                                <Grid item>
-                                    <Button color="primary" variant="contained" onClick={openProductAuth}>
-                                        {`Login with API Token`}
-                                    </Button>
-                                </Grid>
-                            </React.Fragment>
-                        )}
+                                    <Grid item>
+                                        <Button color="primary" variant="contained" onClick={openProductAuth}>
+                                            {`Login with API Token`}
+                                        </Button>
+                                    </Grid>
+                                    {isRemoteAuthButtonVisible && (
+                                        <Grid item>
+                                            <Button onClick={remoteAuth}>Remote Auth</Button>
+                                        </Grid>
+                                    )}
+                                </React.Fragment>
+                            ) : (
+                                <React.Fragment>
+                                    <Grid item>
+                                        <Button color="primary" variant="contained" onClick={openProductAuth}>
+                                            {`Login with API Token`}
+                                        </Button>
+                                    </Grid>
+                                </React.Fragment>
+                            )}
+                        </Grid>
+                    </Grid>
+                    <Grid item>
+                        <SiteList product={product} sites={sites} editServer={handleEdit} />
                     </Grid>
                 </Grid>
-                <Grid item>
-                    <SiteList product={product} sites={sites} editServer={handleEdit} />
-                </Grid>
             </Grid>
-        </Grid>
-    </React.Fragment>
-);
+        </React.Fragment>
+    );
+};

--- a/src/react/atlascode/config/configController.test.ts
+++ b/src/react/atlascode/config/configController.test.ts
@@ -82,6 +82,7 @@ describe('configController', () => {
                 viewPullRequest: expect.any(Function),
                 viewJiraIssue: expect.any(Function),
                 openNativeSettings: expect.any(Function),
+                startAuthFlow: expect.any(Function),
             });
         });
     });

--- a/src/react/atlascode/config/configController.ts
+++ b/src/react/atlascode/config/configController.ts
@@ -63,6 +63,7 @@ export interface ConfigControllerApi {
     createJiraIssue: () => void;
     viewJiraIssue: () => void;
     openNativeSettings: () => void;
+    startAuthFlow: () => void;
 }
 
 export const emptyApi: ConfigControllerApi = {
@@ -135,6 +136,9 @@ export const emptyApi: ConfigControllerApi = {
         return;
     },
     openNativeSettings: (): void => {
+        return;
+    },
+    startAuthFlow: (): void => {
         return;
     },
 };
@@ -610,6 +614,10 @@ export function useConfigControllerV3(): [ConfigV3State, ConfigControllerApi] {
         postMessage({ type: ConfigActionType.OpenNativeSettings });
     }, [postMessage]);
 
+    const startAuthFlow = useCallback((): void => {
+        postMessage({ type: ConfigActionType.StartAuthFlow });
+    }, [postMessage]);
+
     const controllerApi = useMemo<ConfigControllerApi>((): ConfigControllerApi => {
         return {
             postMessage: postMessage,
@@ -629,6 +637,7 @@ export function useConfigControllerV3(): [ConfigV3State, ConfigControllerApi] {
             viewPullRequest: viewPullRequest,
             viewJiraIssue: viewJiraIssue,
             openNativeSettings: openNativeSettings,
+            startAuthFlow: startAuthFlow,
         };
     }, [
         handleConfigChange,
@@ -648,6 +657,7 @@ export function useConfigControllerV3(): [ConfigV3State, ConfigControllerApi] {
         viewPullRequest,
         viewJiraIssue,
         openNativeSettings,
+        startAuthFlow,
     ]);
 
     return [state, controllerApi];
@@ -923,6 +933,10 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
         postMessage({ type: ConfigActionType.OpenNativeSettings });
     }, [postMessage]);
 
+    const startAuthFlow = useCallback((): void => {
+        postMessage({ type: ConfigActionType.StartAuthFlow });
+    }, [postMessage]);
+
     const controllerApi = useMemo<ConfigControllerApi>((): ConfigControllerApi => {
         return {
             postMessage: postMessage,
@@ -942,6 +956,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
             viewPullRequest: viewPullRequest,
             viewJiraIssue: viewJiraIssue,
             openNativeSettings: openNativeSettings,
+            startAuthFlow: startAuthFlow,
         };
     }, [
         handleConfigChange,
@@ -961,6 +976,7 @@ export function useConfigController(): [ConfigState, ConfigControllerApi] {
         viewPullRequest,
         viewJiraIssue,
         openNativeSettings,
+        startAuthFlow,
     ]);
 
     return [state, controllerApi];

--- a/src/webview/singleViewFactory.ts
+++ b/src/webview/singleViewFactory.ts
@@ -135,6 +135,11 @@ export class SingleWebview<FD, R> implements ReactWebview<FD> {
             this._panel.reveal(column ? column : ViewColumn.Active); // , false);
         }
 
+        // The webview might not be ready at this point; see another usage in `onMessageReceived`
+        this.updateFeatureMetadata();
+    }
+
+    public updateFeatureMetadata() {
         if (this._controller) {
             // Send feature gates to the panel in a message
             this.fireFeatureGates(this._controller.requiredFeatureFlags);
@@ -184,6 +189,9 @@ export class SingleWebview<FD, R> implements ReactWebview<FD> {
                     const { site, product } = this._controller.screenDetails();
                     this._analyticsApi.fireViewScreenEvent('atlascodePmfBanner', site, product);
                 }
+
+                // Using `refresh` for webview readiness indication here - update feature flag data when ready
+                this.updateFeatureMetadata();
             }
         }
     }


### PR DESCRIPTION
### What Is This Change?

This change does 2 things:

1. Establish a way to propagate and use feature flags to our `SingleWebview`-architecture webviews via `FeatureFlagContextProvider`. At the moment, it's only used in `settings` pages
2. Use the new context provider to plug the new authentication flow into Jira panels in both versions of our settings page

The visual part:

| Old settings | New settings |
|----|----|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/dd3682ac-955f-4204-ab1b-fac9a343a32d" />|<img width="739" height="240" alt="image" src="https://github.com/user-attachments/assets/f2a35658-0666-40cc-8ae1-fa8d7768ec74" />|
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/d51d8176-85d6-4577-a0ee-f3e9bf7d7abd" />| <img width="600" alt="image" src="https://github.com/user-attachments/assets/e6c8e089-2879-47f2-a7de-9dabbb246cdf" />


Bitbucket is not affected:
<img width="230" alt="image" src="https://github.com/user-attachments/assets/7f6cad9d-f84f-4da6-8353-c8838464dd49" />


### How Has This Been Tested?

manually! :) See images above

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`