### PR TITLE
Build action: Cancel previous build when new one is triggered

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,13 @@ permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
     branches:
-      - '**'
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
+      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### What Is This Change?

This change instructs GitHub to cancel an ongoing build action for the same PR when a new build has been triggered.
This is to avoid wasting resources on a build that becomes stale.

### How Has This Been Tested?

- It hasn't.