### PR TITLE
Build action: Run only for Pull Requests to main, and skip draft PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,10 @@ permissions:
   contents: read
 
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - '**'
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### What Is This Change?

Instead of running a build for every `push`, this change limits the build workflow to be run only for:
- Pull Requests that want to merge to main
- Pull Requests that are ready for review (not drafts)

NOTE: I still don't know if 
- this change will prevent draft from manually triggering a build action
- this change will prevent PR for a non-main branch to merge

### How Has This Been Tested?

- It hasn't.