### PR TITLE
[AXON-977] make quickflow awaitable + actually wait for OAuth

### DIFF
--- a/src/onboarding/quickFlow/authentication/states/terminal.ts
+++ b/src/onboarding/quickFlow/authentication/states/terminal.ts
@@ -1,28 +1,12 @@
 import { BasicAuthInfo, PATAuthInfo, ProductJira } from 'src/atlclients/authInfo';
 import { Container } from 'src/container';
-import { SETTINGS_URL } from 'src/uriHandler';
+import { window } from 'vscode';
 
 import { Transition } from '../../types';
 import { AuthFlowUI } from '../authFlowUI';
-import { AuthenticationType, AuthState, PartialAuthData, ServerCredentialType } from '../types';
+import { AuthState, PartialAuthData, ServerCredentialType } from '../types';
 
 export class TerminalAuthStates {
-    public static runOauth: AuthState = {
-        name: 'runOauth',
-        isTerminal: true,
-        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
-            if (!data.authenticationType || data.authenticationType !== AuthenticationType.OAuth) {
-                throw new Error('Authentication type must be OAuth to run OAuth flow');
-            }
-
-            await Container.loginManager.userInitiatedOAuthLogin(
-                { host: 'atlassian.net', product: ProductJira },
-                SETTINGS_URL,
-            );
-            return Transition.done();
-        },
-    };
-
     public static addAPIToken: AuthState = {
         name: 'addAPIToken',
         isTerminal: true,
@@ -76,6 +60,25 @@ export class TerminalAuthStates {
                 authInfo,
             );
 
+            return Transition.done();
+        },
+    };
+
+    public static oauthFailure: AuthState = {
+        name: 'oauthFailure',
+        isTerminal: true,
+        isFailure: true,
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            window.showErrorMessage('OAuth authentication failed');
+            return Transition.done();
+        },
+    };
+
+    public static oauthSuccess: AuthState = {
+        name: 'oauthSuccess',
+        isTerminal: true,
+        action: async (data: PartialAuthData, ui: AuthFlowUI) => {
+            // No action needed
             return Transition.done();
         },
     };

--- a/src/onboarding/quickFlow/authentication/types.ts
+++ b/src/onboarding/quickFlow/authentication/types.ts
@@ -9,8 +9,8 @@ export enum SpecialSiteOptions {
 }
 
 export enum AuthenticationType {
-    OAuth = 'OAuth',
-    ApiToken = 'API Token',
+    OAuth = 'Cloud - Basic',
+    ApiToken = 'Cloud - Full',
     Server = 'Server',
 }
 
@@ -25,11 +25,11 @@ export enum SSLConfigurationType {
     CustomClientSideCerts = 'Custom client-side certificates',
 }
 
+export const AUTHENTICATION_SUCCESSFUL = 'Authentication successful';
+
 export type AuthFlowData = {
     // Product is assumed to be Jira, for now
     product: Product;
-
-    skipAllowed: boolean;
 
     isNewSite: boolean;
     site: string;
@@ -47,6 +47,10 @@ export type AuthFlowData = {
     sslCertsPath: string;
     pfxPath: string;
     pfxPassphrase: string;
+
+    // Metadata
+    skipAllowed?: boolean;
+    hasOAuthFailed?: boolean;
 };
 
 export type PartialAuthData = Partial<AuthFlowData>;

--- a/src/onboarding/quickFlow/types.ts
+++ b/src/onboarding/quickFlow/types.ts
@@ -13,6 +13,9 @@ export type State<UIType, DataType> = {
 
     /** Is this state terminal? */
     isTerminal?: boolean;
+
+    /** Is this terminal state a failure? */
+    isFailure?: boolean;
 };
 
 type TransitionInfo<UIType, DataType> = [DataType | undefined, State<UIType, DataType> | undefined];
@@ -34,10 +37,18 @@ export class Transition {
     }
 }
 
+export enum QuickFlowStatus {
+    Started = 'started',
+    InProgress = 'in_progress',
+    Completed = 'completed',
+    Cancelled = 'cancelled',
+    Failed = 'failed',
+}
+
 export type QuickFlowAnalyticsEvent = {
     flowType: string;
     flowId: string;
-    status: 'started' | 'in_progress' | 'completed' | 'cancelled';
+    status: QuickFlowStatus;
 
     origin?: string;
     direction?: 'forward' | 'back';


### PR DESCRIPTION
### What Is This Change?


This change has several things going on at once (terribly sorry about that, it kind of just happened 😦):

1. Add an explicit failure state in the flow
2. Make it possible to `await` on the flow execution
3. Add a special type of loading UI, use it when running OAuth from any source
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e2e9bb36-1ee5-4337-a580-f23e3a27b2da" />
4. Reword the phrasing in the authentication type picker to bring it a bit more in line with design (this needs further cleanup)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/77ddb3d4-8bd7-4a2a-9685-8f9faa1018a4" />
5. Add a bit more instrumentation about failure states, specifically

There's going to be a very quick follow-up to this, including:
1. More cleanup on wording/design
2. More loading states for confirming cloud/server credentials, and a similar rework for those terminal states

### How Has This Been Tested?

Manually :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`