### PR TITLE
[AXON-976] re-word and cleanup

### DIFF
--- a/src/onboarding/quickFlow/authentication/authFlowUI.ts
+++ b/src/onboarding/quickFlow/authentication/authFlowUI.ts
@@ -70,8 +70,8 @@ export class AuthFlowUI {
         if (sites.length === 0 && state.authenticationType === AuthenticationType.ApiToken && !state.hasOAuthFailed) {
             sites.push({
                 label: SpecialSiteOptions.OAuth,
-                detail: 'Select this to OAuth before proceeding',
-                iconPath: new ThemeIcon('info'),
+                detail: 'Select this option to complete Basic authentication and view all available cloud sites',
+                iconPath: new ThemeIcon('cloud'),
             });
         }
         const choices = [
@@ -100,7 +100,7 @@ export class AuthFlowUI {
                     detail: 'Get basic access to your Atlassian work items',
                 },
                 {
-                    iconPath: new ThemeIcon('key'),
+                    iconPath: new ThemeIcon('cloud'),
                     label: AuthenticationType.ApiToken,
                     description: 'Uses API token',
                     detail: 'Get the full power of Atlassian integration, including experimental and AI features',
@@ -295,9 +295,14 @@ export class AuthFlowUI {
     }
 
     public inputPassword(state: PartialData, passwordName: string): Promise<UiResponse> {
+        const prompt =
+            state.authenticationType === AuthenticationType.ApiToken
+                ? 'You can always visit [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) to generate a new token'
+                : '';
         return this.baseUI.showInputBox({
             placeHolder: `Enter your ${passwordName}`,
             password: true,
+            prompt,
             value: state.password || '',
             valueSelection: state.password ? [0, state.password.length] : undefined,
         });
@@ -331,7 +336,7 @@ export class AuthFlowUI {
                     await new Promise((resolveDelay) => setTimeout(resolveDelay, 300));
 
                     // Resolve here to move forward to the error handling step
-                    resolve(error?.message || 'OAuth authentication failed');
+                    resolve(error?.message || 'Basic authentication failed');
                 }
             },
         });

--- a/src/onboarding/quickFlow/authentication/authFlowUI.ts
+++ b/src/onboarding/quickFlow/authentication/authFlowUI.ts
@@ -95,15 +95,15 @@ export class AuthFlowUI {
             [
                 {
                     iconPath: new ThemeIcon('cloud'),
-                    label: AuthenticationType.ApiToken,
-                    description: 'Uses API token',
-                    detail: 'Get the full power of Atlassian integration, including experimental and AI features',
-                },
-                {
-                    iconPath: new ThemeIcon('cloud'),
                     label: AuthenticationType.OAuth,
                     description: 'Uses OAuth',
                     detail: 'Get basic access to your Atlassian work items',
+                },
+                {
+                    iconPath: new ThemeIcon('cloud'),
+                    label: AuthenticationType.ApiToken,
+                    description: 'Uses API token',
+                    detail: 'Get the full power of Atlassian integration, including experimental and AI features',
                 },
                 {
                     iconPath: new ThemeIcon('server'),

--- a/src/onboarding/quickFlow/authentication/authFlowUI.ts
+++ b/src/onboarding/quickFlow/authentication/authFlowUI.ts
@@ -95,15 +95,15 @@ export class AuthFlowUI {
             [
                 {
                     iconPath: new ThemeIcon('cloud'),
-                    label: AuthenticationType.OAuth,
-                    description: 'Uses OAuth',
-                    detail: 'Get basic access to your Atlassian work items',
-                },
-                {
-                    iconPath: new ThemeIcon('cloud'),
                     label: AuthenticationType.ApiToken,
                     description: 'Uses API token',
                     detail: 'Get the full power of Atlassian integration, including experimental and AI features',
+                },
+                {
+                    iconPath: new ThemeIcon('cloud'),
+                    label: AuthenticationType.OAuth,
+                    description: 'Uses OAuth',
+                    detail: 'Get basic access to your Atlassian work items',
                 },
                 {
                     iconPath: new ThemeIcon('server'),

--- a/src/onboarding/quickFlow/authentication/types.ts
+++ b/src/onboarding/quickFlow/authentication/types.ts
@@ -5,12 +5,12 @@ import { AuthFlowUI } from './authFlowUI';
 
 export enum SpecialSiteOptions {
     NewSite = 'Log in to a new site...',
-    OAuth = 'Login with OAuth to see available cloud sites',
+    OAuth = 'Show available cloud sites...',
 }
 
 export enum AuthenticationType {
     OAuth = 'Cloud - Basic',
-    ApiToken = 'Cloud - Full',
+    ApiToken = 'Cloud - Full Access',
     Server = 'Server',
 }
 


### PR DESCRIPTION
### What Is This Change?

> Edit: the 2nd commit brings `Full Access` option to the top
> <img width="777" height="301" alt="image" src="https://github.com/user-attachments/assets/f005f0fd-a0ea-4d72-a4e4-3fb955efb164" />


Small changes to word choice in places, with the general idea being _DON'T MENTION OAUTH ANYWHERE_, lol :D

(except in the one description for "Cloud - Basic")

### How Has This Been Tested?
<img width="748" height="256" alt="image" src="https://github.com/user-attachments/assets/0167d8f4-a0f8-4361-83e8-402f05efa620" />
<img width="745" height="178" alt="image" src="https://github.com/user-attachments/assets/32fbb77f-2f28-43c0-b496-042208761581" />


Basic checks:

- [x] `npm run lint`
- [x] `npm run test`