### PR TITLE
[AXON-977] await server login; issue notifications after auth

### DIFF
--- a/src/onboarding/quickFlow/authentication/states/common.ts
+++ b/src/onboarding/quickFlow/authentication/states/common.ts
@@ -141,7 +141,7 @@ export class CommonAuthStates {
                 [AuthenticationType.ApiToken]: TerminalAuthStates.addAPIToken,
                 [AuthenticationType.Server]: ServerAuthStates.showContextPathPrompt,
                 // Should be unreachable
-                [AuthenticationType.OAuth]: TerminalAuthStates.oauthFailure,
+                [AuthenticationType.OAuth]: TerminalAuthStates.authFailure,
             };
 
             if (data.skipAllowed && data.password !== undefined) {
@@ -176,14 +176,14 @@ export class CommonAuthStates {
                 return Transition.forward(
                     data.authenticationType === AuthenticationType.ApiToken
                         ? CommonAuthStates.selectSiteFromDropdown
-                        : TerminalAuthStates.oauthSuccess,
+                        : TerminalAuthStates.authSuccess,
                 );
             }
 
             return Transition.forward(
                 data.authenticationType === AuthenticationType.ApiToken
                     ? CommonAuthStates.selectSiteFromDropdown
-                    : TerminalAuthStates.oauthFailure,
+                    : TerminalAuthStates.authFailure,
                 { hasOAuthFailed: true },
             );
         },

--- a/src/onboarding/quickFlow/authentication/states/terminal.ts
+++ b/src/onboarding/quickFlow/authentication/states/terminal.ts
@@ -9,30 +9,32 @@ import { AuthState, PartialAuthData, ServerCredentialType } from '../types';
 export class TerminalAuthStates {
     public static addAPIToken: AuthState = {
         name: 'addAPIToken',
-        isTerminal: true,
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
             if (!data.site || !data.username || !data.password) {
                 throw new Error('Missing required fields for API Token authentication');
             }
 
-            Container.loginManager.userInitiatedServerLogin(
-                {
-                    host: data.site,
-                    product: ProductJira,
-                },
-                {
-                    username: data.username,
-                    password: data.password,
-                } as BasicAuthInfo,
-            );
+            try {
+                await Container.loginManager.userInitiatedServerLogin(
+                    {
+                        host: data.site,
+                        product: ProductJira,
+                    },
+                    {
+                        username: data.username,
+                        password: data.password,
+                    } as BasicAuthInfo,
+                );
 
-            return Transition.done();
+                return Transition.forward(TerminalAuthStates.authSuccess);
+            } catch (err) {
+                return Transition.forward(TerminalAuthStates.authFailure, { error: err.message || err });
+            }
         },
     };
 
     public static finishServerAuth: AuthState = {
         name: 'serverAuth',
-        isTerminal: true,
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
             if (!data.site) {
                 throw new Error('Missing required fields for Server authentication');
@@ -48,37 +50,41 @@ export class TerminalAuthStates {
                           password: data.password,
                       } as BasicAuthInfo);
 
-            Container.loginManager.userInitiatedServerLogin(
-                {
-                    host: data.site,
-                    product: ProductJira,
-                    contextPath: data.contextPath,
-                    customSSLCertPaths: data.sslCertsPath,
-                    pfxPath: data.pfxPath,
-                    pfxPassphrase: data.pfxPassphrase,
-                },
-                authInfo,
-            );
+            try {
+                await Container.loginManager.userInitiatedServerLogin(
+                    {
+                        host: data.site,
+                        product: ProductJira,
+                        contextPath: data.contextPath,
+                        customSSLCertPaths: data.sslCertsPath,
+                        pfxPath: data.pfxPath,
+                        pfxPassphrase: data.pfxPassphrase,
+                    },
+                    authInfo,
+                );
 
-            return Transition.done();
+                return Transition.forward(TerminalAuthStates.authSuccess);
+            } catch (err) {
+                return Transition.forward(TerminalAuthStates.authFailure, { error: err.message || err });
+            }
         },
     };
 
-    public static oauthFailure: AuthState = {
-        name: 'oauthFailure',
+    public static authFailure: AuthState = {
+        name: 'authFailure',
         isTerminal: true,
         isFailure: true,
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
-            window.showErrorMessage('OAuth authentication failed');
+            window.showErrorMessage(data.error ? `Authentication failed: ${data.error}` : 'Authentication failed');
             return Transition.done();
         },
     };
 
-    public static oauthSuccess: AuthState = {
-        name: 'oauthSuccess',
+    public static authSuccess: AuthState = {
+        name: 'authSuccess',
         isTerminal: true,
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
-            // No action needed
+            window.showInformationMessage('Authentication successful!');
             return Transition.done();
         },
     };

--- a/src/onboarding/quickFlow/authentication/types.ts
+++ b/src/onboarding/quickFlow/authentication/types.ts
@@ -51,6 +51,7 @@ export type AuthFlowData = {
     // Metadata
     skipAllowed?: boolean;
     hasOAuthFailed?: boolean;
+    error?: string;
 };
 
 export type PartialAuthData = Partial<AuthFlowData>;


### PR DESCRIPTION
### What Is This Change?

We now have small notifications to indicate success or failure in the authentication workflow:

Success:
<img width="596" height="104" alt="image" src="https://github.com/user-attachments/assets/daddd872-0c25-4bd8-8842-f431b7928dcd" />

Failure:
<img width="572" height="157" alt="image" src="https://github.com/user-attachments/assets/a78c75a7-31e1-44f3-b6c2-86876c4e9347" />

We now also correctly await the server/API token login

### How Has This Been Tested?

Manually (see pictures above :))

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
