### PR TITLE
[NOISSUE] use input validation to test API token/server credentials

### DIFF
--- a/src/atlclients/loginManager.ts
+++ b/src/atlclients/loginManager.ts
@@ -288,4 +288,61 @@ export class LoginManager {
         const data = await response.json();
         return data.cloudId;
     }
+
+    public async testCredentials(
+        site: SiteInfo,
+        credentials: BasicAuthInfo | PATAuthInfo,
+    ): Promise<{ isOk: boolean; reason?: string }> {
+        const authHeader = this.authHeader(credentials);
+        // For cloud instances we can use the user ID as the credential ID (they're globally unique). Server instances
+        // will have a much smaller pool of user IDs so we use an arbitrary UUID as the credential ID.
+
+        try {
+            let siteDetailsUrl = '';
+            let apiUrl = '';
+            const protocol = site.protocol ? site.protocol : 'https:';
+            const contextPath = site.contextPath ? site.contextPath : '';
+            const transport = getAxiosInstance();
+            switch (site.product.key) {
+                case ProductJira.key:
+                    siteDetailsUrl = `${protocol}//${site.host}${contextPath}/rest/api/2/myself`;
+                    apiUrl = `${protocol}//${site.host}${contextPath}/rest`;
+                    break;
+                case ProductBitbucket.key:
+                    apiUrl = `${protocol}//${site.host}${contextPath}`;
+                    // Needed when using a API key to login (credentials is PATAuthInfo):
+                    const res = await transport(`${apiUrl}/rest/api/latest/build/capabilities`, {
+                        method: 'GET',
+                        headers: {
+                            Authorization: authHeader,
+                        },
+                        ...getAgent(site),
+                    });
+                    const slugRegex = /[\[\:\/\?#@\!\$&'\(\)\*\+,;\=%\\\[\]]/gi;
+                    let ausername = res.headers['x-ausername'];
+                    // convert the %40 and similar to special characters
+                    ausername = decodeURIComponent(ausername);
+                    // replace special characters with underscore (_)
+                    ausername = ausername.replace(slugRegex, '_');
+                    siteDetailsUrl = `${apiUrl}/rest/api/1.0/users/${ausername}`;
+                    break;
+            }
+
+            const response = await transport(siteDetailsUrl, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: authHeader,
+                },
+                ...getAgent(site),
+            });
+            if (!response.status || response.status !== 200) {
+                return { isOk: false, reason: `HTTP error! status: ${response.status}` };
+            }
+        } catch (err) {
+            return { isOk: false, reason: err.message };
+        }
+
+        return { isOk: true };
+    }
 }

--- a/src/onboarding/quickFlow/authentication/authFlowUI.ts
+++ b/src/onboarding/quickFlow/authentication/authFlowUI.ts
@@ -294,7 +294,11 @@ export class AuthFlowUI {
         });
     }
 
-    public inputPassword(state: PartialData, passwordName: string): Promise<UiResponse> {
+    public inputPassword(
+        state: PartialData,
+        passwordName: string,
+        preAcceptValidationFunc?: (value: string) => Promise<string | undefined>,
+    ): Promise<UiResponse> {
         const prompt =
             state.authenticationType === AuthenticationType.ApiToken
                 ? 'You can always visit [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) to generate a new token'
@@ -305,6 +309,7 @@ export class AuthFlowUI {
             prompt,
             value: state.password || '',
             valueSelection: state.password ? [0, state.password.length] : undefined,
+            preAcceptValidationFunc,
         });
     }
 


### PR DESCRIPTION
### What Is This Change?

This is kind of a proposed enhancement? Feel free to merge, nuke or iterate :)

This PR introduces the 1st part of our credential-saving logic as validation on the password input - basically, when user hits `enter`, we try to ping `/rest/api/2/myself` with the assembled credentials first, and show an error message if it fails.

There are 2 alternatives to this:
 * Don't do anything - user gets error at the end of the flow and has to restart from scratch
 * Fail during a special loading state like what we have for OAuth. Honestly, I kinda like that one better, but maybe we can iterate?

Works for API token:
<img width="745" height="125" alt="image" src="https://github.com/user-attachments/assets/8ee7e871-49c0-4d8e-9b3b-3aed369f3b8c" />

Works for server auth - although we might need to do the special ssl/path settings before password for this to work in all cases:
<img width="739" height="137" alt="image" src="https://github.com/user-attachments/assets/d7b8a08b-8c37-4299-ae3c-7e680ca3ce9c" />

### How Has This Been Tested?

Tried this against API token and server auth with instenv - in case of the server auth, the correct input takes a bit of time and correctly shows the loading state

Basic checks:

- [x] `npm run lint`
- [x ] `npm run test`