### PR TITLE
[NOISSUE] chore: server authentication - make password/PAT last step

### DIFF
--- a/src/onboarding/quickFlow/authentication/authFlowUI.ts
+++ b/src/onboarding/quickFlow/authentication/authFlowUI.ts
@@ -124,14 +124,14 @@ export class AuthFlowUI {
         return this.baseUI.showQuickPick(
             [
                 {
-                    label: 'Yes',
-                    description: 'Your Jira server has a path',
-                    detail: `For example: https://${site}/path/to/jira`,
-                },
-                {
                     label: 'No',
                     description: 'Your Jira server is running at the root',
                     detail: `For example: https://${site}/`,
+                },
+                {
+                    label: 'Yes',
+                    description: 'Your Jira server has a path',
+                    detail: `For example: https://${site}/path/to/jira`,
                 },
             ],
             {

--- a/src/onboarding/quickFlow/authentication/states/common.ts
+++ b/src/onboarding/quickFlow/authentication/states/common.ts
@@ -52,7 +52,7 @@ export class CommonAuthStates {
             const transitions = {
                 [AuthenticationType.OAuth]: CommonAuthStates.inputUsername,
                 [AuthenticationType.ApiToken]: CommonAuthStates.inputUsername,
-                [AuthenticationType.Server]: ServerAuthStates.chooseServerAuthType,
+                [AuthenticationType.Server]: ServerAuthStates.showContextPathPrompt,
             };
 
             if (data.skipAllowed && data.site !== undefined) {
@@ -80,7 +80,7 @@ export class CommonAuthStates {
             const transitions = {
                 [AuthenticationType.OAuth]: CommonAuthStates.inputUsername,
                 [AuthenticationType.ApiToken]: CommonAuthStates.inputUsername,
-                [AuthenticationType.Server]: ServerAuthStates.chooseServerAuthType,
+                [AuthenticationType.Server]: ServerAuthStates.showContextPathPrompt,
             };
 
             const { value, action } = await ui.inputNewSite(data);
@@ -139,7 +139,7 @@ export class CommonAuthStates {
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
             const transitions = {
                 [AuthenticationType.ApiToken]: TerminalAuthStates.addAPIToken,
-                [AuthenticationType.Server]: ServerAuthStates.showContextPathPrompt,
+                [AuthenticationType.Server]: TerminalAuthStates.finishServerAuth,
                 // Should be unreachable
                 [AuthenticationType.OAuth]: TerminalAuthStates.oauthFailure,
             };

--- a/src/onboarding/quickFlow/authentication/states/server.ts
+++ b/src/onboarding/quickFlow/authentication/states/server.ts
@@ -33,7 +33,7 @@ export class ServerAuthStates {
         name: 'inputPAT',
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
             if (data.skipAllowed && data.personalAccessToken !== undefined) {
-                return Transition.forward(ServerAuthStates.showContextPathPrompt);
+                return Transition.forward(TerminalAuthStates.finishServerAuth);
             }
 
             const { value, action } = await ui.inputPassword(data, 'Personal Access Token');
@@ -41,7 +41,7 @@ export class ServerAuthStates {
                 return Transition.back();
             }
 
-            return Transition.forward(ServerAuthStates.showContextPathPrompt, { personalAccessToken: value });
+            return Transition.forward(TerminalAuthStates.finishServerAuth, { personalAccessToken: value });
         },
     };
 
@@ -87,7 +87,7 @@ export class ServerAuthStates {
         name: 'chooseSslConfigurationType',
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
             const transitions = {
-                [SSLConfigurationType.Default]: TerminalAuthStates.finishServerAuth,
+                [SSLConfigurationType.Default]: ServerAuthStates.chooseServerAuthType,
                 [SSLConfigurationType.CustomCA]: ServerAuthStates.inputSslCertsPath,
                 [SSLConfigurationType.CustomClientSideCerts]: ServerAuthStates.inputPfxPath,
             };
@@ -111,7 +111,7 @@ export class ServerAuthStates {
         name: 'inputSslCertsPath',
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
             if (data.skipAllowed && data.sslCertsPath !== undefined) {
-                return Transition.forward(TerminalAuthStates.finishServerAuth);
+                return Transition.forward(ServerAuthStates.chooseServerAuthType);
             }
 
             const { value, action } = await ui.inputSslCertsPath(data);
@@ -119,7 +119,7 @@ export class ServerAuthStates {
                 return Transition.back();
             }
 
-            return Transition.forward(TerminalAuthStates.finishServerAuth, { sslCertsPath: value });
+            return Transition.forward(ServerAuthStates.chooseServerAuthType, { sslCertsPath: value });
         },
     };
 
@@ -143,7 +143,7 @@ export class ServerAuthStates {
         name: 'inputPfxPassphrase',
         action: async (data: PartialAuthData, ui: AuthFlowUI) => {
             if (data.skipAllowed && data.pfxPassphrase !== undefined) {
-                return Transition.forward(TerminalAuthStates.finishServerAuth);
+                return Transition.forward(ServerAuthStates.chooseServerAuthType);
             }
 
             const { value, action } = await ui.inputPfxPassphrase(data);
@@ -151,7 +151,7 @@ export class ServerAuthStates {
                 return Transition.back();
             }
 
-            return Transition.forward(TerminalAuthStates.finishServerAuth, { pfxPassphrase: value });
+            return Transition.forward(ServerAuthStates.chooseServerAuthType, { pfxPassphrase: value });
         },
     };
 }


### PR DESCRIPTION
### What Is This Change?

> Note: this change takes care of edge cases in #874 

To make validation work in all cases, we might want to consider always having the PAT/password input at the end.
This change:
* Reorders server authentication process to ask for context path/SSL stuff first
* Does a minor cosmetic change of putting the default option for contextPath (`no`) on top

### How Has This Been Tested?

Manually - clicked through the process of server authentication

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`