### PR TITLE
Don't require protocol (defaults to https) in auth's URL

### DIFF
--- a/src/react/atlascode/config/auth/dialog/AuthDialog.tsx
+++ b/src/react/atlascode/config/auth/dialog/AuthDialog.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../../../../atlclients/authInfo';
 import { emptySiteWithAuthInfo, SiteWithAuthInfo } from '../../../../../lib/ipc/toUI/config';
 import { useFormValidation } from '../../../common/form/useFormValidation';
-import { validateRequiredString, validateStartsWithProtocol } from '../../../util/fieldValidators';
+import { validateRequiredString, validateUrl } from '../../../util/fieldValidators';
 import { CustomSiteAuthForm } from './CustomSiteAuthForm';
 import { JiraBasicAuthForm } from './JiraApiTokenAuthForm';
 import { emptyAuthFormState, FormFields } from './types';
@@ -167,7 +167,7 @@ export const AuthDialog: React.FunctionComponent<AuthDialogProps> = memo(
             [],
         );
 
-        const registerUrl = useCallback(register(validateStartsWithProtocol), []); // eslint-disable-line react-hooks/exhaustive-deps
+        const registerUrl = useCallback(register(validateUrl), []); // eslint-disable-line react-hooks/exhaustive-deps
         const registerRequiredString = useCallback(register(validateRequiredString), []); // eslint-disable-line react-hooks/exhaustive-deps
 
         return (

--- a/src/react/atlascode/util/authFormUtils.ts
+++ b/src/react/atlascode/util/authFormUtils.ts
@@ -3,7 +3,11 @@ import { cloudHostnames } from '../constants';
 
 export function isCustomUrl(url: string): boolean {
     try {
-        const urlObj = new URL(url);
+        const urlObj = URL.parse(url) || URL.parse('https://' + url);
+        if (!urlObj) {
+            return false;
+        }
+
         return cloudHostnames.every((host) => !urlObj.hostname.endsWith(host));
     } catch {
         return false;

--- a/src/react/atlascode/util/fieldValidators.ts
+++ b/src/react/atlascode/util/fieldValidators.ts
@@ -1,7 +1,19 @@
-const rProtocol = /^((https?):)?\/\/.+$/i;
+export function validateUrl(name: string, value?: string): string | undefined {
+    const url = tryParseURL(value);
+    if (!url || (url.protocol !== 'http:' && url.protocol !== 'https:')) {
+        return `${name} must be a valid URL`;
+    }
 
-export function validateStartsWithProtocol(name: string, value?: string): string | undefined {
-    return value !== undefined && rProtocol.test(value) ? undefined : `${name} must be a valid URL`;
+    return undefined;
+}
+
+function tryParseURL(url: string | undefined): URL | null {
+    if (url) {
+        try {
+            return URL.parse(url) || URL.parse('https://' + url);
+        } catch {}
+    }
+    return null;
 }
 
 export function validateRequiredString(name: string, value?: string): string | undefined {


### PR DESCRIPTION
### What Is This Change?

To ease writing an https/cloud URL, the protocol can be omitted.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`