### PR TITLE
AXON-993: fix empty site select issue in create issue page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
+## What's new in 3.8.12
+
+### Bug Fixes
+
+- Fixed issue in create issue page when site select is empty after changing issue type
+
 ## What's new in 3.8.11
 
 ### Features

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -378,9 +378,12 @@ export class CreateIssueWebview
             this._screenData.issueTypeUIs[issueType.id],
             this._screenData.issueTypeUIs[this._selectedIssueTypeId!].selectFieldOptions,
         );
+        const currentSiteOptions = this._screenData.issueTypeUIs[this._selectedIssueTypeId!].selectFieldOptions.site;
+
         this._screenData.issueTypeUIs[issueType.id].selectFieldOptions = {
             ...this._screenData.issueTypeUIs[issueType.id].selectFieldOptions,
             ...selectOverrides,
+            ...(currentSiteOptions && { site: currentSiteOptions }),
         };
 
         this._screenData.issueTypeUIs[issueType.id].fieldValues['issuetype'] = issueType;


### PR DESCRIPTION
### What Is This Change?

- Fix issue when site select is empty after changing the issue type

Behaviour before fix: 

https://github.com/user-attachments/assets/9ecd20de-a575-4810-b2c7-cff3e2fde25c


Behaviour after fix: 

https://github.com/user-attachments/assets/247abe01-b320-4bed-b3ab-3203b4e837cb




<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change