### PR TITLE
AXON-994: Add delay to Jira issue transitions for proper sidebar updates

### DIFF
--- a/e2e/scenarios/jira/updateIssueStatus.spec.ts
+++ b/e2e/scenarios/jira/updateIssueStatus.spec.ts
@@ -22,7 +22,7 @@ export async function updateIssueStatus(page: Page, request: APIRequestContext) 
     const cleanupSearchMock = await setupSearchMock(request, NEXT_STATUS);
 
     await jiraIssuePage.status.changeTo(NEXT_STATUS);
-    await page.waitForTimeout(2_000);
+    await page.waitForTimeout(6_000);
 
     await jiraIssuePage.status.expectEqual(NEXT_STATUS);
     await atlascodeDrawer.jira.expectIssueStatus(ISSUE_NAME, NEXT_STATUS);

--- a/src/jira/transitionIssue.test.ts
+++ b/src/jira/transitionIssue.test.ts
@@ -6,6 +6,7 @@ import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { Commands } from '../constants';
 import { Container } from '../container';
 import { Logger } from '../logger';
+import { OnJiraEditedRefreshDelay } from '../util/time';
 import { transitionIssue } from './transitionIssue';
 
 // Mock dependencies
@@ -96,8 +97,14 @@ describe('transitionIssue', () => {
         // Verify
         expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockedSiteDetails);
         expect(mockJiraClient.transitionIssue).toHaveBeenCalledWith('TEST-123', 'transition-1');
-        expect(commands.executeCommand).toHaveBeenCalledWith(Commands.RefreshAssignedWorkItemsExplorer);
-        expect(commands.executeCommand).toHaveBeenCalledWith(Commands.RefreshCustomJqlExplorer);
+        expect(commands.executeCommand).toHaveBeenCalledWith(
+            Commands.RefreshAssignedWorkItemsExplorer,
+            OnJiraEditedRefreshDelay,
+        );
+        expect(commands.executeCommand).toHaveBeenCalledWith(
+            Commands.RefreshCustomJqlExplorer,
+            OnJiraEditedRefreshDelay,
+        );
         expect(Container.analyticsClient.sendTrackEvent).toHaveBeenCalled();
     });
 
@@ -116,8 +123,14 @@ describe('transitionIssue', () => {
         // Verify
         expect(Container.clientManager.jiraClient).toHaveBeenCalledWith(mockedSiteDetails);
         expect(mockJiraClient.transitionIssue).toHaveBeenCalledWith('TEST-123', 'transition-1');
-        expect(commands.executeCommand).toHaveBeenCalledWith(Commands.RefreshAssignedWorkItemsExplorer);
-        expect(commands.executeCommand).toHaveBeenCalledWith(Commands.RefreshCustomJqlExplorer);
+        expect(commands.executeCommand).toHaveBeenCalledWith(
+            Commands.RefreshAssignedWorkItemsExplorer,
+            OnJiraEditedRefreshDelay,
+        );
+        expect(commands.executeCommand).toHaveBeenCalledWith(
+            Commands.RefreshCustomJqlExplorer,
+            OnJiraEditedRefreshDelay,
+        );
         expect(Container.analyticsClient.sendTrackEvent).toHaveBeenCalled();
     });
 

--- a/src/jira/transitionIssue.ts
+++ b/src/jira/transitionIssue.ts
@@ -11,6 +11,7 @@ import { DetailedSiteInfo, emptySiteInfo } from '../atlclients/authInfo';
 import { Commands } from '../constants';
 import { Container } from '../container';
 import { Logger } from '../logger';
+import { OnJiraEditedRefreshDelay } from '../util/time';
 
 export async function transitionIssue(
     issueOrKey: MinimalIssueOrKeyAndSite<DetailedSiteInfo>,
@@ -53,8 +54,8 @@ async function performTransition(
         const client = await Container.clientManager.jiraClient(site);
         await client.transitionIssue(issueKey, transition.id);
 
-        vscode.commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
-        vscode.commands.executeCommand(Commands.RefreshCustomJqlExplorer);
+        vscode.commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer, OnJiraEditedRefreshDelay);
+        vscode.commands.executeCommand(Commands.RefreshCustomJqlExplorer, OnJiraEditedRefreshDelay);
 
         issueTransitionedEvent(site, issueKey, analyticsData?.source).then((e) => {
             Container.analyticsClient.sendTrackEvent(e);


### PR DESCRIPTION
### What Is This Change?

**Problem**
When users drag Jira issues between status columns (e.g., from `"Done"` to `"In Progress"`), the issues would disappear from the "Assigned Jira Work Items" sidebar instead of appearing, or vice versa. This was happening because the sidebar refresh was occurring too quickly before Jira's API indexes were updated.

**Solution**
Added a 4-second delay (`OnJiraEditedRefreshDelay`) before refreshing the sidebar views, consistent with other parts of the codebase that handle Jira issue updates.

**Demos**:

Before
https://www.loom.com/share/00c00bde760146679e59eb3b74304368

After
https://www.loom.com/share/467e735db92d410cbe3f09e2baab3bea

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change