### PR TITLE
[AXON-1029] Rovo Dev should be disabled if the whole Jira feature is disabled

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -227,21 +227,24 @@ export class Container {
         }
 
         if (!process.env.ROVODEV_BBY) {
+            // refresh Rovo Dev when auth sites change
             this._siteManager.onDidSitesAvailableChange(async () => {
-                if (await this.updateFeatureFlagTenantId(this._siteManager.primarySite?.id)) {
-                    if (this._featureFlagClient.checkGate(Features.RovoDevEnabled)) {
-                        await this.enableRovoDev(context);
-                    } else {
-                        await this.disableRovoDev();
-                    }
-                }
+                await this.updateFeatureFlagTenantId();
+                await this.refreshRovoDev(context);
             });
+
+            // refresh Rovo Dev when Jira gets enabled or disabled
+            context.subscriptions.push(
+                configuration.onDidChange(async (e) => {
+                    if (configuration.changed(e, 'jira.enabled')) {
+                        await this.updateFeatureFlagTenantId();
+                        await this.refreshRovoDev(context);
+                    }
+                }, this),
+            );
         }
 
-        const tenantId = this._siteManager.primarySite?.id;
-        if (tenantId) {
-            await this.updateFeatureFlagTenantId(tenantId);
-        }
+        await this.updateFeatureFlagTenantId();
 
         context.subscriptions.push(AtlascodeUriHandler.create(this._analyticsApi, this._bitbucketHelper));
 
@@ -251,13 +254,18 @@ export class Container {
 
         this._onboardingProvider = new OnboardingProvider();
 
-        if (process.env.ROVODEV_BBY || this.featureFlagClient.checkGate(Features.RovoDevEnabled)) {
+        if (
+            process.env.ROVODEV_BBY ||
+            (this.config.jira.enabled && this.featureFlagClient.checkGate(Features.RovoDevEnabled))
+        ) {
             this._isRovoDevEnabled = true;
             await this.enableRovoDev(context);
         }
     }
 
-    static async updateFeatureFlagTenantId(tenantId: string | undefined): Promise<boolean> {
+    static async updateFeatureFlagTenantId(): Promise<boolean> {
+        const tenantId = Container.config.jira.enabled ? this._siteManager.primarySite?.id : undefined;
+
         try {
             await this._featureFlagClient.updateUser({ tenantId });
             this.pushFeatureUpdatesToUI();
@@ -265,6 +273,14 @@ export class Container {
         } catch (err) {
             Logger.error('RovoDev', err, "FeatureFlagClient: Failed to update user's tenantId");
             return false;
+        }
+    }
+
+    static async refreshRovoDev(context: ExtensionContext) {
+        if (this.config.jira.enabled && this._featureFlagClient.checkGate(Features.RovoDevEnabled)) {
+            await this.enableRovoDev(context);
+        } else {
+            await this.disableRovoDev();
         }
     }
 

--- a/src/siteManager.test.ts
+++ b/src/siteManager.test.ts
@@ -18,6 +18,7 @@ import { Container } from './container';
 
 describe('SiteManager', () => {
     let siteManager: SiteManager;
+    let siteManager_resolvePrimarySite: () => void;
     let mockGlobalStore: Memento;
     let mockAuthChangeEmitter: EventEmitter<AuthInfoEvent>;
     let mockCredentialManager: CredentialManager;
@@ -89,6 +90,7 @@ describe('SiteManager', () => {
 
         // Create a SiteManager instance
         siteManager = new SiteManager(mockGlobalStore);
+        siteManager_resolvePrimarySite = () => siteManager['resolvePrimarySite']();
     });
 
     afterEach(() => {
@@ -401,7 +403,7 @@ describe('SiteManager', () => {
             const serverSite = createDetailedSiteInfo(ProductJira, 'server', 'user1', false);
             storedSites.set(`${ProductJira.key}Sites`, [serverSite]);
 
-            siteManager.resolvePrimarySite();
+            siteManager_resolvePrimarySite();
 
             expect(siteManager.primarySite).toBeUndefined();
         });
@@ -413,7 +415,7 @@ describe('SiteManager', () => {
             cloudSiteB.name = 'Beta';
             storedSites.set(`${ProductJira.key}Sites`, [cloudSiteB, cloudSiteA]);
 
-            siteManager.resolvePrimarySite();
+            siteManager_resolvePrimarySite();
 
             expect(siteManager.primarySite).toEqual(cloudSiteA);
         });
@@ -425,11 +427,11 @@ describe('SiteManager', () => {
             cloudSiteB.name = 'Beta';
             storedSites.set(`${ProductJira.key}Sites`, [cloudSiteA, cloudSiteB]);
 
-            siteManager.resolvePrimarySite();
+            siteManager_resolvePrimarySite();
             const firstPrimary = siteManager.primarySite;
 
             // Call again, should not change
-            siteManager.resolvePrimarySite();
+            siteManager_resolvePrimarySite();
             expect(siteManager.primarySite).toBe(firstPrimary);
         });
 
@@ -438,14 +440,14 @@ describe('SiteManager', () => {
             cloudSiteA.name = 'Alpha';
             storedSites.set(`${ProductJira.key}Sites`, [cloudSiteA]);
 
-            siteManager.resolvePrimarySite();
+            siteManager_resolvePrimarySite();
             expect(siteManager.primarySite).toEqual(cloudSiteA);
 
             const cloudSiteB = createDetailedSiteInfo(ProductJira, 'cloudB', 'userB', true);
             cloudSiteB.name = 'Beta';
             storedSites.set(`${ProductJira.key}Sites`, [cloudSiteB]);
 
-            siteManager.resolvePrimarySite();
+            siteManager_resolvePrimarySite();
             expect(siteManager.primarySite).toEqual(cloudSiteB);
         });
     });

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -44,7 +44,7 @@ export class SiteManager extends Disposable {
     /**
      * Fallback logic to resolve a primary tenant for feature flag purposes
      */
-    public resolvePrimarySite(): DetailedSiteInfo | undefined {
+    private resolvePrimarySite(): DetailedSiteInfo | undefined {
         const allSites = this.readSitesFromGlobalStore(ProductJira.key);
         const cloudSites = allSites?.filter((site) => site.isCloud);
 


### PR DESCRIPTION
### What Is This Change?

Rovo Dev uses Jira sites' authentication token for its enablement and token usage.
If Jira is fully disabled, its sites shouldn't be used, therefore Rovo Dev should be disabled.

This PR addresses that.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`