### PR TITLE
[AXON-891]: added error msg into retry prompt rendering

### DIFF
--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -63,7 +63,7 @@ export const renderChatHistory = (
             return <ChatMessageItem msg={msg} />;
         case 'RovoDevRetry':
             const retryMsg: DefaultMessage = {
-                text: 'Unable to process the request ' + '`' + msg.tool_name + '`',
+                text: msg.content,
                 source: 'RovoDev',
             };
             return (

--- a/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
@@ -26,7 +26,7 @@ export const ChatMessageItem: React.FC<{
         <>
             <div
                 className={`chat-message ${messageTypeStyles}`}
-                style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '8px' }}
+                style={{ display: 'flex', flexDirection: 'row', alignItems: 'start', gap: '8px' }}
             >
                 {icon && <div className="message-icon">{icon}</div>}
                 <div className="message-content">{content}</div>


### PR DESCRIPTION
### What Is This Change?

Replaced `retry-prompt` rendering with te error's context for better understanding of error.

<img width="408" height="147" alt="Screenshot 2025-09-02 at 2 06 00 PM" src="https://github.com/user-attachments/assets/9e0da53a-3d85-40e0-9154-8a6000f4aea1" />


### How Has This Been Tested?


manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`