### PR TITLE
[AXON-1031] Rovo Dev prompt box gets reset on "eyed context" change

### DIFF
--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
@@ -135,26 +135,22 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
         removeMonacoStyles();
 
         if (container) {
-            const completionProvider = monaco.languages.registerCompletionItemProvider(
-                'plaintext',
-                createSlashCommandProvider(),
-            );
-            const editor = createMonacoPromptEditor(container);
-            setupPromptKeyBindings(editor, onSend);
-            setupAutoResize(editor);
-            setupCommands(editor, onSend, onCopy, handleMemoryCommand, handleTriggerFeedbackCommand);
+            setEditor((prev) => {
+                if (prev) {
+                    return prev;
+                }
 
-            editor.setValue(promptText);
+                monaco.languages.registerCompletionItemProvider('plaintext', createSlashCommandProvider());
 
-            setEditor(editor);
+                const editor = createMonacoPromptEditor(container);
+                setupPromptKeyBindings(editor, onSend);
+                setupAutoResize(editor);
+                setupCommands(editor, onSend, onCopy, handleMemoryCommand, handleTriggerFeedbackCommand);
 
-            return () => {
-                completionProvider.dispose();
-                editor.dispose();
-            };
+                return editor;
+            });
         }
-        return () => {};
-    }, [handleMemoryCommand, handleTriggerFeedbackCommand, onCopy, onSend, promptText]);
+    }, [handleMemoryCommand, handleTriggerFeedbackCommand, onCopy, onSend, setEditor]);
 
     React.useEffect(() => {
         if (!editor) {

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
@@ -129,27 +129,28 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
     };
 
     React.useEffect(() => {
-        const container = document.getElementById('prompt-editor-container');
+        setEditor((prev) => {
+            if (prev) {
+                return prev;
+            }
 
-        // Remove Monaco's color stylesheet
-        removeMonacoStyles();
+            const container = document.getElementById('prompt-editor-container');
+            if (!container) {
+                return null;
+            }
 
-        if (container) {
-            setEditor((prev) => {
-                if (prev) {
-                    return prev;
-                }
+            // Remove Monaco's color stylesheet
+            removeMonacoStyles();
 
-                monaco.languages.registerCompletionItemProvider('plaintext', createSlashCommandProvider());
+            monaco.languages.registerCompletionItemProvider('plaintext', createSlashCommandProvider());
 
-                const editor = createMonacoPromptEditor(container);
-                setupPromptKeyBindings(editor, onSend);
-                setupAutoResize(editor);
-                setupCommands(editor, onSend, onCopy, handleMemoryCommand, handleTriggerFeedbackCommand);
+            const editor = createMonacoPromptEditor(container);
+            setupPromptKeyBindings(editor, onSend);
+            setupAutoResize(editor);
+            setupCommands(editor, onSend, onCopy, handleMemoryCommand, handleTriggerFeedbackCommand);
 
-                return editor;
-            });
-        }
+            return editor;
+        });
     }, [handleMemoryCommand, handleTriggerFeedbackCommand, onCopy, onSend, setEditor]);
 
     React.useEffect(() => {


### PR DESCRIPTION
### What Is This Change?

Bug:
![bug1031](https://github.com/user-attachments/assets/8edd9c87-5cf8-49fb-8f8a-6d46ee81910b)

Fix:
![fix1031](https://github.com/user-attachments/assets/3eed2193-7016-4cf7-8416-c69ede309b4f)

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`