### PR TITLE
Rovo Dev: fixed color and submit regression in Prompt Box

### DIFF
--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
@@ -18,7 +18,6 @@ interface PromptInputBoxProps {
     hideButtons?: boolean;
     state: State;
     promptText: string;
-    onPromptTextChange: (text: string) => void;
     isDeepPlanEnabled: boolean;
     onDeepPlanToggled: () => void;
     onSend: (text: string) => void;
@@ -105,6 +104,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                 const value = editor.getValue();
                 if (value.trim()) {
                     onSend(value);
+                    editor.setValue('');
                 }
             },
             '!suggestWidgetVisible',
@@ -139,9 +139,6 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                 return null;
             }
 
-            // Remove Monaco's color stylesheet
-            removeMonacoStyles();
-
             monaco.languages.registerCompletionItemProvider('plaintext', createSlashCommandProvider());
 
             const editor = createMonacoPromptEditor(container);
@@ -152,6 +149,12 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
             return editor;
         });
     }, [handleMemoryCommand, handleTriggerFeedbackCommand, onCopy, onSend, setEditor]);
+
+    React.useEffect(() => {
+        // Remove Monaco's color stylesheet
+        removeMonacoStyles();
+        editor?.setValue(promptText);
+    }, [editor, promptText]);
 
     React.useEffect(() => {
         if (!editor) {

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -800,7 +800,6 @@ const RovoDevView: React.FC = () => {
                             hideButtons={workspaceCount === 0}
                             state={currentState}
                             promptText={promptText}
-                            onPromptTextChange={(element) => setPromptText(element)}
                             isDeepPlanEnabled={isDeepPlanToggled}
                             onDeepPlanToggled={() => setIsDeepPlanToggled(!isDeepPlanToggled)}
                             onSend={sendPrompt}


### PR DESCRIPTION
### What Is This Change?

Regression caused by #894: 
- Incorrect color of the promptbox text area
- Text doesn't reset after submit

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`