### PR TITLE
[AXON-907] Sync application instance ID with BBY and Rovo Dev

### DIFF
--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -805,7 +805,11 @@ describe('analytics', () => {
         describe('api.rovodev.chat.response.timeToFirstByte', () => {
             it('should create a performance event with correct tag and measure', async () => {
                 const measure = 150;
-                const params = { rovoDevSessionId: 'test-session-123', rovoDevPromptId: 'test-prompt-123' };
+                const params = {
+                    appInstanceId: 'app-123',
+                    rovoDevSessionId: 'test-session-123',
+                    rovoDevPromptId: 'test-prompt-123',
+                };
 
                 const event = await analytics.performanceEvent(
                     'api.rovodev.chat.response.timeToFirstByte',
@@ -825,7 +829,11 @@ describe('analytics', () => {
         describe('api.rovodev.chat.response.timeToFirstMessage', () => {
             it('should create a performance event with correct tag and measure', async () => {
                 const measure = 250;
-                const params = { rovoDevSessionId: 'session-456', rovoDevPromptId: 'prompt-456' };
+                const params = {
+                    appInstanceId: 'app-456',
+                    rovoDevSessionId: 'session-456',
+                    rovoDevPromptId: 'prompt-456',
+                };
 
                 const event = await analytics.performanceEvent(
                     'api.rovodev.chat.response.timeToFirstMessage',
@@ -837,6 +845,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.tag).toEqual('api.rovodev.chat.response.timeToFirstMessage');
                 expect(event.trackEvent.attributes.measure).toEqual(measure);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(params.appInstanceId);
                 expect(event.trackEvent.attributes.rovoDevSessionId).toEqual(params.rovoDevSessionId);
                 expect(event.trackEvent.attributes.rovoDevPromptId).toEqual(params.rovoDevPromptId);
             });
@@ -845,7 +854,11 @@ describe('analytics', () => {
         describe('api.rovodev.chat.response.timeToTechPlan', () => {
             it('should create a performance event with correct tag and measure', async () => {
                 const measure = 500;
-                const params = { rovoDevSessionId: 'session-789', rovoDevPromptId: 'prompt-789' };
+                const params = {
+                    appInstanceId: 'app-789',
+                    rovoDevSessionId: 'session-789',
+                    rovoDevPromptId: 'prompt-789',
+                };
 
                 const event = await analytics.performanceEvent(
                     'api.rovodev.chat.response.timeToTechPlan',
@@ -857,6 +870,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.tag).toEqual('api.rovodev.chat.response.timeToTechPlan');
                 expect(event.trackEvent.attributes.measure).toEqual(measure);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(params.appInstanceId);
                 expect(event.trackEvent.attributes.rovoDevSessionId).toEqual(params.rovoDevSessionId);
                 expect(event.trackEvent.attributes.rovoDevPromptId).toEqual(params.rovoDevPromptId);
             });
@@ -865,7 +879,11 @@ describe('analytics', () => {
         describe('api.rovodev.chat.response.timeToLastMessage', () => {
             it('should create a performance event with correct tag and measure', async () => {
                 const measure = 1000;
-                const params = { rovoDevSessionId: 'session-999', rovoDevPromptId: 'prompt-999' };
+                const params = {
+                    appInstanceId: 'app-999',
+                    rovoDevSessionId: 'session-999',
+                    rovoDevPromptId: 'prompt-999',
+                };
 
                 const event = await analytics.performanceEvent(
                     'api.rovodev.chat.response.timeToLastMessage',
@@ -877,6 +895,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.tag).toEqual('api.rovodev.chat.response.timeToLastMessage');
                 expect(event.trackEvent.attributes.measure).toEqual(measure);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(params.appInstanceId);
                 expect(event.trackEvent.attributes.rovoDevSessionId).toEqual(params.rovoDevSessionId);
                 expect(event.trackEvent.attributes.rovoDevPromptId).toEqual(params.rovoDevPromptId);
             });
@@ -886,6 +905,7 @@ describe('analytics', () => {
             it('should include platform information based on process.platform', async () => {
                 setProcessPlatform('darwin');
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
                 });
@@ -895,6 +915,7 @@ describe('analytics', () => {
 
             it('should include origin information', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
                 });
@@ -904,6 +925,7 @@ describe('analytics', () => {
 
             it('should handle empty string parameters', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: '',
                     rovoDevPromptId: '',
                 });
@@ -914,6 +936,7 @@ describe('analytics', () => {
 
             it('should handle additional parameters in params object', async () => {
                 const params = {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
                     additionalData: 'extra-info',
@@ -926,6 +949,7 @@ describe('analytics', () => {
                     params,
                 );
 
+                expect(event.trackEvent.attributes.appInstanceId).toEqual('test-app-id');
                 expect(event.trackEvent.attributes.rovoDevSessionId).toEqual('test-session');
                 expect(event.trackEvent.attributes.rovoDevPromptId).toEqual('test-prompt');
                 expect(event.trackEvent.attributes.additionalData).toEqual('extra-info');
@@ -981,6 +1005,7 @@ describe('analytics', () => {
         describe('event structure validation', () => {
             it('should return a valid TrackEvent structure', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
                 });
@@ -1001,6 +1026,7 @@ describe('analytics', () => {
 
             it('should have consistent action and actionSubject for timeToFirstByte', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
                 });
@@ -1011,6 +1037,7 @@ describe('analytics', () => {
 
             it('should have consistent action and actionSubject for timeToFirstMessage', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstMessage', 100, {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
                 });
@@ -1021,6 +1048,7 @@ describe('analytics', () => {
 
             it('should have consistent action and actionSubject for timeToTechPlan', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToTechPlan', 100, {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
                 });
@@ -1031,6 +1059,7 @@ describe('analytics', () => {
 
             it('should have consistent action and actionSubject for timeToLastMessage', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToLastMessage', 100, {
+                    appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
                 });
@@ -1043,6 +1072,7 @@ describe('analytics', () => {
 
     // Rovo Dev event tests
     describe('Rovo Dev events', () => {
+        const appInstanceId = 'test-app-session-id';
         const mockSessionId = 'test-session-id';
         const mockPromptId = 'test-prompt-id';
 
@@ -1057,6 +1087,7 @@ describe('analytics', () => {
                 const isManuallyCreated = true;
                 const event = await analytics.rovoDevNewSessionActionEvent(
                     rovoDevEnv,
+                    appInstanceId,
                     mockSessionId,
                     isManuallyCreated,
                 );
@@ -1064,6 +1095,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.action).toEqual('rovoDevNewSessionAction');
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
                 expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
                 expect(event.trackEvent.attributes.isManuallyCreated).toEqual(isManuallyCreated);
             },
@@ -1072,11 +1104,18 @@ describe('analytics', () => {
         it.each(RovoDevEnvironments)(
             'should create rovoDevPromptSentEvent with session and prompt IDs',
             async (rovoDevEnv) => {
-                const event = await analytics.rovoDevPromptSentEvent(rovoDevEnv, mockSessionId, mockPromptId, true);
+                const event = await analytics.rovoDevPromptSentEvent(
+                    rovoDevEnv,
+                    appInstanceId,
+                    mockSessionId,
+                    mockPromptId,
+                    true,
+                );
 
                 expect(event.trackEvent.action).toEqual('rovoDevPromptSent');
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
                 expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
                 expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
                 expect(event.trackEvent.attributes.deepPlanEnabled).toEqual(true);
@@ -1091,6 +1130,7 @@ describe('analytics', () => {
                 const questionsCount = 2;
                 const event = await analytics.rovoDevTechnicalPlanningShownEvent(
                     rovoDevEnv,
+                    appInstanceId,
                     mockSessionId,
                     mockPromptId,
                     stepsCount,
@@ -1101,6 +1141,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.action).toEqual('rovoDevTechnicalPlanningShown');
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
                 expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
                 expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
                 expect(event.trackEvent.attributes.stepsCount).toEqual(stepsCount);
@@ -1115,6 +1156,7 @@ describe('analytics', () => {
                 const filesCount = 4;
                 const event = await analytics.rovoDevFilesSummaryShownEvent(
                     rovoDevEnv,
+                    appInstanceId,
                     mockSessionId,
                     mockPromptId,
                     filesCount,
@@ -1123,6 +1165,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.action).toEqual('rovoDevFilesSummaryShown');
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
                 expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
                 expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
                 expect(event.trackEvent.attributes.filesCount).toEqual(filesCount);
@@ -1136,6 +1179,7 @@ describe('analytics', () => {
                 const filesCount = 3;
                 const event = await analytics.rovoDevFileChangedActionEvent(
                     rovoDevEnv,
+                    appInstanceId,
                     mockSessionId,
                     mockPromptId,
                     action,
@@ -1145,6 +1189,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.action).toEqual('rovoDevFileChangedAction');
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
                 expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
                 expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
                 expect(event.trackEvent.attributes.action).toEqual(action);
@@ -1159,6 +1204,7 @@ describe('analytics', () => {
                 const filesCount = 2;
                 const event = await analytics.rovoDevFileChangedActionEvent(
                     rovoDevEnv,
+                    appInstanceId,
                     mockSessionId,
                     mockPromptId,
                     action,
@@ -1168,6 +1214,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.action).toEqual('rovoDevFileChangedAction');
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
                 expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
                 expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
                 expect(event.trackEvent.attributes.action).toEqual(action);
@@ -1176,11 +1223,17 @@ describe('analytics', () => {
         );
 
         it.each(RovoDevEnvironments)('should create rovoDevStopActionEvent when successful', async (rovoDevEnv) => {
-            const event = await analytics.rovoDevStopActionEvent(rovoDevEnv, mockSessionId, mockPromptId);
+            const event = await analytics.rovoDevStopActionEvent(
+                rovoDevEnv,
+                appInstanceId,
+                mockSessionId,
+                mockPromptId,
+            );
 
             expect(event.trackEvent.action).toEqual('rovoDevStopAction');
             expect(event.trackEvent.actionSubject).toEqual('atlascode');
             expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+            expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
             expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
             expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
             expect(event.trackEvent.attributes.failed).toBeUndefined();
@@ -1188,11 +1241,18 @@ describe('analytics', () => {
 
         it.each(RovoDevEnvironments)('should create rovoDevStopActionEvent when failed', async (rovoDevEnv) => {
             const failed = true;
-            const event = await analytics.rovoDevStopActionEvent(rovoDevEnv, mockSessionId, mockPromptId, failed);
+            const event = await analytics.rovoDevStopActionEvent(
+                rovoDevEnv,
+                appInstanceId,
+                mockSessionId,
+                mockPromptId,
+                failed,
+            );
 
             expect(event.trackEvent.action).toEqual('rovoDevStopAction');
             expect(event.trackEvent.actionSubject).toEqual('atlascode');
             expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+            expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
             expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
             expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
             expect(event.trackEvent.attributes.failed).toEqual(failed);
@@ -1204,6 +1264,7 @@ describe('analytics', () => {
                 const prCreated = true;
                 const event = await analytics.rovoDevGitPushActionEvent(
                     rovoDevEnv,
+                    appInstanceId,
                     mockSessionId,
                     mockPromptId,
                     prCreated,
@@ -1212,6 +1273,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.action).toEqual('rovoDevGitPushAction');
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
                 expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
                 expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
                 expect(event.trackEvent.attributes.prCreated).toEqual(prCreated);
@@ -1224,6 +1286,7 @@ describe('analytics', () => {
                 const prCreated = false;
                 const event = await analytics.rovoDevGitPushActionEvent(
                     rovoDevEnv,
+                    appInstanceId,
                     mockSessionId,
                     mockPromptId,
                     prCreated,
@@ -1232,6 +1295,7 @@ describe('analytics', () => {
                 expect(event.trackEvent.action).toEqual('rovoDevGitPushAction');
                 expect(event.trackEvent.actionSubject).toEqual('atlascode');
                 expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+                expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
                 expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
                 expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
                 expect(event.trackEvent.attributes.prCreated).toEqual(prCreated);
@@ -1239,11 +1303,17 @@ describe('analytics', () => {
         );
 
         it.each(RovoDevEnvironments)('should create rovoDevDetailsExpandedEvent', async (rovoDevEnv) => {
-            const event = await analytics.rovoDevDetailsExpandedEvent(rovoDevEnv, mockSessionId, mockPromptId);
+            const event = await analytics.rovoDevDetailsExpandedEvent(
+                rovoDevEnv,
+                appInstanceId,
+                mockSessionId,
+                mockPromptId,
+            );
 
             expect(event.trackEvent.action).toEqual('rovoDevDetailsExpanded');
             expect(event.trackEvent.actionSubject).toEqual('atlascode');
             expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+            expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
             expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
             expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
         });
@@ -1557,6 +1627,7 @@ describe('analytics', () => {
                     'api.rovodev.chat.response.timeToFirstByte',
                     100,
                     {
+                        appInstanceId: 'test-app-id',
                         rovoDevSessionId: 'test-session',
                         rovoDevPromptId: 'test-prompt',
                     },
@@ -1568,6 +1639,7 @@ describe('analytics', () => {
                 expect(jiraEvent.trackEvent.attributes.tag).toEqual('ui.jira.jqlFetch.render.lcp');
 
                 // RovoDev event should have sessionId/promptId
+                expect(rovoDevEvent.trackEvent.attributes.appInstanceId).toEqual('test-app-id');
                 expect(rovoDevEvent.trackEvent.attributes.rovoDevSessionId).toEqual('test-session');
                 expect(rovoDevEvent.trackEvent.attributes.rovoDevPromptId).toEqual('test-prompt');
                 expect(rovoDevEvent.trackEvent.attributes.tag).toEqual('api.rovodev.chat.response.timeToFirstByte');

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -203,6 +203,7 @@ type JiraPerfEvents =
     | 'ui.jira.editJiraIssue.update.lcp';
 
 interface RovoDevCommonParams {
+    appInstanceId: string;
     rovoDevSessionId: string;
     rovoDevPromptId: string;
 }
@@ -230,25 +231,32 @@ export function performanceEvent(tag: string, measure: number, params?: Record<s
 
 export type RovoDevEnv = 'IDE' | 'Boysenberry';
 
-export function rovoDevNewSessionActionEvent(rovoDevEnv: RovoDevEnv, sessionId: string, isManuallyCreated: boolean) {
+export function rovoDevNewSessionActionEvent(
+    rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
+    sessionId: string,
+    isManuallyCreated: boolean,
+) {
     return trackEvent('rovoDevNewSessionAction', 'atlascode', {
-        attributes: { rovoDevEnv, sessionId, isManuallyCreated },
+        attributes: { rovoDevEnv, appInstanceId, sessionId, isManuallyCreated },
     });
 }
 
 export function rovoDevPromptSentEvent(
     rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
     sessionId: string,
     promptId: string,
     deepPlanEnabled: boolean,
 ) {
     return trackEvent('rovoDevPromptSent', 'atlascode', {
-        attributes: { rovoDevEnv, sessionId, promptId, deepPlanEnabled },
+        attributes: { rovoDevEnv, appInstanceId, sessionId, promptId, deepPlanEnabled },
     });
 }
 
 export function rovoDevTechnicalPlanningShownEvent(
     rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
     sessionId: string,
     promptId: string,
     stepsCount: number,
@@ -256,53 +264,67 @@ export function rovoDevTechnicalPlanningShownEvent(
     questionsCount: number,
 ) {
     return trackEvent('rovoDevTechnicalPlanningShown', 'atlascode', {
-        attributes: { rovoDevEnv, sessionId, promptId, stepsCount, filesCount, questionsCount },
+        attributes: { rovoDevEnv, appInstanceId, sessionId, promptId, stepsCount, filesCount, questionsCount },
     });
 }
 
 export function rovoDevFilesSummaryShownEvent(
     rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
     sessionId: string,
     promptId: string,
     filesCount: number,
 ) {
     return trackEvent('rovoDevFilesSummaryShown', 'atlascode', {
-        attributes: { rovoDevEnv, sessionId, promptId, filesCount },
+        attributes: { rovoDevEnv, appInstanceId, sessionId, promptId, filesCount },
     });
 }
 
 export function rovoDevFileChangedActionEvent(
     rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
     sessionId: string,
     promptId: string,
     action: 'undo' | 'keep',
     filesCount: number,
 ) {
     return trackEvent('rovoDevFileChangedAction', 'atlascode', {
-        attributes: { rovoDevEnv, sessionId, promptId, action, filesCount },
+        attributes: { rovoDevEnv, appInstanceId, sessionId, promptId, action, filesCount },
     });
 }
 
-export function rovoDevStopActionEvent(rovoDevEnv: RovoDevEnv, sessionId: string, promptId: string, failed?: boolean) {
+export function rovoDevStopActionEvent(
+    rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
+    sessionId: string,
+    promptId: string,
+    failed?: boolean,
+) {
     return trackEvent('rovoDevStopAction', 'atlascode', {
-        attributes: { rovoDevEnv, sessionId, promptId, failed },
+        attributes: { rovoDevEnv, appInstanceId, sessionId, promptId, failed },
     });
 }
 
 export function rovoDevGitPushActionEvent(
     rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
     sessionId: string,
     promptId: string,
     prCreated: boolean,
 ) {
     return trackEvent('rovoDevGitPushAction', 'atlascode', {
-        attributes: { rovoDevEnv, sessionId, promptId, prCreated },
+        attributes: { rovoDevEnv, appInstanceId, sessionId, promptId, prCreated },
     });
 }
 
-export function rovoDevDetailsExpandedEvent(rovoDevEnv: RovoDevEnv, sessionId: string, promptId: string) {
+export function rovoDevDetailsExpandedEvent(
+    rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
+    sessionId: string,
+    promptId: string,
+) {
     return trackEvent('rovoDevDetailsExpanded', 'atlascode', {
-        attributes: { rovoDevEnv, sessionId, promptId },
+        attributes: { rovoDevEnv, appInstanceId, sessionId, promptId },
     });
 }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,3 +1,4 @@
+import { v4 } from 'uuid';
 import { env, ExtensionContext, languages, UIKind, workspace } from 'vscode';
 import * as vscode from 'vscode';
 
@@ -467,6 +468,18 @@ export class Container {
 
     public static set configTarget(target: ConfigTarget) {
         this._context.globalState.update(ConfigTargetKey, target);
+    }
+
+    private static _appInstanceId: string;
+    /**
+     * An instance ID randomly generated to identify this specific instance.
+     * Note: closing/opening a workspace causes this ID to change.
+     */
+    public static get appInstanceId() {
+        if (!this._appInstanceId) {
+            this._appInstanceId = v4();
+        }
+        return this._appInstanceId;
     }
 
     private static _featureFlagClient: FeatureFlagClient;

--- a/src/rovo-dev/performanceLogger.test.ts
+++ b/src/rovo-dev/performanceLogger.test.ts
@@ -78,6 +78,7 @@ describe('PerformanceLogger', () => {
 
     describe('promptFirstByteReceived', () => {
         beforeEach(() => {
+            performanceLogger.appInitialized('test-instance-123');
             performanceLogger.sessionStarted('test-session-123');
         });
 
@@ -96,6 +97,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToFirstByte',
                 measureValue,
                 {
+                    appInstanceId: 'test-instance-123',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
                 },
@@ -116,6 +118,7 @@ describe('PerformanceLogger', () => {
 
     describe('promptFirstMessageReceived', () => {
         beforeEach(() => {
+            performanceLogger.appInitialized('test-instance-123');
             performanceLogger.sessionStarted('test-session-123');
         });
 
@@ -134,6 +137,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToFirstMessage',
                 measureValue,
                 {
+                    appInstanceId: 'test-instance-123',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
                 },
@@ -147,6 +151,7 @@ describe('PerformanceLogger', () => {
 
     describe('promptTechnicalPlanReceived', () => {
         beforeEach(() => {
+            performanceLogger.appInitialized('test-instance-123');
             performanceLogger.sessionStarted('test-session-123');
         });
 
@@ -165,6 +170,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToTechPlan',
                 measureValue,
                 {
+                    appInstanceId: 'test-instance-123',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
                 },
@@ -178,6 +184,7 @@ describe('PerformanceLogger', () => {
 
     describe('promptLastMessageReceived', () => {
         beforeEach(() => {
+            performanceLogger.appInitialized('test-instance-123');
             performanceLogger.sessionStarted('test-session-123');
         });
 
@@ -197,6 +204,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToLastMessage',
                 measureValue,
                 {
+                    appInstanceId: 'test-instance-123',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
                 },

--- a/src/rovo-dev/performanceLogger.ts
+++ b/src/rovo-dev/performanceLogger.ts
@@ -5,6 +5,11 @@ import Perf from '../util/perf';
 
 export class PerformanceLogger {
     private currentSessionId: string = '';
+    private appInstanceId: string = '';
+
+    public appInitialized(appInstanceId: string) {
+        this.appInstanceId = appInstanceId;
+    }
 
     public sessionStarted(sessionId: string) {
         this.currentSessionId = sessionId;
@@ -21,6 +26,7 @@ export class PerformanceLogger {
     public async promptFirstByteReceived(promptId: string) {
         const measure = Perf.measure(promptId);
         const evt = await performanceEvent('api.rovodev.chat.response.timeToFirstByte', measure, {
+            appInstanceId: this.appInstanceId,
             rovoDevSessionId: this.currentSessionId,
             rovoDevPromptId: promptId,
         });
@@ -32,6 +38,7 @@ export class PerformanceLogger {
     public async promptFirstMessageReceived(promptId: string) {
         const measure = Perf.measure(promptId);
         const evt = await performanceEvent('api.rovodev.chat.response.timeToFirstMessage', measure, {
+            appInstanceId: this.appInstanceId,
             rovoDevSessionId: this.currentSessionId,
             rovoDevPromptId: promptId,
         });
@@ -43,6 +50,7 @@ export class PerformanceLogger {
     public async promptTechnicalPlanReceived(promptId: string) {
         const measure = Perf.measure(promptId);
         const evt = await performanceEvent('api.rovodev.chat.response.timeToTechPlan', measure, {
+            appInstanceId: this.appInstanceId,
             rovoDevSessionId: this.currentSessionId,
             rovoDevPromptId: promptId,
         });
@@ -54,6 +62,7 @@ export class PerformanceLogger {
     public async promptLastMessageReceived(promptId: string) {
         const measure = Perf.measure(promptId);
         const evt = await performanceEvent('api.rovodev.chat.response.timeToLastMessage', measure, {
+            appInstanceId: this.appInstanceId,
             rovoDevSessionId: this.currentSessionId,
             rovoDevPromptId: promptId,
         });

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -387,6 +387,7 @@ class RovoDevProcessInstance extends RovoDevInstance {
                 const env: NodeJS.ProcessEnv = {
                     USER: process.env.USER,
                     USER_EMAIL: username,
+                    ROVODEV_APP_INSTANCE_ID: Container.appInstanceId,
                     ...(key ? { USER_API_TOKEN: key } : {}),
                 };
 
@@ -493,6 +494,7 @@ class RovoDevTerminalInstance extends RovoDevInstance {
                     env: {
                         USER: process.env.USER,
                         USER_EMAIL: username,
+                        ROVODEV_APP_INSTANCE_ID: Container.appInstanceId,
                         ...(key ? { USER_API_TOKEN: key } : {}),
                     },
                 });


### PR DESCRIPTION
### What Is This Change?

The application instance ID is a unique ID representing the instance of the Application consuming Rovo Dev.
In Boysenberry, it's generated by its platform, and in IDE it's generated by the IDE itself.

This change is for aligning this ID across Atlascode, BBY, and Rovo Dev telemetry.

### How Has This Been Tested?

- [ ] `npm run lint`
- [ ] `npm run test`