### PR TITLE
[AXON-933] Ship the Terminal Rovo Dev to everybody

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ],
     "main": "./build/extension/extension",
     "rovoDev": {
-        "version": "0.11.15"
+        "version": "0.11.16"
     },
     "scripts": {
         "vscode:uninstall": "node ./build/extension/uninstall.js",
@@ -133,7 +133,8 @@
                 "command": "atlascode.rovodev.showTerminal",
                 "title": "Trail Logs",
                 "icon": "$(terminal)",
-                "category": "Rovo Dev"
+                "category": "Rovo Dev",
+                "enablement": "atlascode:rovoDevEnabled"
             },
             {
                 "command": "atlascode.openRovoDevConfig",

--- a/src/rovo-dev/rovoDevApiClient.ts
+++ b/src/rovo-dev/rovoDevApiClient.ts
@@ -177,4 +177,9 @@ export class RovoDevApiClient {
             return false;
         }
     }
+
+    /** Invokes the GET `/shutdown` API. */
+    public async shutdown(): Promise<void> {
+        await this.fetchApi('/shutdown', 'GET');
+    }
 }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -1216,13 +1216,13 @@ ${message}`;
         });
     }
 
-    public async signalProcessStarted(rovoDevPort: number, isTerminal?: boolean) {
+    public async signalProcessStarted(rovoDevPort: number) {
         // initialize the API client
         const rovoDevHost = process.env[rovodevInfo.envVars.host] || 'localhost';
         this._rovoDevApiClient = new RovoDevApiClient(rovoDevHost, rovoDevPort);
 
         // enable the 'show terminal' button only when in debugging
-        setCommandContext(CommandContext.RovoDevTerminalEnabled, !!isTerminal);
+        setCommandContext(CommandContext.RovoDevTerminalEnabled, Container.isDebugging);
 
         const webView = this._webView!;
 
@@ -1308,6 +1308,10 @@ ${message}`;
     }
 
     public signalProcessTerminated(errorMessage?: string) {
+        if (this._processState === RovoDevProcessState.Terminated) {
+            return;
+        }
+
         this.signalRovoDevDisabled('other');
 
         this._processState = RovoDevProcessState.Terminated;
@@ -1320,5 +1324,10 @@ ${message}`;
 
         const error = new Error(errorMessage);
         return this.processError(error, false, true);
+    }
+
+    public async shutdownRovoDev() {
+        await this.rovoDevApiClient?.shutdown();
+        await this.signalProcessTerminated();
     }
 }


### PR DESCRIPTION
### What Is This Change?

The main reason why we couldn't ship it to everybody was the inability to properly terminate the process when running in terminal.

Thanks to the new `shutdown` API, we can how ship it.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`