### PR TITLE
AXON-964: add tooltip, update deprecated icons

### DIFF
--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/ModifiedFileItem.tsx
@@ -1,5 +1,6 @@
-import CheckIcon from '@atlaskit/icon/glyph/check';
-import CrossIcon from '@atlaskit/icon/glyph/cross';
+import CheckMarkIcon from '@atlaskit/icon/core/check-mark';
+import UndoIcon from '@atlaskit/icon/core/undo';
+import Tooltip from '@atlaskit/tooltip';
 import React from 'react';
 
 import { ToolReturnParseResult } from '../../utils';
@@ -47,7 +48,9 @@ export const ModifiedFileItem: React.FC<{
                     onClick={handleUndo}
                     aria-label="Undo changes to this file"
                 >
-                    <CrossIcon size="small" label="Undo" />
+                    <Tooltip content="Undo" position="top">
+                        <UndoIcon size="small" label="Undo" />
+                    </Tooltip>
                 </button>
                 <button
                     disabled={!actionsEnabled}
@@ -55,7 +58,9 @@ export const ModifiedFileItem: React.FC<{
                     onClick={handleKeep}
                     aria-label="Keep changes to this file"
                 >
-                    <CheckIcon size="small" label="Keep" />
+                    <Tooltip content="Keep" position="top">
+                        <CheckMarkIcon size="small" label="Keep" />
+                    </Tooltip>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
### Ticket:
https://softwareteams.atlassian.net/browse/AXON-964

### What Is This Change?
Add a missing tooltip for the updated file section. Update the deprecated icons.

### Before/after screenshots
     Before:
     
<img width="269" height="236" alt="keep-before" src="https://github.com/user-attachments/assets/fcb3300c-0ba8-4329-80c3-2784b1bbea09" />
<img width="269" height="238" alt="undo-before" src="https://github.com/user-attachments/assets/974a591b-362f-41f2-97e2-0079ef280633" />
     After:
     
<img width="267" height="231" alt="keep-after" src="https://github.com/user-attachments/assets/bfd79457-06d5-4839-9208-a023113a1178" />
<img width="276" height="239" alt="undo-after" src="https://github.com/user-attachments/assets/d61052be-1311-4ec5-b353-0abafcbb2c2d" />


### How Has This Been Tested?


Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change