### PR TITLE
Refactor Rovo Dev webview provider

### DIFF
--- a/src/rovo-dev/performanceLogger.test.ts
+++ b/src/rovo-dev/performanceLogger.test.ts
@@ -21,7 +21,7 @@ describe('PerformanceLogger', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        performanceLogger = new PerformanceLogger();
+        performanceLogger = new PerformanceLogger('test-instance-id');
 
         // Setup mock analytics client
         mockAnalyticsClient = {
@@ -78,7 +78,6 @@ describe('PerformanceLogger', () => {
 
     describe('promptFirstByteReceived', () => {
         beforeEach(() => {
-            performanceLogger.appInitialized('test-instance-123');
             performanceLogger.sessionStarted('test-session-123');
         });
 
@@ -97,7 +96,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToFirstByte',
                 measureValue,
                 {
-                    appInstanceId: 'test-instance-123',
+                    appInstanceId: 'test-instance-id',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
                 },
@@ -118,7 +117,6 @@ describe('PerformanceLogger', () => {
 
     describe('promptFirstMessageReceived', () => {
         beforeEach(() => {
-            performanceLogger.appInitialized('test-instance-123');
             performanceLogger.sessionStarted('test-session-123');
         });
 
@@ -137,7 +135,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToFirstMessage',
                 measureValue,
                 {
-                    appInstanceId: 'test-instance-123',
+                    appInstanceId: 'test-instance-id',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
                 },
@@ -151,7 +149,6 @@ describe('PerformanceLogger', () => {
 
     describe('promptTechnicalPlanReceived', () => {
         beforeEach(() => {
-            performanceLogger.appInitialized('test-instance-123');
             performanceLogger.sessionStarted('test-session-123');
         });
 
@@ -170,7 +167,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToTechPlan',
                 measureValue,
                 {
-                    appInstanceId: 'test-instance-123',
+                    appInstanceId: 'test-instance-id',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
                 },
@@ -184,7 +181,6 @@ describe('PerformanceLogger', () => {
 
     describe('promptLastMessageReceived', () => {
         beforeEach(() => {
-            performanceLogger.appInitialized('test-instance-123');
             performanceLogger.sessionStarted('test-session-123');
         });
 
@@ -204,7 +200,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToLastMessage',
                 measureValue,
                 {
-                    appInstanceId: 'test-instance-123',
+                    appInstanceId: 'test-instance-id',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
                 },

--- a/src/rovo-dev/performanceLogger.ts
+++ b/src/rovo-dev/performanceLogger.ts
@@ -5,11 +5,8 @@ import Perf from '../util/perf';
 
 export class PerformanceLogger {
     private currentSessionId: string = '';
-    private appInstanceId: string = '';
 
-    public appInitialized(appInstanceId: string) {
-        this.appInstanceId = appInstanceId;
-    }
+    constructor(private readonly appInstanceId: string) {}
 
     public sessionStarted(sessionId: string) {
         this.currentSessionId = sessionId;

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -1,0 +1,495 @@
+import { Logger } from 'src/logger';
+import { RovoDevViewResponse } from 'src/react/atlascode/rovo-dev/rovoDevViewMessages';
+import { v4 } from 'uuid';
+import { Event, Webview } from 'vscode';
+
+import { PerformanceLogger } from './performanceLogger';
+import { RovoDevResponse, RovoDevResponseParser } from './responseParser';
+import { RovoDevApiClient } from './rovoDevApiClient';
+import { RovoDevTelemetryProvider } from './rovoDevTelemetryProvider';
+import { RovoDevContext, RovoDevPrompt, TechnicalPlan } from './rovoDevTypes';
+import { RovoDevProviderMessage, RovoDevProviderMessageType } from './rovoDevWebviewProviderMessages';
+
+interface TypedWebview<MessageOut, MessageIn> extends Webview {
+    readonly onDidReceiveMessage: Event<MessageIn>;
+    postMessage(message: MessageOut): Thenable<boolean>;
+}
+
+export class RovoDevChatProvider {
+    private _pendingPrompt: RovoDevPrompt | undefined;
+    private _currentPrompt: RovoDevPrompt | undefined;
+    private _rovoDevApiClient: RovoDevApiClient | undefined;
+    private _webView: TypedWebview<RovoDevProviderMessage, RovoDevViewResponse> | undefined;
+
+    private _replayInProgress = false;
+
+    private _currentPromptId: string = '';
+    public get currentPromptId() {
+        return this._currentPromptId;
+    }
+
+    private _pendingCancellation = false;
+    public get pendingCancellation() {
+        return this._pendingCancellation;
+    }
+
+    constructor(
+        private _perfLogger: PerformanceLogger,
+        private _telemetryProvider: RovoDevTelemetryProvider,
+    ) {}
+
+    public setWebview(webView: TypedWebview<RovoDevProviderMessage, RovoDevViewResponse> | undefined) {
+        this._webView = webView;
+    }
+
+    public async setReady(rovoDevApiClient: RovoDevApiClient) {
+        this._rovoDevApiClient = rovoDevApiClient;
+
+        if (this._pendingPrompt) {
+            const pendingPrompt = this._pendingPrompt;
+            this._pendingPrompt = undefined;
+            await this.internalExecuteChat(pendingPrompt, [], true);
+        }
+    }
+
+    public executeChat(prompt: RovoDevPrompt, revertedFiles: string[]) {
+        return this.internalExecuteChat(prompt, revertedFiles, false);
+    }
+
+    private async internalExecuteChat(
+        { text, enable_deep_plan, context }: RovoDevPrompt,
+        revertedFiles: string[],
+        suppressEcho?: boolean,
+    ) {
+        if (!text) {
+            return;
+        }
+
+        const isCommand = text.trim() === '/clear' || text.trim() === '/prune';
+        if (isCommand) {
+            context = undefined;
+        }
+
+        if (!suppressEcho) {
+            await this.sendUserPromptToView(text, context);
+            await this.sendPromptSentToView(text, enable_deep_plan, context);
+        }
+
+        if (!this._rovoDevApiClient) {
+            this._pendingPrompt = { text, enable_deep_plan, context };
+            return;
+        }
+
+        this.beginNewPrompt();
+
+        this._currentPrompt = {
+            text,
+            enable_deep_plan,
+            context,
+        };
+
+        let payloadToSend = text;
+        if (!isCommand) {
+            payloadToSend = this.addUndoContextToPrompt(payloadToSend, revertedFiles);
+            payloadToSend = this.addContextToPrompt(payloadToSend, context);
+        }
+
+        const currentPrompt = this._currentPrompt;
+        const fetchOp = async (client: RovoDevApiClient) => {
+            const response = await client.chat(payloadToSend, enable_deep_plan);
+
+            this._telemetryProvider.fireTelemetryEvent(
+                'rovoDevPromptSentEvent',
+                this._currentPromptId,
+                !!currentPrompt.enable_deep_plan,
+            );
+
+            return this.processChatResponse('chat', response);
+        };
+
+        await this.executeApiWithErrorHandling(fetchOp, true);
+    }
+
+    public async executeReplay(): Promise<void> {
+        this.beginNewPrompt('replay');
+        await this.sendPromptSentToView('', false);
+
+        this._replayInProgress = true;
+
+        await this.executeApiWithErrorHandling(async (client) => {
+            return this.processChatResponse('replay', client.replay());
+        }, false);
+
+        this._replayInProgress = false;
+    }
+
+    public async executeRetryPromptAfterError() {
+        if (!this._currentPrompt) {
+            return;
+        }
+
+        this.beginNewPrompt();
+
+        const currentPrompt = this._currentPrompt;
+        const payloadToSend = this.addRetryAfterErrorContextToPrompt(currentPrompt.text);
+
+        // we need to echo back the prompt to the View since it's not user submitted
+        await this.sendPromptSentToView(payloadToSend, currentPrompt.enable_deep_plan, currentPrompt.context);
+
+        const fetchOp = async (client: RovoDevApiClient) => {
+            const response = await client.chat(payloadToSend, currentPrompt.enable_deep_plan);
+
+            this._telemetryProvider.fireTelemetryEvent(
+                'rovoDevPromptSentEvent',
+                this._currentPromptId,
+                !!currentPrompt.enable_deep_plan,
+            );
+
+            return this.processChatResponse('chat', response);
+        };
+
+        await this.executeApiWithErrorHandling(fetchOp, true);
+    }
+
+    public async executeCancel(fromNewSession: boolean): Promise<boolean> {
+        const webview = this._webView!;
+
+        if (this._pendingCancellation) {
+            throw new Error('Cancellation already in progress');
+        }
+        this._pendingCancellation = true;
+
+        const cancelResponse = await this.executeApiWithErrorHandling((client) => client.cancel(), false);
+
+        this._pendingCancellation = false;
+
+        const success =
+            !!cancelResponse && (cancelResponse.cancelled || cancelResponse.message === 'No chat in progress');
+
+        if (!fromNewSession) {
+            this._telemetryProvider.fireTelemetryEvent(
+                'rovoDevStopActionEvent',
+                this.currentPromptId,
+                success ? undefined : true,
+            );
+        }
+
+        if (!success) {
+            await webview.postMessage({
+                type: RovoDevProviderMessageType.CancelFailed,
+            });
+        }
+
+        return success;
+    }
+
+    private beginNewPrompt(overrideId?: string): void {
+        this._currentPromptId = overrideId || v4();
+        this._telemetryProvider.startNewPrompt(this._currentPromptId);
+    }
+
+    private async processChatResponse(sourceApi: 'chat' | 'replay', fetchOp: Promise<Response> | Response) {
+        const fireTelemetry = sourceApi === 'chat';
+        const response = await fetchOp;
+        if (!response.body) {
+            throw new Error("Error processing the Rovo Dev's response: response is empty.");
+        }
+
+        if (fireTelemetry) {
+            this._perfLogger.promptStarted(this._currentPromptId);
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        const parser =
+            sourceApi === 'replay' ? new RovoDevResponseParser({ mergeAllChunks: true }) : new RovoDevResponseParser();
+
+        let isFirstByte = true;
+        let isFirstMessage = true;
+
+        while (true) {
+            const { done, value } = await reader.read();
+
+            if (fireTelemetry && isFirstByte) {
+                this._perfLogger.promptFirstByteReceived(this._currentPromptId);
+                isFirstByte = false;
+            }
+
+            if (done) {
+                // last response of the stream -> fire performance telemetry event
+                if (fireTelemetry) {
+                    this._perfLogger.promptLastMessageReceived(this._currentPromptId);
+                }
+
+                for (const msg of parser.flush()) {
+                    await this.processRovoDevResponse(sourceApi, msg);
+                }
+                break;
+            }
+
+            const data = decoder.decode(value, { stream: true });
+            for (const msg of parser.parse(data)) {
+                if (fireTelemetry && isFirstMessage) {
+                    this._perfLogger.promptFirstMessageReceived(this._currentPromptId);
+                    isFirstMessage = false;
+                }
+
+                await this.processRovoDevResponse(sourceApi, msg);
+            }
+        }
+
+        // Send final complete message when stream ends
+        await this.completeChatResponse(sourceApi);
+    }
+
+    private completeChatResponse(sourceApi: 'replay' | 'chat' | 'error') {
+        // if (this._processState === RovoDevProcessState.Disabled) {
+        //     return Promise.resolve(false);
+        // }
+
+        const webview = this._webView!;
+        return webview.postMessage({
+            type: RovoDevProviderMessageType.CompleteMessage,
+            isReplay: sourceApi === 'replay',
+        });
+    }
+
+    private processRovoDevResponse(sourceApi: 'chat' | 'replay', response: RovoDevResponse): Thenable<boolean> {
+        // if (this._processState === RovoDevProcessState.Disabled) {
+        //     return Promise.resolve(false);
+        // }
+
+        const fireTelemetry = sourceApi === 'chat';
+        const webview = this._webView!;
+
+        switch (response.event_kind) {
+            case 'text':
+                return webview.postMessage({
+                    type: RovoDevProviderMessageType.Response,
+                    dataObject: response,
+                });
+
+            case 'tool-call':
+                return webview.postMessage({
+                    type: RovoDevProviderMessageType.ToolCall,
+                    dataObject: response,
+                });
+
+            case 'tool-return':
+                if (fireTelemetry && response.tool_name === 'create_technical_plan' && response.parsedContent) {
+                    this._perfLogger.promptTechnicalPlanReceived(this._currentPromptId);
+
+                    const parsedContent = response.parsedContent as TechnicalPlan;
+                    const stepsCount = parsedContent.logicalChanges.length;
+                    const filesCount = parsedContent.logicalChanges.reduce((p, c) => p + c.filesToChange.length, 0);
+                    const questionsCount = parsedContent.logicalChanges.reduce(
+                        (p, c) => p + c.filesToChange.reduce((p2, c2) => p2 + (c2.clarifyingQuestionIfAny ? 1 : 0), 0),
+                        0,
+                    );
+
+                    this._telemetryProvider.fireTelemetryEvent(
+                        'rovoDevTechnicalPlanningShownEvent',
+                        this._currentPromptId,
+                        stepsCount,
+                        filesCount,
+                        questionsCount,
+                    );
+                }
+                return webview.postMessage({
+                    type: RovoDevProviderMessageType.ToolReturn,
+                    dataObject: response,
+                    isReplay: sourceApi === 'replay',
+                });
+
+            case 'retry-prompt':
+                return webview.postMessage({
+                    type: RovoDevProviderMessageType.ToolReturn,
+                    dataObject: response,
+                });
+
+            case 'user-prompt':
+                if (this._replayInProgress) {
+                    const cleanedText = this.stripContextTags(response.content);
+                    this._currentPrompt = {
+                        text: cleanedText,
+                        enable_deep_plan: false,
+                    };
+                    return this.sendUserPromptToView(cleanedText);
+                }
+                return Promise.resolve(false);
+
+            case 'exception':
+                const msg = response.title ? `${response.title} - ${response.message}` : response.message;
+                return this.processError(new Error(msg), false);
+
+            case 'warning':
+                return webview.postMessage({
+                    type: RovoDevProviderMessageType.ErrorMessage,
+                    message: {
+                        type: 'warning',
+                        text: response.message,
+                        title: response.title,
+                        source: 'RovoDevError',
+                        isRetriable: false,
+                        uid: v4(),
+                    },
+                });
+
+            case 'clear':
+                return webview.postMessage({
+                    type: RovoDevProviderMessageType.ClearChat,
+                });
+
+            case 'prune':
+                return webview.postMessage({
+                    type: RovoDevProviderMessageType.ErrorMessage,
+                    message: {
+                        type: 'info',
+                        text: response.message,
+                        source: 'RovoDevError',
+                        isRetriable: false,
+                        uid: v4(),
+                    },
+                });
+
+            default:
+                return Promise.resolve(false);
+        }
+    }
+
+    private stripContextTags(text: string): string {
+        // Remove content between <context> and </context> tags (including the tags themselves)
+        // This regex handles multiline content and nested tags
+        let cleanedText = text.replace(/<context>[\s\S]*?<\/context>/gi, '');
+
+        // Clean up excessive whitespace that might be left behind
+        cleanedText = cleanedText.replace(/\n\s*\n\s*\n/g, '\n\n'); // Replace 3+ newlines with 2
+
+        return cleanedText.trim();
+    }
+
+    private async executeApiWithErrorHandling<T>(
+        func: (client: RovoDevApiClient) => Promise<T>,
+        isErrorRetriable: boolean,
+    ): Promise<T | void> {
+        if (this._rovoDevApiClient) {
+            try {
+                return await func(this._rovoDevApiClient);
+            } catch (error) {
+                await this.processError(error, isErrorRetriable);
+            }
+        } else {
+            await this.processError(new Error('RovoDev client not initialized'), false);
+        }
+    }
+
+    private processError(error: Error, isRetriable: boolean, isProcessTerminated?: boolean) {
+        Logger.error('RovoDev', error);
+
+        const webview = this._webView!;
+        return webview.postMessage({
+            type: RovoDevProviderMessageType.ErrorMessage,
+            message: {
+                type: 'error',
+                text: error.message,
+                source: 'RovoDevError',
+                isRetriable,
+                isProcessTerminated,
+                uid: v4(),
+            },
+        });
+    }
+
+    // ------------------------------------
+    //---- CHECK WHAT'S REALLY NEEDED HERE
+    // ------------------------------------
+
+    private async sendUserPromptToView(text: string, context?: RovoDevContext) {
+        const webview = this._webView!;
+
+        return await webview.postMessage({
+            type: RovoDevProviderMessageType.UserChatMessage,
+            message: {
+                text: text,
+                source: 'User',
+                context: context,
+            },
+        });
+    }
+
+    private async sendPromptSentToView(text: string, enable_deep_plan: boolean, context?: RovoDevContext) {
+        const webview = this._webView!;
+
+        return await webview.postMessage({
+            type: RovoDevProviderMessageType.PromptSent,
+            text,
+            enable_deep_plan,
+            context: context,
+        });
+    }
+
+    private addContextToPrompt(message: string, context?: RovoDevContext): string {
+        if (!context) {
+            return message;
+        }
+
+        let extra = '';
+        if (context.focusInfo && context.focusInfo.enabled && !context.focusInfo.invalid) {
+            extra += `
+            <context>
+                I have this open in editor:
+                    <name>${context.focusInfo.file.name}</name>
+                        <absolute_path>${context.focusInfo.file.absolutePath}</absolute_path>
+                        <relative_path>${context.focusInfo.file.relativePath}</relative_path>
+                        ${
+                            context.focusInfo.selection
+                                ? `<lines>${context.focusInfo.selection.start}-${context.focusInfo.selection.end}</lines>`
+                                : ''
+                        }
+                        Please avoid excessively repeating the context in the response.
+                </context>`;
+        }
+
+        if (context.contextItems && context.contextItems.length > 0) {
+            extra += `
+                <context>
+                    I have these additional context items:
+                    ${context.contextItems
+                        .map(
+                            (item) => `
+                        <item>
+                            <name>${item.file.name}</name>
+                            <absolute_path>${item.file.absolutePath}</absolute_path>
+                            <relative_path>${item.file.relativePath}</relative_path>
+                            ${item.selection ? `<lines>${item.selection.start}-${item.selection.end}</lines>` : ''}
+                        </item>`,
+                        )
+                        .join('\n')}
+                </context>`;
+        }
+
+        // Trim excessive whitespace:
+        extra = extra.replace(/\s+/g, ' ').trim();
+        return `${message}\n${extra}`.trim();
+    }
+
+    private addUndoContextToPrompt(message: string, revertedFiles: string[]): string {
+        if (revertedFiles.length) {
+            const files = revertedFiles.join('\n');
+            return `<context>
+    The following files have been reverted:
+    ${files}
+</context>
+            
+${message}`;
+        } else {
+            return message;
+        }
+    }
+
+    private addRetryAfterErrorContextToPrompt(message: string): string {
+        return `<context>The previous response interrupted prematurely because of an error. Continue processing the previous prompt from the point where it was interrupted.
+    <previous_prompt>${message}</previous_prompt>
+</context>`;
+    }
+}

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -68,8 +68,9 @@ export class RovoDevChatProvider {
 
         if (!suppressEcho) {
             await this.sendUserPromptToView(text, context);
-            await this.sendPromptSentToView(text, enable_deep_plan, context);
         }
+
+        await this.sendPromptSentToView(text, enable_deep_plan, context);
 
         if (!this._rovoDevApiClient) {
             this._pendingPrompt = { text, enable_deep_plan, context };

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -400,10 +400,6 @@ export class RovoDevChatProvider {
         });
     }
 
-    // ------------------------------------
-    //---- CHECK WHAT'S REALLY NEEDED HERE
-    // ------------------------------------
-
     private async sendUserPromptToView(text: string, context?: RovoDevContext) {
         const webview = this._webView!;
 

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -55,7 +55,7 @@ export class RovoDevChatProvider {
     private async internalExecuteChat(
         { text, enable_deep_plan, context }: RovoDevPrompt,
         revertedFiles: string[],
-        suppressEcho?: boolean,
+        flushingPendingPrompt: boolean,
     ) {
         if (!text) {
             return;
@@ -66,7 +66,7 @@ export class RovoDevChatProvider {
             context = undefined;
         }
 
-        if (!suppressEcho) {
+        if (!flushingPendingPrompt) {
             await this.sendUserPromptToView(text, context);
         }
 

--- a/src/rovo-dev/rovoDevTelemetryProvider.ts
+++ b/src/rovo-dev/rovoDevTelemetryProvider.ts
@@ -12,6 +12,7 @@ import {
     rovoDevStopActionEvent,
     rovoDevTechnicalPlanningShownEvent,
 } from '../../src/analytics';
+import { PerformanceLogger } from './performanceLogger';
 
 const rovoDevTelemetryEvents = {
     rovoDevFileChangedActionEvent,
@@ -40,10 +41,17 @@ export class RovoDevTelemetryProvider {
 
     private _firedTelemetryForCurrentPrompt: TelemetryRecord<boolean> = {};
 
+    private readonly _perfLogger: PerformanceLogger;
+    public get perfLogger() {
+        return this._perfLogger;
+    }
+
     constructor(
         private readonly rovoDevEnv: RovoDevEnv,
         private readonly appInstanceId: string,
-    ) {}
+    ) {
+        this._perfLogger = new PerformanceLogger(this.appInstanceId);
+    }
 
     public startNewSession(chatSessionId: string, manuallyCreated: boolean) {
         this._chatSessionId = chatSessionId;
@@ -51,6 +59,8 @@ export class RovoDevTelemetryProvider {
         this._firedTelemetryForCurrentPrompt = {};
 
         this.fireTelemetryEvent('rovoDevNewSessionActionEvent', manuallyCreated);
+
+        this.perfLogger.sessionStarted(this._chatSessionId);
     }
 
     public startNewPrompt(promptId: string) {

--- a/src/rovo-dev/rovoDevTelemetryProvider.ts
+++ b/src/rovo-dev/rovoDevTelemetryProvider.ts
@@ -1,0 +1,92 @@
+import { Container } from 'src/container';
+import { Logger } from 'src/logger';
+
+import {
+    rovoDevDetailsExpandedEvent,
+    RovoDevEnv,
+    rovoDevFileChangedActionEvent,
+    rovoDevFilesSummaryShownEvent,
+    rovoDevGitPushActionEvent,
+    rovoDevNewSessionActionEvent,
+    rovoDevPromptSentEvent,
+    rovoDevStopActionEvent,
+    rovoDevTechnicalPlanningShownEvent,
+} from '../../src/analytics';
+
+const rovoDevTelemetryEvents = {
+    rovoDevFileChangedActionEvent,
+    rovoDevFilesSummaryShownEvent,
+    rovoDevGitPushActionEvent,
+    rovoDevNewSessionActionEvent,
+    rovoDevPromptSentEvent,
+    rovoDevStopActionEvent,
+    rovoDevTechnicalPlanningShownEvent,
+    rovoDevDetailsExpandedEvent,
+};
+
+type ParametersSkip3<T extends (...args: any) => any> =
+    // eslint-disable-next-line no-unused-vars
+    Parameters<T> extends [infer _1, infer _2, infer _3, ...infer Rest] ? Rest : never;
+
+type TelemetryFunction = keyof typeof rovoDevTelemetryEvents;
+
+type TelemetryRecord<T> = {
+    [x in TelemetryFunction]?: T;
+};
+
+export class RovoDevTelemetryProvider {
+    private _chatSessionId: string = '';
+    private _currentPromptId: string = '';
+
+    private _firedTelemetryForCurrentPrompt: TelemetryRecord<boolean> = {};
+
+    constructor(
+        private readonly rovoDevEnv: RovoDevEnv,
+        private readonly appInstanceId: string,
+    ) {}
+
+    public startNewSession(chatSessionId: string, manuallyCreated: boolean) {
+        this._chatSessionId = chatSessionId;
+        this._currentPromptId = '';
+        this._firedTelemetryForCurrentPrompt = {};
+
+        this.fireTelemetryEvent('rovoDevNewSessionActionEvent', manuallyCreated);
+    }
+
+    public startNewPrompt(promptId: string) {
+        this._currentPromptId = promptId;
+        this._firedTelemetryForCurrentPrompt = {};
+    }
+
+    // This function esures that the same telemetry event is not sent twice for the same prompt
+    public fireTelemetryEvent<T extends TelemetryFunction>(
+        funcName: T,
+        ...params: ParametersSkip3<(typeof rovoDevTelemetryEvents)[T]>
+    ): void {
+        if (!this._chatSessionId) {
+            throw new Error('Unable to send Rovo Dev telemetry: ChatSessionId not initialized');
+        }
+        // rovoDevNewSessionActionEvent is the only event that doesn't need the promptId
+        if (funcName !== 'rovoDevNewSessionActionEvent' && !this._currentPromptId) {
+            throw new Error('Unable to send Rovo Dev telemetry: PromptId not initialized');
+        }
+
+        // the following events can be fired multiple times during the same prompt
+        delete this._firedTelemetryForCurrentPrompt['rovoDevFileChangedActionEvent'];
+
+        if (!this._firedTelemetryForCurrentPrompt[funcName]) {
+            this._firedTelemetryForCurrentPrompt[funcName] = true;
+
+            // add `rovoDevEnv` and `sessionId` as the first two arguments
+            params.unshift(this.rovoDevEnv, this.appInstanceId, this._chatSessionId);
+
+            const ret: ReturnType<(typeof rovoDevTelemetryEvents)[T]> = rovoDevTelemetryEvents[funcName].apply(
+                undefined,
+                params,
+            );
+            ret.then((evt) => Container.analyticsClient.sendTrackEvent(evt));
+
+            Logger.debug(`Event fired: ${funcName}(${params})`);
+        }
+    }
+}

--- a/src/rovo-dev/rovoDevTypes.ts
+++ b/src/rovo-dev/rovoDevTypes.ts
@@ -25,7 +25,7 @@ export type RovoDevContext = {
 
 export interface RovoDevPrompt {
     text: string;
-    enable_deep_plan?: boolean;
+    enable_deep_plan: boolean;
     context?: RovoDevContext;
 }
 

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -22,17 +22,6 @@ import {
     workspace,
 } from 'vscode';
 
-import {
-    rovoDevDetailsExpandedEvent,
-    RovoDevEnv,
-    rovoDevFileChangedActionEvent,
-    rovoDevFilesSummaryShownEvent,
-    rovoDevGitPushActionEvent,
-    rovoDevNewSessionActionEvent,
-    rovoDevPromptSentEvent,
-    rovoDevStopActionEvent,
-    rovoDevTechnicalPlanningShownEvent,
-} from '../../src/analytics';
 import { Container } from '../../src/container';
 import { Logger } from '../../src/logger';
 import { Commands, rovodevInfo } from '../constants';
@@ -44,39 +33,19 @@ import {
 import { GitErrorCodes } from '../typings/git';
 import { getHtmlForView } from '../webview/common/getHtmlForView';
 import { PerformanceLogger } from './performanceLogger';
-import { RovoDevResponse, RovoDevResponseParser } from './responseParser';
 import { RovoDevApiClient, RovoDevHealthcheckResponse } from './rovoDevApiClient';
+import { RovoDevChatProvider } from './rovoDevChatProvider';
 import { RovoDevFeedbackManager } from './rovoDevFeedbackManager';
 import { RovoDevProcessManager } from './rovoDevProcessManager';
 import { RovoDevPullRequestHandler } from './rovoDevPullRequestHandler';
-import { RovoDevContext, RovoDevContextItem, RovoDevInitState, RovoDevPrompt, TechnicalPlan } from './rovoDevTypes';
+import { RovoDevTelemetryProvider } from './rovoDevTelemetryProvider';
+import { RovoDevContext, RovoDevContextItem, RovoDevInitState } from './rovoDevTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from './rovoDevWebviewProviderMessages';
-
-type ParametersSkip3<T extends (...args: any) => any> =
-    // eslint-disable-next-line no-unused-vars
-    Parameters<T> extends [infer _1, infer _2, infer _3, ...infer Rest] ? Rest : never;
-
-type TelemetryFunction = keyof typeof rovoDevTelemetryEvents;
-
-type TelemetryRecord<T> = {
-    [x in TelemetryFunction]?: T;
-};
 
 interface TypedWebview<MessageOut, MessageIn> extends Webview {
     readonly onDidReceiveMessage: Event<MessageIn>;
     postMessage(message: MessageOut): Thenable<boolean>;
 }
-
-const rovoDevTelemetryEvents = {
-    rovoDevFileChangedActionEvent,
-    rovoDevFilesSummaryShownEvent,
-    rovoDevGitPushActionEvent,
-    rovoDevNewSessionActionEvent,
-    rovoDevPromptSentEvent,
-    rovoDevStopActionEvent,
-    rovoDevTechnicalPlanningShownEvent,
-    rovoDevDetailsExpandedEvent,
-};
 
 enum RovoDevProcessState {
     NotStarted,
@@ -92,7 +61,9 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private readonly appInstanceId: string;
 
     private readonly _prHandler: RovoDevPullRequestHandler | undefined;
-    private readonly _perfLogger = new PerformanceLogger();
+    private readonly _perfLogger: PerformanceLogger;
+    private readonly _telemetryProvider: RovoDevTelemetryProvider;
+    private readonly _chatProvider: RovoDevChatProvider;
 
     private _webView?: TypedWebview<RovoDevProviderMessage, RovoDevViewResponse>;
     private _rovoDevApiClient?: RovoDevApiClient;
@@ -100,12 +71,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private _initialized = false;
 
     private _chatSessionId: string = '';
-    private _currentPromptId: string = '';
-    private _currentPrompt: RovoDevPrompt | undefined;
-    private _pendingPrompt: RovoDevPrompt | undefined;
-    private _pendingCancellation = false;
-
-    private _firedTelemetryForCurrentPrompt: TelemetryRecord<boolean> = {};
 
     // we keep the data in this collection so we can attach some metadata to the next
     // prompt informing Rovo Dev that those files has been reverted
@@ -154,7 +119,12 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             this.appInstanceId = Container.appInstanceId;
         }
 
-        this._perfLogger.appInitialized(this.appInstanceId);
+        this._perfLogger = new PerformanceLogger(this.appInstanceId);
+        this._telemetryProvider = new RovoDevTelemetryProvider(
+            this.isBoysenberry ? 'Boysenberry' : 'IDE',
+            this.appInstanceId,
+        );
+        this._chatProvider = new RovoDevChatProvider(this._perfLogger, this._telemetryProvider);
     }
 
     public resolveWebviewView(
@@ -162,8 +132,10 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         _context: WebviewViewResolveContext,
         _token: CancellationToken,
     ): Thenable<void> | void {
-        this._webView = webviewView.webview;
-        const webview = this._webView;
+        const webview = webviewView.webview;
+        this._webView = webview;
+
+        this._chatProvider.setWebview(webview);
 
         webview.options = {
             enableCommandUris: true,
@@ -190,12 +162,14 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             try {
                 switch (e.type) {
                     case RovoDevViewResponseType.Prompt:
-                        await this.executeChat(e);
+                        const revertedChanges = this._revertedChanges;
+                        this._revertedChanges = [];
+                        await this._chatProvider.executeChat(e, revertedChanges);
                         break;
 
                     case RovoDevViewResponseType.CancelResponse:
-                        if (!this._pendingCancellation) {
-                            await this.executeCancel(false);
+                        if (!this._chatProvider.pendingCancellation) {
+                            await this._chatProvider.executeCancel(false);
                         }
                         break;
 
@@ -216,7 +190,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         break;
 
                     case RovoDevViewResponseType.RetryPromptAfterError:
-                        await this.executeRetryPromptAfterError();
+                        await this._chatProvider.executeRetryPromptAfterError();
                         break;
 
                     case RovoDevViewResponseType.GetCurrentBranchName:
@@ -232,13 +206,17 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         break;
 
                     case RovoDevViewResponseType.ReportChangedFilesPanelShown:
-                        this.fireTelemetryEvent('rovoDevFilesSummaryShownEvent', this._currentPromptId, e.filesCount);
+                        this._telemetryProvider.fireTelemetryEvent(
+                            'rovoDevFilesSummaryShownEvent',
+                            this._chatProvider.currentPromptId,
+                            e.filesCount,
+                        );
                         break;
 
                     case RovoDevViewResponseType.ReportChangesGitPushed:
-                        this.fireTelemetryEvent(
+                        this._telemetryProvider.fireTelemetryEvent(
                             'rovoDevGitPushActionEvent',
-                            this._currentPromptId,
+                            this._chatProvider.currentPromptId,
                             e.pullRequestCreated,
                         );
                         break;
@@ -253,7 +231,10 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         break;
 
                     case RovoDevViewResponseType.ReportThinkingDrawerExpanded:
-                        this.fireTelemetryEvent('rovoDevDetailsExpandedEvent', this._currentPromptId);
+                        this._telemetryProvider.fireTelemetryEvent(
+                            'rovoDevDetailsExpandedEvent',
+                            this._chatProvider.currentPromptId,
+                        );
                         break;
 
                     case RovoDevViewResponseType.WebviewReady:
@@ -307,45 +288,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private beginNewSession(sessionId: string | null | undefined, manuallyCreated: boolean): void {
         this._chatSessionId = sessionId ?? v4();
         this._perfLogger.sessionStarted(this._chatSessionId);
-        this.fireTelemetryEvent('rovoDevNewSessionActionEvent', manuallyCreated);
-    }
-
-    private beginNewPrompt(overrideId?: string): void {
-        this._currentPromptId = overrideId || v4();
-        this._firedTelemetryForCurrentPrompt = {};
-    }
-
-    // This function esures that the same telemetry event is not sent twice for the same prompt
-    private fireTelemetryEvent<T extends TelemetryFunction>(
-        funcName: T,
-        ...params: ParametersSkip3<(typeof rovoDevTelemetryEvents)[T]>
-    ): void {
-        if (!this._chatSessionId) {
-            throw new Error('Unable to send Rovo Dev telemetry: ChatSessionId not initialized');
-        }
-        // rovoDevNewSessionActionEvent is the only event that doesn't need the promptId
-        if (funcName !== 'rovoDevNewSessionActionEvent' && !this._currentPromptId) {
-            throw new Error('Unable to send Rovo Dev telemetry: PromptId not initialized');
-        }
-
-        // the following events can be fired multiple times during the same prompt
-        delete this._firedTelemetryForCurrentPrompt['rovoDevFileChangedActionEvent'];
-
-        if (!this._firedTelemetryForCurrentPrompt[funcName]) {
-            this._firedTelemetryForCurrentPrompt[funcName] = true;
-
-            // add `rovoDevEnv` and `sessionId` as the first two arguments
-            const rovoDevEnv: RovoDevEnv = this.isBoysenberry ? 'Boysenberry' : 'IDE';
-            params.unshift(rovoDevEnv, this.appInstanceId, this._chatSessionId);
-
-            const ret: ReturnType<(typeof rovoDevTelemetryEvents)[T]> = rovoDevTelemetryEvents[funcName].apply(
-                undefined,
-                params,
-            );
-            ret.then((evt) => Container.analyticsClient.sendTrackEvent(evt));
-
-            Logger.debug(`Event fired: ${funcName}(${params})`);
-        }
+        this._telemetryProvider.startNewSession(this._chatSessionId, manuallyCreated);
     }
 
     // Helper to get openFile info from a document
@@ -415,72 +358,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         );
     }
 
-    private async processChatResponse(sourceApi: 'chat' | 'replay', fetchOp: Promise<Response> | Response) {
-        const fireTelemetry = sourceApi === 'chat';
-        const response = await fetchOp;
-        if (!response.body) {
-            throw new Error("Error processing the Rovo Dev's response: response is empty.");
-        }
-
-        if (fireTelemetry) {
-            this._perfLogger.promptStarted(this._currentPromptId);
-        }
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        const parser =
-            sourceApi === 'replay' ? new RovoDevResponseParser({ mergeAllChunks: true }) : new RovoDevResponseParser();
-
-        let isFirstByte = true;
-        let isFirstMessage = true;
-
-        while (true) {
-            const { done, value } = await reader.read();
-
-            if (fireTelemetry && isFirstByte) {
-                this._perfLogger.promptFirstByteReceived(this._currentPromptId);
-                isFirstByte = false;
-            }
-
-            if (done) {
-                // last response of the stream -> fire performance telemetry event
-                if (fireTelemetry) {
-                    this._perfLogger.promptLastMessageReceived(this._currentPromptId);
-                }
-
-                for (const msg of parser.flush()) {
-                    await this.processRovoDevResponse(sourceApi, msg);
-                }
-                break;
-            }
-
-            const data = decoder.decode(value, { stream: true });
-            for (const msg of parser.parse(data)) {
-                if (fireTelemetry && isFirstMessage) {
-                    this._perfLogger.promptFirstMessageReceived(this._currentPromptId);
-                    isFirstMessage = false;
-                }
-
-                await this.processRovoDevResponse(sourceApi, msg);
-            }
-        }
-
-        // Send final complete message when stream ends
-        await this.completeChatResponse(sourceApi);
-    }
-
-    private completeChatResponse(sourceApi: 'replay' | 'chat' | 'error') {
-        if (this._processState === RovoDevProcessState.Disabled) {
-            return Promise.resolve(false);
-        }
-
-        const webview = this._webView!;
-        return webview.postMessage({
-            type: RovoDevProviderMessageType.CompleteMessage,
-            isReplay: sourceApi === 'replay',
-        });
-    }
-
     private processError(
         error: Error & { gitErrorCode?: GitErrorCodes },
         isRetriable: boolean,
@@ -500,286 +377,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                 uid: v4(),
             },
         });
-    }
-
-    private async sendUserPromptToView({ text, enable_deep_plan, context }: RovoDevPrompt) {
-        const webview = this._webView!;
-
-        return await webview.postMessage({
-            type: RovoDevProviderMessageType.UserChatMessage,
-            message: {
-                text: text,
-                source: 'User',
-                context: context,
-            },
-        });
-    }
-
-    private async sendPromptSentToView({ text, enable_deep_plan, context }: RovoDevPrompt) {
-        const webview = this._webView!;
-
-        return await webview.postMessage({
-            type: RovoDevProviderMessageType.PromptSent,
-            text,
-            enable_deep_plan,
-            context: context,
-        });
-    }
-
-    private processRovoDevResponse(sourceApi: 'chat' | 'replay', response: RovoDevResponse): Thenable<boolean> {
-        const fireTelemetry = sourceApi === 'chat';
-        const webview = this._webView!;
-
-        if (this._processState === RovoDevProcessState.Disabled) {
-            return Promise.resolve(false);
-        }
-
-        switch (response.event_kind) {
-            case 'text':
-                return webview.postMessage({
-                    type: RovoDevProviderMessageType.Response,
-                    dataObject: response,
-                });
-
-            case 'tool-call':
-                return webview.postMessage({
-                    type: RovoDevProviderMessageType.ToolCall,
-                    dataObject: response,
-                });
-
-            case 'tool-return':
-                if (fireTelemetry && response.tool_name === 'create_technical_plan' && response.parsedContent) {
-                    this._perfLogger.promptTechnicalPlanReceived(this._currentPromptId);
-
-                    const parsedContent = response.parsedContent as TechnicalPlan;
-                    const stepsCount = parsedContent.logicalChanges.length;
-                    const filesCount = parsedContent.logicalChanges.reduce((p, c) => p + c.filesToChange.length, 0);
-                    const questionsCount = parsedContent.logicalChanges.reduce(
-                        (p, c) => p + c.filesToChange.reduce((p2, c2) => p2 + (c2.clarifyingQuestionIfAny ? 1 : 0), 0),
-                        0,
-                    );
-
-                    this.fireTelemetryEvent(
-                        'rovoDevTechnicalPlanningShownEvent',
-                        this._currentPromptId,
-                        stepsCount,
-                        filesCount,
-                        questionsCount,
-                    );
-                }
-                return webview.postMessage({
-                    type: RovoDevProviderMessageType.ToolReturn,
-                    dataObject: response,
-                    isReplay: sourceApi === 'replay',
-                });
-
-            case 'retry-prompt':
-                return webview.postMessage({
-                    type: RovoDevProviderMessageType.ToolReturn,
-                    dataObject: response,
-                });
-
-            case 'user-prompt':
-                // receiving a user-prompt pre-initialized means we are in the 'replay' response
-                if (!this._initialized) {
-                    const cleanedText = this.stripContextTags(response.content);
-                    this._currentPrompt = {
-                        text: cleanedText,
-                        // TODO: content is not restored here at the moment, so we'll just render all prompts as they were submitted
-                    };
-                    return this.sendUserPromptToView({ text: cleanedText });
-                }
-                return Promise.resolve(false);
-
-            case 'exception':
-                const msg = response.title ? `${response.title} - ${response.message}` : response.message;
-                return this.processError(new Error(msg), false);
-
-            case 'warning':
-                return webview.postMessage({
-                    type: RovoDevProviderMessageType.ErrorMessage,
-                    message: {
-                        type: 'warning',
-                        text: response.message,
-                        title: response.title,
-                        source: 'RovoDevError',
-                        isRetriable: false,
-                        uid: v4(),
-                    },
-                });
-
-            case 'clear':
-                return webview.postMessage({
-                    type: RovoDevProviderMessageType.ClearChat,
-                });
-
-            case 'prune':
-                return webview.postMessage({
-                    type: RovoDevProviderMessageType.ErrorMessage,
-                    message: {
-                        type: 'info',
-                        text: response.message,
-                        source: 'RovoDevError',
-                        isRetriable: false,
-                        uid: v4(),
-                    },
-                });
-
-            default:
-                return Promise.resolve(false);
-        }
-    }
-
-    private stripContextTags(text: string): string {
-        // Remove content between <context> and </context> tags (including the tags themselves)
-        // This regex handles multiline content and nested tags
-        let cleanedText = text.replace(/<context>[\s\S]*?<\/context>/gi, '');
-
-        // Clean up excessive whitespace that might be left behind
-        cleanedText = cleanedText.replace(/\n\s*\n\s*\n/g, '\n\n'); // Replace 3+ newlines with 2
-
-        return cleanedText.trim();
-    }
-
-    private addContextToPrompt(message: string, context?: RovoDevContext): string {
-        if (!context) {
-            return message;
-        }
-
-        let extra = '';
-        if (context.focusInfo && context.focusInfo.enabled && !context.focusInfo.invalid) {
-            extra += `
-            <context>
-                I have this open in editor:
-                    <name>${context.focusInfo.file.name}</name>
-                        <absolute_path>${context.focusInfo.file.absolutePath}</absolute_path>
-                        <relative_path>${context.focusInfo.file.relativePath}</relative_path>
-                        ${
-                            context.focusInfo.selection
-                                ? `<lines>${context.focusInfo.selection.start}-${context.focusInfo.selection.end}</lines>`
-                                : ''
-                        }
-                        Please avoid excessively repeating the context in the response.
-                </context>`;
-        }
-
-        if (context.contextItems && context.contextItems.length > 0) {
-            extra += `
-                <context>
-                    I have these additional context items:
-                    ${context.contextItems
-                        .map(
-                            (item) => `
-                        <item>
-                            <name>${item.file.name}</name>
-                            <absolute_path>${item.file.absolutePath}</absolute_path>
-                            <relative_path>${item.file.relativePath}</relative_path>
-                            ${item.selection ? `<lines>${item.selection.start}-${item.selection.end}</lines>` : ''}
-                        </item>`,
-                        )
-                        .join('\n')}
-                </context>`;
-        }
-
-        // Trim excessive whitespace:
-        extra = extra.replace(/\s+/g, ' ').trim();
-        return `${message}\n${extra}`.trim();
-    }
-
-    private addUndoContextToPrompt(message: string): string {
-        if (this._revertedChanges.length) {
-            const files = this._revertedChanges.join('\n');
-            this._revertedChanges = [];
-            return `<context>
-    The following files have been reverted:
-    ${files}
-</context>
-            
-${message}`;
-        } else {
-            return message;
-        }
-    }
-
-    private addRetryAfterErrorContextToPrompt(message: string): string {
-        return `<context>The previous response interrupted prematurely because of an error. Continue processing the previous prompt from the point where it was interrupted.
-    <previous_prompt>${message}</previous_prompt>
-</context>`;
-    }
-
-    private async executeChat({ text, enable_deep_plan, context }: RovoDevPrompt, suppressEcho?: boolean) {
-        if (!text) {
-            return;
-        }
-
-        const isCommand = text.trim() === '/clear' || text.trim() === '/prune';
-
-        if (!suppressEcho) {
-            await this.sendUserPromptToView({ text, enable_deep_plan, context: isCommand ? undefined : context });
-        }
-
-        this.beginNewPrompt();
-
-        this._currentPrompt = {
-            text,
-            enable_deep_plan,
-            context,
-        };
-
-        await this.sendPromptSentToView({ text, enable_deep_plan, context: isCommand ? undefined : context });
-
-        let payloadToSend = text;
-        if (!isCommand) {
-            payloadToSend = this.addUndoContextToPrompt(payloadToSend);
-            payloadToSend = this.addContextToPrompt(payloadToSend, context);
-        }
-
-        const currentPrompt = this._currentPrompt;
-        const fetchOp = async (client: RovoDevApiClient) => {
-            const response = await client.chat(payloadToSend, enable_deep_plan);
-
-            this.fireTelemetryEvent('rovoDevPromptSentEvent', this._currentPromptId, !!currentPrompt.enable_deep_plan);
-
-            return this.processChatResponse('chat', response);
-        };
-
-        if (this._initialized) {
-            await this.executeApiWithErrorHandling(fetchOp, true);
-        } else {
-            this._pendingPrompt = {
-                text: payloadToSend,
-                enable_deep_plan,
-                context,
-            };
-        }
-    }
-
-    private async executeRetryPromptAfterError() {
-        if (!this._initialized || !this._currentPrompt) {
-            return;
-        }
-
-        this.beginNewPrompt();
-
-        const currentPrompt = this._currentPrompt;
-        const payloadToSend = this.addRetryAfterErrorContextToPrompt(currentPrompt.text);
-
-        // we need to echo back the prompt to the View since it's not user submitted
-        await this.sendPromptSentToView({
-            text: payloadToSend,
-            enable_deep_plan: currentPrompt.enable_deep_plan,
-            context: currentPrompt.context,
-        });
-
-        const fetchOp = async (client: RovoDevApiClient) => {
-            const response = await client.chat(payloadToSend, currentPrompt.enable_deep_plan);
-
-            this.fireTelemetryEvent('rovoDevPromptSentEvent', this._currentPromptId, !!currentPrompt.enable_deep_plan);
-
-            return this.processChatResponse('chat', response);
-        };
-
-        await this.executeApiWithErrorHandling(fetchOp, true);
     }
 
     private async addContextItem(contextItem: RovoDevContextItem): Promise<void> {
@@ -866,7 +463,12 @@ ${message}`;
         }
 
         // new session is a no-op if there are no folders opened or if the process is not initialized
-        if (this.isDisabled || !workspace.workspaceFolders?.length || !this._initialized || this._pendingCancellation) {
+        if (
+            this.isDisabled ||
+            !workspace.workspaceFolders?.length ||
+            !this._initialized ||
+            this._chatProvider.pendingCancellation
+        ) {
             return;
         }
 
@@ -876,7 +478,7 @@ ${message}`;
                 type: RovoDevProviderMessageType.ForceStop,
             });
             try {
-                const cancelled = await this.executeCancel(true);
+                const cancelled = await this._chatProvider.executeCancel(true);
                 if (!cancelled) {
                     return;
                 }
@@ -892,43 +494,6 @@ ${message}`;
             });
 
             return this.beginNewSession(sessionId, true);
-        }, false);
-    }
-
-    private async executeCancel(fromNewSession: boolean): Promise<boolean> {
-        const webview = this._webView!;
-
-        if (this._pendingCancellation) {
-            throw new Error('Cancellation already in progress');
-        }
-        this._pendingCancellation = true;
-
-        const cancelResponse = await this.executeApiWithErrorHandling((client) => client.cancel(), false);
-
-        this._pendingCancellation = false;
-
-        const success =
-            !!cancelResponse && (cancelResponse.cancelled || cancelResponse.message === 'No chat in progress');
-
-        if (!fromNewSession) {
-            this.fireTelemetryEvent('rovoDevStopActionEvent', this._currentPromptId, success ? undefined : true);
-        }
-
-        if (!success) {
-            await webview.postMessage({
-                type: RovoDevProviderMessageType.CancelFailed,
-            });
-        }
-
-        return success;
-    }
-
-    private async executeReplay(): Promise<void> {
-        this.beginNewPrompt('replay');
-        await this.sendPromptSentToView({ text: '', enable_deep_plan: false, context: undefined });
-
-        await this.executeApiWithErrorHandling(async (client) => {
-            return this.processChatResponse('replay', client.replay());
         }, false);
     }
 
@@ -1029,7 +594,12 @@ ${message}`;
         const paths = files.map((x) => x.filePath);
         this._revertedChanges.push(...paths);
 
-        this.fireTelemetryEvent('rovoDevFileChangedActionEvent', this._currentPromptId, 'undo', files.length);
+        this._telemetryProvider.fireTelemetryEvent(
+            'rovoDevFileChangedActionEvent',
+            this._chatProvider.currentPromptId,
+            'undo',
+            files.length,
+        );
     }
 
     private async executeKeepFiles(files: ModifiedFile[]) {
@@ -1040,7 +610,12 @@ ${message}`;
 
         await Promise.all(promises);
 
-        this.fireTelemetryEvent('rovoDevFileChangedActionEvent', this._currentPromptId, 'keep', files.length);
+        this._telemetryProvider.fireTelemetryEvent(
+            'rovoDevFileChangedActionEvent',
+            this._chatProvider.currentPromptId,
+            'keep',
+            files.length,
+        );
     }
 
     public async executeTriggerFeedback() {
@@ -1101,6 +676,7 @@ ${message}`;
             await this.processError(e, false);
         }
     }
+
     private async executeApiWithErrorHandling<T>(
         func: (client: RovoDevApiClient) => Promise<T>,
         isErrorRetriable: boolean,
@@ -1132,7 +708,9 @@ ${message}`;
         }
 
         // Actually invoke the rovodev service, feed responses to the webview as normal
-        await this.executeChat({ text: prompt, context }, false);
+        const revertedChanges = this._revertedChanges;
+        this._revertedChanges = [];
+        await this._chatProvider.executeChat({ text: prompt, enable_deep_plan: false, context }, revertedChanges);
     }
 
     /**
@@ -1237,6 +815,7 @@ ${message}`;
             500,
             () => !this.rovoDevApiClient,
         );
+
         if (!this._rovoDevApiClient) {
             return;
         }
@@ -1250,7 +829,7 @@ ${message}`;
 
                 this.beginNewSession(sessionId, false);
                 if (this.isBoysenberry) {
-                    await this.executeReplay();
+                    await this._chatProvider.executeReplay();
                 }
             } else {
                 throw new Error(
@@ -1272,13 +851,7 @@ ${message}`;
         if (thrownError) {
             await this.processError(thrownError, false);
         } else {
-            // re-send the buffered prompt
-            if (this._pendingPrompt) {
-                const pendingPrompt = this._pendingPrompt;
-                this._pendingPrompt = undefined;
-
-                await this.executeChat(pendingPrompt, true);
-            }
+            await this._chatProvider.setReady(this._rovoDevApiClient);
         }
 
         // extra sanity checks here


### PR DESCRIPTION
### What Is This Change?

The Rovo Dev webview provider grew too big to be properly maintainable.

This change extracts from it:
- the chat management, including replay and cancellations, into `RovoDevChatProvider`
- the telemetry code, into `RovoDevTelemetryProvider`

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`