### PR TITLE
AXON-1056: RovoDev: URLs in the chat should be clickable

### DIFF
--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -12,6 +12,7 @@ export const mdParser = new MarkdownIt({
     html: true,
     breaks: true,
     typographer: true,
+    linkify: true,
 });
 
 export interface OpenFileFunc {


### PR DESCRIPTION
### What Is This Change?

**Before**:
<img width="791" height="938" alt="image" src="https://github.com/user-attachments/assets/8efacdfd-2ba7-467d-ae97-3b138760d30e" />

**After**:
https://www.loom.com/share/3ce69f63c7bf4799be30f42ed7cf0c0d

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change