### PR TITLE
AXON-1011 - reset Start Plan button on response finalization, error, and cancellation

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -100,6 +100,9 @@ const RovoDevView: React.FC = () => {
         if (currentMessage) {
             setChatStream((prev) => [...prev, currentMessage]);
         }
+        if (isDeepPlanCreated) {
+            setIsDeepPlanCreated(false);
+        }
         setCurrentMessage(null);
 
         const changedFilesCount = totalModifiedFiles.filter(
@@ -122,6 +125,7 @@ const RovoDevView: React.FC = () => {
         curThinkingMessages,
         currentMessage,
         totalModifiedFiles,
+        isDeepPlanCreated,
     ]);
 
     const handleAppendError = useCallback(
@@ -141,12 +145,15 @@ const RovoDevView: React.FC = () => {
             else if (currentState === State.WaitingForPrompt) {
                 finalizeResponse();
             }
+            if (isDeepPlanCreated) {
+                setIsDeepPlanCreated(false);
+            }
             setChatStream((prev) => {
                 setRetryAfterErrorEnabled(msg.isRetriable ? msg.uid : '');
                 return [...prev, msg];
             });
         },
-        [curThinkingMessages, currentMessage, currentState, finalizeResponse],
+        [curThinkingMessages, currentMessage, currentState, finalizeResponse, isDeepPlanCreated],
     );
 
     const validateResponseFinalized = useCallback(() => {
@@ -626,12 +633,15 @@ const RovoDevView: React.FC = () => {
         }
 
         setCurrentState(State.CancellingResponse);
+        if (isDeepPlanCreated) {
+            setIsDeepPlanCreated(false);
+        }
 
         // Send the signal to cancel the response
         postMessage({
             type: RovoDevViewResponseType.CancelResponse,
         });
-    }, [postMessage, currentState, setCurrentState]);
+    }, [postMessage, currentState, setCurrentState, isDeepPlanCreated]);
 
     const openFile = useCallback(
         (filePath: string, tryShowDiff?: boolean, range?: number[]) => {


### PR DESCRIPTION
### What Is This Change?

Cleaned up deep plan state on:

- finalizeResponse
- handleAppendError
- cancelResponse

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change