### PR TITLE
[AXON-803, AXON-1062] Expose Rovo Dev commands in the view's context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -629,8 +629,24 @@
                     "group": "navigation@2"
                 },
                 {
+                    "command": "atlascode.openRovoDevConfig",
+                    "when": "view == atlascode.views.rovoDev.webView",
+                    "group": "rovoDevContextMenu1@1"
+                },
+                {
+                    "command": "atlascode.openRovoDevGlobalMemory",
+                    "when": "view == atlascode.views.rovoDev.webView",
+                    "group": "rovoDevContextMenu1@2"
+                },
+                {
+                    "command": "atlascode.openRovoDevMcpJson",
+                    "when": "view == atlascode.views.rovoDev.webView",
+                    "group": "rovoDevContextMenu1@3"
+                },
+                {
                     "command": "atlascode.rovodev.shareFeedback",
-                    "when": "view == atlascode.views.rovoDev.webView"
+                    "when": "view == atlascode.views.rovoDev.webView",
+                    "group": "rovoDevContextMenu2@1"
                 },
                 {
                     "command": "atlascode.jira.createIssue",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,6 +26,7 @@ import { Logger } from './logger';
 import { AuthenticationType } from './onboarding/quickFlow/authentication/types';
 import { RovoDevProcessManager } from './rovo-dev/rovoDevProcessManager';
 import { RovoDevContext } from './rovo-dev/rovoDevTypes';
+import { openRovoDevConfigFile } from './rovo-dev/rovoDevUtils';
 import { Experiments, Features } from './util/featureFlags';
 import { AbstractBaseNode } from './views/nodes/abstractBaseNode';
 import { IssueNode } from './views/nodes/issueNode';
@@ -492,8 +493,6 @@ export function registerRovoDevCommands(vscodeContext: ExtensionContext) {
             }
             Container.rovodevWebviewProvider.invokeRovoDevAskCommand(prompt, context);
         }),
-    );
-    vscodeContext.subscriptions.push(
         commands.registerCommand(Commands.RovodevAsk, (prompt: string, context?: RovoDevContext) => {
             Container.rovodevWebviewProvider.invokeRovoDevAskCommand(prompt, context);
         }),
@@ -504,8 +503,6 @@ export function registerRovoDevCommands(vscodeContext: ExtensionContext) {
         commands.registerCommand(Commands.RovodevShareFeedback, () =>
             Container.rovodevWebviewProvider.executeTriggerFeedback(),
         ),
-    );
-    vscodeContext.subscriptions.push(
         commands.registerCommand(Commands.RovodevAddToContext, async () => {
             const context = buildContext(window.activeTextEditor, vscodeContext);
             if (!context || !context.contextItems || context.contextItems.length === 0) {
@@ -516,6 +513,15 @@ export function registerRovoDevCommands(vscodeContext: ExtensionContext) {
             context.contextItems.forEach((item) => {
                 Container.rovodevWebviewProvider.addToContext(item);
             });
+        }),
+        commands.registerCommand(Commands.OpenRovoDevConfig, async () => {
+            await openRovoDevConfigFile('.rovodev/config.yml', 'Rovo Dev settings file');
+        }),
+        commands.registerCommand(Commands.OpenRovoDevMcpJson, async () => {
+            await openRovoDevConfigFile('.rovodev/mcp.json', 'Rovo Dev MCP configuration');
+        }),
+        commands.registerCommand(Commands.OpenRovoDevGlobalMemory, async () => {
+            await openRovoDevConfigFile('.rovodev/.agent.md', 'Rovo Dev Global Memory file');
         }),
     );
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -16,7 +16,6 @@ import { CommandContext, setCommandContext } from './commandContext';
 import { registerDebugCommands } from './commands';
 import { openPullRequest } from './commands/bitbucket/pullRequest';
 import { configuration, IConfig } from './config/configuration';
-import { Commands } from './constants';
 import { PmfStats } from './feedback/pmfStats';
 import { JQLManager } from './jira/jqlManager';
 import { JiraProjectManager } from './jira/projectManager';
@@ -308,7 +307,6 @@ export class Container {
                         providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],
                     }),
                     (this._rovodevWebviewProvider = new RovoDevWebviewProvider(context, context.extensionPath)),
-                    this.configureRovodevSettingsCommands(context),
                 );
 
                 context.subscriptions.push(this._rovodevDisposable);
@@ -363,38 +361,6 @@ export class Container {
                 factory.updateFeatureMetadata();
             }
         }
-    }
-
-    static configureRovodevSettingsCommands(context: ExtensionContext) {
-        async function openConfigFile(subPath: string, friendlyName: string) {
-            const home = process.env.HOME || process.env.USERPROFILE;
-            if (!home) {
-                vscode.window.showErrorMessage('Could not determine home directory.');
-                return;
-            }
-            const filePath = `${home}/${subPath}`;
-            try {
-                const doc = await workspace.openTextDocument(filePath);
-                await vscode.window.showTextDocument(doc);
-            } catch (err) {
-                vscode.window.showErrorMessage(`Could not open ${friendlyName} (${filePath}): ${err}`);
-            }
-        }
-
-        const disposable = vscode.Disposable.from(
-            vscode.commands.registerCommand(Commands.OpenRovoDevConfig, async () => {
-                await openConfigFile('.rovodev/config.yml', 'Rovo Dev settings file');
-            }),
-            vscode.commands.registerCommand(Commands.OpenRovoDevMcpJson, async () => {
-                await openConfigFile('.rovodev/mcp.json', 'Rovo Dev MCP configuration');
-            }),
-            vscode.commands.registerCommand(Commands.OpenRovoDevGlobalMemory, async () => {
-                await openConfigFile('.rovodev/.agent.md', 'Rovo Dev Global Memory file');
-            }),
-        );
-        context.subscriptions.push(disposable);
-
-        return disposable;
     }
 
     static focus() {

--- a/src/rovo-dev/rovoDevUtils.ts
+++ b/src/rovo-dev/rovoDevUtils.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs';
+import { window, workspace } from 'vscode';
+
+export type SupportedConfigFiles = '.rovodev/config.yml' | '.rovodev/mcp.json' | '.rovodev/.agent.md';
+
+export async function openRovoDevConfigFile(configFile: SupportedConfigFiles, friendlyName: string) {
+    const home = process.env.HOME || process.env.USERPROFILE;
+    if (!home) {
+        window.showErrorMessage('Could not determine home directory.');
+        return;
+    }
+
+    const filePath = `${home}/${configFile}`;
+
+    // create the file if it doesn't exist
+    if (!fs.existsSync(filePath)) {
+        switch (configFile) {
+            case '.rovodev/mcp.json':
+                fs.writeFileSync(filePath, '{\n    "mcpServers": {}\n}', { flush: true });
+                break;
+            case '.rovodev/.agent.md':
+                fs.writeFileSync(filePath, '', { flush: true });
+                break;
+        }
+    }
+
+    try {
+        const doc = await workspace.openTextDocument(filePath);
+        await window.showTextDocument(doc);
+    } catch (err) {
+        window.showErrorMessage(`Could not open ${friendlyName} (${filePath}): ${err}`);
+    }
+}


### PR DESCRIPTION
### What Is This Change?

<img width="565" height="155" alt="image" src="https://github.com/user-attachments/assets/4ba201d7-dd95-427b-a9ff-e44ab03a0354" />

Also, if the `mcp.json` or the .memory.md` file don't exist, it creates them.

The `config.yml` file is not being auto-created as
- it's supposed to be already there if Rovo Dev has been started
- its default state cannot be determined by Atlascode

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`