### PR TITLE
[AXON-1072] Refactoring of Rovo Dev view currentState, fixed disappearing prompt after download

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ],
     "main": "./build/extension/extension",
     "rovoDev": {
-        "version": "0.11.16"
+        "version": "0.11.18"
     },
     "scripts": {
         "vscode:uninstall": "node ./build/extension/uninstall.js",

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.test.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.test.tsx
@@ -33,13 +33,13 @@ jest.mock('monaco-editor', () => ({
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { State } from 'src/rovo-dev/rovoDevTypes';
+import { DisabledState, State } from 'src/rovo-dev/rovoDevTypes';
 
 import { PromptInputBox } from './PromptInput';
 
 describe('PromptInputBox', () => {
     const defaultProps = {
-        state: State.WaitingForPrompt,
+        currentState: { state: 'WaitingForPrompt' } as Exclude<State, DisabledState>,
         promptText: '',
         onPromptTextChange: jest.fn(),
         isDeepPlanEnabled: false,
@@ -63,7 +63,7 @@ describe('PromptInputBox', () => {
     });
 
     it('renders Stop button when state is not WaitingForPrompt', () => {
-        render(<PromptInputBox {...defaultProps} state={State.GeneratingResponse} />);
+        render(<PromptInputBox {...defaultProps} currentState={{ state: 'GeneratingResponse' }} />);
         expect(screen.getByLabelText('Stop')).toBeTruthy();
     });
 
@@ -74,7 +74,7 @@ describe('PromptInputBox', () => {
     });
 
     it('calls onCancel when Stop button is clicked', () => {
-        render(<PromptInputBox {...defaultProps} state={State.GeneratingResponse} />);
+        render(<PromptInputBox {...defaultProps} currentState={{ state: 'GeneratingResponse' }} />);
         fireEvent.click(screen.getByLabelText('Stop'));
         expect(defaultProps.onCancel).toHaveBeenCalled();
     });
@@ -86,7 +86,7 @@ describe('PromptInputBox', () => {
     });
 
     it('disables Stop button when state is CancellingResponse', () => {
-        render(<PromptInputBox {...defaultProps} state={State.CancellingResponse} />);
+        render(<PromptInputBox {...defaultProps} currentState={{ state: 'CancellingResponse' }} />);
         fireEvent.click(screen.getByLabelText('Stop'));
         expect(defaultProps.onCancel).toHaveBeenCalledTimes(0);
     });
@@ -98,7 +98,7 @@ describe('PromptInputBox', () => {
     });
 
     it('disables deep plan button when state is not WaitingForPrompt', () => {
-        render(<PromptInputBox {...defaultProps} state={State.GeneratingResponse} />);
+        render(<PromptInputBox {...defaultProps} currentState={{ state: 'GeneratingResponse' }} />);
         fireEvent.click(screen.getAllByRole('button', { name: '' })[1]);
         expect(defaultProps.onDeepPlanToggled).toHaveBeenCalledTimes(0);
     });

--- a/src/react/atlascode/rovo-dev/rovoDevLanding.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevLanding.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SubState } from 'src/rovo-dev/rovoDevTypes';
+import { State } from 'src/rovo-dev/rovoDevTypes';
 
 import { inChatButtonStyles } from './rovoDevViewStyles';
 
@@ -69,8 +69,8 @@ const RovoDevImg = () => {
     );
 };
 
-export const RovoDevLanding: React.FC<{ subState: SubState; onLoginClick: () => void }> = ({
-    subState,
+export const RovoDevLanding: React.FC<{ currentState: State; onLoginClick: () => void }> = ({
+    currentState,
     onLoginClick,
 }) => {
     if (process.env.ROVODEV_BBY) {
@@ -97,12 +97,18 @@ export const RovoDevLanding: React.FC<{ subState: SubState; onLoginClick: () => 
                 Rovo Dev can help you understand context of your repository, suggest and make updates.
             </div>
 
-            {subState === SubState.NeedAuth && (
+            {currentState.state === 'Disabled' && currentState.subState === 'NeedAuth' && (
                 <div style={{ marginTop: '24px' }}>
                     <div>Please authenticate with a Jira site using an API token to enable Rovo Dev.</div>
                     <button style={{ ...inChatButtonStyles, marginTop: '8px' }} onClick={onLoginClick}>
                         Login with Jira API Token
                     </button>
+                </div>
+            )}
+
+            {currentState.state === 'Disabled' && currentState.subState === 'NoWorkspaceOpen' && (
+                <div style={{ marginTop: '24px' }}>
+                    <div>Please open a folder to start a chat session with Rovo Dev.</div>
                 </div>
             )}
         </div>

--- a/src/react/atlascode/rovo-dev/tools/ToolCallItem.test.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolCallItem.test.tsx
@@ -1,6 +1,5 @@
 import { Matcher, render, SelectorMatcherOptions } from '@testing-library/react';
 import React from 'react';
-import { RovoDevInitState } from 'src/rovo-dev/rovoDevTypes';
 
 import { ToolCallMessage } from '../utils';
 import { parseToolCallMessage, ToolCallItem } from './ToolCallItem';
@@ -31,7 +30,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Expanding code', toolMessage, getByText);
     });
@@ -45,7 +46,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Finding and replacing code', toolMessage, getByText);
     });
@@ -59,7 +62,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Opening files', toolMessage, getByText);
     });
@@ -73,7 +78,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Creating file', toolMessage, getByText);
     });
@@ -87,7 +94,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Deleting file', toolMessage, getByText);
     });
@@ -101,7 +110,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Executing bash command', toolMessage, getByText);
     });
@@ -115,7 +126,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Creating technical plan', toolMessage, getByText);
     });
@@ -129,7 +142,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Grep file content with pattern', toolMessage, getByText);
     });
@@ -143,7 +158,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('Grep file path', toolMessage, getByText);
     });
@@ -157,7 +174,9 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        const { getByText } = render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        const { getByText } = render(
+            <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
+        );
 
         validateMessage('unknown_tool', toolMessage, getByText);
     });
@@ -171,7 +190,7 @@ describe('ToolCallItem', () => {
         };
         const toolMessage = parseToolCallMessage(msg);
 
-        render(<ToolCallItem toolMessage={toolMessage} state={RovoDevInitState.Initialized} />);
+        render(<ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />);
 
         const loadingIcon = document.querySelector('.codicon.codicon-loading.codicon-modifier-spin');
         expect(loadingIcon).toBeTruthy();

--- a/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { RovoDevInitState } from 'src/rovo-dev/rovoDevTypes';
+import { DisabledState, InitializingDownladingState, InitializingState, State } from 'src/rovo-dev/rovoDevTypes';
 
 import { ToolCallMessage } from '../utils';
 
@@ -7,12 +7,11 @@ export const DEFAULT_LOADING_MESSAGE: string = 'Rovo dev is working';
 
 export const ToolCallItem: React.FC<{
     toolMessage: string;
-    state: RovoDevInitState;
-    downloadProgress?: [number, number];
-}> = ({ toolMessage, state, downloadProgress }) => {
+    currentState: Exclude<State, DisabledState>;
+}> = ({ toolMessage, currentState }) => {
     const getMessage = useCallback(
-        () => (state === RovoDevInitState.Initialized ? toolMessage : getInitStatusMessage(state)),
-        [toolMessage, state],
+        () => (currentState.state === 'Initializing' ? getInitStatusMessage(currentState) : toolMessage),
+        [toolMessage, currentState],
     );
 
     return (
@@ -21,13 +20,15 @@ export const ToolCallItem: React.FC<{
                 <i className="codicon codicon-loading codicon-modifier-spin" />
                 <span>{getMessage()}</span>
             </div>
-            {state === RovoDevInitState.UpdatingBinaries && !!downloadProgress && downloadProgress[1] > 0 && (
-                <progress
-                    max={downloadProgress[1]}
-                    value={downloadProgress[0]}
-                    style={{ alignSelf: 'center', width: '100px', marginLeft: '4px' }}
-                />
-            )}
+            {currentState.state === 'Initializing' &&
+                currentState.subState === 'UpdatingBinaries' &&
+                currentState.totalBytes > 0 && (
+                    <progress
+                        max={currentState.totalBytes}
+                        value={currentState.downloadedBytes}
+                        style={{ alignSelf: 'center', width: '100px', marginLeft: '4px' }}
+                    />
+                )}
         </div>
     );
 };
@@ -61,14 +62,12 @@ export function parseToolCallMessage(msg: ToolCallMessage): string {
     }
 }
 
-function getInitStatusMessage(state: RovoDevInitState): string {
-    switch (state) {
-        case RovoDevInitState.NotInitialized:
+function getInitStatusMessage(state: InitializingState | InitializingDownladingState): string {
+    switch (state.subState) {
+        case 'Other':
             return 'Rovo Dev is initializing';
-        case RovoDevInitState.UpdatingBinaries:
+        case 'UpdatingBinaries':
             return 'Rovo Dev is updating';
-        case RovoDevInitState.Initialized:
-            return DEFAULT_LOADING_MESSAGE;
         default:
             // @ts-expect-error ts(2339) - state here should be 'never'
             return state.toString();

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -32,6 +32,10 @@ export class RovoDevChatProvider {
         return this._pendingCancellation;
     }
 
+    public get isPromptPending() {
+        return !!this._pendingPrompt;
+    }
+
     constructor(private _telemetryProvider: RovoDevTelemetryProvider) {}
 
     public setWebview(webView: TypedWebview<RovoDevProviderMessage, RovoDevViewResponse> | undefined) {

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -175,7 +175,7 @@ export class RovoDevProcessManager {
         this.rovoDevInstance = undefined;
     }
 
-    private static async downloadBinaryThenInitialize(context: ExtensionContext, rovoDevURIs: RovoDevURIs) {
+    private static async downloadBinaryThenInitialize(rovoDevURIs: RovoDevURIs) {
         const baseDir = rovoDevURIs.RovoDevBaseDir;
         const versionDir = rovoDevURIs.RovoDevVersionDir;
         const zipUrl = rovoDevURIs.RovoDevZipUrl;
@@ -190,6 +190,8 @@ export class RovoDevProcessManager {
             return;
         }
 
+        this.rovoDevWebviewProvider.signalBinaryDownloadStarted(0);
+
         try {
             if (fs.existsSync(baseDir)) {
                 await getFsPromise((callback) => fs.rm(baseDir, { recursive: true, force: true }, callback));
@@ -197,7 +199,7 @@ export class RovoDevProcessManager {
 
             const onProgressChange = (downloadedBytes: number, totalBytes: number | undefined) => {
                 if (totalBytes) {
-                    this.rovoDevWebviewProvider.signalDownloadProgress(downloadedBytes, totalBytes);
+                    this.rovoDevWebviewProvider.signalBinaryDownloadProgress(downloadedBytes, totalBytes);
                 }
             };
 
@@ -235,8 +237,7 @@ export class RovoDevProcessManager {
 
         try {
             if (!fs.existsSync(rovoDevURIs.RovoDevBinPath)) {
-                this.rovoDevWebviewProvider.signalBinaryDownloadStarted();
-                await this.downloadBinaryThenInitialize(context, rovoDevURIs);
+                await this.downloadBinaryThenInitialize(rovoDevURIs);
             }
 
             await this.startRovoDev(credentials, rovoDevURIs);

--- a/src/rovo-dev/rovoDevTypes.ts
+++ b/src/rovo-dev/rovoDevTypes.ts
@@ -51,23 +51,29 @@ export interface TechnicalPlan {
     logicalChanges: TechnicalPlanLogicalChange[];
 }
 
-export const enum State {
-    Disabled,
-    NoWorkspaceOpen,
-    WaitingForPrompt,
-    GeneratingResponse,
-    CancellingResponse,
-    ExecutingPlan,
-    ProcessTerminated,
+// ---- Rovo Dev Chat States ----
+
+export interface BasicState {
+    state: 'WaitingForPrompt' | 'GeneratingResponse' | 'CancellingResponse' | 'ExecutingPlan' | 'ProcessTerminated';
 }
 
-export const enum SubState {
-    None,
-    NeedAuth, // for Disable state
+export interface InitializingState {
+    state: 'Initializing';
+    subState: 'Other';
+    isPromptPending: boolean;
 }
 
-export const enum RovoDevInitState {
-    NotInitialized,
-    UpdatingBinaries,
-    Initialized,
+export interface InitializingDownladingState {
+    state: 'Initializing';
+    subState: 'UpdatingBinaries';
+    isPromptPending: boolean;
+    downloadedBytes: number;
+    totalBytes: number;
 }
+
+export interface DisabledState {
+    state: 'Disabled';
+    subState: 'NeedAuth' | 'NoWorkspaceOpen' | 'Other';
+}
+
+export type State = BasicState | InitializingState | InitializingDownladingState | DisabledState;

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -2,7 +2,7 @@ import { ReducerAction } from '@atlassianlabs/guipi-core-controller';
 
 import { ChatMessage, ErrorMessage } from '../react/atlascode/rovo-dev/utils';
 import { RovoDevResponse } from './responseParser';
-import { RovoDevContextItem, RovoDevInitState, RovoDevPrompt } from './rovoDevTypes';
+import { RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
 
 export const enum RovoDevProviderMessageType {
     RovoDevDisabled = 'rovoDevDisabled',
@@ -14,9 +14,10 @@ export const enum RovoDevProviderMessageType {
     ToolReturn = 'toolReturn',
     ErrorMessage = 'errorMessage',
     ClearChat = 'clearChat',
-    SetInitState = 'setInitState',
     ProviderReady = 'providerReady',
+    SetInitializing = 'setInitializing',
     SetDownloadProgress = 'setDownloadProgress',
+    RovoDevReady = 'rovoDevReady',
     CancelFailed = 'cancelFailed',
     CreatePRComplete = 'createPRComplete',
     GetCurrentBranchNameComplete = 'getCurrentBranchNameComplete',
@@ -41,9 +42,13 @@ export type RovoDevProviderMessage =
     | ReducerAction<RovoDevProviderMessageType.ToolReturn, RovoDevObjectResponse>
     | ReducerAction<RovoDevProviderMessageType.ErrorMessage, { message: ErrorMessage }>
     | ReducerAction<RovoDevProviderMessageType.ClearChat>
-    | ReducerAction<RovoDevProviderMessageType.SetInitState, { newState: RovoDevInitState }>
     | ReducerAction<RovoDevProviderMessageType.ProviderReady, { workspaceCount: number }>
-    | ReducerAction<RovoDevProviderMessageType.SetDownloadProgress, { downloadedBytes: number; totalBytes: number }>
+    | ReducerAction<RovoDevProviderMessageType.SetInitializing, { isPromptPending: boolean }>
+    | ReducerAction<
+          RovoDevProviderMessageType.SetDownloadProgress,
+          { isPromptPending: boolean; downloadedBytes: number; totalBytes: number }
+      >
+    | ReducerAction<RovoDevProviderMessageType.RovoDevReady, { isPromptPending: boolean }>
     | ReducerAction<RovoDevProviderMessageType.CancelFailed>
     | ReducerAction<RovoDevProviderMessageType.CreatePRComplete, { data: { url?: string; error?: string } }>
     | ReducerAction<RovoDevProviderMessageType.GetCurrentBranchNameComplete, { data: { branchName?: string } }>


### PR DESCRIPTION
### What Is This Change?

1. This change merges the following view states into a single state, making the states transition little more predictable and reliable: `currentState`, `currentSubState`, `initState`, `downloadProgress`

2. It also fixes the disappearing prompt after the download has finished.

3. It also changes the "open workspace" message into a clearer view:

| Before | After |
|-----|-----|
| <img width="454" height="591" alt="image" src="https://github.com/user-attachments/assets/556ee0da-9f16-48ed-bf8c-bb97419edf5d" /> | <img width="455" height="591" alt="image" src="https://github.com/user-attachments/assets/b4b558b4-27d8-4bc2-b57a-97f3f150b861" /> |

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`