### PR TITLE
AXON-911: added basic rendering for grep tool

### DIFF
--- a/src/react/atlascode/rovo-dev/tools/ToolReturnItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolReturnItem.tsx
@@ -4,7 +4,7 @@ import SearchIcon from '@atlaskit/icon/glyph/search';
 import TrashIcon from '@atlaskit/icon/glyph/trash';
 import React from 'react';
 
-import { OpenFileFunc } from '../common/common';
+import { mdParser, OpenFileFunc } from '../common/common';
 import { ToolReturnParseResult } from '../utils';
 
 export const ToolReturnParsedItem: React.FC<{
@@ -12,7 +12,7 @@ export const ToolReturnParsedItem: React.FC<{
     openFile: OpenFileFunc;
 }> = ({ msg, openFile }) => {
     const toolIcon = msg.type ? iconMap[msg.type] : undefined;
-
+    const content = mdParser.renderInline(msg.content);
     return (
         <a
             className={`tool-return-item-base tool-return-item ${msg.filePath ? 'tool-return-file-path' : ''}`}
@@ -20,7 +20,7 @@ export const ToolReturnParsedItem: React.FC<{
         >
             {toolIcon && <>{toolIcon}</>}
             <div className="tool-return-item-base" style={{ flexWrap: 'wrap' }}>
-                {msg.content}
+                <div className="tool-return-content" dangerouslySetInnerHTML={{ __html: content }} />
                 {renderTitle(msg)}
             </div>
         </a>

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -170,16 +170,29 @@ export function parseToolReturnMessage(rawMsg: ToolReturnGenericMessage): ToolRe
             }
             break;
 
-        case 'grep_file_content':
-            const grepArgs = msg.args && JSON.parse(msg.args);
-            if (grepArgs?.pattern) {
-                const pattern = grepArgs.pattern;
-                resp.push({
-                    content: `Searched file content${pattern ? ` for pattern:` : ''}`,
-                    title: `"${pattern}"`,
-                    type: 'open',
-                });
+        case 'grep':
+            const toolCallArgs = msg.args;
+            const searchPattern = toolCallArgs ? JSON.parse(toolCallArgs).content_pattern : undefined;
+            const pathGlob = toolCallArgs ? JSON.parse(toolCallArgs).path_glob : undefined;
+            const matches = msg.content.split('\n').filter((line) => line.trim() !== '');
+            let content = 'Searched files';
+            if (searchPattern && pathGlob) {
+                content = `Searched for \`${searchPattern}\` in files matching \`${pathGlob}\``;
+            } else if (pathGlob) {
+                content = `Searched files matching \`${pathGlob}\``;
+            } else if (searchPattern) {
+                content = `Searched for \`${searchPattern}\``;
             }
+
+            resp.push({
+                title:
+                    matches.length > 0
+                        ? `${matches.length} ${matches.length > 1 ? 'matches' : 'match'} found`
+                        : 'No matches found',
+                content: content,
+                type: 'open',
+            });
+
             break;
 
         case 'create_technical_plan':


### PR DESCRIPTION
### What Is This Change?

Removed old grep command rendering

Added new rendering for `grep` tool

3 cases:
1. Only content search
<img width="398" height="113" alt="Screenshot 2025-09-11 at 3 35 39 PM" src="https://github.com/user-attachments/assets/9fa71b8c-3595-4492-8061-5bb6f7081975" />

2. Only file search
<img width="395" height="208" alt="Screenshot 2025-09-11 at 3 35 57 PM" src="https://github.com/user-attachments/assets/832ec020-c5f9-4305-9884-c412fb4e2fb4" />

3. content search within files
<img width="410" height="66" alt="Screenshot 2025-09-11 at 3 35 49 PM" src="https://github.com/user-attachments/assets/0bac261d-b96f-439f-ad9d-f8c6123e9d30" />

### How Has This Been Tested?

Manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`