### PR TITLE
AXON-1116: update rovo dev chat styles to most recent designs

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -2,12 +2,17 @@ body {
     padding: 0 !important;
 }
 
+.rovoDevChat * {
+    scrollbar-width: auto;
+    scrollbar-color: var(--vscode-scrollbarSlider-background) transparent;
+}
+
 .rovoDevChat {
     display: flex;
     flex-direction: column;
     align-items: center;
     box-sizing: border-box;
-    background-color: var(--vscode-editor-background);
+    background-color: var(--vscode-sideBar-background);
     font-size: var(--vscode-font-size);
     font-family: var(--vscode-font-family);
     height: 100vh;
@@ -572,8 +577,12 @@ body {
     flex-direction: column;
     width: 100%;
     gap: 8px;
-    background: var(--vscode-sideBar-background);
+    padding-top: 8px;
+    border: solid 1px var(--vscode-dropdown-border);
+    border-bottom: none;
+    margin-bottom: -4px;
     padding-bottom: 4px;
+    border-radius: 4px 4px 0 0;
 }
 
 .updated-files-header {
@@ -629,7 +638,7 @@ body {
 .input-section-container {
     width: 100%;
     background-color: var(--vscode-sideBar-background);
-    padding: 16px 16px 6px 16px;
+    padding: 8px 16px 6px 16px;
     border-radius: 12px 12px 0 0;
 }
 


### PR DESCRIPTION
### What Is This Change?

Based on the UI tweaks here: https://hello.atlassian.net/wiki/spaces/~653356388/pages/5729327249/UI+tweaks+RovoDev

updated the chat background and modified file component

Before:
<img width="362" height="928" alt="Screenshot 2025-09-11 at 4 31 42 PM" src="https://github.com/user-attachments/assets/59d670f0-1670-4b52-93e0-4a6a08a3bd97" />

After:
<img width="359" height="923" alt="Screenshot 2025-09-11 at 4 25 54 PM" src="https://github.com/user-attachments/assets/9924506a-cc01-472c-8a78-33701eb0dc91" />


### How Has This Been Tested?

manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`