### PR TITLE
[AXON-1119, AXON-1120] Fix missing chat response due to init race condition

### DIFF
--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -76,7 +76,6 @@ export class RovoDevChatProvider {
         }
 
         if (!flushingPendingPrompt) {
-            this.beginNewPrompt();
             await this.sendUserPromptToView(text, context);
         }
 
@@ -86,6 +85,8 @@ export class RovoDevChatProvider {
             this._pendingPrompt = { text, enable_deep_plan, context };
             return;
         }
+
+        this.beginNewPrompt();
 
         this._currentPrompt = {
             text,

--- a/src/rovo-dev/rovoDevTelemetryProvider.ts
+++ b/src/rovo-dev/rovoDevTelemetryProvider.ts
@@ -36,8 +36,6 @@ type TelemetryRecord<T> = {
 };
 
 export class RovoDevTelemetryProvider {
-    private readonly isDebugging = Container.isDebugging;
-
     private _chatSessionId: string = '';
     private _currentPromptId: string = '';
 
@@ -51,6 +49,7 @@ export class RovoDevTelemetryProvider {
     constructor(
         private readonly rovoDevEnv: RovoDevEnv,
         private readonly appInstanceId: string,
+        private readonly onError: (error: Error) => void,
     ) {
         this._perfLogger = new PerformanceLogger(this.appInstanceId);
     }
@@ -82,23 +81,13 @@ export class RovoDevTelemetryProvider {
         ...params: ParametersSkip3<(typeof rovoDevTelemetryEvents)[T]>
     ): void {
         if (!this._chatSessionId) {
-            const error = new Error('Unable to send Rovo Dev telemetry: ChatSessionId not initialized');
-            if (this.isDebugging) {
-                throw error;
-            } else {
-                Logger.error(error);
-                return;
-            }
+            this.onError(new Error('Unable to send Rovo Dev telemetry: ChatSessionId not initialized'));
+            return;
         }
         // rovoDevNewSessionActionEvent is the only event that doesn't need the promptId
         if (funcName !== 'rovoDevNewSessionActionEvent' && !this._currentPromptId) {
-            const error = new Error('Unable to send Rovo Dev telemetry: PromptId not initialized');
-            if (this.isDebugging) {
-                throw error;
-            } else {
-                Logger.error(error);
-                return;
-            }
+            this.onError(new Error('Unable to send Rovo Dev telemetry: PromptId not initialized'));
+            return;
         }
 
         // the following events can be fired multiple times during the same prompt

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -115,9 +115,14 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             this.appInstanceId = Container.appInstanceId;
         }
 
+        const onTelemetryError = Container.isDebugging
+            ? (error: Error) => this.processError(error, false)
+            : (error: Error) => Logger.error(error);
+
         this._telemetryProvider = new RovoDevTelemetryProvider(
             this.isBoysenberry ? 'Boysenberry' : 'IDE',
             this.appInstanceId,
+            onTelemetryError,
         );
         this._chatProvider = new RovoDevChatProvider(this._telemetryProvider);
     }


### PR DESCRIPTION
### What Is This Change?

In the chat provider, when a prompt is being submitted while Rovo Dev is still initializing, we are beginning a new prompt before we begin a new session.
This causes telemetry errors and broken chat.

This change fixes that.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`