### PR TITLE
AXON-1061: Fix feedback collector context

### DIFF
--- a/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
@@ -274,8 +274,8 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
 
             {currentState.state === 'WaitingForPrompt' && (
                 <FollowUpActionFooter>
-                    {deepPlanCreated && <CodePlanButton execute={executeCodePlan} />}
-                    {canCreatePR && !deepPlanCreated && hasChangesInGit && (
+                    {deepPlanCreated && !feedbackVisible && <CodePlanButton execute={executeCodePlan} />}
+                    {canCreatePR && !deepPlanCreated && !feedbackVisible && hasChangesInGit && (
                         <PullRequestForm
                             onCancel={() => {
                                 setCanCreatePR(false);

--- a/src/rovo-dev/rovoDevFeedbackManager.test.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.test.ts
@@ -169,7 +169,31 @@ describe('RovoDevFeedbackManager', () => {
             expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
         });
 
-        it('should include context information in payload', async () => {
+        it('should include context information in payload: BBY', async () => {
+            const feedback = {
+                feedbackType: 'general' as const,
+                feedbackMessage: 'Test feedback',
+                canContact: false,
+            };
+
+            await RovoDevFeedbackManager.submitFeedback(feedback, true);
+
+            expect(mockTransport).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        fields: expect.arrayContaining([
+                            expect.objectContaining({
+                                id: 'customfield_10047',
+                                value: expect.stringContaining('"component": "Boysenberry - vscode"'),
+                            }),
+                        ]),
+                    }),
+                }),
+            );
+        });
+
+        it('should include context information in payload: IDE', async () => {
             const feedback = {
                 feedbackType: 'general' as const,
                 feedbackMessage: 'Test feedback',
@@ -185,7 +209,7 @@ describe('RovoDevFeedbackManager', () => {
                         fields: expect.arrayContaining([
                             expect.objectContaining({
                                 id: 'customfield_10047',
-                                value: expect.stringContaining('"component": "Boysenberry - vscode"'),
+                                value: expect.stringContaining('"component": "IDE - vscode"'),
                             }),
                         ]),
                     }),

--- a/src/rovo-dev/rovoDevFeedbackManager.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.ts
@@ -4,6 +4,8 @@ import { getAxiosInstance } from 'src/jira/jira-client/providers';
 import { Logger } from 'src/logger';
 import * as vscode from 'vscode';
 
+import { MIN_SUPPORTED_ROVODEV_VERSION } from './rovoDevProcessManager';
+
 interface FeedbackObject {
     feedbackType: 'bug' | 'reportContent' | 'general';
     feedbackMessage: string;
@@ -14,9 +16,9 @@ interface FeedbackObject {
 const FEEDBACK_ENDPOINT = `https://jsd-widget.atlassian.com/api/embeddable/57037b9e-743e-407d-bb03-441a13c7afd0/request?requestTypeId=3066`;
 
 export class RovoDevFeedbackManager {
-    public static async submitFeedback(feedback: FeedbackObject): Promise<void> {
+    public static async submitFeedback(feedback: FeedbackObject, isBBY: boolean = false): Promise<void> {
         const transport = getAxiosInstance();
-        const context = this.getContext();
+        const context = this.getContext(isBBY);
 
         let userEmail = 'do-not-reply@atlassian.com';
         let userName = 'unknown';
@@ -99,11 +101,12 @@ export class RovoDevFeedbackManager {
         vscode.window.showInformationMessage('Thank you for your feedback!');
     }
 
-    private static getContext() {
+    private static getContext(isBBY: boolean = false): any {
         return {
-            component: 'Boysenberry - vscode',
+            component: isBBY ? 'Boysenberry - vscode' : 'IDE - vscode',
             extensionVersion: Container.version,
             vscodeVersion: vscode.version,
+            rovoDevVersion: MIN_SUPPORTED_ROVODEV_VERSION,
         };
     }
 }

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -13,7 +13,7 @@ import { rovodevInfo } from '../constants';
 import { Container } from '../container';
 import { RovoDevWebviewProvider } from './rovoDevWebviewProvider';
 
-const MIN_SUPPORTED_ROVODEV_VERSION = packageJson.rovoDev.version;
+export const MIN_SUPPORTED_ROVODEV_VERSION = packageJson.rovoDev.version;
 
 function GetRovoDevURIs(context: ExtensionContext) {
     const extensionPath = context.storageUri!.fsPath;

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -264,12 +264,15 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
                     case RovoDevViewResponseType.SendFeedback:
                         console.log('Send feedback message received in provider');
-                        RovoDevFeedbackManager.submitFeedback({
-                            feedbackType: e.feedbackType,
-                            feedbackMessage: e.feedbackMessage,
-                            canContact: e.canContact,
-                            lastTenMessages: e.lastTenMessages,
-                        });
+                        RovoDevFeedbackManager.submitFeedback(
+                            {
+                                feedbackType: e.feedbackType,
+                                feedbackMessage: e.feedbackMessage,
+                                canContact: e.canContact,
+                                lastTenMessages: e.lastTenMessages,
+                            },
+                            !!this.isBoysenberry,
+                        );
                         break;
 
                     case RovoDevViewResponseType.LaunchJiraAuth:


### PR DESCRIPTION
### What Is This Change?

Added field for rovo dev version

Now if user leaves feedback in local IDE, component field = `IDE - vscode`

BBY:
<img width="371" height="190" alt="Screenshot 2025-09-11 at 4 54 45 PM" src="https://github.com/user-attachments/assets/04bd7b5e-5919-49d9-9fda-51079719ed09" />

IDE:
<img width="252" height="186" alt="Screenshot 2025-09-11 at 4 49 52 PM" src="https://github.com/user-attachments/assets/b4bf72f8-5611-4c61-94ea-5ff87f2269a8" />


also fixed bug where footer actions appearing at same time:

feedback takes priority if triggered

### How Has This Been Tested?

manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`