### PR TITLE
[AXON-1121] Fix boysenberry initializes with a 'Rovo Dev is working' spinner

### DIFF
--- a/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
@@ -205,6 +205,19 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
         [setFeedbackVisible],
     );
 
+    const shouldShowToolCall = React.useMemo(() => {
+        switch (currentState.state) {
+            case 'Disabled':
+            case 'ProcessTerminated':
+            case 'WaitingForPrompt':
+                return false;
+            case 'Initializing':
+                return currentState.isPromptPending;
+            default:
+                return true;
+        }
+    }, [currentState]);
+
     return (
         <div ref={chatEndRef} className="chat-message-container">
             <RovoDevLanding currentState={currentState} onLoginClick={onLoginClick} onOpenFolder={onOpenFolder} />
@@ -266,7 +279,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                     return null;
                 })}
 
-            {currentState.state !== 'Disabled' && currentState.state !== 'ProcessTerminated' && pendingToolCall && (
+            {shouldShowToolCall && pendingToolCall && (
                 <div style={{ marginBottom: '16px' }}>
                     <ToolCallItem toolMessage={pendingToolCall} currentState={currentState} />
                 </div>

--- a/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
-import { DisabledState, InitializingDownladingState, InitializingState, State } from 'src/rovo-dev/rovoDevTypes';
+import { InitializingDownladingState, InitializingState, State } from 'src/rovo-dev/rovoDevTypes';
 
 import { ToolCallMessage } from '../utils';
 
 export const ToolCallItem: React.FC<{
     toolMessage: string;
-    currentState: Exclude<State, DisabledState>;
+    currentState: State;
 }> = ({ toolMessage, currentState }) => {
     const getMessage = useCallback(
         () => (currentState.state === 'Initializing' ? getInitStatusMessage(currentState) : toolMessage),


### PR DESCRIPTION
### What Is This Change?

This change makes sure that the "working spinner" is showing only when necessary, based on the state of Rovo Dev.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`