### PR TITLE
[Rovo Dev] Clean up promptText view state

### DIFF
--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.test.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.test.tsx
@@ -70,7 +70,7 @@ describe('PromptInputBox', () => {
     });
 
     it('calls onSend when Send button is clicked', () => {
-        render(<PromptInputBox {...defaultProps} promptText="test prompt" />);
+        render(<PromptInputBox {...defaultProps} />);
         jest.spyOn(editor, 'getValue').mockReturnValue('text prompt');
         fireEvent.click(screen.getByLabelText('Send prompt'));
         expect(defaultProps.onSend).toHaveBeenCalled();

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
@@ -27,7 +27,6 @@ interface PromptInputBoxProps {
     disabled?: boolean;
     hideButtons?: boolean;
     currentState: NonDisabledState;
-    promptText: string;
     isDeepPlanEnabled: boolean;
     onDeepPlanToggled: () => void;
     onSend: (text: string) => boolean;
@@ -71,7 +70,6 @@ function createEditor() {
 export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
     disabled,
     currentState,
-    promptText,
     isDeepPlanEnabled,
     onDeepPlanToggled,
     onSend,
@@ -85,6 +83,11 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
 
     // create the editor only once - use onSend hook to retry
     React.useEffect(() => setEditor((prev) => prev ?? createEditor()), [onSend]);
+
+    React.useEffect(() => {
+        // Remove Monaco's color stylesheet
+        removeMonacoStyles();
+    }, [editor]);
 
     const handleSend = React.useCallback(() => {
         const value = editor && editor.getValue();
@@ -104,12 +107,6 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
             setupMonacoCommands(editor, onSend, onCopy, handleMemoryCommand, handleTriggerFeedbackCommand);
         }
     }, [editor, onSend, onCopy, handleMemoryCommand, handleTriggerFeedbackCommand]);
-
-    React.useEffect(() => {
-        // Remove Monaco's color stylesheet
-        removeMonacoStyles();
-        editor?.setValue(promptText);
-    }, [editor, promptText]);
 
     React.useEffect(() => {
         if (!editor) {

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -78,7 +78,6 @@ function mapRovoDevDisabledReasonToSubState(reason: RovoDevDisabledReason): Disa
 
 const RovoDevView: React.FC = () => {
     const [currentState, setCurrentState] = useState<State>({ state: 'WaitingForPrompt' });
-    const [promptText, setPromptText] = useState('');
     const [pendingToolCallMessage, setPendingToolCallMessage] = useState('');
     const [retryAfterErrorEnabled, setRetryAfterErrorEnabled] = useState('');
     const [totalModifiedFiles, setTotalModifiedFiles] = useState<ToolReturnParseResult[]>([]);
@@ -500,8 +499,6 @@ const RovoDevView: React.FC = () => {
                 context: promptContextCollection.filter((x) => x.enabled),
             });
 
-            // Clear the input field
-            setPromptText('');
             return true;
         },
         [
@@ -512,7 +509,6 @@ const RovoDevView: React.FC = () => {
             setIsDeepPlanCreated,
             setCurrentState,
             postMessage,
-            setPromptText,
         ],
     );
 
@@ -726,7 +722,6 @@ const RovoDevView: React.FC = () => {
                         <PromptInputBox
                             disabled={currentState.state === 'ProcessTerminated'}
                             currentState={currentState}
-                            promptText={promptText}
                             isDeepPlanEnabled={isDeepPlanToggled}
                             onDeepPlanToggled={() => setIsDeepPlanToggled(!isDeepPlanToggled)}
                             onSend={sendPrompt}


### PR DESCRIPTION
### What Is This Change?

This state is actually unused, as the prompt box value is now managed via monaco.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`