### PR TITLE
FLOW-486 Add aiResult analytic after viewing file for 5s

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -328,6 +328,30 @@ export function rovoDevDetailsExpandedEvent(
     });
 }
 
+export function rovoDevAiResultViewedEvent(
+    rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
+    sessionId: string,
+    promptId: string,
+    dwellMs: number,
+) {
+    return trackEvent('viewed', 'aiResult', {
+        attributes: {
+            rovoDevEnv,
+            appInstanceId,
+            sessionId,
+            promptId,
+            dwellMs,
+            xid: 'rovodev-sessions',
+            singleInstrumentationID: promptId,
+            aiFeatureName: 'rovodevSessions',
+            proactiveGeneratedAI: 0,
+            userGeneratedAI: 1,
+            isAIFeature: 1,
+        },
+    });
+}
+
 // Jira issue events
 
 export async function issueCreatedEvent(site: DetailedSiteInfo, issueKey: string): Promise<TrackEvent> {

--- a/src/rovo-dev/rovoDevDwellTracker.test.ts
+++ b/src/rovo-dev/rovoDevDwellTracker.test.ts
@@ -1,0 +1,77 @@
+import { expansionCastTo } from 'testsutil';
+import * as vscode from 'vscode';
+
+import { RovoDevDwellTracker } from './rovoDevDwellTracker';
+
+jest.useFakeTimers();
+
+describe('RovoDevDwellTracker', () => {
+    let mockTelemetry: any;
+    const fireTelemetryEvent = jest.fn();
+
+    const mockApiClient: any = {
+        getCacheFilePath: jest.fn(),
+    };
+
+    const getCurrentPromptId = () => 'prompt-123';
+
+    const makeEditor = (path: string) => ({
+        document: {
+            uri: { fsPath: path, toString: () => `file://${path}`, scheme: 'file' },
+            isUntitled: false,
+        },
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        expansionCastTo<any>(vscode.window).activeTextEditor = undefined;
+
+        mockTelemetry = {
+            fireTelemetryEvent,
+        };
+    });
+
+    it('fires telemetry after dwell when file has a Rovo Dev cache', async () => {
+        mockApiClient.getCacheFilePath.mockResolvedValue('/tmp/cache.txt');
+        expansionCastTo<any>(vscode.window).activeTextEditor = makeEditor('/workspace/fileA.ts');
+
+        const tracker = new RovoDevDwellTracker(mockTelemetry, getCurrentPromptId, () => mockApiClient, 1000);
+
+        await jest.advanceTimersByTimeAsync(1100);
+
+        expect(fireTelemetryEvent).toHaveBeenCalledWith('rovoDevAiResultViewedEvent', 'prompt-123', 1000);
+
+        tracker.dispose();
+    });
+
+    it('does not fire telemetry if cache lookup fails', async () => {
+        mockApiClient.getCacheFilePath.mockRejectedValue(new Error('no cache'));
+        expansionCastTo<any>(vscode.window).activeTextEditor = makeEditor('/workspace/fileB.ts');
+
+        const tracker = new RovoDevDwellTracker(mockTelemetry, getCurrentPromptId, () => mockApiClient, 1000);
+
+        await jest.advanceTimersByTimeAsync(1100);
+
+        expect(fireTelemetryEvent).not.toHaveBeenCalled();
+
+        tracker.dispose();
+    });
+
+    it('does not fire telemetry when no active promptId', async () => {
+        mockApiClient.getCacheFilePath.mockResolvedValue('/tmp/cache.txt');
+        expansionCastTo<any>(vscode.window).activeTextEditor = makeEditor('/workspace/fileC.ts');
+
+        const tracker = new RovoDevDwellTracker(
+            mockTelemetry,
+            () => '',
+            () => mockApiClient,
+            1000,
+        );
+
+        await jest.advanceTimersByTimeAsync(1100);
+
+        expect(fireTelemetryEvent).not.toHaveBeenCalled();
+
+        tracker.dispose();
+    });
+});

--- a/src/rovo-dev/rovoDevDwellTracker.test.ts
+++ b/src/rovo-dev/rovoDevDwellTracker.test.ts
@@ -35,7 +35,7 @@ describe('RovoDevDwellTracker', () => {
         mockApiClient.getCacheFilePath.mockResolvedValue('/tmp/cache.txt');
         expansionCastTo<any>(vscode.window).activeTextEditor = makeEditor('/workspace/fileA.ts');
 
-        const tracker = new RovoDevDwellTracker(mockTelemetry, getCurrentPromptId, () => mockApiClient, 1000);
+        const tracker = new RovoDevDwellTracker(mockTelemetry, getCurrentPromptId, mockApiClient, 1000);
 
         await jest.advanceTimersByTimeAsync(1100);
 
@@ -48,7 +48,7 @@ describe('RovoDevDwellTracker', () => {
         mockApiClient.getCacheFilePath.mockRejectedValue(new Error('no cache'));
         expansionCastTo<any>(vscode.window).activeTextEditor = makeEditor('/workspace/fileB.ts');
 
-        const tracker = new RovoDevDwellTracker(mockTelemetry, getCurrentPromptId, () => mockApiClient, 1000);
+        const tracker = new RovoDevDwellTracker(mockTelemetry, getCurrentPromptId, mockApiClient, 1000);
 
         await jest.advanceTimersByTimeAsync(1100);
 
@@ -61,12 +61,7 @@ describe('RovoDevDwellTracker', () => {
         mockApiClient.getCacheFilePath.mockResolvedValue('/tmp/cache.txt');
         expansionCastTo<any>(vscode.window).activeTextEditor = makeEditor('/workspace/fileC.ts');
 
-        const tracker = new RovoDevDwellTracker(
-            mockTelemetry,
-            () => '',
-            () => mockApiClient,
-            1000,
-        );
+        const tracker = new RovoDevDwellTracker(mockTelemetry, () => '', mockApiClient, 1000);
 
         await jest.advanceTimersByTimeAsync(1100);
 

--- a/src/rovo-dev/rovoDevDwellTracker.ts
+++ b/src/rovo-dev/rovoDevDwellTracker.ts
@@ -27,13 +27,6 @@ export class RovoDevDwellTracker implements Disposable {
 
         // Listen for editor changes and visible range changes (scrolling)
         this.disposables.push(window.onDidChangeActiveTextEditor((e) => this.onEditorFocusChanged(e)));
-        this.disposables.push(
-            window.onDidChangeTextEditorVisibleRanges((e) => {
-                if (e.textEditor === this.activeEditor) {
-                    this.startDwellTimer();
-                }
-            }),
-        );
 
         this.startDwellTimer();
     }

--- a/src/rovo-dev/rovoDevDwellTracker.ts
+++ b/src/rovo-dev/rovoDevDwellTracker.ts
@@ -1,0 +1,119 @@
+import { Disposable, TextEditor, window } from 'vscode';
+
+import { RovoDevApiClient } from './rovoDevApiClient';
+import { RovoDevTelemetryProvider } from './rovoDevTelemetryProvider';
+
+/**
+ * Tracks when a user dwells on a file that has been modified by Rovo Dev and fires an analytics event.
+ * Global listener: catches navigation via explorer, tabs, etc. Not limited to clicks from the Rovo Dev UI.
+ *
+ * The RovoDevTelemetryProvider already dedupes the same telemetry function per promptId,
+ * so this tracker simply attempts to fire the event; the provider ensures only one fires per prompt.
+ */
+export class RovoDevDwellTracker implements Disposable {
+    private disposables: Disposable[] = [];
+
+    private activeEditor: TextEditor | undefined;
+    private dwellTimer: NodeJS.Timeout | undefined;
+
+    constructor(
+        private readonly telemetry: RovoDevTelemetryProvider,
+        private readonly getCurrentPromptId: () => string,
+        private readonly getApiClient: () => RovoDevApiClient | undefined,
+        private readonly dwellMs: number = 5000,
+    ) {
+        this.activeEditor = window.activeTextEditor;
+
+        // Listen for editor changes and visible range changes (scrolling)
+        this.disposables.push(window.onDidChangeActiveTextEditor((e) => this.onEditorFocusChanged(e)));
+        this.disposables.push(
+            window.onDidChangeTextEditorVisibleRanges((e) => {
+                if (e.textEditor === this.activeEditor) {
+                    this.startDwellTimer();
+                }
+            }),
+        );
+
+        this.startDwellTimer();
+    }
+
+    private onEditorFocusChanged(editor: TextEditor | undefined) {
+        this.activeEditor = editor;
+        this.startDwellTimer();
+    }
+
+    private clearDwellTimer() {
+        if (this.dwellTimer) {
+            clearTimeout(this.dwellTimer);
+            this.dwellTimer = undefined;
+        }
+    }
+
+    public startDwellTimer() {
+        this.clearDwellTimer();
+
+        if (!this.activeEditor) {
+            return;
+        }
+
+        const doc = this.activeEditor.document;
+        if (!doc || doc.isUntitled || (doc.uri.scheme !== 'file' && doc.uri.scheme !== 'vscode-userdata')) {
+            return;
+        }
+
+        const editorAtStart = this.activeEditor;
+        const uriAtStart = doc.uri.toString();
+
+        this.dwellTimer = setTimeout(async () => {
+            // Ensure we are still on the same editor and document
+            const current = window.activeTextEditor;
+            if (!current || current !== editorAtStart || current.document.uri.toString() !== uriAtStart) {
+                return;
+            }
+
+            const promptId = this.getCurrentPromptId();
+            if (!promptId) {
+                // We only report when associated with an active prompt
+                return;
+            }
+
+            try {
+                const client = this.getApiClient();
+                if (!client) {
+                    return;
+                }
+                const filename = this.getFileNamefromPath(current.document.uri.fsPath);
+                if (filename === undefined) {
+                    return;
+                }
+
+                // If this succeeds, the file has a pre-Rovo Dev cached version, meaning it was modified by Rovo Dev
+                await client.getCacheFilePath(filename);
+
+                // Fire analytics: one-per-prompt deduping is handled by telemetry provider
+                this.telemetry.fireTelemetryEvent('rovoDevAiResultViewedEvent', promptId, this.dwellMs);
+            } catch {
+                // Not a Rovo Dev modified file or API not ready; ignore silently
+            }
+        }, this.dwellMs);
+    }
+
+    private getFileNamefromPath(path: string): string | undefined {
+        if (path === undefined) {
+            return undefined;
+        }
+        // Support windows and unix paths
+        const parts = path.split('\\')?.pop()?.split('/');
+        return parts?.pop();
+    }
+
+    dispose(): void {
+        this.clearDwellTimer();
+        for (const d of this.disposables) {
+            try {
+                d.dispose();
+            } catch {}
+        }
+        this.disposables = [];
+    }
+}

--- a/src/rovo-dev/rovoDevTelemetryProvider.ts
+++ b/src/rovo-dev/rovoDevTelemetryProvider.ts
@@ -2,6 +2,7 @@ import { Container } from 'src/container';
 import { Logger } from 'src/logger';
 
 import {
+    rovoDevAiResultViewedEvent,
     rovoDevDetailsExpandedEvent,
     RovoDevEnv,
     rovoDevFileChangedActionEvent,
@@ -23,6 +24,7 @@ const rovoDevTelemetryEvents = {
     rovoDevStopActionEvent,
     rovoDevTechnicalPlanningShownEvent,
     rovoDevDetailsExpandedEvent,
+    rovoDevAiResultViewedEvent,
 };
 
 type ParametersSkip3<T extends (...args: any) => any> =

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -954,7 +954,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             this._dwellTracker = new RovoDevDwellTracker(
                 this._telemetryProvider,
                 () => this._chatProvider.currentPromptId,
-                () => this._rovoDevApiClient,
+                this._rovoDevApiClient,
             );
             await this._chatProvider.executeReplay();
         }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -34,6 +34,7 @@ import { GitErrorCodes } from '../typings/git';
 import { getHtmlForView } from '../webview/common/getHtmlForView';
 import { RovoDevApiClient, RovoDevHealthcheckResponse } from './rovoDevApiClient';
 import { RovoDevChatProvider } from './rovoDevChatProvider';
+import { RovoDevDwellTracker } from './rovoDevDwellTracker';
 import { RovoDevFeedbackManager } from './rovoDevFeedbackManager';
 import { RovoDevProcessManager } from './rovoDevProcessManager';
 import { RovoDevPullRequestHandler } from './rovoDevPullRequestHandler';
@@ -78,6 +79,8 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private _revertedChanges: string[] = [];
 
     private _disposables: Disposable[] = [];
+
+    private _dwellTracker?: RovoDevDwellTracker;
 
     private _extensionPath: string;
     private _extensionUri: Uri;
@@ -578,6 +581,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                 Uri.file(resolvedPath),
                 `${filePath} (Rovo Dev)`,
             );
+            this._dwellTracker?.startDwellTimer();
         } else {
             let range: Range | undefined;
             if (_range && Array.isArray(_range)) {
@@ -592,6 +596,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                     preview: true,
                     selection: range || undefined,
                 });
+                this._dwellTracker?.startDwellTimer();
             } catch (error) {
                 if (createOnFail) {
                     await getFsPromise((callback) => fs.writeFile(resolvedPath, '', callback));
@@ -944,6 +949,13 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         await this._chatProvider.setReady(this._rovoDevApiClient);
 
         if (this.isBoysenberry) {
+            // Initialize global dwell tracker now that API client exists
+            this._dwellTracker?.dispose();
+            this._dwellTracker = new RovoDevDwellTracker(
+                this._telemetryProvider,
+                () => this._chatProvider.currentPromptId,
+                () => this._rovoDevApiClient,
+            );
             await this._chatProvider.executeReplay();
         }
 
@@ -976,6 +988,8 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         this._rovoDevApiClient = undefined;
         this._chatProvider.shutdown();
         this._telemetryProvider.shutdown();
+        this._dwellTracker?.dispose();
+        this._dwellTracker = undefined;
 
         if (!overrideFullMessage) {
             errorMessage = errorMessage


### PR DESCRIPTION
### What Is This Change?

When Boysenberry mode is enabled, track when users dwell on AI Generated code, and send an `aiResult viewed` analytic event if the user dwells for 5+seconds.

Loom demo: https://www.loom.com/share/026d89ce9d5449a49105817f7d48b82d

### How Has This Been Tested?

- Unit tests
- Tested locally - see loom demo

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [X] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)
N/A - only applicable for Boysenberry mode

Recommendations:
- [x] Update the CHANGELOG if making a user facing change
N/A - not user-facing change