### PR TITLE
[Rovo Dev] Reset pending prompt on shutdown

### DIFF
--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -56,6 +56,7 @@ export class RovoDevChatProvider {
 
     public shutdown() {
         this._rovoDevApiClient = undefined;
+        this._pendingPrompt = undefined;
     }
 
     public executeChat(prompt: RovoDevPrompt, revertedFiles: string[]) {


### PR DESCRIPTION
### What Is This Change?

On chat provider shutdown, the provider should forget about the pending prompt, or it'll be picked up next time the process gets restarted.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`