### PR TITLE
AXON-1136 finalize step

### DIFF
--- a/e2e/scenarios/jira/loginNotification.spec.ts
+++ b/e2e/scenarios/jira/loginNotification.spec.ts
@@ -8,6 +8,5 @@ export async function loginNotification(page: Page) {
 
     // Verify initial unauthenticated state: login prompt is visible in both sidebar and notifications
     await new AtlascodeDrawer(page).jira.expectLoginToJiraItemExists();
-    // await new AppNotifications(page).expectNotification(/Log in to Jira/);
-    await new AppNotifications(page).expectNotification(/Error for test/);
+    await new AppNotifications(page).expectNotification(/Log in to Jira/);
 }


### PR DESCRIPTION
### What Is This Change?

GitHub considers "skipped actions" satisfying the requirement for merging.

Before: 

<img width="918" height="693" alt="image" src="https://github.com/user-attachments/assets/fb7be068-c2a0-4724-8d9f-05854ad3ebf1" />

After:

<img width="1025" height="554" alt="Screenshot 2025-09-16 at 13 32 35" src="https://github.com/user-attachments/assets/f9748af9-2929-4590-be1d-13a1583b7dd0" />
