### PR TITLE
AXON-1113: start work with rovo dev button fix

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -724,11 +724,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     }
 
     public async invokeRovoDevAskCommand(prompt: string, context?: RovoDevContextItem[]): Promise<void> {
-        if (this.isDisabled) {
-            return;
-        }
-
-        // focus on the specific vscode view
+        // Always focus on the specific vscode view, even if disabled (so user can see the login prompt)
         commands.executeCommand('atlascode.views.rovoDev.webView.focus');
 
         // Wait for the webview to initialize, up to 5 seconds
@@ -740,6 +736,12 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         );
 
         if (!initialized) {
+            return;
+        }
+
+        // If disabled, we still want to show the webview but don't execute the chat
+        // The webview will show the appropriate login prompt
+        if (this.isDisabled) {
             return;
         }
 


### PR DESCRIPTION
### Ticket:
https://softwareteams.atlassian.net/browse/AXON-1113

### What Is This Change?
When I click on the 'Start with Rovo Dev!' button, it works and opens the Rovo Dev chat only the first time. The second click, whether for the same or another Jira issue where we can see that button, does not work if I am not logged in with a Jira API token.

### Demo:
https://www.loom.com/share/659fea2c33f545faa0be1268204bb111

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change