### PR TITLE
AXON-1138: Fix Create Issue form stability and input rendering

### DIFF
--- a/src/webviews/components/fieldValidators.test.ts
+++ b/src/webviews/components/fieldValidators.test.ts
@@ -105,6 +105,15 @@ describe('fieldValidators', () => {
             expect(validateString('test', state)).toBeUndefined();
             expect(validateString('', state)).toBe('EMPTY');
         });
+
+        it('should return "EMPTY" for non-string values (objects, arrays, numbers, booleans)', () => {
+            expect(validateString({} as any)).toBe('EMPTY');
+            expect(validateString([] as any)).toBe('EMPTY');
+            expect(validateString(123 as any)).toBe('EMPTY');
+            expect(validateString(0 as any)).toBe('EMPTY');
+            expect(validateString(true as any)).toBe('EMPTY');
+            expect(validateString(false as any)).toBe('EMPTY');
+        });
     });
 
     describe('isValidString', () => {

--- a/src/webviews/components/fieldValidators.ts
+++ b/src/webviews/components/fieldValidators.ts
@@ -13,8 +13,16 @@ export function validateMultiSelect(value: string, state: any): string | undefin
     //return (value !== undefined && value.length > 0) ? undefined : "EMPTY";
 }
 
-export function validateString(value: string, state?: any): string | undefined {
-    if (!value || value.trim().length < 1) {
+export function validateString(value: any, state?: any): string | undefined {
+    // Treat falsy values as empty (undefined, null, empty string, 0, false)
+    if (!value) {
+        return 'EMPTY';
+    }
+    // Only non-empty strings are valid
+    if (typeof value !== 'string') {
+        return 'EMPTY';
+    }
+    if (value.trim().length < 1) {
         return 'EMPTY';
     }
     return undefined;

--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -158,6 +158,21 @@ export abstract class AbstractIssueEditorPage<
         return val;
     }
 
+    private coerceToString(value: any): string {
+        if (value === undefined || value === null) {
+            return '';
+        }
+        const t = typeof value;
+        if (t === 'string') {
+            return value as string;
+        }
+        if (t === 'number' || t === 'boolean') {
+            return String(value);
+        }
+        // For any other type (objects, symbols, functions), render empty string
+        return '';
+    }
+
     onMessageReceived(e: any): boolean {
         let handled: boolean = false;
         switch (e.type) {
@@ -430,8 +445,7 @@ export abstract class AbstractIssueEditorPage<
                 let validationFailMessage = '';
                 const valType = field.valueType;
 
-                const defaultVal =
-                    this.state.fieldValues[field.key] === undefined ? '' : this.state.fieldValues[field.key];
+                const defaultVal = this.coerceToString(this.state.fieldValues[field.key]);
                 switch (valType) {
                     case ValueType.Number: {
                         validationFailMessage = `${field.name} must be a number`;
@@ -455,8 +469,8 @@ export abstract class AbstractIssueEditorPage<
                     if ((field as InputFieldUI).isMultiline) {
                         markup = (
                             <EditRenderedTextArea
-                                text={this.state.fieldValues[`${field.key}`]}
-                                renderedText={this.state.fieldValues[`${field.key}.rendered`]}
+                                text={this.coerceToString(this.state.fieldValues[`${field.key}`])}
+                                renderedText={this.coerceToString(this.state.fieldValues[`${field.key}.rendered`])}
                                 fetchUsers={async (input: string) =>
                                     (await this.fetchUsers(input)).map((user) => ({
                                         displayName: user.displayName,
@@ -512,6 +526,7 @@ export abstract class AbstractIssueEditorPage<
                             let markup = (
                                 <Textfield
                                     {...fieldArgs.fieldProps}
+                                    value={this.coerceToString(fieldArgs.fieldProps.value)}
                                     className="ac-inputField"
                                     isDisabled={this.state.isSomethingLoading}
                                     onChange={chain(fieldArgs.fieldProps.onChange, (e: any) =>
@@ -524,7 +539,7 @@ export abstract class AbstractIssueEditorPage<
                                 markup = (
                                     <JiraIssueTextAreaEditor
                                         {...fieldArgs.fieldProps}
-                                        value={this.state.fieldValues[field.key]}
+                                        value={this.coerceToString(this.state.fieldValues[field.key])}
                                         isDisabled={this.state.isSomethingLoading}
                                         onChange={chain(fieldArgs.fieldProps.onChange, (val: string) =>
                                             this.handleInlineEdit(field, val),
@@ -561,7 +576,7 @@ export abstract class AbstractIssueEditorPage<
                             id={field.key}
                             name={field.key}
                             isLoading={this.state.loadingField === field.key}
-                            defaultValue={this.state.fieldValues[field.key]}
+                            defaultValue={this.coerceToString(this.state.fieldValues[field.key])}
                             isDisabled={this.state.isSomethingLoading}
                             className="ac-select-container"
                             selectProps={{ className: 'ac-select-container', classNamePrefix: 'ac-select' }}
@@ -619,7 +634,7 @@ export abstract class AbstractIssueEditorPage<
                         <DateTimePicker
                             id={field.key}
                             name={field.key}
-                            defaultValue={this.state.fieldValues[field.key]}
+                            defaultValue={this.coerceToString(this.state.fieldValues[field.key])}
                             isDisabled={this.state.isSomethingLoading}
                             className="ac-select-container"
                             datePickerSelectProps={{

--- a/src/webviews/components/issue/EditRenderedTextArea.tsx
+++ b/src/webviews/components/issue/EditRenderedTextArea.tsx
@@ -22,7 +22,7 @@ export const EditRenderedTextArea: React.FC<Props> = ({
     fetchImage,
 }: Props) => {
     const [editing, setEditing] = useState(false);
-    const [commentInputValue, setCommentInputValue] = useState(text);
+    const [commentInputValue, setCommentInputValue] = useState(text ?? '');
     const [isSaving, setIsSaving] = useState(false);
 
     const handleSave = async () => {
@@ -57,7 +57,7 @@ export const EditRenderedTextArea: React.FC<Props> = ({
                         appearance="default"
                         onClick={() => {
                             setEditing(false);
-                            setCommentInputValue(text);
+                            setCommentInputValue(text ?? '');
                         }}
                     >
                         Cancel

--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
@@ -146,8 +146,14 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
                         }
                     }
 
-                    this.updateInternals(issueData);
-                    this.setState(issueData, () => {
+                    // Merge new field values over existing to avoid losing values
+                    const mergedFieldValues = fieldValues
+                        ? { ...this.state.fieldValues, ...fieldValues }
+                        : this.state.fieldValues;
+                    const mergedIssueData: CreateIssueData = { ...issueData, fieldValues: mergedFieldValues };
+
+                    this.updateInternals(mergedIssueData);
+                    this.setState(mergedIssueData, () => {
                         this.setState({
                             isSomethingLoading: false,
                             loadingField: '',


### PR DESCRIPTION
This PR addresses AXON-1138: Interface disappears when selecting issue type in 'Create Jira Issue' dropdown.\n\nKey changes:\n- Merge incoming fieldValues on 'update' to preserve form state (prevents transient blank states)\n- Harden validateString to guard !value and non-string inputs from DC project switches\n- Ensure text inputs/textareas/inline editors render primitives only (string/number/boolean), otherwise '' to avoid [object Object]\n- Initialize/reset EditRenderedTextArea state to avoid undefined leaking into UI\n\nManual verification steps:\n1. Switch project and issue types on both Cloud and DC; form fields should not disappear and should retain values unless changed\n2. For DC sites, switching projects no longer crashes on validateString and text fields no longer show [object Object]\n\nJira: https://softwareteams.atlassian.net/browse/AXON-1138