### PR TITLE
AXON-1143: change chat styles to match BBY designs

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -633,7 +633,7 @@ body {
 }
 
 .updated-files-action {
-    color: var(--vscode-button-secondaryForeground);
+    color: var(--vscode-input-foreground);
     background-color: inherit;
     border: none;
     border-radius: 4px;
@@ -641,7 +641,7 @@ body {
 }
 
 #bordered-button {
-    border: 1px solid var(--vscode-button-border);
+    border: 1px solid var(--vscode-editorWidget-border);
 }
 
 .updated-files-action:disabled {
@@ -650,6 +650,7 @@ body {
 
 .updated-files-action:hover {
     background-color: var(--vscode-button-secondaryHoverBackground);
+    color: var(--vscode-button-secondaryForeground)
 }
 
 .secondary {
@@ -851,11 +852,13 @@ body {
 }
 
 .vscode-high-contrast .prompt-button-primary,
-.vscode-high-contrast .prompt-button-secondary {
+.vscode-high-contrast .prompt-button-secondary,
+.vscode-high-contrast .prompt-button-secondary-open {
     border: 2px solid var(--vscode-contrastBorder);
 }
 .vscode-high-contrast .prompt-button-primary:hover,
-.vscode-high-contrast .prompt-button-secondary:hover {
+.vscode-high-contrast .prompt-button-secondary:hover,
+.vscode-high-contrast .prompt-button-secondary-open:hover {
     border: 2px solid var(--vscode-focusBorder);
 }
 

--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -239,13 +239,14 @@ body {
     align-items: center;
     justify-content: center;
     border: 1px solid var(--vscode-editorWidget-border);
+    border-radius: 6px;
     max-width: 400px;
-    background-color: var(--vscode-button-secondaryBackground);
+    background-color: inherit;
     padding: 6px 12px;
 }
 
 .code-plan-button:hover {
-    background-color: var(--vscode-button-secondaryHoverBackground);
+    border: 1px solid var(--vscode-focusBorder);
     cursor: pointer;
 }
 
@@ -365,6 +366,7 @@ body {
     background-color: var(--vscode-button-background);
     color: var(--vscode-button-foreground);
     border: 0;
+    border-radius: 6px;
 }
 .pull-request-button:hover {
     background-color: var(--vscode-button-hoverBackground);
@@ -421,6 +423,7 @@ body {
     width: 100%;
     padding: 6px 8px;
     border: 1px solid var(--vscode-input-border);
+    border-radius: 4px;
     background-color: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
 }
@@ -448,6 +451,19 @@ body {
     background-color: var(--vscode-checkbox-selectBackground);
 }
 
+
+.form-select {
+    width: 100%;
+    border: 1px solid var(--vscode-dropdown-border);
+    border-radius: 4px;
+    background-color: var(--vscode-dropdown-background);
+    color: var(--vscode-dropdown-foreground);
+}
+
+.form-select:focus {
+    outline: var(--vscode-focusBorder) solid 1px;
+}
+
 .form-actions {
     display: flex;
     flex-direction: row;
@@ -463,11 +479,12 @@ body {
     align-items: center;
     gap: 8px;
     border: 0;
+    border-radius: 4px;
     cursor: pointer;
 }
 
 .form-cancel-button {
-    background-color: var(--vscode-button-secondaryBackground);
+    background-color: inherit;
     color: var(--vscode-button-secondaryForeground);
 }
 
@@ -589,9 +606,9 @@ body {
     padding-top: 8px;
     border: solid 1px var(--vscode-dropdown-border);
     border-bottom: none;
-    margin-bottom: -4px;
-    padding-bottom: 4px;
-    border-radius: 4px 4px 0 0;
+    margin-bottom: -16px;
+    padding-bottom: 16px;
+    border-radius: 16px 16px 0 0;
 }
 
 .updated-files-header {
@@ -616,14 +633,24 @@ body {
 }
 
 .updated-files-action {
-    cursor: pointer;
+    color: var(--vscode-button-secondaryForeground);
+    background-color: inherit;
+    border: none;
+    border-radius: 4px;
     padding: 2px 6px;
+}
+
+#bordered-button {
+    border: 1px solid var(--vscode-button-border);
 }
 
 .updated-files-action:disabled {
     cursor: not-allowed;
 }
 
+.updated-files-action:hover {
+    background-color: var(--vscode-button-secondaryHoverBackground);
+}
 
 .secondary {
     color: var(--vscode-button-secondaryForeground);
@@ -657,9 +684,9 @@ body {
     flex-direction: column;
     gap: 8px;
     border : 1px solid var(--vscode-input-border);
-    border-radius: 4px;
+    border-radius: 16px;
     background-color: var(--vscode-input-background);
-    padding: 8px;
+    padding: 12px;
 }
 
 .monaco-editor {
@@ -694,10 +721,12 @@ body {
 .prompt-button-secondary {
     display: flex;
     align-items: center;
-    border: 1px solid var(--vscode-button-border);
-    border-radius: 2px;
+    justify-content: center;
+    border-radius: 50%;
+    border: none;
     padding: 2px 6px;
-    height: 100%;
+    height: 32px;
+    width: 32px;
 }
 
 .prompt-button-primary {
@@ -707,6 +736,17 @@ body {
 
 .prompt-button-primary:hover {
     background-color: var(--vscode-button-hoverBackground);
+}
+
+.prompt-button-primary:disabled,
+.prompt-button-secondary:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.prompt-button-primary:disabled {
+    background-color: var(--vscode-sideBar-background);
+    color: var(--vscode-disabledForeground);
 }
 
 .prompt-button-secondary {
@@ -743,8 +783,9 @@ body {
     align-items: center;
     gap: 4px;
     border: 1px solid var(--vscode-focusBorder);
+    height: 32px;
     padding: 2px 6px;
-    border-radius: 2px;
+    border-radius: 8px;
     background-color: var(--vscode-inputOption-activeBackground);
     color: var(--vscode-inputOption-activeForeground);
     cursor: pointer;
@@ -756,17 +797,6 @@ body {
     color: var(--vscode-descriptionForeground);
     margin-top: 8px;
     opacity: 0.7;
-}
-
-.form-select {
-    width: 100%;
-    border: 1px solid var(--vscode-dropdown-border);
-    background-color: var(--vscode-dropdown-background);
-    color: var(--vscode-dropdown-foreground);
-}
-
-.form-select:focus {
-    outline: var(--vscode-focusBorder) solid 1px;
 }
 
 /* High contrast theme overrides */
@@ -797,22 +827,35 @@ body {
     border: 2px solid var(--vscode-focusBorder);
 }
 
-.vscode-high-contrast .updated-files-action {
+.vscode-high-contrast .updated-files-action,
+.vscode-high-contrast #bordered-button {
     border: 2px solid var(--vscode-contrastBorder);
 }
 
-.vscode-high-contrast .updated-files-action:hover {
+.vscode-high-contrast .updated-files-action:hover,
+.vscode-high-contrast #bordered-button:hover
+ {
     border: 2px solid var(--vscode-focusBorder);
 }
 
-.vscode-high-contrast .updated-files-action:disabled {
+.vscode-high-contrast .updated-files-action:disabled,
+.vscode-high-contrast #bordered-button:disabled {
     border: 2px solid var(--vscode-disabledForeground);
     opacity: 0.5;
 }
 
-.vscode-high-contrast .prompt-button {
+.vscode-high-contrast .prompt-button-primary,
+.vscode-high-contrast .prompt-button-secondary {
     border: 2px solid var(--vscode-contrastBorder);
 }
-.vscode-high-contrast .prompt-button:hover {
+.vscode-high-contrast .prompt-button-primary:hover,
+.vscode-high-contrast .prompt-button-secondary:hover {
+    border: 2px solid var(--vscode-focusBorder);
+}
+
+.vscode-high-contrast .code-plan-button {
+    border: 2px solid var(--vscode-contrastBorder);
+}
+.vscode-high-contrast .code-plan-button:hover {
     border: 2px solid var(--vscode-focusBorder);
 }

--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -718,7 +718,8 @@ body {
 }
 
 .prompt-button-primary,
-.prompt-button-secondary {
+.prompt-button-secondary,
+.prompt-button-secondary-open {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -741,7 +742,6 @@ body {
 .prompt-button-primary:disabled,
 .prompt-button-secondary:disabled {
     cursor: not-allowed;
-    opacity: 0.5;
 }
 
 .prompt-button-primary:disabled {
@@ -755,9 +755,15 @@ body {
 }
 
 .prompt-button-secondary:hover {
+    color: var(--vscode-button-secondaryForeground);
     background-color: var(--vscode-button-secondaryHoverBackground);
 }
 
+.prompt-button-secondary-open {
+    color: var(--vscode-inputOption-activeForeground);
+    background-color: var(--vscode-inputOption-activeBackground);
+    border: 1px solid var(--vscode-focusBorder);
+}
 
 .prompt-settings-item {
     display: flex;
@@ -785,7 +791,7 @@ body {
     border: 1px solid var(--vscode-focusBorder);
     height: 32px;
     padding: 2px 6px;
-    border-radius: 8px;
+    border-radius: 16px;
     background-color: var(--vscode-inputOption-activeBackground);
     color: var(--vscode-inputOption-activeForeground);
     cursor: pointer;
@@ -857,5 +863,12 @@ body {
     border: 2px solid var(--vscode-contrastBorder);
 }
 .vscode-high-contrast .code-plan-button:hover {
+    border: 2px solid var(--vscode-focusBorder);
+}
+
+.vscode-high-contrast .deep-plan-indicator {
+    border: 2px solid var(--vscode-contrastBorder);
+}
+.vscode-high-contrast .deep-plan-indicator:hover {
     border: 2px solid var(--vscode-focusBorder);
 }

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.test.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.test.tsx
@@ -70,10 +70,11 @@ describe('PromptInputBox', () => {
     });
 
     it('calls onSend when Send button is clicked', () => {
-        render(<PromptInputBox {...defaultProps} />);
         jest.spyOn(editor, 'getValue').mockReturnValue('text prompt');
+        jest.spyOn(editor, 'onDidChangeModelContent').mockImplementation((cb) => cb());
+        render(<PromptInputBox {...defaultProps} />);
         fireEvent.click(screen.getByLabelText('Send prompt'));
-        expect(defaultProps.onSend).toHaveBeenCalled();
+        expect(defaultProps.onSend).toHaveBeenCalledWith('text prompt');
     });
 
     it('calls onCancel when Stop button is clicked', () => {

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
@@ -1,4 +1,5 @@
 import AddIcon from '@atlaskit/icon/core/add';
+import AiGenerativeTextSummaryIcon from '@atlaskit/icon/core/ai-generative-text-summary';
 import SendIcon from '@atlaskit/icon/core/arrow-up';
 import CrossIcon from '@atlaskit/icon/core/cross';
 import VideoStopOverlayIcon from '@atlaskit/icon/core/video-stop-overlay';
@@ -7,10 +8,8 @@ import Tooltip from '@atlaskit/tooltip';
 import * as monaco from 'monaco-editor';
 import React from 'react';
 import { DisabledState, State } from 'src/rovo-dev/rovoDevTypes';
-
 type NonDisabledState = Exclude<State, DisabledState>;
 
-import { AiGenerativeTextSummaryIcon } from '../../rovoDevView';
 import { rovoDevTextareaStyles } from '../../rovoDevViewStyles';
 import PromptSettingsPopup from '../prompt-settings-popup/PromptSettingsPopup';
 import {
@@ -168,7 +167,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                             <AddIcon label="Add context" />
                         </button>
                     </Tooltip>
-                    <Tooltip content="Prompt customizations">
+                    <Tooltip content="Preferences">
                         <PromptSettingsPopup
                             onToggleDeepPlan={onDeepPlanToggled}
                             isDeepPlanEnabled={isDeepPlanEnabled}
@@ -182,7 +181,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                                 title="Deep plan is enabled"
                                 onClick={() => onDeepPlanToggled()}
                             >
-                                <AiGenerativeTextSummaryIcon />
+                                <AiGenerativeTextSummaryIcon label="deep plan icon" />
                                 <CrossIcon size="small" label="disable deep plan" />
                             </div>
                         </Tooltip>

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/PromptInput.tsx
@@ -37,8 +37,8 @@ interface PromptInputBoxProps {
 }
 
 const TextAreaMessages: Record<NonDisabledState['state'], string> = {
-    ['Initializing']: 'Type in a question',
-    ['WaitingForPrompt']: 'Type in a question',
+    ['Initializing']: 'Write a prompt or use / for actions',
+    ['WaitingForPrompt']: 'Write a prompt or use / for actions',
     ['GeneratingResponse']: 'Generating response...',
     ['CancellingResponse']: 'Cancelling the response...',
     ['ExecutingPlan']: 'Executing the code plan...',
@@ -53,7 +53,7 @@ const getTextAreaPlaceholder = (isGeneratingResponse: boolean, currentState: Non
     }
 };
 
-function createEditor() {
+function createEditor(setIsEmpty?: (isEmpty: boolean) => void) {
     const container = document.getElementById('prompt-editor-container');
     if (!container) {
         return undefined;
@@ -62,6 +62,13 @@ function createEditor() {
     monaco.languages.registerCompletionItemProvider('plaintext', createSlashCommandProvider());
 
     const editor = createMonacoPromptEditor(container);
+    editor.onDidChangeModelContent(() => {
+        if (editor.getValue().trim().length === 0) {
+            setIsEmpty?.(true);
+        } else {
+            setIsEmpty?.(false);
+        }
+    });
     setupAutoResize(editor);
     return editor;
 }
@@ -79,9 +86,10 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
     handleTriggerFeedbackCommand,
 }) => {
     const [editor, setEditor] = React.useState<ReturnType<typeof createEditor>>(undefined);
+    const [isEmpty, setIsEmpty] = React.useState(true);
 
     // create the editor only once - use onSend hook to retry
-    React.useEffect(() => setEditor((prev) => prev ?? createEditor()), [onSend]);
+    React.useEffect(() => setEditor((prev) => prev ?? createEditor(setIsEmpty)), [onSend]);
 
     React.useEffect(() => {
         // Remove Monaco's color stylesheet
@@ -149,7 +157,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                     flexWrap: 'wrap',
                 }}
             >
-                <div style={{ display: 'flex', gap: 4 }}>
+                <div style={{ display: 'flex', flexDirection: 'row', alignContent: 'center', gap: 4 }}>
                     <Tooltip content="Add context">
                         <button
                             className="prompt-button-secondary"
@@ -186,7 +194,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                             className="prompt-button-primary"
                             aria-label="send"
                             onClick={() => handleSend()}
-                            disabled={disabled || !isWaitingForPrompt}
+                            disabled={disabled || !isWaitingForPrompt || isEmpty}
                         >
                             <SendIcon label="Send prompt" />
                         </button>
@@ -195,6 +203,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                         <Tooltip content="Stop generating" position="top">
                             <button
                                 className="prompt-button-secondary"
+                                id="bordered-button"
                                 aria-label="stop"
                                 onClick={() => onCancel()}
                                 disabled={disabled || currentState.state === 'CancellingResponse'}

--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-settings-popup/PromptSettingsPopup.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-settings-popup/PromptSettingsPopup.tsx
@@ -1,9 +1,9 @@
+import AiGenerativeTextSummaryIcon from '@atlaskit/icon/core/ai-generative-text-summary';
+import CrossIcon from '@atlaskit/icon/core/cross';
 import CustomizeIcon from '@atlaskit/icon/core/customize';
 import Popup, { PopupComponentProps } from '@atlaskit/popup';
 import Toggle from '@atlaskit/toggle';
 import React from 'react';
-
-import { AiGenerativeTextSummaryIcon } from '../../rovoDevView';
 interface PromptSettingsPopupProps {
     onToggleDeepPlan: () => void;
     isDeepPlanEnabled: boolean;
@@ -37,23 +37,27 @@ const PromptSettingsPopup: React.FC<PromptSettingsPopupProps> = ({ onToggleDeepP
             shouldRenderToParent
             isOpen={isOpen}
             trigger={(props) => (
-                <button
-                    {...props}
-                    onClick={() => setIsOpen((prev) => !prev)}
-                    aria-selected={isOpen}
-                    className="prompt-button-secondary"
-                    aria-label="Prompt settings"
-                    style={
-                        isOpen
-                            ? {
-                                  border: '1px solid var(--vscode-focusBorder)',
-                                  backgroundColor: 'var(--vscode-inputOption-activeBackground)',
-                              }
-                            : {}
-                    }
-                >
-                    <CustomizeIcon label="Prompt settings" />
-                </button>
+                <>
+                    {isOpen ? (
+                        <button
+                            {...props}
+                            onClick={() => setIsOpen((prev) => !prev)}
+                            className="prompt-button-secondary-open"
+                            aria-label="Prompt settings (open)"
+                        >
+                            <CrossIcon label="Close prompt settings" />
+                        </button>
+                    ) : (
+                        <button
+                            {...props}
+                            onClick={() => setIsOpen((prev) => !prev)}
+                            className="prompt-button-secondary"
+                            aria-label="Prompt settings"
+                        >
+                            <CustomizeIcon label="Prompt settings" />
+                        </button>
+                    )}
+                </>
             )}
             content={() => (
                 <PromptSettingsItem
@@ -87,7 +91,7 @@ const PromptSettingsItem: React.FC<{
                 {(() => {
                     switch (label) {
                         case 'Plan':
-                            return <AiGenerativeTextSummaryIcon />;
+                            return <AiGenerativeTextSummaryIcon label="Deep plan" />;
                         default:
                             return <CustomizeIcon label="Customize prompt" />;
                     }

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.tsx
@@ -29,14 +29,15 @@ export const UpdatedFilesComponent: React.FC<{
                 <div>
                     <button
                         disabled={!actionsEnabled}
-                        className="updated-files-action secondary"
+                        className="updated-files-action"
                         onClick={() => onUndo(modifiedFiles)}
                     >
                         Undo
                     </button>
                     <button
                         disabled={!actionsEnabled}
-                        className="updated-files-action primary"
+                        className="updated-files-action"
+                        id="bordered-button"
                         onClick={() => onKeep(modifiedFiles)}
                     >
                         Keep

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -1,7 +1,6 @@
 import './RovoDev.css';
 import './RovoDevCodeHighlighting.css';
 
-import CloseIcon from '@atlaskit/icon/core/close';
 import { setGlobalTheme } from '@atlaskit/tokens';
 import { highlightElement } from '@speed-highlight/core';
 import { detectLanguage } from '@speed-highlight/core/detect';
@@ -38,30 +37,6 @@ import {
 } from './utils';
 
 const DEFAULT_LOADING_MESSAGE: string = 'Rovo dev is working';
-
-// TODO - replace with @atlaskit/icon implementation
-export const AiGenerativeTextSummaryIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 16 16"
-        fill="none"
-        role="presentation"
-        style={{ width: '16px', height: '16px', overflow: 'hidden', verticalAlign: 'bottom' }}
-    >
-        <path
-            d="M0 0H14V1.5H0V0ZM0 4.1663H14V5.6663H0V4.1663ZM10.7958 8.49428C10.9038 8.19825 11.1853 8.00129 11.5004 8.00129C11.8155 8.00129 12.0975 8.19825 12.2055 8.49428L12.8206 10.1807L14.507 10.7958C14.803 10.9038 15 11.1853 15 11.5004C15 11.8155 14.803 12.0975 14.507 12.2055L12.8206 12.8206L12.2055 14.507C12.0975 14.803 11.816 15 11.5009 15C11.1858 15 10.9038 14.803 10.7958 14.507L10.1807 12.8206L8.49428 12.2055C8.19825 12.0975 8.00129 11.816 8.00129 11.5009C8.00129 11.1858 8.19825 10.9038 8.49428 10.7958L10.1807 10.1807L10.7958 8.49428ZM0 8.3326H7V9.8326H0V8.3326ZM0 12.4989H5V13.9989H0V12.4989Z"
-            fill="currentColor"
-        />
-    </svg>
-);
-
-export const CloseIconDeepPlan: React.FC<{}> = () => {
-    return (
-        <span style={{ zoom: '0.5' }}>
-            <CloseIcon label="" />
-        </span>
-    );
-};
 
 function mapRovoDevDisabledReasonToSubState(reason: RovoDevDisabledReason): DisabledState['subState'] {
     switch (reason) {
@@ -351,10 +326,6 @@ const RovoDevView: React.FC = () => {
                         tool_call_id: object.tool_call_id, // Optional ID for tracking
                         args: object.toolCallMessage.args,
                     };
-
-                    if (object.tool_name === 'create_technical_plan') {
-                        setIsDeepPlanCreated(true);
-                    }
 
                     setPendingToolCallMessage(DEFAULT_LOADING_MESSAGE); // Clear pending tool call
                     appendResponse(returnMessage);

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -352,6 +352,10 @@ const RovoDevView: React.FC = () => {
                         args: object.toolCallMessage.args,
                     };
 
+                    if (object.tool_name === 'create_technical_plan') {
+                        setIsDeepPlanCreated(true);
+                    }
+
                     setPendingToolCallMessage(DEFAULT_LOADING_MESSAGE); // Clear pending tool call
                     appendResponse(returnMessage);
                     break;

--- a/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.test.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.test.tsx
@@ -9,7 +9,7 @@ describe('CodePlanButton', () => {
         const { container, getByText } = render(<CodePlanButton execute={mockExecute} />);
 
         expect(container.querySelector('.code-plan-button-container')).toBeTruthy();
-        expect(getByText('Start plan')).toBeTruthy();
+        expect(getByText('Generate code')).toBeTruthy();
     });
 
     it('calls execute function when clicked', () => {
@@ -17,7 +17,7 @@ describe('CodePlanButton', () => {
 
         const { getByText } = render(<CodePlanButton execute={mockExecute} />);
 
-        const button = getByText('Start plan');
+        const button = getByText('Generate code');
         fireEvent.click(button);
 
         expect(mockExecute).toHaveBeenCalledTimes(1);
@@ -38,7 +38,7 @@ describe('CodePlanButton', () => {
         const mockExecute = jest.fn();
         const { getByText } = render(<CodePlanButton execute={mockExecute} disabled={true} />);
 
-        const button = getByText('Start plan');
+        const button = getByText('Generate code');
 
         fireEvent.click(button);
         expect(mockExecute).toHaveBeenCalledTimes(0);

--- a/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/CodePlanButton.tsx
@@ -9,7 +9,7 @@ export const CodePlanButton: React.FC<CodePlanButtonProps> = ({ execute, disable
     return (
         <div className="code-plan-button-container">
             <button disabled={disabled} className="code-plan-button" onClick={() => execute()}>
-                <span>Start plan</span>
+                <span>Generate code</span>
             </button>
         </div>
     );


### PR DESCRIPTION
### What Is This Change?

Change button + border radii + padding styles to match BBY styles

Changes:

<img width="339" height="132" alt="Screenshot 2025-09-16 at 3 51 22 PM" src="https://github.com/user-attachments/assets/ad346161-11df-48f1-96e2-63f89adb5789" />
<img width="345" height="136" alt="Screenshot 2025-09-16 at 3 51 31 PM" src="https://github.com/user-attachments/assets/ce645127-a07c-4801-b1ca-159216e0777e" />
<img width="370" height="186" alt="Screenshot 2025-09-16 at 3 51 59 PM" src="https://github.com/user-attachments/assets/19d3a0e5-605e-4f53-9aae-fda0cf8443e4" />
<img width="345" height="127" alt="Screenshot 2025-09-16 at 3 52 09 PM" src="https://github.com/user-attachments/assets/d3a6cea1-8fac-4aa2-932f-3d26cd549ac2" />
<img width="341" height="246" alt="Screenshot 2025-09-16 at 3 57 13 PM" src="https://github.com/user-attachments/assets/ab12e3f1-4b8d-404f-92a3-1604dbd6a454" />
<img width="328" height="355" alt="Screenshot 2025-09-16 at 3 57 24 PM" src="https://github.com/user-attachments/assets/6d4738c5-7e57-4c57-9229-d901c47556eb" />
<img width="341" height="179" alt="Screenshot 2025-09-16 at 4 00 38 PM" src="https://github.com/user-attachments/assets/567e1660-8691-424a-8159-0d9689284225" />
<img width="327" height="84" alt="Screenshot 2025-09-16 at 4 02 25 PM" src="https://github.com/user-attachments/assets/89cf6ffb-b20c-4d1a-b966-ae27ddecdd63" />
<img width="329" height="237" alt="Screenshot 2025-09-16 at 4 02 36 PM" src="https://github.com/user-attachments/assets/ff71f72a-6cad-440f-8a6f-f38f64b372e5" />

### How Has This Been Tested?

manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`