### PR TITLE
AXON-1109: Site drop down for Auth should be in alphabetical order

### DIFF
--- a/src/react/atlascode/config/auth/SiteList.test.tsx
+++ b/src/react/atlascode/config/auth/SiteList.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { AuthInfoState, Product, ProductJira } from '../../../../atlclients/authInfo';
+import { SiteWithAuthInfo } from '../../../../lib/ipc/toUI/config';
+import { ConfigControllerContext } from '../configController';
+import { SiteList } from './SiteList';
+
+// Mock the deduplicateOAuthSites function
+jest.mock('./siteDeduplication', () => ({
+    deduplicateOAuthSites: jest.fn((sites) => sites),
+}));
+
+// Mock the useBorderBoxStyles hook
+jest.mock('../../common/useBorderBoxStyles', () => ({
+    useBorderBoxStyles: () => ({ box: 'mock-border-box-class' }),
+}));
+
+// Mock makeStyles to avoid theme issues
+jest.mock('@mui/styles', () => ({
+    makeStyles: () => () => ({
+        root: 'mock-root-class',
+        iconStyle: 'mock-icon-class',
+    }),
+}));
+
+const mockController = {
+    logout: jest.fn(),
+    login: jest.fn(),
+} as any;
+
+const createMockSiteWithAuth = (siteName: string): SiteWithAuthInfo => ({
+    site: {
+        id: siteName,
+        name: siteName,
+        host: `${siteName}.com`,
+        isCloud: true,
+        product: ProductJira,
+        avatarUrl: '',
+        baseLinkUrl: '',
+        baseApiUrl: '',
+        userId: '',
+        credentialId: '',
+    },
+    auth: {
+        state: AuthInfoState.Valid,
+        user: {
+            id: `user-${siteName}`,
+            email: `${siteName}@example.com`,
+            displayName: siteName,
+            avatarUrl: '',
+        },
+    },
+});
+
+const renderSiteList = (sites: SiteWithAuthInfo[], product: Product = ProductJira) => {
+    return render(
+        <ConfigControllerContext.Provider value={mockController}>
+            <SiteList sites={sites} product={product} editServer={jest.fn()} />
+        </ConfigControllerContext.Provider>,
+    );
+};
+
+describe('SiteList', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should display sites in alphabetical order by site name', () => {
+        const sites = [
+            createMockSiteWithAuth('ZebraSite'),
+            createMockSiteWithAuth('AlphaSite'),
+            createMockSiteWithAuth('BetaSite'),
+            createMockSiteWithAuth('GammaSite'),
+        ];
+
+        renderSiteList(sites);
+
+        const siteElements = screen.getAllByText(/Site$/);
+        const siteNames = siteElements.map((element) => element.textContent);
+
+        expect(siteNames).toEqual(['AlphaSite', 'BetaSite', 'GammaSite', 'ZebraSite']);
+    });
+
+    it('should sort sites case-insensitively', () => {
+        const sites = [
+            createMockSiteWithAuth('zulu'),
+            createMockSiteWithAuth('Alpha'),
+            createMockSiteWithAuth('beta'),
+            createMockSiteWithAuth('Charlie'),
+        ];
+
+        renderSiteList(sites);
+
+        const siteElements = screen.getAllByText(/^(zulu|Alpha|beta|Charlie)$/);
+        const siteNames = siteElements.map((element) => element.textContent);
+
+        expect(siteNames).toEqual(['Alpha', 'beta', 'Charlie', 'zulu']);
+    });
+});

--- a/src/react/atlascode/config/auth/SiteList.tsx
+++ b/src/react/atlascode/config/auth/SiteList.tsx
@@ -121,6 +121,9 @@ export const SiteList: React.FunctionComponent<SiteListProps> = ({ sites, produc
     // Deduplicate OAuth sites by username and update display names
     const deduplicatedSites = deduplicateOAuthSites(sites);
 
+    // Sort sites alphabetically by site name
+    const sortedSites = deduplicatedSites.sort((a, b) => a.site.name.localeCompare(b.site.name));
+
     const editOrLogout = (siteWithAuth: SiteWithAuthInfo) => {
         if (isOAuthInfo(siteWithAuth.auth)) {
             controller.logout(siteWithAuth.site);
@@ -133,9 +136,7 @@ export const SiteList: React.FunctionComponent<SiteListProps> = ({ sites, produc
 
     return (
         <div className={clsx(classes.root, borderBox.box)}>
-            <List>
-                {generateListItems(product, deduplicatedSites, controller.logout, editOrLogout, classes.iconStyle)}
-            </List>
+            <List>{generateListItems(product, sortedSites, controller.logout, editOrLogout, classes.iconStyle)}</List>
         </div>
     );
 };


### PR DESCRIPTION
### What Is This Change?

| Before | After |
|:--|:--|
| <img width="614" height="254" alt="Screenshot 2025-09-16 at 17 08 33" src="https://github.com/user-attachments/assets/a65ee33f-de5a-4964-93e6-991cb7953459" /> | <img width="618" height="251" alt="Screenshot 2025-09-16 at 17 10 39" src="https://github.com/user-attachments/assets/3fc97d97-a333-48f4-a8b7-47d439ea2710" /> |

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change