### PR TITLE
[AXON-1145] Fix missing RovoDevEnv value in Rovo Dev perf events

### DIFF
--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -806,6 +806,7 @@ describe('analytics', () => {
             it('should create a performance event with correct tag and measure', async () => {
                 const measure = 150;
                 const params = {
+                    rovoDevEnv: 'IDE' as const,
                     appInstanceId: 'app-123',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId: 'test-prompt-123',
@@ -830,6 +831,7 @@ describe('analytics', () => {
             it('should create a performance event with correct tag and measure', async () => {
                 const measure = 250;
                 const params = {
+                    rovoDevEnv: 'IDE' as const,
                     appInstanceId: 'app-456',
                     rovoDevSessionId: 'session-456',
                     rovoDevPromptId: 'prompt-456',
@@ -855,6 +857,7 @@ describe('analytics', () => {
             it('should create a performance event with correct tag and measure', async () => {
                 const measure = 500;
                 const params = {
+                    rovoDevEnv: 'IDE' as const,
                     appInstanceId: 'app-789',
                     rovoDevSessionId: 'session-789',
                     rovoDevPromptId: 'prompt-789',
@@ -880,6 +883,7 @@ describe('analytics', () => {
             it('should create a performance event with correct tag and measure', async () => {
                 const measure = 1000;
                 const params = {
+                    rovoDevEnv: 'IDE' as const,
                     appInstanceId: 'app-999',
                     rovoDevSessionId: 'session-999',
                     rovoDevPromptId: 'prompt-999',
@@ -905,6 +909,7 @@ describe('analytics', () => {
             it('should include platform information based on process.platform', async () => {
                 setProcessPlatform('darwin');
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
@@ -915,6 +920,7 @@ describe('analytics', () => {
 
             it('should include origin information', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
@@ -925,6 +931,7 @@ describe('analytics', () => {
 
             it('should handle empty string parameters', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: '',
                     rovoDevPromptId: '',
@@ -936,6 +943,7 @@ describe('analytics', () => {
 
             it('should handle additional parameters in params object', async () => {
                 const params = {
+                    rovoDevEnv: 'IDE' as const,
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
@@ -1005,6 +1013,7 @@ describe('analytics', () => {
         describe('event structure validation', () => {
             it('should return a valid TrackEvent structure', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
@@ -1026,6 +1035,7 @@ describe('analytics', () => {
 
             it('should have consistent action and actionSubject for timeToFirstByte', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstByte', 100, {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
@@ -1037,6 +1047,7 @@ describe('analytics', () => {
 
             it('should have consistent action and actionSubject for timeToFirstMessage', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToFirstMessage', 100, {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
@@ -1048,6 +1059,7 @@ describe('analytics', () => {
 
             it('should have consistent action and actionSubject for timeToTechPlan', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToTechPlan', 100, {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
@@ -1059,6 +1071,7 @@ describe('analytics', () => {
 
             it('should have consistent action and actionSubject for timeToLastMessage', async () => {
                 const event = await analytics.performanceEvent('api.rovodev.chat.response.timeToLastMessage', 100, {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-app-id',
                     rovoDevSessionId: 'test-session',
                     rovoDevPromptId: 'test-prompt',
@@ -1627,6 +1640,7 @@ describe('analytics', () => {
                     'api.rovodev.chat.response.timeToFirstByte',
                     100,
                     {
+                        rovoDevEnv: 'IDE',
                         appInstanceId: 'test-app-id',
                         rovoDevSessionId: 'test-session',
                         rovoDevPromptId: 'test-prompt',

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -203,6 +203,7 @@ type JiraPerfEvents =
     | 'ui.jira.editJiraIssue.update.lcp';
 
 interface RovoDevCommonParams {
+    rovoDevEnv: RovoDevEnv;
     appInstanceId: string;
     rovoDevSessionId: string;
     rovoDevPromptId: string;

--- a/src/rovo-dev/performanceLogger.test.ts
+++ b/src/rovo-dev/performanceLogger.test.ts
@@ -21,7 +21,7 @@ describe('PerformanceLogger', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        performanceLogger = new PerformanceLogger('test-instance-id');
+        performanceLogger = new PerformanceLogger('IDE', 'test-instance-id');
 
         // Setup mock analytics client
         mockAnalyticsClient = {
@@ -96,6 +96,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToFirstByte',
                 measureValue,
                 {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-instance-id',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
@@ -135,6 +136,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToFirstMessage',
                 measureValue,
                 {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-instance-id',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
@@ -167,6 +169,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToTechPlan',
                 measureValue,
                 {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-instance-id',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,
@@ -200,6 +203,7 @@ describe('PerformanceLogger', () => {
                 'api.rovodev.chat.response.timeToLastMessage',
                 measureValue,
                 {
+                    rovoDevEnv: 'IDE',
                     appInstanceId: 'test-instance-id',
                     rovoDevSessionId: 'test-session-123',
                     rovoDevPromptId,

--- a/src/rovo-dev/performanceLogger.ts
+++ b/src/rovo-dev/performanceLogger.ts
@@ -1,4 +1,4 @@
-import { performanceEvent } from '../../src/analytics';
+import { performanceEvent, RovoDevEnv } from '../../src/analytics';
 import { Container } from '../../src/container';
 import { Logger } from '../../src/logger';
 import Perf from '../util/perf';
@@ -6,7 +6,10 @@ import Perf from '../util/perf';
 export class PerformanceLogger {
     private currentSessionId: string = '';
 
-    constructor(private readonly appInstanceId: string) {}
+    constructor(
+        private readonly rovoDevEnv: RovoDevEnv,
+        private readonly appInstanceId: string,
+    ) {}
 
     public sessionStarted(sessionId: string) {
         this.currentSessionId = sessionId;
@@ -23,6 +26,7 @@ export class PerformanceLogger {
     public async promptFirstByteReceived(promptId: string) {
         const measure = Perf.measure(promptId);
         const evt = await performanceEvent('api.rovodev.chat.response.timeToFirstByte', measure, {
+            rovoDevEnv: this.rovoDevEnv,
             appInstanceId: this.appInstanceId,
             rovoDevSessionId: this.currentSessionId,
             rovoDevPromptId: promptId,
@@ -35,6 +39,7 @@ export class PerformanceLogger {
     public async promptFirstMessageReceived(promptId: string) {
         const measure = Perf.measure(promptId);
         const evt = await performanceEvent('api.rovodev.chat.response.timeToFirstMessage', measure, {
+            rovoDevEnv: this.rovoDevEnv,
             appInstanceId: this.appInstanceId,
             rovoDevSessionId: this.currentSessionId,
             rovoDevPromptId: promptId,
@@ -47,6 +52,7 @@ export class PerformanceLogger {
     public async promptTechnicalPlanReceived(promptId: string) {
         const measure = Perf.measure(promptId);
         const evt = await performanceEvent('api.rovodev.chat.response.timeToTechPlan', measure, {
+            rovoDevEnv: this.rovoDevEnv,
             appInstanceId: this.appInstanceId,
             rovoDevSessionId: this.currentSessionId,
             rovoDevPromptId: promptId,
@@ -59,6 +65,7 @@ export class PerformanceLogger {
     public async promptLastMessageReceived(promptId: string) {
         const measure = Perf.measure(promptId);
         const evt = await performanceEvent('api.rovodev.chat.response.timeToLastMessage', measure, {
+            rovoDevEnv: this.rovoDevEnv,
             appInstanceId: this.appInstanceId,
             rovoDevSessionId: this.currentSessionId,
             rovoDevPromptId: promptId,

--- a/src/rovo-dev/rovoDevTelemetryProvider.ts
+++ b/src/rovo-dev/rovoDevTelemetryProvider.ts
@@ -53,7 +53,7 @@ export class RovoDevTelemetryProvider {
         private readonly appInstanceId: string,
         private readonly onError: (error: Error) => void,
     ) {
-        this._perfLogger = new PerformanceLogger(this.appInstanceId);
+        this._perfLogger = new PerformanceLogger(this.rovoDevEnv, this.appInstanceId);
     }
 
     public startNewSession(chatSessionId: string, manuallyCreated: boolean) {


### PR DESCRIPTION
### What Is This Change?

The `rovoDevEnv` attribute allow us to discriminate from which environment Rovo Dev is running from.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`