### PR TITLE
Add the Rovo Dev Session Id to the feedback form

### DIFF
--- a/src/rovo-dev/rovoDevFeedbackManager.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.ts
@@ -11,6 +11,7 @@ interface FeedbackObject {
     feedbackMessage: string;
     canContact: boolean;
     lastTenMessages?: string[];
+    rovoDevSessionId?: string;
 }
 
 const FEEDBACK_ENDPOINT = `https://jsd-widget.atlassian.com/api/embeddable/57037b9e-743e-407d-bb03-441a13c7afd0/request?requestTypeId=3066`;
@@ -18,7 +19,7 @@ const FEEDBACK_ENDPOINT = `https://jsd-widget.atlassian.com/api/embeddable/57037
 export class RovoDevFeedbackManager {
     public static async submitFeedback(feedback: FeedbackObject, isBBY: boolean = false): Promise<void> {
         const transport = getAxiosInstance();
-        const context = this.getContext(isBBY);
+        const context = this.getContext(isBBY, feedback.rovoDevSessionId);
 
         let userEmail = 'do-not-reply@atlassian.com';
         let userName = 'unknown';
@@ -101,12 +102,13 @@ export class RovoDevFeedbackManager {
         vscode.window.showInformationMessage('Thank you for your feedback!');
     }
 
-    private static getContext(isBBY: boolean = false): any {
+    private static getContext(isBBY: boolean = false, rovoDevSessionId?: string): any {
         return {
             component: isBBY ? 'Boysenberry - vscode' : 'IDE - vscode',
             extensionVersion: Container.version,
             vscodeVersion: vscode.version,
             rovoDevVersion: MIN_SUPPORTED_ROVODEV_VERSION,
+            ...(rovoDevSessionId && { rovoDevSessionId }),
         };
     }
 }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -291,6 +291,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                                 feedbackMessage: e.feedbackMessage,
                                 canContact: e.canContact,
                                 lastTenMessages: e.lastTenMessages,
+                                rovoDevSessionId: process.env.SANDBOX_SESSION_ID,
                             },
                             !!this.isBoysenberry,
                         );


### PR DESCRIPTION
### What Is This Change?

Added the Rovo Dev Session ID to help with investigations if user's are reporting a problem, this will help us search in Splunk logs

### How Has This Been Tested?

Added this to my local .env - which is the environment variable platform saves our session id in
```
SANDBOX_SESSION_ID=bf6f3d33-6f37-46a1-97a3-8125d4217685
```
Ran editor locally, and submitted feedback

https://customerfeedback.atlassian.net/jira/servicedesk/projects/DAIF/queues/custom/3907/DAIF-2217

<img width="1068" height="772" alt="image" src="https://github.com/user-attachments/assets/f7501f0c-41b9-4652-9674-a498f122a4f8" />