### PR TITLE
[AXON-823] Clean up quick debug command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,7 +9,6 @@ import {
     viewScreenEvent,
 } from './analytics';
 import { BasicAuthInfo, DetailedSiteInfo, ProductBitbucket, ProductJira } from './atlclients/authInfo';
-import { fetchIssueSuggestions } from './atlclients/issueBuilder';
 import { showBitbucketDebugInfo } from './bitbucket/bbDebug';
 import { rerunPipeline } from './commands/bitbucket/rerunPipeline';
 import { runPipeline } from './commands/bitbucket/runPipeline';
@@ -549,12 +548,6 @@ export function registerDebugCommands(vscodeContext: ExtensionContext): Disposab
             window.showInformationMessage('[DEBUG] Atlascode: Quick command');
 
             // Add your logic here
-            try {
-                const result = await fetchIssueSuggestions('TODO: refactor this');
-                window.showInformationMessage(`[DEBUG] Result: ${JSON.stringify(result)}`);
-            } catch (e) {
-                window.showErrorMessage(`[DEBUG] Error: ${e}`);
-            }
         }),
 
         // Login to a cloud site with API token


### PR DESCRIPTION
### What Is This Change?

Tiny fixup to remove the TODO issue suggestion from the debug quick command

### How Has This Been Tested?

Manually. Also, this is never visible outside of debug

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`