### PR TITLE
[AXON-823] Minor fix to the work item suggestion

### DIFF
--- a/src/commands/jira/createIssue.ts
+++ b/src/commands/jira/createIssue.ts
@@ -32,11 +32,12 @@ export async function createIssue(data: Uri | TodoIssueData | undefined, source?
     if (isTodoIssueData(data)) {
         const settings = await buildSuggestionSettings();
         const todoData = simplify(data);
+        const suggestionManager = new IssueSuggestionManager(settings);
 
         await Container.createIssueWebview.createOrShow(
             ViewColumn.Beside,
             {
-                description: descriptionForUri(data.uri),
+                ...(await suggestionManager.generateDummyIssueSuggestion(todoData)),
                 uri: data.uri,
                 position: data.insertionPoint,
                 onCreated: annotateComment,
@@ -46,8 +47,6 @@ export async function createIssue(data: Uri | TodoIssueData | undefined, source?
         );
 
         try {
-            const suggestionManager = new IssueSuggestionManager(settings);
-
             await suggestionManager.generate(todoData).then(async (suggestion) => {
                 await Container.createIssueWebview.fastUpdateFields({
                     summary: suggestion.summary,

--- a/src/commands/jira/issueSuggestionManager.ts
+++ b/src/commands/jira/issueSuggestionManager.ts
@@ -75,7 +75,9 @@ export class IssueSuggestionManager {
     }
 
     async generate(data: SimplifiedTodoIssueData) {
-        return this.settings.isEnabled ? this.generateIssueSuggestion(data) : this.generateDummyIssueSuggestion(data);
+        return this.settings.isEnabled && this.settings.isAvailable
+            ? this.generateIssueSuggestion(data)
+            : this.generateDummyIssueSuggestion(data);
     }
 
     async sendFeedback(isPositive: boolean, data: SimplifiedTodoIssueData) {


### PR DESCRIPTION
### What Is This Change?

If the API key is not provided for the AI issue suggestion:

 * Don't try to make the API call 🤦 
 * Use uniformly generated summary/description as fallback

### How Has This Been Tested?

Manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`