### PR TITLE
[AXON-1140] Fixed Rovo Dev prompts injecting html into the view

### DIFF
--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -8,14 +8,18 @@ import { ToolReturnParsedItem } from '../tools/ToolReturnItem';
 import { ChatMessage, DefaultMessage, parseToolReturnMessage } from '../utils';
 import { ErrorMessageItem } from './errorMessage';
 
-export const mdParser = new MarkdownIt({
-    html: true,
+const mdParser = new MarkdownIt({
+    html: false,
     breaks: true,
     typographer: true,
     linkify: true,
 });
 
 mdParser.linkify.set({ fuzzyLink: false });
+
+export const MarkedDown: React.FC<{ value: string }> = ({ value }) => {
+    return <span dangerouslySetInnerHTML={{ __html: mdParser.render(value) }} />;
+};
 
 export interface OpenFileFunc {
     (filePath: string, tryShowDiff?: boolean, lineRange?: number[]): void;

--- a/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
+++ b/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
@@ -4,7 +4,7 @@ import { RovoDevProviderMessage, RovoDevProviderMessageType } from 'src/rovo-dev
 import { ConnectionTimeout } from 'src/util/time';
 
 import { useMessagingApi } from '../../messagingApi';
-import { mdParser } from '../common/common';
+import { MarkedDown } from '../common/common';
 import { RovoDevViewResponse, RovoDevViewResponseType } from '../rovoDevViewMessages';
 import { DefaultMessage } from '../utils';
 
@@ -147,10 +147,9 @@ export const PullRequestForm: React.FC<PullRequestFormProps> = ({
 
 export const PullRequestChatItem: React.FC<{ msg: DefaultMessage }> = ({ msg }) => {
     const content = (
-        <div
-            style={{ display: 'flex', flexDirection: 'column' }}
-            dangerouslySetInnerHTML={{ __html: mdParser.render(msg.text || '') }}
-        />
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <MarkedDown value={msg.text || ''} />
+        </div>
     );
     return (
         <div className="chat-message pull-request-chat-item agent-message">

--- a/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
@@ -3,7 +3,7 @@ import ThumbsDownIcon from '@atlaskit/icon/core/thumbs-down';
 import ThumbsUpIcon from '@atlaskit/icon/core/thumbs-up';
 import React from 'react';
 
-import { mdParser } from '../common/common';
+import { MarkedDown } from '../common/common';
 import { PromptContextCollection } from '../prompt-box/promptContext/promptContextCollection';
 import { DefaultMessage } from '../utils';
 
@@ -15,12 +15,6 @@ export const ChatMessageItem: React.FC<{
     onFeedback?: (isPositive: boolean) => void;
 }> = ({ msg, icon, enableActions, onCopy, onFeedback }) => {
     const messageTypeStyles = msg.source === 'User' ? 'user-message' : 'agent-message';
-    const content = (
-        <div
-            style={{ display: 'flex', flexDirection: 'column' }}
-            dangerouslySetInnerHTML={{ __html: mdParser.render(msg.text || '') }}
-        />
-    );
 
     return (
         <>
@@ -29,7 +23,11 @@ export const ChatMessageItem: React.FC<{
                 style={{ display: 'flex', flexDirection: 'row', alignItems: 'start', gap: '8px' }}
             >
                 {icon && <div className="message-icon">{icon}</div>}
-                <div className="message-content">{content}</div>
+                <div className="message-content">
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                        <MarkedDown value={msg.text || ''} />
+                    </div>
+                </div>
             </div>
             {msg.source === 'User' && msg.context && (
                 <div className="message-context">

--- a/src/react/atlascode/rovo-dev/technical-plan/FileToChangeComponent.test.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/FileToChangeComponent.test.tsx
@@ -10,9 +10,7 @@ jest.mock('../common/common', () => ({
             {filePath}
         </button>
     ),
-    mdParser: {
-        render: (text: string) => `<p>${text}</p>`,
-    },
+    MarkedDown: ({ value }: { value: string }) => <span>{value}</span>,
 }));
 
 describe('FileToChangeComponent', () => {

--- a/src/react/atlascode/rovo-dev/technical-plan/FileToChangeComponent.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/FileToChangeComponent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FileLozenge, mdParser, OpenFileFunc } from '../common/common';
+import { FileLozenge, MarkedDown, OpenFileFunc } from '../common/common';
 
 interface FileToChangeComponentProps {
     filePath: string;
@@ -13,12 +13,9 @@ export const FileToChangeComponent: React.FC<FileToChangeComponentProps> = ({
     openFile,
     descriptionOfChange,
 }) => {
-    const renderDescription = (description: string) => {
-        return <span dangerouslySetInnerHTML={{ __html: mdParser.render(description) }} />;
-    };
     return (
         <div className="file-to-change">
-            {descriptionOfChange && renderDescription(descriptionOfChange)}
+            {descriptionOfChange && <MarkedDown value={descriptionOfChange} />}
             <div className="file-to-change-info">
                 <div className="lozenge-container">
                     <p>File to modify: </p>

--- a/src/react/atlascode/rovo-dev/technical-plan/TechnicalPlanComponent.tsx
+++ b/src/react/atlascode/rovo-dev/technical-plan/TechnicalPlanComponent.tsx
@@ -2,7 +2,7 @@ import QuestionCircleIcon from '@atlaskit/icon/glyph/question-circle';
 import React from 'react';
 import { TechnicalPlan } from 'src/rovo-dev/rovoDevTypes';
 
-import { mdParser, OpenFileFunc } from '../common/common';
+import { MarkedDown, OpenFileFunc } from '../common/common';
 import { LogicalChange } from './LogicalChange';
 
 interface TechnicalPlanProps {
@@ -61,7 +61,7 @@ export const TechnicalPlanComponent: React.FC<TechnicalPlanProps> = ({ content, 
                             />
                             <div style={{ display: 'flex', flexDirection: 'row', gap: '4px' }}>
                                 <div>{idx + 1}. </div>
-                                <span dangerouslySetInnerHTML={{ __html: mdParser.render(question) }} />
+                                <MarkedDown value={question} />
                             </div>
                         </div>
                     );

--- a/src/react/atlascode/rovo-dev/tools/ToolReturnItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolReturnItem.tsx
@@ -4,7 +4,7 @@ import SearchIcon from '@atlaskit/icon/glyph/search';
 import TrashIcon from '@atlaskit/icon/glyph/trash';
 import React from 'react';
 
-import { mdParser, OpenFileFunc } from '../common/common';
+import { MarkedDown, OpenFileFunc } from '../common/common';
 import { ToolReturnParseResult } from '../utils';
 
 export const ToolReturnParsedItem: React.FC<{
@@ -12,15 +12,17 @@ export const ToolReturnParsedItem: React.FC<{
     openFile: OpenFileFunc;
 }> = ({ msg, openFile }) => {
     const toolIcon = msg.type ? iconMap[msg.type] : undefined;
-    const content = mdParser.renderInline(msg.content);
+
     return (
         <a
             className={`tool-return-item-base tool-return-item ${msg.filePath ? 'tool-return-file-path' : ''}`}
             onClick={() => msg.filePath && openFile(msg.filePath)}
         >
-            {toolIcon && <>{toolIcon}</>}
+            {toolIcon}
             <div className="tool-return-item-base" style={{ flexWrap: 'wrap' }}>
-                <div className="tool-return-content" dangerouslySetInnerHTML={{ __html: content }} />
+                <div className="tool-return-content">
+                    <MarkedDown value={msg.content} />
+                </div>
                 {renderTitle(msg)}
             </div>
         </a>


### PR DESCRIPTION
### What Is This Change?

Html tags should not be added to the DOM directly, but interpreted as text.
The markdown formatter has an option to disallow html to be included in the final formatting.

| Before | After |
|-----|-----|
| <img width="298" height="76" alt="image" src="https://github.com/user-attachments/assets/202b29f2-9bb9-4a7a-b038-53eaf04f5417" /> | <img width="257" height="60" alt="image" src="https://github.com/user-attachments/assets/03dbb305-1997-4cb2-930f-41c1fce6fdec" /> |

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`