### PR TITLE
[Rovo Dev] Fixed the healtcheck polling, and more informative API call failures

### DIFF
--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -413,7 +413,7 @@ class RovoDevTerminalInstance extends RovoDevInstance {
                     rovoDevWebviewProvider.signalProcessStarted(port);
                     resolve();
                 } catch (error) {
-                    reject(new Error(`failed to execute Rovo Dev: ${error.message || error.toString()}`));
+                    reject(new Error(`failed to execute Rovo Dev: ${error.message || error}`));
                 }
             });
         });

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -783,12 +783,12 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         commands.executeCommand('atlascode.views.rovoDev.webView.focus');
 
         // Wait for the webview to initialize, up to 5 seconds
-        const initialized = await safeWaitFor(
-            (value) => !!value,
-            () => !!this._webView,
-            5000,
-            50,
-        );
+        const initialized = await safeWaitFor({
+            condition: (value) => !!value,
+            check: () => !!this._webView,
+            timeout: 5000,
+            interval: 50,
+        });
 
         if (!initialized) {
             return;
@@ -909,17 +909,15 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private async initializeWithHealthcheck(rovoDevApiClient: RovoDevApiClient, timeout = 10000) {
         this._rovoDevApiClient = rovoDevApiClient;
 
-        const webView = this._webView!;
-
-        // wait for Rovo Dev to be ready, for up to 10 seconds
-        const result = await safeWaitFor(
-            (info) => !!info && info.status !== 'unhealthy', // TODO: remove check for unhealthy after Rovo Dev fixes this status
-            () => this.executeHealthcheckInfo(),
+        const result = await safeWaitFor({
+            condition: (info) => !!info && info.status !== 'unhealthy', // TODO: remove check for unhealthy after Rovo Dev fixes this status
+            check: () => this.executeHealthcheckInfo(),
             timeout,
-            500,
-            () => !this.rovoDevApiClient,
-        );
+            interval: 500,
+            abortIf: () => !this.rovoDevApiClient,
+        });
 
+        const webView = this._webView!;
         const rovoDevClient = this._rovoDevApiClient;
 
         // if the client becomes undefined, it means the process terminated while we were polling the healtcheck

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -934,7 +934,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         // if result is undefined, it means we didn't manage to contact Rovo Dev within the allotted time
         // TODO - this scenario needs a better handling
         if (!result) {
-            //await rovoDevClient.shutdown();
+            await rovoDevClient.shutdown();
 
             this.signalProcessTerminated(
                 `Unable to initialize RovoDev at "${this._rovoDevApiClient.baseApiUrl}". Service wasn't ready within ${timeout} ms`,
@@ -949,7 +949,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         // if result is unhealthy, it means Rovo Dev has failed during initialization (e.g., some MCP servers failed to start)
         // we can't continue - shutdown and set the process as terminated so the user can try again.
         if (result.status === 'unhealthy') {
-            //await rovoDevClient.shutdown();
+            await rovoDevClient.shutdown();
 
             this.signalProcessTerminated(
                 'Failed to initialize Rovo Dev.\nPlease start a new chat session to try again.',
@@ -961,7 +961,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         // this scenario is when the user is not allowed to run Rovo Dev because it's disabled by the Jira administrator
         // TODO - handle this better: AXON-1024
         if (result.status === 'entitlement check failed') {
-            //await rovoDevClient.shutdown();
+            await rovoDevClient.shutdown();
 
             this.signalProcessTerminated(
                 'Rovo Dev is currently disabled in your Jira site.\nPlease contact your administrator to enable it.',

--- a/src/util/waitFor.test.ts
+++ b/src/util/waitFor.test.ts
@@ -9,7 +9,7 @@ describe('waitFor', () => {
         let value = 0;
         const check = () => ++value;
         const condition = (v: number) => v >= 3;
-        const result = await waitFor(condition, check, 1000, 10);
+        const result = await waitFor({ condition, check, timeout: 1000, interval: 10 });
         expect(result).toBe(3);
     });
 
@@ -17,7 +17,7 @@ describe('waitFor', () => {
         let value = 0;
         const check = () => ++value;
         const condition = (v: number) => v >= 100;
-        await expect(waitFor(condition, check, 50, 10)).rejects.toThrow('failed');
+        await expect(waitFor({ condition, check, timeout: 50, interval: 10 })).rejects.toThrow('failed');
     });
 
     it('throws if aborted', async () => {
@@ -25,7 +25,7 @@ describe('waitFor', () => {
         const check = () => ++value;
         const condition = (v: number) => v >= 3;
         const abortIf = () => value === 2;
-        await expect(waitFor(condition, check, 1000, 10, abortIf)).rejects.toThrow('aborted');
+        await expect(waitFor({ condition, check, timeout: 1000, interval: 10, abortIf })).rejects.toThrow('aborted');
     });
 });
 
@@ -34,7 +34,7 @@ describe('safeWaitFor', () => {
         let value = 0;
         const check = () => ++value;
         const condition = (v: number) => v >= 2;
-        const result = await safeWaitFor(condition, check, 1000, 10);
+        const result = await safeWaitFor({ condition, check, timeout: 1000, interval: 10 });
         expect(result).toBe(2);
     });
 
@@ -42,7 +42,7 @@ describe('safeWaitFor', () => {
         let value = 0;
         const check = () => ++value;
         const condition = (v: number) => v >= 100;
-        const result = await safeWaitFor(condition, check, 50, 10);
+        const result = await safeWaitFor({ condition, check, timeout: 50, interval: 10 });
         expect(result).toBeUndefined();
     });
 
@@ -51,7 +51,7 @@ describe('safeWaitFor', () => {
         const check = () => ++value;
         const condition = (v: number) => v >= 3;
         const abortIf = () => value === 2;
-        const result = await safeWaitFor(condition, check, 1000, 10, abortIf);
+        const result = await safeWaitFor({ condition, check, timeout: 1000, interval: 10, abortIf });
         expect(result).toBeUndefined();
     });
 });

--- a/src/util/waitFor.test.ts
+++ b/src/util/waitFor.test.ts
@@ -1,5 +1,9 @@
 import { safeWaitFor, waitFor } from './waitFor';
 
+jest.mock('timers/promises', () => ({
+    setTimeout: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe('waitFor', () => {
     it('resolves when condition is met', async () => {
         let value = 0;

--- a/src/util/waitFor.test.ts
+++ b/src/util/waitFor.test.ts
@@ -1,0 +1,53 @@
+import { safeWaitFor, waitFor } from './waitFor';
+
+describe('waitFor', () => {
+    it('resolves when condition is met', async () => {
+        let value = 0;
+        const check = () => ++value;
+        const condition = (v: number) => v >= 3;
+        const result = await waitFor(condition, check, 1000, 10);
+        expect(result).toBe(3);
+    });
+
+    it('throws if timeout occurs before condition is met', async () => {
+        let value = 0;
+        const check = () => ++value;
+        const condition = (v: number) => v >= 100;
+        await expect(waitFor(condition, check, 50, 10)).rejects.toThrow('failed');
+    });
+
+    it('throws if aborted', async () => {
+        let value = 0;
+        const check = () => ++value;
+        const condition = (v: number) => v >= 3;
+        const abortIf = () => value === 2;
+        await expect(waitFor(condition, check, 1000, 10, abortIf)).rejects.toThrow('aborted');
+    });
+});
+
+describe('safeWaitFor', () => {
+    it('returns result when condition is met', async () => {
+        let value = 0;
+        const check = () => ++value;
+        const condition = (v: number) => v >= 2;
+        const result = await safeWaitFor(condition, check, 1000, 10);
+        expect(result).toBe(2);
+    });
+
+    it('returns undefined if timeout occurs', async () => {
+        let value = 0;
+        const check = () => ++value;
+        const condition = (v: number) => v >= 100;
+        const result = await safeWaitFor(condition, check, 50, 10);
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if aborted', async () => {
+        let value = 0;
+        const check = () => ++value;
+        const condition = (v: number) => v >= 3;
+        const abortIf = () => value === 2;
+        const result = await safeWaitFor(condition, check, 1000, 10, abortIf);
+        expect(result).toBeUndefined();
+    });
+});

--- a/src/util/waitFor.ts
+++ b/src/util/waitFor.ts
@@ -1,0 +1,81 @@
+import { setTimeout } from 'timers/promises';
+
+type ExecuteCheckReturnType<T> = { checkPassed: true; result: T } | { checkPassed: false };
+
+const executeCheck = async <T>(
+    check: () => Promise<T> | T,
+    condition: (value: T | undefined) => Promise<boolean> | boolean,
+): Promise<ExecuteCheckReturnType<T>> => {
+    try {
+        const result = await check();
+        const passed = await condition(result);
+        return passed ? { checkPassed: true, result } : { checkPassed: false };
+    } catch {
+        return { checkPassed: false };
+    }
+};
+
+/**
+ * Polls the provided `check` function every `interval` milliseconds until the callback `condition` returns true, or the timeout time `timeout` occurrs.
+ * @param condition The condition to wait for
+ * @param check The check to perform at the given interval time.
+ * @param timeout The timeout, in milliseconds, after which we give up.
+ * @param interval The interval in milliseconds.
+ * @param abortIf An optional callback, executed between intervals, that causes this wait to abort prematurely if its condition verifies.
+ * @returns The last value returned by `check` when the `condition` satisfies.
+ * @throws If `abortIf` returns true, or the `timeout` occurs.
+ */
+export async function waitFor<T>(
+    condition: (value: T | undefined) => Promise<boolean> | boolean,
+    check: () => Promise<T> | T,
+    timeout: number,
+    interval: number,
+    abortIf?: () => boolean,
+): Promise<T> {
+    if (abortIf?.()) {
+        throw new Error('aborted');
+    }
+
+    let checkOutcome = await executeCheck(check, condition);
+
+    while (!checkOutcome.checkPassed && timeout) {
+        await setTimeout(interval);
+        timeout -= interval;
+
+        if (abortIf?.()) {
+            throw new Error('aborted');
+        }
+
+        checkOutcome = await executeCheck(check, condition);
+    }
+
+    if (!checkOutcome.checkPassed) {
+        throw new Error('failed');
+    }
+
+    return checkOutcome.result;
+}
+
+/**
+ * Safe version of `waitFor` - returns undefined instead of throwing exceptions.
+ * Polls the provided `check` function every `interval` milliseconds until the callback `condition` returns true, or the timeout time `timeout` occurrs.
+ * @param condition The condition to wait for
+ * @param check The check to perform at the given interval time.
+ * @param timeout The timeout, in milliseconds, after which we give up.
+ * @param interval The interval in milliseconds.
+ * @param abortIf An optional callback, executed between intervals, that causes this wait to abort prematurely if its condition verifies.
+ * @returns The last value returned by `check` when the `condition` satisfies, or undefined if either `abortIf` returns true, or the `timeout` occurs.
+ */
+export async function safeWaitFor<T>(
+    condition: (value: T | undefined) => Promise<boolean> | boolean,
+    check: () => Promise<T> | T,
+    timeoutMs: number,
+    interval: number,
+    abortIf?: () => boolean,
+): Promise<T | undefined> {
+    try {
+        return await waitFor(condition, check, timeoutMs, interval, abortIf);
+    } catch {
+        return undefined;
+    }
+}

--- a/src/util/waitFor.ts
+++ b/src/util/waitFor.ts
@@ -17,21 +17,28 @@ const executeCheck = async <T>(
 
 /**
  * Polls the provided `check` function every `interval` milliseconds until the callback `condition` returns true, or the timeout time `timeout` occurrs.
- * @param condition The condition to wait for
- * @param check The check to perform at the given interval time.
- * @param timeout The timeout, in milliseconds, after which we give up.
- * @param interval The interval in milliseconds.
- * @param abortIf An optional callback, executed between intervals, that causes this wait to abort prematurely if its condition verifies.
+ * @param args
+ * - `condition` The condition to wait for
+ * - `check` The check to perform at the given interval time.
+ * - `timeout` The timeout, in milliseconds, after which we give up.
+ * - `interval` The interval in milliseconds.
+ * - `abortIf` An optional callback, executed between intervals, that causes this wait to abort prematurely if its condition verifies.
  * @returns The last value returned by `check` when the `condition` satisfies.
  * @throws If `abortIf` returns true, or the `timeout` occurs.
  */
-export async function waitFor<T>(
-    condition: (value: T | undefined) => Promise<boolean> | boolean,
-    check: () => Promise<T> | T,
-    timeout: number,
-    interval: number,
-    abortIf?: () => boolean,
-): Promise<T> {
+export async function waitFor<T>({
+    condition,
+    check,
+    timeout,
+    interval,
+    abortIf,
+}: {
+    condition: (value: T | undefined) => Promise<boolean> | boolean;
+    check: () => Promise<T> | T;
+    timeout: number;
+    interval: number;
+    abortIf?: () => boolean;
+}): Promise<T> {
     if (abortIf?.()) {
         throw new Error('aborted');
     }
@@ -59,22 +66,17 @@ export async function waitFor<T>(
 /**
  * Safe version of `waitFor` - returns undefined instead of throwing exceptions.
  * Polls the provided `check` function every `interval` milliseconds until the callback `condition` returns true, or the timeout time `timeout` occurrs.
- * @param condition The condition to wait for
- * @param check The check to perform at the given interval time.
- * @param timeout The timeout, in milliseconds, after which we give up.
- * @param interval The interval in milliseconds.
- * @param abortIf An optional callback, executed between intervals, that causes this wait to abort prematurely if its condition verifies.
+ * @param args
+ * - `condition` The condition to wait for
+ * - `check` The check to perform at the given interval time.
+ * - `timeout` The timeout, in milliseconds, after which we give up.
+ * - `interval` The interval in milliseconds.
+ * - `abortIf` An optional callback, executed between intervals, that causes this wait to abort prematurely if its condition verifies.
  * @returns The last value returned by `check` when the `condition` satisfies, or undefined if either `abortIf` returns true, or the `timeout` occurs.
  */
-export async function safeWaitFor<T>(
-    condition: (value: T | undefined) => Promise<boolean> | boolean,
-    check: () => Promise<T> | T,
-    timeoutMs: number,
-    interval: number,
-    abortIf?: () => boolean,
-): Promise<T | undefined> {
+export async function safeWaitFor<T>(...args: Parameters<typeof waitFor<T>>) {
     try {
-        return await waitFor(condition, check, timeoutMs, interval, abortIf);
+        return await waitFor(...args);
     } catch {
         return undefined;
     }


### PR DESCRIPTION
### What Is This Change?

Fixed a bug in the healthcheck poll that was preventing the newly changed status to be detected.
Initialization time reduced thanks to this fix.

Also, added a try/catch in the inner fetch function of the api client to inform what's the failure reason when Node's fetch failed to send a request.

### How Has This Been Tested?

- [x] `npm run lint`
- [x] `npm run test`
- [x] `manual tests`