### PR TITLE
[Rovo Dev][Debuggability] Don't shutdown Rovo Dev when unhealthy so the terminal can stay alive

### DIFF
--- a/src/util/waitFor.test.ts
+++ b/src/util/waitFor.test.ts
@@ -38,19 +38,28 @@ describe('safeWaitFor', () => {
         expect(result).toBe(2);
     });
 
-    it('returns undefined if timeout occurs', async () => {
+    it('returns last check() value if timeout occurs', async () => {
         let value = 0;
         const check = () => ++value;
         const condition = (v: number) => v >= 100;
         const result = await safeWaitFor({ condition, check, timeout: 50, interval: 10 });
-        expect(result).toBeUndefined();
+        expect(result).toBe(6);
     });
 
-    it('returns undefined if aborted', async () => {
+    it('returns last check() if aborted', async () => {
         let value = 0;
         const check = () => ++value;
-        const condition = (v: number) => v >= 3;
-        const abortIf = () => value === 2;
+        const condition = (v: number) => v >= 10;
+        const abortIf = () => value === 5;
+        const result = await safeWaitFor({ condition, check, timeout: 1000, interval: 10, abortIf });
+        expect(result).toBe(5);
+    });
+
+    it('returns undefined if aborted immediately', async () => {
+        let value = 0;
+        const check = () => ++value;
+        const condition = (v: number) => v >= 10;
+        const abortIf = () => true;
         const result = await safeWaitFor({ condition, check, timeout: 1000, interval: 10, abortIf });
         expect(result).toBeUndefined();
     });


### PR DESCRIPTION
### What Is This Change?

When Rovo Dev can't initialize (unhealthy status), today we shut it down to dispose resources.
Unfortunately, when debugging, this is inconvenient because we can't access the terminal anymore to inspect its logs.

This change prevents the shutdown to happen when Rovo Dev fails to initialize.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`