### PR TITLE
ESLint: Disallow the use of React dangerouslySetInnerHTML

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ const compat = new FlatCompat({
 });
 
 export default tseslint.config(
-    ...compat.plugins('@typescript-eslint', 'react', 'react-hooks', 'import', 'prettier', 'simple-import-sort'),
+    ...compat.plugins('@typescript-eslint', 'react', 'react-dom', 'react-hooks', 'import', 'prettier', 'simple-import-sort'),
     {
         languageOptions: {
             ecmaVersion: 2020,
@@ -35,6 +35,7 @@ export default tseslint.config(
         rules: {
             'prettier/prettier': 'error',
             'react/jsx-filename-extension': [2, { extensions: ['.js', '.jsx', '.ts', '.tsx'] }],
+            'react-dom/no-dangerously-set-innerhtml': 'error',
             'react-hooks/exhaustive-deps': 'error',
             '@typescript-eslint/await-thenable': 'error',
             '@typescript-eslint/naming-convention': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,6 +170,7 @@
                 "eslint-plugin-import": "^2.30.0",
                 "eslint-plugin-prettier": "^5.2.1",
                 "eslint-plugin-react": "^7.36.0",
+                "eslint-plugin-react-dom": "^1.53.1",
                 "eslint-plugin-react-hooks": "^5.2.0",
                 "eslint-plugin-simple-import-sort": "^12.1.1",
                 "fork-ts-checker-notifier-webpack-plugin": "^9.0.0",
@@ -4592,6 +4593,922 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint-react/ast": {
+            "version": "1.53.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@eslint-react/ast/-/ast-1.53.1.tgz",
+            "integrity": "sha512-qvUC99ewtriJp9quVEOvZ6+RHcsMLfVQ0OhZ4/LupZUDhjW7GiX1dxJsFaxHdJ9rLNLhQyLSPmbAToeqUrSruQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-react/eff": "1.53.1",
+                "@typescript-eslint/types": "^8.43.0",
+                "@typescript-eslint/typescript-estree": "^8.43.0",
+                "@typescript-eslint/utils": "^8.43.0",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.8.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/project-service": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+            "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.44.0",
+                "@typescript-eslint/types": "^8.44.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+            "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+            "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/types": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-8.44.0.tgz",
+            "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+            "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.44.0",
+                "@typescript-eslint/tsconfig-utils": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+            "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+            "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@eslint-react/ast/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@eslint-react/core": {
+            "version": "1.53.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@eslint-react/core/-/core-1.53.1.tgz",
+            "integrity": "sha512-8prroos5/Uvvh8Tjl1HHCpq4HWD3hV9tYkm7uXgKA6kqj0jHlgRcQzuO6ZPP7feBcK3uOeug7xrq03BuG8QKCA==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-react/ast": "1.53.1",
+                "@eslint-react/eff": "1.53.1",
+                "@eslint-react/kit": "1.53.1",
+                "@eslint-react/shared": "1.53.1",
+                "@eslint-react/var": "1.53.1",
+                "@typescript-eslint/scope-manager": "^8.43.0",
+                "@typescript-eslint/type-utils": "^8.43.0",
+                "@typescript-eslint/types": "^8.43.0",
+                "@typescript-eslint/utils": "^8.43.0",
+                "birecord": "^0.1.1",
+                "ts-pattern": "^5.8.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/@typescript-eslint/project-service": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+            "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.44.0",
+                "@typescript-eslint/types": "^8.44.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+            "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+            "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/@typescript-eslint/type-utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz",
+            "integrity": "sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0",
+                "@typescript-eslint/utils": "8.44.0",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/@typescript-eslint/types": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-8.44.0.tgz",
+            "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+            "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.44.0",
+                "@typescript-eslint/tsconfig-utils": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/@typescript-eslint/utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+            "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+            "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@eslint-react/core/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@eslint-react/eff": {
+            "version": "1.53.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@eslint-react/eff/-/eff-1.53.1.tgz",
+            "integrity": "sha512-uq20lPRAmsWRjIZm+mAV/2kZsU2nDqn5IJslxGWe3Vfdw23hoyhEw3S1KKlxbftwbTvsZjKvVP0iw3bZo/NUpg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/kit": {
+            "version": "1.53.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@eslint-react/kit/-/kit-1.53.1.tgz",
+            "integrity": "sha512-zOi2le9V4rMrJvQV4OeedGvMGvDT46OyFPOwXKs7m0tQu5vXVJ8qwIPaVQT1n/WIuvOg49OfmAVaHpGxK++xLQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-react/eff": "1.53.1",
+                "@typescript-eslint/utils": "^8.43.0",
+                "ts-pattern": "^5.8.0",
+                "zod": "^4.1.5"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/project-service": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+            "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.44.0",
+                "@typescript-eslint/types": "^8.44.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+            "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+            "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/types": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-8.44.0.tgz",
+            "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+            "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.44.0",
+                "@typescript-eslint/tsconfig-utils": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+            "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+            "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@eslint-react/kit/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@eslint-react/shared": {
+            "version": "1.53.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@eslint-react/shared/-/shared-1.53.1.tgz",
+            "integrity": "sha512-gomJQmFqQgQVI3Ra4vTMG/s6a4bx3JqeNiTBjxBJt4C9iGaBj458GkP4LJHX7TM6xUzX+fMSKOPX7eV3C/+UCw==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-react/eff": "1.53.1",
+                "@eslint-react/kit": "1.53.1",
+                "@typescript-eslint/utils": "^8.43.0",
+                "ts-pattern": "^5.8.0",
+                "zod": "^4.1.5"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/project-service": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+            "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.44.0",
+                "@typescript-eslint/types": "^8.44.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+            "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+            "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/types": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-8.44.0.tgz",
+            "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+            "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.44.0",
+                "@typescript-eslint/tsconfig-utils": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+            "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+            "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@eslint-react/shared/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@eslint-react/var": {
+            "version": "1.53.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@eslint-react/var/-/var-1.53.1.tgz",
+            "integrity": "sha512-yzwopvPntcHU7mmDvWzRo1fb8QhjD8eDRRohD11rTV1u7nWO4QbJi0pOyugQakvte1/W11Y0Vr8Of0Ojk/A6zg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-react/ast": "1.53.1",
+                "@eslint-react/eff": "1.53.1",
+                "@typescript-eslint/scope-manager": "^8.43.0",
+                "@typescript-eslint/types": "^8.43.0",
+                "@typescript-eslint/utils": "^8.43.0",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.8.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/@typescript-eslint/project-service": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+            "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.44.0",
+                "@typescript-eslint/types": "^8.44.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+            "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+            "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/@typescript-eslint/types": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-8.44.0.tgz",
+            "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+            "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.44.0",
+                "@typescript-eslint/tsconfig-utils": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/@typescript-eslint/utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+            "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+            "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@eslint-react/var/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@eslint/config-array": {
@@ -9259,6 +10176,12 @@
             "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
             "license": "MIT"
         },
+        "node_modules/birecord": {
+            "version": "0.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/birecord/-/birecord-0.1.1.tgz",
+            "integrity": "sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==",
+            "dev": true
+        },
         "node_modules/bl": {
             "version": "4.1.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/bl/-/bl-4.1.0.tgz",
@@ -9947,6 +10870,12 @@
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
             "license": "MIT"
+        },
+        "node_modules/compare-versions": {
+            "version": "6.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/compare-versions/-/compare-versions-6.1.1.tgz",
+            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+            "dev": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -12360,6 +13289,200 @@
             },
             "peerDependencies": {
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom": {
+            "version": "1.53.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/eslint-plugin-react-dom/-/eslint-plugin-react-dom-1.53.1.tgz",
+            "integrity": "sha512-UYrWJ2cS4HpJ1A5XBuf1HfMpPoLdfGil+27g/ldXfGemb4IXqlxHt4ANLyC8l2CWcE3SXGJW7mTslL34MG0qTQ==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-react/ast": "1.53.1",
+                "@eslint-react/core": "1.53.1",
+                "@eslint-react/eff": "1.53.1",
+                "@eslint-react/kit": "1.53.1",
+                "@eslint-react/shared": "1.53.1",
+                "@eslint-react/var": "1.53.1",
+                "@typescript-eslint/scope-manager": "^8.43.0",
+                "@typescript-eslint/types": "^8.43.0",
+                "@typescript-eslint/utils": "^8.43.0",
+                "compare-versions": "^6.1.1",
+                "string-ts": "^2.2.1",
+                "ts-pattern": "^5.8.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": "^4.9.5 || ^5.3.3"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": false
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/project-service": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+            "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.44.0",
+                "@typescript-eslint/types": "^8.44.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+            "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+            "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/types": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-8.44.0.tgz",
+            "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+            "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.44.0",
+                "@typescript-eslint/tsconfig-utils": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/utils": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+            "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.44.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+            "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.44.0",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-react-dom/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/eslint-plugin-react-hooks": {
@@ -22574,6 +23697,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/string-ts": {
+            "version": "2.2.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/string-ts/-/string-ts-2.2.1.tgz",
+            "integrity": "sha512-Q2u0gko67PLLhbte5HmPfdOjNvUKbKQM+mCNQae6jE91DmoFHY6HH9GcdqCeNx87DZ2KKjiFxmA0R/42OneGWw==",
+            "dev": true
+        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/string-width/-/string-width-4.2.3.tgz",
@@ -23569,6 +24698,12 @@
             "engines": {
                 "node": ">=0.3.1"
             }
+        },
+        "node_modules/ts-pattern": {
+            "version": "5.8.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ts-pattern/-/ts-pattern-5.8.0.tgz",
+            "integrity": "sha512-kIjN2qmWiHnhgr5DAkAafF9fwb0T5OhMVSWrm8XEdTFnX6+wfXwYOFjeF86UZ54vduqiR7BfqScFmXSzSaH8oA==",
+            "dev": true
         },
         "node_modules/ts-toolbelt": {
             "version": "9.6.0",
@@ -25028,6 +26163,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.1.9",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/zod/-/zod-4.1.9.tgz",
+            "integrity": "sha512-HI32jTq0AUAC125z30E8bQNz0RQ+9Uc+4J7V97gLYjZVKRjeydPgGt6dvQzFrav7MYOUGFqqOGiHpA/fdbd0cQ==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1606,6 +1606,7 @@
         "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.36.0",
+        "eslint-plugin-react-dom": "^1.53.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "fork-ts-checker-notifier-webpack-plugin": "^9.0.0",

--- a/src/react/atlascode/pullrequest/InlineRenderedTextEditor.tsx
+++ b/src/react/atlascode/pullrequest/InlineRenderedTextEditor.tsx
@@ -74,6 +74,7 @@ const InlineRenderedTextEditor: React.FC<InlineTextEditorProps> = (props: Inline
             onMouseLeave={handleFocusOut}
         >
             <Grid item xs>
+                {/* eslint-disable-next-line react-dom/no-dangerously-set-innerhtml -- TODO check if needed */}
                 <Typography variant="body1" dangerouslySetInnerHTML={{ __html: props.htmlContent }} />
             </Grid>
             <Grid item>

--- a/src/react/atlascode/pullrequest/NestedComment.tsx
+++ b/src/react/atlascode/pullrequest/NestedComment.tsx
@@ -157,6 +157,7 @@ export const NestedComment: React.FunctionComponent<NestedCommentProps> = ({
                                 <CircularProgress />
                             </Box>
                             <Box hidden={isLoading}>
+                                {/* eslint-disable-next-line react-dom/no-dangerously-set-innerhtml -- TODO check if needed */}
                                 <Typography dangerouslySetInnerHTML={{ __html: comment.htmlContent }} />
                             </Box>
                             <Grid item>

--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -18,6 +18,7 @@ const mdParser = new MarkdownIt({
 mdParser.linkify.set({ fuzzyLink: false });
 
 export const MarkedDown: React.FC<{ value: string }> = ({ value }) => {
+    // eslint-disable-next-line react-dom/no-dangerously-set-innerhtml -- necessary to apply MarkDown formatting
     return <span dangerouslySetInnerHTML={{ __html: mdParser.render(value) }} />;
 };
 

--- a/src/webviews/components/RenderedContent.tsx
+++ b/src/webviews/components/RenderedContent.tsx
@@ -36,5 +36,6 @@ export const RenderedContent: React.FC<Props> = (props: Props) => {
         );
     }, [props.fetchImage, ref]); // eslint-disable-line react-hooks/exhaustive-deps
 
+    // eslint-disable-next-line react-dom/no-dangerously-set-innerhtml -- TODO check if needed
     return <p ref={ref} dangerouslySetInnerHTML={{ __html: props.html }} />;
 };

--- a/src/webviews/components/issue/StartWorkPage.tsx
+++ b/src/webviews/components/issue/StartWorkPage.tsx
@@ -371,6 +371,7 @@ export default class StartWorkPage extends WebviewComponent<Emit, Accept, {}, St
                     >
                         <p>{issue.summary}</p>
                     </PageHeader>
+                    {/* eslint-disable-next-line react-dom/no-dangerously-set-innerhtml -- TODO check if needed */}
                     <p dangerouslySetInnerHTML={{ __html: issue.descriptionHtml }} />
                 </GridColumn>
             );
@@ -391,6 +392,7 @@ export default class StartWorkPage extends WebviewComponent<Emit, Accept, {}, St
                             {this.state.result.successMessage && (
                                 <SectionMessage appearance="confirmation" title="Work Started">
                                     <div className="start-work-success">
+                                        {/* eslint-disable-next-line react-dom/no-dangerously-set-innerhtml -- TODO check if needed */}
                                         <p dangerouslySetInnerHTML={{ __html: this.state.result.successMessage }} />
                                     </div>
                                 </SectionMessage>

--- a/src/webviews/components/selectFieldHelper.tsx
+++ b/src/webviews/components/selectFieldHelper.tsx
@@ -194,6 +194,7 @@ const LabelOption = (props: any) => {
 
     return (
         <components.Option {...props}>
+            {/* eslint-disable-next-line react-dom/no-dangerously-set-innerhtml -- TODO check if needed */}
             <div ref={props.innerRef} {...props.innerProps} dangerouslySetInnerHTML={{ __html: label }} />
         </components.Option>
     );


### PR DESCRIPTION
### What Is This Change?

Added the following rule: https://eslint-react.xyz/docs/rules/dom-no-dangerously-set-innerhtml
to disallow the usage of React's dangerouslySetInnerHTML, since it's a security risk if not properly guarded.

Current usage has been allow-listed.

### How Has This Been Tested?

- [X] `npm run lint`