### PR TITLE
Axon 1155 rovo chat markdown is no longer rendering headers

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -339,6 +339,11 @@ body {
     align-self: flex-start;
 }
 
+.agent-message strong {
+    font-weight: bold;
+    color: var(--vscode-editor-foreground);
+}
+
 .user-message {
     background-color: var(--vscode-editor-selectionBackground);
     align-self: flex-end;
@@ -353,6 +358,11 @@ body {
     word-break: break-word;
     color: var(--vscode-editor-foreground);
     max-width: 100%;
+}
+
+.message-content strong {
+    font-weight: bold;
+    color: var(--vscode-editor-foreground);
 }
 
 /* Pull Request button styles */


### PR DESCRIPTION
### What Is This Change?
Rovo chat markdown is not rendering headers

| Header | Header |
|--------|--------|
| 
<img width="384" height="336" alt="1155-before" src="https://github.com/user-attachments/assets/775aa9de-f526-41cd-a3b9-ec15e420bd56" />
 | Cell |
| Cell | Cell |
| Cell | Cell |
| Cell | Cell | 

### How Has This Been Tested?


Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change