### PR TITLE
AXON-1132 removed outline for Rovo prompt input

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -33,6 +33,10 @@ body {
     font-size: var(--vscode-font-size) !important;
 }
 
+#prompt-editor-container > .monaco-editor {
+    outline: none;
+}
+
 .rovoDevChat button {
     cursor: pointer;
 }


### PR DESCRIPTION
### What Is This Change?

Removed outline for Rovo prompt input.
This was an issue for few Cursor themes and remaining color inconsistency is also affects only these few themes because these themes use rgba with alpha channel (set to 0.33) for several elements. 

### Demo:
Before: 
<img width="291" height="105" alt="Screenshot 2025-09-22 at 14 36 59" src="https://github.com/user-attachments/assets/1ba63b1c-34e2-49c9-b6f0-5334e7b57eb7" />

After: 
<img width="291" height="101" alt="Screenshot 2025-09-22 at 19 59 27" src="https://github.com/user-attachments/assets/671393a3-9ca9-4af2-897d-4e4041f9c388" />


### How Has This Been Tested?

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`