### PR TITLE
Fix Logger.error signature and some incorrect Error data

### DIFF
--- a/src/atlclients/authStore.ts
+++ b/src/atlclients/authStore.ts
@@ -209,6 +209,7 @@ export class CredentialManager implements Disposable {
                         } else if (Container.siteManager.getSiteForId(site.product, site.id)) {
                             // if keychain does not have any auth info for the current site but the site has been saved, we need to remove it
                             Logger.error(
+                                undefined,
                                 new Error(
                                     `removing dead site for product ${site.product.key} credentialID: ${site.credentialId}`,
                                 ),
@@ -286,7 +287,7 @@ export class CredentialManager implements Disposable {
             try {
                 await inFlight;
             } catch (e) {
-                Logger.error(e, 'error refreshing token');
+                Logger.error(undefined, e, 'error refreshing token');
                 return Promise.reject(
                     `Your ${site.product.name} session has expired. Please sign in again to continue.`,
                 );
@@ -306,7 +307,7 @@ export class CredentialManager implements Disposable {
                 try {
                     await Container.context.secrets.store(`${productKey}-${credentialId}`, JSON.stringify(info));
                 } catch (e) {
-                    Logger.error(e, `Error writing to secretstorage`);
+                    Logger.error(undefined, e, `Error writing to secretstorage`);
                 }
             },
             { priority: Priority.Write },

--- a/src/atlclients/clientManager.ts
+++ b/src/atlclients/clientManager.ts
@@ -187,7 +187,7 @@ export class ClientManager implements Disposable {
                 });
             });
         } catch (e) {
-            Logger.error(e, `Failed to refresh tokens`);
+            Logger.error(undefined, e, `Failed to refresh tokens`);
             throw e;
         }
         return newClient!;
@@ -257,7 +257,7 @@ export class ClientManager implements Disposable {
         const credentials = await Container.credentialManager.getAuthInfo(site, false);
 
         if (credentials?.state === AuthInfoState.Invalid) {
-            Logger.error(new Error('Error creating client: credentials state is Invalid'));
+            Logger.error(undefined, new Error('Error creating client: credentials state is Invalid'));
             if (!this.hasWarnedOfFailure) {
                 window
                     .showErrorMessage(

--- a/src/atlclients/graphql/graphqlClient.ts
+++ b/src/atlclients/graphql/graphqlClient.ts
@@ -27,7 +27,7 @@ export async function graphqlRequest<T = any>(
         Logger.debug('GraphQL response', { response });
         return response;
     } catch (error) {
-        Logger.error(error, 'GraphQL request failed');
+        Logger.error(undefined, error, 'GraphQL request failed');
         throw error;
     }
 }

--- a/src/atlclients/issueBuilder.ts
+++ b/src/atlclients/issueBuilder.ts
@@ -93,7 +93,7 @@ export const fetchIssueSuggestions = async (prompt: string, context?: string): P
 
         return responseData;
     } catch (error) {
-        Logger.error(error, 'Error fetching issue suggestions');
+        Logger.error(undefined, error, 'Error fetching issue suggestions');
         throw error;
     }
 };

--- a/src/atlclients/loginManager.ts
+++ b/src/atlclients/loginManager.ts
@@ -116,7 +116,7 @@ export class LoginManager {
 
             this.fireExplicitSiteChangeEvent(siteDetails);
         } catch (e) {
-            Logger.error(e, `Error authenticating with provider '${provider}'`);
+            Logger.error(undefined, e, `Error authenticating with provider '${provider}'`);
             vscode.window.showErrorMessage(`There was an error authenticating with provider '${provider}': ${e}`);
         }
     }
@@ -153,7 +153,7 @@ export class LoginManager {
 
                 this.fireExplicitSiteChangeEvent([siteDetails]);
             } catch (err) {
-                Logger.error(err, `Error authenticating with ${site.product.name}`);
+                Logger.error(undefined, err, `Error authenticating with ${site.product.name}`);
                 return Promise.reject(`Error authenticating with ${site.product.name}: ${err}`);
             }
         }
@@ -169,7 +169,7 @@ export class LoginManager {
 
                 this.fireExplicitSiteChangeEvent([siteDetails]);
             } catch (err) {
-                Logger.error(err, `Error authenticating with ${site.product.name}`);
+                Logger.error(undefined, err, `Error authenticating with ${site.product.name}`);
                 return Promise.reject(`Error authenticating with ${site.product.name}: ${err}`);
             }
         }

--- a/src/atlclients/negotiate.test.ts
+++ b/src/atlclients/negotiate.test.ts
@@ -129,7 +129,11 @@ describe('negotiate', () => {
             const mockSocket = {};
             pingHandler!(JSON.stringify(mockSite), mockSocket);
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error in Negotiate.startListening requestSite');
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                undefined,
+                error,
+                'Error in Negotiate.startListening requestSite',
+            );
             expect(mockIPCInstance.server.emit).toHaveBeenCalledWith(mockSocket, 'atlascode-ack');
         });
     });
@@ -225,7 +229,7 @@ describe('negotiate', () => {
                 const result = await negotiator.requestTokenRefreshForSite('test-site');
 
                 expect(negotiator.negotiationRound).toHaveBeenCalledTimes(3);
-                expect(mockLogger.error).toHaveBeenCalledWith(expect.any(Error));
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, expect.any(Error));
                 expect(result).toBe(false);
             });
         });

--- a/src/atlclients/negotiate.ts
+++ b/src/atlclients/negotiate.ts
@@ -36,7 +36,7 @@ export function startListening(requestSite: (site: DetailedSiteInfo) => void) {
             try {
                 requestSite(site);
             } catch (e) {
-                Logger.error(e, 'Error in Negotiate.startListening requestSite');
+                Logger.error(undefined, e, 'Error in Negotiate.startListening requestSite');
             }
             Logger.debug(`${tag}: done requesting site`);
             ipc.server.emit(socket, ACK_MESSAGE);
@@ -80,7 +80,7 @@ export class Negotiator {
                 return result;
             }
         }
-        Logger.error(new Error(`Failed to negotiate a responsible PID after ${MAX_ROUNDS} rounds`));
+        Logger.error(undefined, new Error(`Failed to negotiate a responsible PID after ${MAX_ROUNDS} rounds`));
         return false;
     }
 

--- a/src/atlclients/oauthDancer.ts
+++ b/src/atlclients/oauthDancer.ts
@@ -238,7 +238,7 @@ export class OAuthDancer implements Disposable {
                 await listenPromise(31415, () => {});
                 Logger.debug('auth server started on port 31415');
             } catch (err) {
-                Logger.error(err, 'Unable to start auth listener on localhost:31415');
+                Logger.error(undefined, err, 'Unable to start auth listener on localhost:31415');
                 return Promise.reject(`Unable to start auth listener on localhost:31415: ${err}`);
             }
 

--- a/src/atlclients/oauthRefresher.ts
+++ b/src/atlclients/oauthRefresher.ts
@@ -68,7 +68,7 @@ export class OAuthRefesher implements Disposable {
             }
         } catch (err) {
             const responseStatusDescription = err.response?.status ? ` ${err.response.status}` : '';
-            Logger.error(err, 'Error while refreshing tokens' + responseStatusDescription);
+            Logger.error(undefined, err, 'Error while refreshing tokens' + responseStatusDescription);
             if (err.response?.status === 401 || err.response?.status === 403) {
                 Logger.debug(`Invalidating credentials due to ${err.response.status} while refreshing tokens`);
                 response.shouldInvalidate = true;

--- a/src/atlclients/responseHandlers/BitbucketResponseHandler.ts
+++ b/src/atlclients/responseHandlers/BitbucketResponseHandler.ts
@@ -28,7 +28,7 @@ export class BitbucketResponseHandler extends ResponseHandler {
             const data = tokenResponse.data;
             return { accessToken: data.access_token, refreshToken: data.refresh_token, receivedAt: Date.now() };
         } catch (err) {
-            Logger.error(err, 'Error fetching Bitbucket tokens');
+            Logger.error(undefined, err, 'Error fetching Bitbucket tokens');
             throw new Error(`Error fetching Bitbucket tokens: ${err}`);
         }
     }
@@ -76,7 +76,7 @@ export class BitbucketResponseHandler extends ResponseHandler {
                 avatarUrl: userData.links.avatar.href,
             };
         } catch (err) {
-            Logger.error(err, 'Error fetching Bitbucket user');
+            Logger.error(undefined, err, 'Error fetching Bitbucket user');
             throw new Error(`Error fetching Bitbucket user: ${err}`);
         }
     }

--- a/src/atlclients/responseHandlers/JiraPKCEResponseHandler.ts
+++ b/src/atlclients/responseHandlers/JiraPKCEResponseHandler.ts
@@ -29,7 +29,7 @@ export class JiraPKCEResponseHandler extends ResponseHandler {
             const data = tokenResponse.data;
             return { accessToken: data.access_token, refreshToken: data.refresh_token, receivedAt: Date.now() };
         } catch (err) {
-            Logger.error(err, 'Error fetching Jira tokens');
+            Logger.error(undefined, err, 'Error fetching Jira tokens');
             const data = err?.response?.data;
             const newErr = new Error(`Error fetching Jira tokens: ${err}
             
@@ -62,7 +62,7 @@ export class JiraPKCEResponseHandler extends ResponseHandler {
                 avatarUrl: data.avatarUrls['48x48'],
             };
         } catch (err) {
-            Logger.error(err, 'Error fetching Jira user');
+            Logger.error(undefined, err, 'Error fetching Jira user');
             throw new Error(`Error fetching Jira user: ${err}`);
         }
     }
@@ -81,7 +81,7 @@ export class JiraPKCEResponseHandler extends ResponseHandler {
 
             return resourcesResponse.data;
         } catch (err) {
-            Logger.error(err, 'Error fetching Jira resources');
+            Logger.error(undefined, err, 'Error fetching Jira resources');
             throw new Error(`Error fetching Jira resources: ${err}`);
         }
     }

--- a/src/bitbucket/bitbucket-cloud/pullRequests.ts
+++ b/src/bitbucket/bitbucket-cloud/pullRequests.ts
@@ -213,7 +213,7 @@ export class CloudPullRequestApi implements PullRequestApi {
         try {
             prTypeData = await this.client.get(prTypeUrl);
         } catch (ex) {
-            Logger.error(ex, `Fetching prTypeData failed for the PR: ${pr.data.id}}`);
+            Logger.error(undefined, ex, `Fetching prTypeData failed for the PR: ${pr.data.id}}`);
         }
         const conflictedFiles: string[] = [];
         if (prTypeData.data.diff_type === 'TOPIC') {
@@ -222,7 +222,7 @@ export class CloudPullRequestApi implements PullRequestApi {
             try {
                 resp = await this.client.get(conflictUrl);
             } catch (ex) {
-                Logger.error(ex, `Fetching conflict data failed for the PR: ${pr.data.id}}`);
+                Logger.error(undefined, ex, `Fetching conflict data failed for the PR: ${pr.data.id}}`);
             }
             resp.data.forEach((data: { path: '' }) => conflictedFiles.push(data.path));
         }
@@ -240,7 +240,7 @@ export class CloudPullRequestApi implements PullRequestApi {
             const response = await this.client.get(diffUrl);
             data = response.data;
         } catch (ex) {
-            Logger.error(ex, `Fetching diffStat failed for the PR: ${pr.data.id}`);
+            Logger.error(undefined, ex, `Fetching diffStat failed for the PR: ${pr.data.id}`);
         }
 
         if (!data.values) {
@@ -393,7 +393,7 @@ export class CloudPullRequestApi implements PullRequestApi {
 
             return this.convertDataToTask(data, site);
         } catch (e) {
-            Logger.error(e, 'Error creating new task using API');
+            Logger.error(undefined, e, 'Error creating new task using API');
             throw new Error(`Error creating new task using API: ${e}`);
         }
     }
@@ -419,7 +419,7 @@ export class CloudPullRequestApi implements PullRequestApi {
 
             return this.convertDataToTask(data, site);
         } catch (e) {
-            Logger.error(e, 'Error editing task using API');
+            Logger.error(undefined, e, 'Error editing task using API');
             throw new Error(`Error editing task using API: ${e}`);
         }
     }
@@ -433,7 +433,7 @@ export class CloudPullRequestApi implements PullRequestApi {
                 {},
             );
         } catch (e) {
-            Logger.error(e, 'Error deleting task using API');
+            Logger.error(undefined, e, 'Error deleting task using API');
             throw new Error(`Error deleting task using API: ${e}`);
         }
     }

--- a/src/bitbucket/checkoutHelper.test.ts
+++ b/src/bitbucket/checkoutHelper.test.ts
@@ -329,7 +329,7 @@ describe('BitbucketCheckoutHelper', () => {
 
             await checkoutHelper.pullRequest(repoUrl, pullRequestId);
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error opening pull request');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error opening pull request');
             expect(mockWindow.showInformationMessage).toHaveBeenCalledWith(
                 'Cannot open pull request. Authenticate with Bitbucket in the extension settings and try again.',
                 'Open auth settings',

--- a/src/bitbucket/checkoutHelper.ts
+++ b/src/bitbucket/checkoutHelper.ts
@@ -135,7 +135,7 @@ export class BitbucketCheckoutHelper implements CheckoutHelper {
                 workspaceRepo: wsRepo,
             });
         } catch (e) {
-            Logger.error(e, 'Error opening pull request');
+            Logger.error(undefined, e, 'Error opening pull request');
             this.showLoginMessage(
                 'Cannot open pull request. Authenticate with Bitbucket in the extension settings and try again.',
             );

--- a/src/bitbucket/httpClient.test.ts
+++ b/src/bitbucket/httpClient.test.ts
@@ -165,7 +165,7 @@ describe('HTTPClient', () => {
             mockTransport.mockRejectedValue(error);
 
             await expect(httpClient.getUrl(url)).rejects.toThrow('Network error');
-            expect(Logger.error).toHaveBeenCalledWith(error, 'Error getting URL', url);
+            expect(Logger.error).toHaveBeenCalledWith(undefined, error, 'Error getting URL', url);
         });
     });
 

--- a/src/bitbucket/httpClient.ts
+++ b/src/bitbucket/httpClient.ts
@@ -68,7 +68,7 @@ export class HTTPClient {
             });
             return { data: res.data, headers: res.headers };
         } catch (e) {
-            Logger.error(e, 'Error getting URL', url);
+            Logger.error(undefined, e, 'Error getting URL', url);
             if (e.response) {
                 return Promise.reject(await this.errorHandler(e.response));
             } else {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -160,7 +160,7 @@ export function registerCommands(vscodeContext: ExtensionContext) {
                         const target = issue.transitions.find((x) => x.name === transition.label);
                         if (!target) {
                             window.showErrorMessage(`Transition ${transition.label} not found`);
-                            Logger.error(new Error('Transition not found'));
+                            Logger.error(undefined, new Error('Transition not found'));
                             return;
                         }
 
@@ -375,7 +375,7 @@ export function registerCommands(vscodeContext: ExtensionContext) {
                         const target = issue.transitions.find((x) => x.name === transition.label);
                         if (!target) {
                             window.showErrorMessage(`Transition ${transition.label} not found`);
-                            Logger.error(new Error('Transition not found'));
+                            Logger.error(undefined, new Error('Transition not found'));
                             return;
                         }
 

--- a/src/commands/bitbucket/rerunPipeline.ts
+++ b/src/commands/bitbucket/rerunPipeline.ts
@@ -20,7 +20,7 @@ export async function rerunPipeline(pipeline: Pipeline) {
             commands.executeCommand(Commands.RefreshPipelines);
         }, 500);
     } catch (e) {
-        Logger.error(e, 'Error rerunning build');
+        Logger.error(undefined, e, 'Error rerunning build');
         window.showErrorMessage(`Error rerunning build`);
     }
 }

--- a/src/commands/bitbucket/runPipeline.ts
+++ b/src/commands/bitbucket/runPipeline.ts
@@ -63,7 +63,7 @@ async function showBranchPicker(remote: Remote) {
                 try {
                     await bbApi.pipelines!.triggerPipeline(bbSite!, target);
                 } catch (e) {
-                    Logger.error(e, 'Error building branch');
+                    Logger.error(undefined, e, 'Error building branch');
                     window.showErrorMessage(`Error building branch`);
                 }
                 // Seems like there's a bit of lag between a build starting and it showing up in the list API.

--- a/src/commands/jira/createIssue.ts
+++ b/src/commands/jira/createIssue.ts
@@ -55,7 +55,7 @@ export async function createIssue(data: Uri | TodoIssueData | undefined, source?
             });
         } catch (error) {
             // The view is already created with legacy logic, do nothing
-            Logger.error(error, 'Error generating issue suggestion settings');
+            Logger.error(undefined, error, 'Error generating issue suggestion settings');
         }
 
         startIssueCreationEvent('todoComment', ProductJira).then((e) => {

--- a/src/commands/jira/issueSuggestionManager.ts
+++ b/src/commands/jira/issueSuggestionManager.ts
@@ -57,7 +57,7 @@ export class IssueSuggestionManager {
                 error: '',
             };
         } catch (error) {
-            Logger.error(error, 'Error fetching issue suggestions');
+            Logger.error(undefined, error, 'Error fetching issue suggestions');
             window.showErrorMessage('Error fetching issue suggestions: ' + error.message);
             return {
                 summary: '',
@@ -89,7 +89,7 @@ export class IssueSuggestionManager {
             // TODO: actually send an analytics event
             window.showInformationMessage(`Thank you for your feedback!`);
         } catch (error) {
-            Logger.error(error, 'Error sending feedback');
+            Logger.error(undefined, error, 'Error sending feedback');
             window.showErrorMessage('Error sending feedback: ' + error.message);
         }
     }

--- a/src/commands/jira/showIssue.ts
+++ b/src/commands/jira/showIssue.ts
@@ -64,7 +64,7 @@ export async function showIssueForURL(issueURL: string) {
         await showIssueForSiteIdAndKey(site.id, issueKey);
     } catch (e) {
         vscode.window.showErrorMessage('Invalid URL.');
-        Logger.error(e, 'Could not show issue for URL');
+        Logger.error(undefined, e, 'Could not show issue for URL');
     }
 }
 export async function showIssueForSiteIdAndKey(siteId: string, issueKey: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,7 @@ export async function activate(context: ExtensionContext) {
             NotificationManagerImpl.getInstance().listen();
         }
     } catch (e) {
-        Logger.error(e, 'Error initializing atlascode!');
+        Logger.error(undefined, e, 'Error initializing atlascode!');
     }
 
     startListening((site: DetailedSiteInfo) => {
@@ -130,7 +130,7 @@ async function activateBitbucketFeatures() {
         }
         gitExt = await gitExtension.activate();
     } catch (e) {
-        Logger.error(e, 'Error activating vscode.git extension');
+        Logger.error(undefined, e, 'Error activating vscode.git extension');
         window.showWarningMessage(
             'Activating Bitbucket features failed. There was an issue activating vscode.git extension.',
         );
@@ -142,7 +142,7 @@ async function activateBitbucketFeatures() {
         const bbContext = new BitbucketContext(gitApi);
         Container.initializeBitbucket(bbContext);
     } catch (e) {
-        Logger.error(e, 'Activating Bitbucket features failed');
+        Logger.error(undefined, e, 'Activating Bitbucket features failed');
         window.showWarningMessage('Activating Bitbucket features failed');
     }
 }

--- a/src/jira/jira-client/providers.test.ts
+++ b/src/jira/jira-client/providers.test.ts
@@ -304,7 +304,7 @@ describe('providers', () => {
             const agent = getAgent(siteWithSSLCerts);
 
             expect(agent).toEqual({});
-            expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), 'Error while creating agent');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, expect.any(Error), 'Error while creating agent');
         });
 
         it('skips Charles proxy setup when charlesDebugOnly is true but not debugging', () => {

--- a/src/jira/jira-client/providers.ts
+++ b/src/jira/jira-client/providers.ts
@@ -139,7 +139,7 @@ export const getAgent: AgentProvider = (site?: SiteInfo) => {
             }
         }
     } catch (err) {
-        Logger.error(err, 'Error while creating agent');
+        Logger.error(undefined, err, 'Error while creating agent');
         agent = {};
     }
 

--- a/src/jira/settingsManager.ts
+++ b/src/jira/settingsManager.ts
@@ -63,7 +63,7 @@ export class JiraSettingsManager extends Disposable {
                 cMeta = await client.getCreateIssueMetadata(projectKey);
                 this._projectKeyCMetaStore.set(projectKey, cMeta);
             } catch (error) {
-                Logger.error(error, 'Create issue metadata not available.');
+                Logger.error(undefined, error, 'Create issue metadata not available.');
             }
         }
         return this._projectKeyCMetaStore.get(projectKey);
@@ -82,7 +82,7 @@ export class JiraSettingsManager extends Disposable {
             } catch (err) {
                 // TODO: [VSCODE-549] use /configuration to get settings
                 // for now we need to catch 404 and set an empty array.
-                Logger.error(err, 'issue links not enabled');
+                Logger.error(undefined, err, 'issue links not enabled');
             } finally {
                 this._issueLinkTypesStore.set(site.id, ilts);
             }

--- a/src/jira/transitionIssue.test.ts
+++ b/src/jira/transitionIssue.test.ts
@@ -151,7 +151,7 @@ describe('transitionIssue', () => {
 
         // Execute and verify
         await expect(transitionIssue(mockedIssue, mockedTransition)).rejects.toThrow('API error');
-        expect(Logger.error).toHaveBeenCalledWith(error, 'Error executing transitionIssue');
+        expect(Logger.error).toHaveBeenCalledWith(undefined, error, 'Error executing transitionIssue');
     });
 
     it('should handle errors from transitionIssue API call', async () => {
@@ -162,6 +162,6 @@ describe('transitionIssue', () => {
 
         // Execute and verify
         await expect(transitionIssue(mockedIssue, mockedTransition)).rejects.toEqual(error);
-        expect(Logger.error).toHaveBeenCalledWith(error, 'Error executing transitionIssue');
+        expect(Logger.error).toHaveBeenCalledWith(undefined, error, 'Error executing transitionIssue');
     });
 });

--- a/src/jira/transitionIssue.ts
+++ b/src/jira/transitionIssue.ts
@@ -37,7 +37,7 @@ export async function transitionIssue(
         await performTransition(issueKey, transition, site, analyticsData);
         return;
     } catch (e) {
-        Logger.error(e, 'Error executing transitionIssue');
+        Logger.error(undefined, e, 'Error executing transitionIssue');
         throw e;
     }
 }
@@ -61,7 +61,7 @@ async function performTransition(
             Container.analyticsClient.sendTrackEvent(e);
         });
     } catch (err) {
-        Logger.error(err, 'Error executing performTransition');
+        Logger.error(undefined, err, 'Error executing performTransition');
         throw err;
     }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,0 @@
-export interface Logger {
-    info(message?: any, ...params: any[]): void;
-    debug(message?: any, ...params: any[]): void;
-    warn(message?: any, ...params: any[]): void;
-    error(ex: Error, errorMessage?: string): void;
-}

--- a/src/lib/webview/controller/config/configV3WebviewController.test.ts
+++ b/src/lib/webview/controller/config/configV3WebviewController.test.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import * as vscode from 'vscode';
@@ -13,7 +14,6 @@ import { WebViewID } from '../../../ipc/models/common';
 import { ConfigTarget, ConfigV3Section } from '../../../ipc/models/config';
 import { CommonMessageType } from '../../../ipc/toUI/common';
 import { ConfigMessageType, SectionV3ChangeMessage } from '../../../ipc/toUI/config';
-import { Logger } from '../../../logger';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { ConfigActionApi } from './configActionApi';
 import { ConfigV3WebviewController, id } from './configV3WebviewController';
@@ -203,7 +203,7 @@ describe('ConfigV3WebviewController', () => {
 
             await controller['invalidate']();
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating configuration');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating configuration');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -282,7 +282,7 @@ describe('ConfigV3WebviewController', () => {
 
             await controller.onMessageReceived({ type: CommonActionType.Refresh });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating configuration');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating configuration');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -339,7 +339,7 @@ describe('ConfigV3WebviewController', () => {
                 authInfo: mockAuthInfo,
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Authentication error');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Authentication error');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -454,7 +454,7 @@ describe('ConfigV3WebviewController', () => {
                 userInput: 'test',
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'JQL fetch error');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'JQL fetch error');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -488,7 +488,7 @@ describe('ConfigV3WebviewController', () => {
                 site: mockSite,
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'JQL fetch error');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'JQL fetch error');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -551,7 +551,7 @@ describe('ConfigV3WebviewController', () => {
                 startAt: 0,
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Filter fetch error');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Filter fetch error');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -608,7 +608,7 @@ describe('ConfigV3WebviewController', () => {
                 jql: 'project = TEST',
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'JQL Validate network error');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'JQL Validate network error');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -639,7 +639,7 @@ describe('ConfigV3WebviewController', () => {
                 removes: [],
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating configuration');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating configuration');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),

--- a/src/lib/webview/controller/config/configV3WebviewController.ts
+++ b/src/lib/webview/controller/config/configV3WebviewController.ts
@@ -1,6 +1,7 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import Axios from 'axios';
 import { ConfigV3Section } from 'src/lib/ipc/models/config';
+import { Logger } from 'src/logger';
 import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import { env } from 'vscode';
@@ -15,7 +16,6 @@ import { ConfigAction, ConfigActionType } from '../../../ipc/fromUI/config';
 import { WebViewID } from '../../../ipc/models/common';
 import { CommonMessage, CommonMessageType } from '../../../ipc/toUI/common';
 import { ConfigMessageType, ConfigResponse, ConfigV3Message, SectionV3ChangeMessage } from '../../../ipc/toUI/config';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';
@@ -112,7 +112,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                 }
             }
         } catch (e) {
-            this._logger.error(e, 'Error updating configuration');
+            this._logger.error(undefined, e, 'Error updating configuration');
             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
         } finally {
             this._isRefreshing = false;
@@ -139,7 +139,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                 try {
                     await this.invalidate();
                 } catch (e) {
-                    this._logger.error(e, 'Error refeshing config');
+                    this._logger.error(undefined, e, 'Error refeshing config');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error refeshing config'),
@@ -154,7 +154,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                     try {
                         await this._api.authenticateServer(msg.siteInfo, msg.authInfo);
                     } catch (e) {
-                        this._logger.error(e, 'Authentication error');
+                        this._logger.error(undefined, e, 'Authentication error');
                         this.postMessage({
                             type: CommonMessageType.Error,
                             reason: formatError(e, 'Authentication error'),
@@ -210,7 +210,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                         if (Axios.isCancel(e)) {
                             this._logger.warn(formatError(e));
                         } else {
-                            this._logger.error(e, 'JQL fetch error');
+                            this._logger.error(undefined, e, 'JQL fetch error');
                             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                         }
                     }
@@ -226,7 +226,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                             data: data,
                         });
                     } catch (e) {
-                        this._logger.error(e, 'JQL fetch error');
+                        this._logger.error(undefined, e, 'JQL fetch error');
                         this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                     }
                 }
@@ -250,7 +250,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                         if (Axios.isCancel(e)) {
                             this._logger.warn(formatError(e));
                         } else {
-                            this._logger.error(e, 'Filter fetch error');
+                            this._logger.error(undefined, e, 'Filter fetch error');
                             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                         }
                     }
@@ -269,7 +269,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                         if (Axios.isCancel(e)) {
                             this._logger.warn(formatError(e));
                         } else {
-                            this._logger.error(e, 'JQL Validate network error');
+                            this._logger.error(undefined, e, 'JQL Validate network error');
                             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                         }
                     }
@@ -280,7 +280,7 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
                 try {
                     this._api.updateSettings(msg.target, msg.changes, msg.removes);
                 } catch (e) {
-                    this._logger.error(e, 'Error updating configuration');
+                    this._logger.error(undefined, e, 'Error updating configuration');
                     this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                 }
                 break;

--- a/src/lib/webview/controller/config/configWebviewController.test.ts
+++ b/src/lib/webview/controller/config/configWebviewController.test.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import * as vscode from 'vscode';
@@ -13,7 +14,6 @@ import { WebViewID } from '../../../ipc/models/common';
 import { ConfigSection, ConfigTarget } from '../../../ipc/models/config';
 import { CommonMessageType } from '../../../ipc/toUI/common';
 import { ConfigMessageType, SectionChangeMessage } from '../../../ipc/toUI/config';
-import { Logger } from '../../../logger';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { ConfigActionApi } from './configActionApi';
 import { ConfigWebviewController, id } from './configWebviewController';
@@ -203,7 +203,7 @@ describe('ConfigWebviewController', () => {
 
             await controller['invalidate']();
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating configuration');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating configuration');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -237,7 +237,7 @@ describe('ConfigWebviewController', () => {
 
             await controller.onMessageReceived({ type: CommonActionType.Refresh });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error refeshing config');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error refeshing config');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -301,7 +301,7 @@ describe('ConfigWebviewController', () => {
                 authInfo: mockAuthInfo,
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Authentication error');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Authentication error');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -416,7 +416,7 @@ describe('ConfigWebviewController', () => {
                 userInput: 'test',
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'JQL fetch error');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'JQL fetch error');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),
@@ -508,7 +508,7 @@ describe('ConfigWebviewController', () => {
                 removes: [],
             });
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating configuration');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating configuration');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.anything(),

--- a/src/lib/webview/controller/config/configWebviewController.ts
+++ b/src/lib/webview/controller/config/configWebviewController.ts
@@ -1,5 +1,6 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import { env } from 'vscode';
@@ -14,7 +15,6 @@ import { ConfigAction, ConfigActionType } from '../../../ipc/fromUI/config';
 import { WebViewID } from '../../../ipc/models/common';
 import { CommonMessage, CommonMessageType } from '../../../ipc/toUI/common';
 import { ConfigMessage, ConfigMessageType, ConfigResponse, SectionChangeMessage } from '../../../ipc/toUI/config';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';
@@ -111,7 +111,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                 }
             }
         } catch (e) {
-            this._logger.error(e, 'Error updating configuration');
+            this._logger.error(undefined, e, 'Error updating configuration');
             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
         } finally {
             this._isRefreshing = false;
@@ -138,7 +138,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                 try {
                     await this.invalidate();
                 } catch (e) {
-                    this._logger.error(e, 'Error refeshing config');
+                    this._logger.error(undefined, e, 'Error refeshing config');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error refeshing config'),
@@ -153,7 +153,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                     try {
                         await this._api.authenticateServer(msg.siteInfo, msg.authInfo);
                     } catch (e) {
-                        this._logger.error(e, 'Authentication error');
+                        this._logger.error(undefined, e, 'Authentication error');
                         this.postMessage({
                             type: CommonMessageType.Error,
                             reason: formatError(e, 'Authentication error'),
@@ -163,7 +163,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                     try {
                         await this._api.authenticateCloud(msg.siteInfo, this._settingsUrl);
                     } catch (e) {
-                        this._logger.error(e, 'Cloud authentication error');
+                        this._logger.error(undefined, e, 'Cloud authentication error');
                         this.postMessage({
                             type: CommonMessageType.Error,
                             reason: formatError(e, 'Cloud authentication error'),
@@ -217,7 +217,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                         if (Axios.isCancel(e)) {
                             this._logger.warn(formatError(e));
                         } else {
-                            this._logger.error(e, 'JQL fetch error');
+                            this._logger.error(undefined, e, 'JQL fetch error');
                             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                         }
                     }
@@ -233,7 +233,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                             data: data,
                         });
                     } catch (e) {
-                        this._logger.error(e, 'JQL fetch error');
+                        this._logger.error(undefined, e, 'JQL fetch error');
                         this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                     }
                 }
@@ -257,7 +257,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                         if (Axios.isCancel(e)) {
                             this._logger.warn(formatError(e));
                         } else {
-                            this._logger.error(e, 'Filter fetch error');
+                            this._logger.error(undefined, e, 'Filter fetch error');
                             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                         }
                     }
@@ -276,7 +276,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                         if (Axios.isCancel(e)) {
                             this._logger.warn(formatError(e));
                         } else {
-                            this._logger.error(e, 'JQL Validate network error');
+                            this._logger.error(undefined, e, 'JQL Validate network error');
                             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                         }
                     }
@@ -287,7 +287,7 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
                 try {
                     this._api.updateSettings(msg.target, msg.changes, msg.removes);
                 } catch (e) {
-                    this._logger.error(e, 'Error updating configuration');
+                    this._logger.error(undefined, e, 'Error updating configuration');
                     this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
                 }
                 break;

--- a/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.test.ts
+++ b/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.test.ts
@@ -1,3 +1,5 @@
+import { Logger } from 'src/logger';
+
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import {
     Pipeline,
@@ -11,14 +13,13 @@ import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
 import { PipelineSummaryAction, PipelineSummaryActionType } from '../../../ipc/fromUI/pipelineSummary';
 import { PipelineSummaryMessageType } from '../../../ipc/toUI/pipelineSummary';
-import { Logger } from '../../../logger';
 import { MessagePoster } from '../webviewController';
 import { PipelinesSummaryActionApi } from './pipelinesSummaryActionApi';
 import { PipelineSummaryWebviewController } from './pipelineSummaryWebviewController';
 
 // Mock dependencies
-jest.mock('../../../logger');
 jest.mock('../../../analyticsApi');
+jest.mock('src/logger');
 
 describe('PipelineSummaryWebviewController', () => {
     let controller: PipelineSummaryWebviewController;
@@ -377,7 +378,7 @@ describe('PipelineSummaryWebviewController', () => {
 
                 await controllerWithoutPipeline.onMessageReceived(fetchLogMessage);
 
-                expect(mockLogger.error).toHaveBeenCalledWith(expect.any(Error));
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, expect.any(Error));
                 expect(mockApi.fetchLogRange).not.toHaveBeenCalled();
             });
 
@@ -462,7 +463,7 @@ describe('PipelineSummaryWebviewController', () => {
 
                 await controllerWithoutPipeline.onMessageReceived(rerunMessage);
 
-                expect(mockLogger.error).toHaveBeenCalledWith(expect.any(Error));
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, expect.any(Error));
                 expect(mockAnalytics.firePipelineRerunEvent).not.toHaveBeenCalled();
                 expect(mockApi.rerunPipeline).not.toHaveBeenCalled();
             });

--- a/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.ts
+++ b/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.ts
@@ -1,3 +1,5 @@
+import { Logger } from 'src/logger';
+
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import {
     Pipeline,
@@ -11,7 +13,6 @@ import { CommonActionType } from '../../../ipc/fromUI/common';
 import { PipelineSummaryAction, PipelineSummaryActionType } from '../../../ipc/fromUI/pipelineSummary';
 import { CommonMessage } from '../../../ipc/toUI/common';
 import { PipelineSummaryMessage, PipelineSummaryMessageType } from '../../../ipc/toUI/pipelineSummary';
-import { Logger } from '../../../logger';
 import { MessagePoster, WebviewController } from '../webviewController';
 import { PipelinesSummaryActionApi } from './pipelinesSummaryActionApi';
 
@@ -66,7 +67,7 @@ export class PipelineSummaryWebviewController implements WebviewController<Pipel
             }
             case PipelineSummaryActionType.FetchLogRange: {
                 if (!this.pipeline) {
-                    this.logger.error(new Error(`Missing a pipeline. no idea`));
+                    this.logger.error(undefined, new Error(`Missing a pipeline. no idea`));
                     return;
                 }
                 const logRef = msg.reference;
@@ -84,7 +85,7 @@ export class PipelineSummaryWebviewController implements WebviewController<Pipel
             }
             case PipelineSummaryActionType.ReRunPipeline: {
                 if (!this.pipeline) {
-                    this.logger.error(new Error(`Missing a pipeline. no idea`));
+                    this.logger.error(undefined, new Error(`Missing a pipeline. no idea`));
                     return;
                 }
 

--- a/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.test.ts
+++ b/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.test.ts
@@ -1,5 +1,6 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import { Commit, FileDiff, FileStatus, PullRequest, User, WorkspaceRepo } from '../../../../bitbucket/model';
@@ -17,16 +18,15 @@ import {
 import { WebViewID } from '../../../ipc/models/common';
 import { CommonMessageType } from '../../../ipc/toUI/common';
 import { CreatePullRequestMessageType, RepoData } from '../../../ipc/toUI/createPullRequest';
-import { Logger } from '../../../logger';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster } from '../webviewController';
 import { CreatePullRequestActionApi } from './createPullRequestActionApi';
 import { CreatePullRequestWebviewController } from './createPullRequestWebviewController';
 
 // Mock dependencies
-jest.mock('../../../logger');
 jest.mock('../../../analyticsApi');
 jest.mock('../common/commonActionMessageHandler');
+jest.mock('src/logger');
 jest.mock('axios');
 
 // Helper functions to create mock objects
@@ -283,7 +283,7 @@ describe('CreatePullRequestWebviewController', () => {
 
             await controller.update();
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating start work page');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating start work page');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.any(String),
@@ -327,7 +327,7 @@ describe('CreatePullRequestWebviewController', () => {
 
                 await controller.onMessageReceived({ type: CommonActionType.Refresh });
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating start work page');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating start work page');
                 expect(mockMessagePoster).toHaveBeenCalledWith({
                     type: CommonMessageType.Error,
                     reason: expect.any(String),
@@ -376,7 +376,7 @@ describe('CreatePullRequestWebviewController', () => {
                     ...action,
                 });
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error fetching issue for branch name');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error fetching issue for branch name');
                 expect(mockMessagePoster).not.toHaveBeenCalled();
             });
         });
@@ -417,7 +417,7 @@ describe('CreatePullRequestWebviewController', () => {
                     ...action,
                 });
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error fetching commits');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error fetching commits');
                 expect(mockMessagePoster).not.toHaveBeenCalled();
             });
         });
@@ -454,7 +454,7 @@ describe('CreatePullRequestWebviewController', () => {
                     ...action,
                 });
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error opening diff');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error opening diff');
                 expect(mockMessagePoster).not.toHaveBeenCalled();
             });
         });
@@ -511,7 +511,7 @@ describe('CreatePullRequestWebviewController', () => {
                     ...action,
                 });
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error fetching users');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error fetching users');
                 expect(mockMessagePoster).toHaveBeenCalledWith({
                     type: CommonMessageType.Error,
                     reason: expect.objectContaining({
@@ -580,7 +580,7 @@ describe('CreatePullRequestWebviewController', () => {
                     ...action,
                 });
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error creating pull request');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error creating pull request');
                 expect(mockMessagePoster).toHaveBeenNthCalledWith(1, {
                     type: CreatePullRequestMessageType.SubmitResponse,
                     pr: undefined!,

--- a/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.ts
+++ b/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.ts
@@ -1,5 +1,6 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 
 import { Registry } from '../../../../analytics';
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
@@ -14,7 +15,6 @@ import {
     CreatePullRequestMessageType,
     CreatePullRequestResponse,
 } from '../../../ipc/toUI/createPullRequest';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';
@@ -68,7 +68,7 @@ export class CreatePullRequestWebviewController implements WebviewController<Wor
                 repoData: repoData,
             });
         } catch (e) {
-            this.logger.error(e, 'Error updating start work page');
+            this.logger.error(undefined, e, 'Error updating start work page');
             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
         } finally {
             this.isRefreshing = false;
@@ -86,7 +86,7 @@ export class CreatePullRequestWebviewController implements WebviewController<Wor
                 try {
                     await this.invalidate();
                 } catch (e) {
-                    this.logger.error(e, 'Error refeshing start work page');
+                    this.logger.error(undefined, e, 'Error refeshing start work page');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error refeshing start work page'),
@@ -104,7 +104,7 @@ export class CreatePullRequestWebviewController implements WebviewController<Wor
                         });
                     }
                 } catch (e) {
-                    this.logger.error(e, 'Error fetching issue for branch name');
+                    this.logger.error(undefined, e, 'Error fetching issue for branch name');
                     // ignore posting error to UI
                 }
                 break;
@@ -121,7 +121,7 @@ export class CreatePullRequestWebviewController implements WebviewController<Wor
                         fileDiffs,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error fetching commits');
+                    this.logger.error(undefined, e, 'Error fetching commits');
                     // ignore posting error to UI
                 }
                 break;
@@ -134,7 +134,7 @@ export class CreatePullRequestWebviewController implements WebviewController<Wor
                         ProductBitbucket,
                     );
                 } catch (e) {
-                    this.logger.error(e, 'Error opening diff');
+                    this.logger.error(undefined, e, 'Error opening diff');
                     // ignore posting error to UI
                 }
                 break;
@@ -149,7 +149,7 @@ export class CreatePullRequestWebviewController implements WebviewController<Wor
                     if (Axios.isCancel(e)) {
                         this.logger.warn(formatError(e));
                     } else {
-                        this.logger.error(e, 'Error fetching users');
+                        this.logger.error(undefined, e, 'Error fetching users');
                         this.postMessage({
                             type: CommonMessageType.Error,
                             reason: formatError(e, 'Error fetching users'),
@@ -166,7 +166,7 @@ export class CreatePullRequestWebviewController implements WebviewController<Wor
                     });
                     this.analytics.firePrCreatedEvent(msg.sourceSiteRemote.site!.details);
                 } catch (e) {
-                    this.logger.error(e, 'Error creating pull request');
+                    this.logger.error(undefined, e, 'Error creating pull request');
                     this.postMessage({
                         type: CreatePullRequestMessageType.SubmitResponse,
                         pr: undefined!,

--- a/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.test.ts
+++ b/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.test.ts
@@ -1,5 +1,6 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Uri } from 'vscode';
 
 import { DetailedSiteInfo } from '../../../../atlclients/authInfo';
@@ -23,7 +24,6 @@ import {
     emptyPullRequestDetailsInitMessage,
     PullRequestDetailsMessageType,
 } from '../../../ipc/toUI/pullRequestDetails';
-import { Logger } from '../../../logger';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster } from '../webviewController';
 import { PullRequestDetailsActionApi } from './pullRequestDetailsActionApi';
@@ -31,9 +31,9 @@ import { PullRequestDetailsWebviewController } from './pullRequestDetailsWebview
 
 // Mock dependencies
 jest.mock('../../../../views/notifications/notificationManager');
-jest.mock('../../../logger');
 jest.mock('../../../analyticsApi');
 jest.mock('../common/commonActionMessageHandler');
+jest.mock('src/logger');
 jest.mock('axios');
 
 // Helper functions to create mock objects
@@ -262,7 +262,7 @@ describe('PullRequestDetailsWebviewController', () => {
 
             await controller.update();
 
-            expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating pull request');
+            expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating pull request');
             expect(mockMessagePoster).toHaveBeenCalledWith({
                 type: CommonMessageType.Error,
                 reason: expect.any(String),
@@ -299,7 +299,7 @@ describe('PullRequestDetailsWebviewController', () => {
                 const action: CommonAction = { type: CommonActionType.Refresh };
                 await controller.onMessageReceived(action);
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating pull request');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating pull request');
                 expect(mockMessagePoster).toHaveBeenCalledWith({
                     type: CommonMessageType.Error,
                     reason: expect.any(String),
@@ -361,7 +361,7 @@ describe('PullRequestDetailsWebviewController', () => {
 
                 await controller.onMessageReceived(action);
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error fetching users');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error fetching users');
                 expect(mockMessagePoster).toHaveBeenCalledWith({
                     type: CommonMessageType.Error,
                     reason: expect.any(Object),
@@ -403,7 +403,7 @@ describe('PullRequestDetailsWebviewController', () => {
 
                 await controller.onMessageReceived(action);
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error fetching users');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error fetching users');
                 expect(mockMessagePoster).toHaveBeenCalledWith({
                     type: CommonMessageType.Error,
                     reason: expect.any(Object),

--- a/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.ts
+++ b/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.ts
@@ -1,6 +1,7 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Uri } from 'vscode';
 
 import { DetailedSiteInfo } from '../../../../atlclients/authInfo';
@@ -27,7 +28,6 @@ import {
     PullRequestDetailsMessageType,
     PullRequestDetailsResponse,
 } from '../../../ipc/toUI/pullRequestDetails';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';
@@ -202,7 +202,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
             this.inlineComments = tasksAndComments.inlineComments;
             this.tasks = tasksAndComments.tasks;
         } catch (e) {
-            this.logger.error(e, 'Error updating pull request');
+            this.logger.error(undefined, e, 'Error updating pull request');
             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
         } finally {
             this.isRefreshing = false;
@@ -219,7 +219,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                 try {
                     await this.invalidate();
                 } catch (e) {
-                    this.logger.error(e, 'Error refreshing pull request');
+                    this.logger.error(undefined, e, 'Error refreshing pull request');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error refreshing pull request'),
@@ -239,7 +239,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                     if (Axios.isCancel(e)) {
                         this.logger.warn(formatError(e));
                     } else {
-                        this.logger.error(e, 'Error fetching users');
+                        this.logger.error(undefined, e, 'Error fetching users');
                         this.postMessage({
                             type: CommonMessageType.Error,
                             reason: formatError(e, 'Error fetching users'),
@@ -257,7 +257,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         reviewers: reviewers,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error fetching users');
+                    this.logger.error(undefined, e, 'Error fetching users');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error fetching users'),
@@ -279,7 +279,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         htmlSummary: pr.data.htmlSummary,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error fetching users');
+                    this.logger.error(undefined, e, 'Error fetching users');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error fetching users'),
@@ -296,7 +296,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         title: pr.data.title,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error fetching users');
+                    this.logger.error(undefined, e, 'Error fetching users');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error fetching users'),
@@ -314,7 +314,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         status: status,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error updating approval status');
+                    this.logger.error(undefined, e, 'Error updating approval status');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error updating approval status'),
@@ -332,7 +332,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         branchName: newBranchName,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error checking out pull request');
+                    this.logger.error(undefined, e, 'Error checking out pull request');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error checking out pull request'),
@@ -355,7 +355,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         comments: this.pageComments,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error adding comment');
+                    this.logger.error(undefined, e, 'Error adding comment');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error adding comment'),
@@ -381,7 +381,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         comments: this.pageComments,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error editing comment');
+                    this.logger.error(undefined, e, 'Error editing comment');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error editing comment'),
@@ -404,7 +404,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         comments: this.pageComments,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error deleting comment');
+                    this.logger.error(undefined, e, 'Error deleting comment');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error deleting comment'),
@@ -434,7 +434,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         comments: this.pageComments,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error adding task');
+                    this.logger.error(undefined, e, 'Error adding task');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error adding task'),
@@ -462,7 +462,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         comments: this.pageComments,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error editing task');
+                    this.logger.error(undefined, e, 'Error editing task');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error editing task'),
@@ -485,7 +485,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                         comments: this.pageComments,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error deleting task');
+                    this.logger.error(undefined, e, 'Error deleting task');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error deleting task'),
@@ -502,7 +502,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                     //Inline comments are passed in to avoid refetching them.
                     await this.api.openDiffViewForFile(this.pr, msg.fileDiff, this.inlineComments!);
                 } catch (e) {
-                    this.logger.error(e, 'Error opening diff');
+                    this.logger.error(undefined, e, 'Error opening diff');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error opening diff'),
@@ -523,7 +523,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                     this.pr = { ...this.pr, ...updatedPullRequest };
                     this.update();
                 } catch (e) {
-                    this.logger.error(e, 'Error merging pull request');
+                    this.logger.error(undefined, e, 'Error merging pull request');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error merging pull request'),
@@ -534,7 +534,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                 try {
                     await this.api.openJiraIssue(msg.issue);
                 } catch (e) {
-                    this.logger.error(e, 'Error opening jira issue');
+                    this.logger.error(undefined, e, 'Error opening jira issue');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error opening jira issue'),
@@ -546,7 +546,7 @@ export class PullRequestDetailsWebviewController implements WebviewController<Pu
                 try {
                     await this.api.openBuildStatus(this.pr, msg.buildStatus);
                 } catch (e) {
-                    this.logger.error(e, 'Error opening build status');
+                    this.logger.error(undefined, e, 'Error opening build status');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error opening build status'),

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.test.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.test.ts
@@ -1,5 +1,6 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import { createEmptyMinimalIssue, MinimalIssue, Transition } from '@atlassianlabs/jira-pi-common-models';
+import { Logger } from 'src/logger';
 
 import { DetailedSiteInfo, emptySiteInfo, ProductBitbucket } from '../../../../atlclients/authInfo';
 import { BitbucketBranchingModel, WorkspaceRepo } from '../../../../bitbucket/model';
@@ -16,7 +17,6 @@ import {
     StartWorkInitMessage,
     StartWorkMessageType,
 } from '../../../ipc/toUI/startWork';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster } from '../webviewController';
@@ -346,7 +346,7 @@ describe('StartWorkWebviewController', () => {
 
                 await controller.onMessageReceived(startRequestAction);
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error executing start work action');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error executing start work action');
                 expect(mockMessagePoster).toHaveBeenCalledWith({
                     type: CommonMessageType.Error,
                     reason: 'Formatted error message',
@@ -463,7 +463,7 @@ describe('StartWorkWebviewController', () => {
 
                 await controller.onMessageReceived(getImageAction);
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error fetching image');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error fetching image');
                 expect(mockMessagePoster).toHaveBeenCalledWith({
                     type: 'getImageDone',
                     imgData: '',
@@ -593,7 +593,7 @@ describe('StartWorkWebviewController', () => {
 
                 await controller.onMessageReceived({ type: CommonActionType.Refresh });
 
-                expect(mockLogger.error).toHaveBeenCalledWith(error, 'Error updating start work page');
+                expect(mockLogger.error).toHaveBeenCalledWith(undefined, error, 'Error updating start work page');
                 expect(mockMessagePoster).toHaveBeenCalledWith({
                     type: CommonMessageType.Error,
                     reason: 'Formatted error message',

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -1,5 +1,6 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import { ConfigSection, ConfigSubSection, ConfigV3Section, ConfigV3SubSection } from 'src/lib/ipc/models/config';
+import { Logger } from 'src/logger';
 import * as vscode from 'vscode';
 
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
@@ -24,7 +25,6 @@ import {
     StartWorkMessageType,
     StartWorkResponse,
 } from '../../../ipc/toUI/startWork';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';
@@ -122,7 +122,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                 isRovoDevEnabled: Container.isRovoDevEnabled,
             });
         } catch (e) {
-            this.logger.error(e, 'Error updating start work page');
+            this.logger.error(undefined, e, 'Error updating start work page');
             this.postMessage({ type: CommonMessageType.Error, reason: formatError(e) });
         } finally {
             this.isRefreshing = false;
@@ -159,7 +159,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                     });
                     this.analytics.fireIssueWorkStartedEvent(this.initData.issue.siteDetails, msg.pushBranchToRemote);
                 } catch (e) {
-                    this.logger.error(e, 'Error executing start work action');
+                    this.logger.error(undefined, e, 'Error executing start work action');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error executing start work action'),
@@ -214,7 +214,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                         nonce: msg.nonce,
                     } as any);
                 } catch (e) {
-                    this.logger.error(e, 'Error fetching image');
+                    this.logger.error(undefined, e, 'Error fetching image');
                     this.postMessage({
                         type: 'getImageDone',
                         imgData: '',
@@ -231,7 +231,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                         enabled,
                     });
                 } catch (e) {
-                    this.logger.error(e, 'Error getting RovoDev preference');
+                    this.logger.error(undefined, e, 'Error getting RovoDev preference');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error getting RovoDev preference'),
@@ -243,7 +243,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                 try {
                     await this.api.updateRovoDevPreference(msg.enabled);
                 } catch (e) {
-                    this.logger.error(e, 'Error updating RovoDev preference');
+                    this.logger.error(undefined, e, 'Error updating RovoDev preference');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error updating RovoDev preference'),
@@ -255,7 +255,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                 try {
                     await this.api.openRovoDev();
                 } catch (e) {
-                    this.logger.error(e, 'Error opening RovoDev');
+                    this.logger.error(undefined, e, 'Error opening RovoDev');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error opening RovoDev'),
@@ -276,7 +276,7 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
                 try {
                     await this.invalidate();
                 } catch (e) {
-                    this.logger.error(e, 'Error refeshing start work page');
+                    this.logger.error(undefined, e, 'Error refeshing start work page');
                     this.postMessage({
                         type: CommonMessageType.Error,
                         reason: formatError(e, 'Error refeshing start work page'),

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -244,7 +244,7 @@ describe('Logger', () => {
                 eventRegistration = Logger.onError(errorHandlerSpy);
 
                 const testError = new Error('test error message');
-                Logger_error(testError, 'Something went wrong');
+                Logger_error(undefined, testError, 'Something went wrong');
 
                 expect(errorHandlerSpy).toHaveBeenCalled();
                 const errorEvent: ErrorEvent = errorHandlerSpy.mock.calls[0][0];
@@ -258,7 +258,7 @@ describe('Logger', () => {
 
         it('should append error to output channel', () => {
             const testError = new Error('test error message');
-            Logger_error(testError, 'Something went wrong');
+            Logger_error(undefined, testError, 'Something went wrong');
 
             expect(mockOutputChannel.appendLine).toHaveBeenCalled();
             const call = (mockOutputChannel.appendLine as jest.Mock).mock.calls[0][0];
@@ -270,7 +270,7 @@ describe('Logger', () => {
             mockContainerIsDebugging();
 
             const testError = new Error('test error message');
-            Logger_error(testError, 'Something went wrong');
+            Logger_error(undefined, testError, 'Something went wrong');
 
             expect(console.error).toHaveBeenCalled();
         });
@@ -281,7 +281,7 @@ describe('Logger', () => {
             Logger.configure(expansionCastTo<ExtensionContext>({ subscriptions: [] }));
 
             const testError = new Error('test error message');
-            Logger_error(testError, 'Something went wrong');
+            Logger_error(undefined, testError, 'Something went wrong');
 
             expect(mockOutputChannel.appendLine).not.toHaveBeenCalled();
             expect(console.error).not.toHaveBeenCalled();
@@ -305,7 +305,7 @@ describe('Logger', () => {
 
     describe('retrieveCallerName', () => {
         function thisFunctionName() {
-            Logger.error(new Error('test error'));
+            Logger.error(undefined, new Error('test error'));
         }
 
         it('should return caller function name', () => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -114,18 +114,8 @@ export class Logger {
         }
     }
 
-    public static error(productArea: ErrorProductArea, ex: Error, errorMessage?: string, ...params: string[]): void;
-    public static error(ex: Error, errorMessage?: string, ...params: string[]): void;
-    public static error(...params: any[]): void {
+    public static error(productArea: ErrorProductArea, ex: Error, errorMessage?: string, ...params: string[]): void {
         const callerName = retrieveCallerName();
-
-        // the following code is ugly, but it's the only way to handle a JS/TS method overload where a new parameter
-        // has been added at the beginning of the arg list.
-        // next improvement will be refactoring every Logger.error in the codebase
-        const productArea: ErrorProductArea = params[0] instanceof Error ? undefined : params.shift();
-        const ex: Error = params.shift();
-        const errorMessage: string | undefined = params.shift();
-
         this.Instance.errorInternal(productArea, ex, callerName, errorMessage, ...params);
     }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -119,18 +119,8 @@ export class Logger {
         this.Instance.errorInternal(productArea, ex, callerName, errorMessage, ...params);
     }
 
-    public error(productArea: ErrorProductArea, ex: Error, errorMessage?: string, ...params: string[]): void;
-    public error(ex: Error, errorMessage?: string, ...params: string[]): void;
-    public error(...params: any[]): void {
+    public error(productArea: ErrorProductArea, ex: Error, errorMessage?: string, ...params: string[]): void {
         const callerName = retrieveCallerName();
-
-        // the following code is ugly, but it's the only way to handle a JS/TS method overload where a new parameter
-        // has been added at the beginning of the arg list.
-        // next improvement will be refactoring every Logger.error in the codebase
-        const productArea: ErrorProductArea = params[0] instanceof Error ? undefined : params.shift();
-        const ex: Error = params.shift();
-        const errorMessage: string | undefined = params.shift();
-
         this.errorInternal(productArea, ex, callerName, errorMessage, ...params);
     }
 

--- a/src/onboarding/onboardingProvider.ts
+++ b/src/onboarding/onboardingProvider.ts
@@ -140,7 +140,7 @@ class OnboardingProvider {
 
     private _handleError(message: string, error: Error) {
         window.showErrorMessage(message);
-        Logger.error(error, message);
+        Logger.error(undefined, error, message);
     }
 
     private _handleSkip(product: Product) {

--- a/src/pipelines/yaml/pipelinesYamlCompletionProvider.test.ts
+++ b/src/pipelines/yaml/pipelinesYamlCompletionProvider.test.ts
@@ -91,7 +91,7 @@ describe('PipelinesYamlCompletionProvider', () => {
             // Wait for the promise to resolve/reject
             await new Promise((resolve) => setTimeout(resolve, 0));
 
-            expect(Logger.error).toHaveBeenCalledWith(mockError, 'Error getting pipes');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, mockError, 'Error getting pipes');
             expect(Logger.debug).toHaveBeenCalledWith('knownpipes', []);
         });
     });

--- a/src/pipelines/yaml/pipelinesYamlCompletionProvider.ts
+++ b/src/pipelines/yaml/pipelinesYamlCompletionProvider.ts
@@ -136,7 +136,7 @@ export class PipelinesYamlCompletionProvider implements CompletionItemProvider {
                 }
             })
             .catch((err) => {
-                Logger.error(err, 'Error getting pipes');
+                Logger.error(undefined, err, 'Error getting pipes');
                 Logger.debug('knownpipes', this.knownPipes);
             });
     }

--- a/src/rovo-dev/rovoDevFeedbackManager.test.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.test.ts
@@ -162,7 +162,7 @@ describe('RovoDevFeedbackManager', () => {
 
             await RovoDevFeedbackManager.submitFeedback(feedback);
 
-            expect(Logger.error).toHaveBeenCalledWith(error, 'Error submitting Rovo Dev feedback');
+            expect(Logger.error).toHaveBeenCalledWith('RovoDev', error, 'Error submitting Rovo Dev feedback');
             expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
                 'There was an error submitting your feedback. Please try again later.',
             );

--- a/src/rovo-dev/rovoDevFeedbackManager.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.ts
@@ -94,7 +94,7 @@ export class RovoDevFeedbackManager {
                 data: payload,
             });
         } catch (error) {
-            Logger.error(error as Error, 'Error submitting Rovo Dev feedback');
+            Logger.error('RovoDev', error as Error, 'Error submitting Rovo Dev feedback');
             vscode.window.showErrorMessage('There was an error submitting your feedback. Please try again later.');
             return;
         }

--- a/src/rovo-dev/rovoDevPullRequestHandler.ts
+++ b/src/rovo-dev/rovoDevPullRequestHandler.ts
@@ -106,7 +106,7 @@ export class RovoDevPullRequestHandler {
                 repo.state.mergeChanges.length === 0
             );
         } catch (error) {
-            Logger.error(error, 'Error checking git state');
+            Logger.error('RovoDev', error, 'Error checking git state');
             return true; // If we can't determine the state, assume it's clean
         }
     }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -136,7 +136,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
         const onTelemetryError = Container.isDebugging
             ? (error: Error) => this.processError(error, false)
-            : (error: Error) => Logger.error(error);
+            : (error: Error) => Logger.error('RovoDev', error);
 
         this._telemetryProvider = new RovoDevTelemetryProvider(
             this.isBoysenberry ? 'Boysenberry' : 'IDE',

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -187,7 +187,7 @@ export class SiteManager extends Disposable {
                 primarySite: this._primarySite,
             });
         } catch (error) {
-            Logger.error(error, 'Error during async site removal');
+            Logger.error(undefined, error, 'Error during async site removal');
         }
     }
 

--- a/src/views/Explorer.ts
+++ b/src/views/Explorer.ts
@@ -51,7 +51,7 @@ export abstract class Explorer extends Disposable {
         try {
             await this.treeView.reveal(node, options);
         } catch (e) {
-            Logger.error(e, 'Error executing Explorer.reveal treeView.reveal');
+            Logger.error(undefined, e, 'Error executing Explorer.reveal treeView.reveal');
         }
     }
 

--- a/src/views/jira/treeViews/utils.test.ts
+++ b/src/views/jira/treeViews/utils.test.ts
@@ -128,6 +128,7 @@ describe('utils', () => {
             const issues = await executeJqlQuery(jqlEntry);
             expect(issues).toHaveLength(0);
             expect(Logger.error).toHaveBeenCalledWith(
+                undefined,
                 error,
                 'Failed to execute default JQL query for site',
                 'site-id-guid',

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -38,7 +38,7 @@ export async function executeJqlQuery(jqlEntry: JQLEntry): Promise<TreeViewIssue
             }
         }
     } catch (e) {
-        Logger.error(e, 'Failed to execute default JQL query for site', jqlEntry.siteId);
+        Logger.error(undefined, e, 'Failed to execute default JQL query for site', jqlEntry.siteId);
     }
 
     return [];

--- a/src/views/notifications/atlassianNotificationNotifier.ts
+++ b/src/views/notifications/atlassianNotificationNotifier.ts
@@ -102,7 +102,7 @@ export class AtlassianNotificationNotifier extends Disposable implements Notific
                     });
             })
             .catch((error) => {
-                Logger.error(error, 'Error fetching notifications');
+                Logger.error(undefined, error, 'Error fetching notifications');
             });
     }
 
@@ -157,7 +157,7 @@ export class AtlassianNotificationNotifier extends Disposable implements Notific
         try {
             adfData = JSON.parse(bodyItem.document.data);
         } catch (error) {
-            Logger.error(error, 'Error parsing ADF data');
+            Logger.error(undefined, error, 'Error parsing ADF data');
             return '';
         }
 
@@ -198,7 +198,7 @@ export class AtlassianNotificationNotifier extends Disposable implements Notific
 
             return allowedBitbucketHosts.includes(parsedUrl.host);
         } catch (error) {
-            Logger.error(error, 'Error parsing URL');
+            Logger.error(undefined, error, 'Error parsing URL');
             return false;
         }
     }
@@ -243,7 +243,7 @@ export class AtlassianNotificationNotifier extends Disposable implements Notific
                 return response.notifications.unseenNotificationCount;
             })
             .catch((error) => {
-                Logger.error(error, 'Error fetching unseen notification count');
+                Logger.error(undefined, error, 'Error fetching unseen notification count');
                 return 0;
             });
     }

--- a/src/views/notifications/newIssueMonitor.test.ts
+++ b/src/views/notifications/newIssueMonitor.test.ts
@@ -312,7 +312,7 @@ describe('NewIssueMonitor', () => {
 
             await monitor.checkForNewIssues();
 
-            expect(Logger.error).toHaveBeenCalledWith(error, 'Error checking for new issues');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, error, 'Error checking for new issues');
         });
     });
 

--- a/src/views/notifications/newIssueMonitor.ts
+++ b/src/views/notifications/newIssueMonitor.ts
@@ -90,7 +90,7 @@ export class NewIssueMonitor {
 
             this.showNotification(notifyIssues);
         } catch (e) {
-            Logger.error(e, 'Error checking for new issues');
+            Logger.error(undefined, e, 'Error checking for new issues');
         }
     }
 

--- a/src/views/pullrequest/gitActions.test.ts
+++ b/src/views/pullrequest/gitActions.test.ts
@@ -344,6 +344,7 @@ describe('gitActions', () => {
                 'Dismiss',
             );
             expect(mockLogger.error).toHaveBeenCalledWith(
+                undefined,
                 new Error('Error checking out the pull request branch: no workspace repo'),
             );
             expect(result).toBe(false);

--- a/src/views/pullrequest/gitActions.ts
+++ b/src/views/pullrequest/gitActions.ts
@@ -14,7 +14,7 @@ export async function checkout(wsRepo: WorkspaceRepo, ref: string, forkCloneUrl:
 export async function checkoutPRBranch(pr: PullRequest, branch: string): Promise<boolean> {
     if (!pr.workspaceRepo) {
         window.showInformationMessage(`Error checking out the pull request branch: no workspace repo`, `Dismiss`);
-        Logger.error(new Error('Error checking out the pull request branch: no workspace repo'));
+        Logger.error(undefined, new Error('Error checking out the pull request branch: no workspace repo'));
         return false;
     }
 

--- a/src/views/pullrequest/pullRequestCreatedMonitor.ts
+++ b/src/views/pullrequest/pullRequestCreatedMonitor.ts
@@ -37,7 +37,7 @@ export class PullRequestCreatedMonitor implements BitbucketActivityMonitor {
                     return newPRs;
                 })
                 .catch((e) => {
-                    Logger.error(e, 'Error while fetching latest pull requests');
+                    Logger.error(undefined, e, 'Error while fetching latest pull requests');
                     return [];
                 });
         });

--- a/src/webview/pipelines/pipelineSummaryActionImplementation.ts
+++ b/src/webview/pipelines/pipelineSummaryActionImplementation.ts
@@ -25,7 +25,7 @@ export class PipelineSummaryActionImplementation implements PipelinesSummaryActi
         try {
             logRanges = await bbApi.pipelines!.getLogRanges(site as any, buildNumber);
         } catch (e) {
-            Logger.error(e, `Failed to fetch log ranges.`);
+            Logger.error(undefined, e, `Failed to fetch log ranges.`);
         }
         const steps = await bbApi.pipelines!.getSteps(site as any, uuid);
         steps.forEach((step: PipelineStep, index) => {
@@ -62,7 +62,7 @@ export class PipelineSummaryActionImplementation implements PipelinesSummaryActi
             const newPipeline = await bbApi.pipelines!.triggerPipeline(pipeline.site, pipeline.target);
             commands.executeCommand(Commands.ShowPipeline, newPipeline);
         } catch (e) {
-            Logger.error(e, 'Error executing PipelineSummaryActionImplementation.rerunPipeline');
+            Logger.error(undefined, e, 'Error executing PipelineSummaryActionImplementation.rerunPipeline');
         }
     }
 }

--- a/src/webviews/abstractIssueEditorWebview.test.ts
+++ b/src/webviews/abstractIssueEditorWebview.test.ts
@@ -567,7 +567,7 @@ describe('AbstractIssueEditorWebview', () => {
             const handled = await webview.testOnMessageReceived(mockMessage);
 
             expect(handled).toBe(true);
-            expect(Logger.error).toHaveBeenCalledWith(expect.any(Error), 'Error fetching issues');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, expect.any(Error), 'Error fetching issues');
             expect(webview.postMessage).toHaveBeenCalledWith({
                 type: 'error',
                 reason: 'Error fetching issues',
@@ -618,7 +618,7 @@ describe('AbstractIssueEditorWebview', () => {
             const handled = await webview.testOnMessageReceived(mockMessage);
 
             expect(handled).toBe(true);
-            expect(Logger.error).toHaveBeenCalledWith(mockError, 'Error fetching options');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, mockError, 'Error fetching options');
             expect(webview.postMessage).toHaveBeenCalledWith({
                 type: 'error',
                 reason: 'Error fetching options',
@@ -683,7 +683,7 @@ describe('AbstractIssueEditorWebview', () => {
             const handled = await webview.testOnMessageReceived(mockMessage);
 
             expect(handled).toBe(true);
-            expect(Logger.error).toHaveBeenCalledWith(mockError, 'Error creating select option');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, mockError, 'Error creating select option');
             expect(webview.postMessage).toHaveBeenCalledWith({
                 type: 'error',
                 reason: 'Error creating select option',

--- a/src/webviews/abstractIssueEditorWebview.ts
+++ b/src/webviews/abstractIssueEditorWebview.ts
@@ -115,7 +115,7 @@ export abstract class AbstractIssueEditorWebview extends AbstractReactWebview {
                                     nonce: msg.nonce,
                                 });
                             } catch (e) {
-                                Logger.error(e, 'Error fetching issues');
+                                Logger.error(undefined, e, 'Error fetching issues');
                                 this.postMessage({
                                     type: 'error',
                                     reason: this.formatErrorReason(e, 'Error fetching issues'),
@@ -140,7 +140,7 @@ export abstract class AbstractIssueEditorWebview extends AbstractReactWebview {
 
                                 this.postMessage({ type: 'selectOptionsList', options: suggestions, nonce: msg.nonce });
                             } catch (e) {
-                                Logger.error(e, 'Error fetching options');
+                                Logger.error(undefined, e, 'Error fetching options');
                                 this.postMessage({
                                     type: 'error',
                                     reason: this.formatErrorReason(e, 'Error fetching options'),
@@ -165,7 +165,7 @@ export abstract class AbstractIssueEditorWebview extends AbstractReactWebview {
                                 const result = await client.postCreateUrl(msg.createUrl, msg.createData);
                                 await this.handleSelectOptionCreated(msg.fieldKey, result, msg.nonce);
                             } catch (e) {
-                                Logger.error(e, 'Error creating select option');
+                                Logger.error(undefined, e, 'Error creating select option');
                                 this.postMessage({
                                     type: 'error',
                                     reason: this.formatErrorReason(e, 'Error creating select option'),

--- a/src/webviews/createIssueProblemsWebview.ts
+++ b/src/webviews/createIssueProblemsWebview.ts
@@ -45,6 +45,7 @@ export class CreateIssueProblemsWebview extends AbstractReactWebview {
         try {
             if (!this._site || !this._project) {
                 Logger.error(
+                    undefined,
                     new Error(`site or project is missing: site: ${this._site}, project: ${this._project}`),
                     'Site or project is missing',
                 );
@@ -59,7 +60,7 @@ export class CreateIssueProblemsWebview extends AbstractReactWebview {
 
             this.postMessage({ type: 'screenRefresh', problems: data.problems, project: this._project });
         } catch (e) {
-            Logger.error(e, 'error updating issue fields');
+            Logger.error(undefined, e, 'error updating issue fields');
             this.postMessage({ type: 'error', reason: `error updating issue fields: ${e}` });
         } finally {
             this.isRefeshing = false;

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -429,7 +429,7 @@ export class CreateIssueWebview
                 Container.analyticsClient.sendTrackEvent(event);
             });
         } catch (e) {
-            Logger.error(e, 'error updating issue fields');
+            Logger.error(undefined, e, 'error updating issue fields');
             this.postMessage({ type: 'error', reason: this.formatErrorReason(e) });
         } finally {
             this.isRefeshing = false;
@@ -696,7 +696,7 @@ export class CreateIssueWebview
                                     }
                                 });
                         } catch (e) {
-                            Logger.error(e, 'Error creating issue');
+                            Logger.error(undefined, e, 'Error creating issue');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error creating issue'),

--- a/src/webviews/jiraIssueWebview.test.ts
+++ b/src/webviews/jiraIssueWebview.test.ts
@@ -373,7 +373,7 @@ describe('JiraIssueWebview', () => {
 
             await jiraIssueWebview['forceUpdateIssue']();
 
-            expect(Logger.error).toHaveBeenCalledWith(error, 'Error updating issue');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, error, 'Error updating issue');
             expect(formatErrorSpy).toHaveBeenCalledWith(error);
             expect(postMessageSpy).toHaveBeenCalledWith({
                 type: 'error',
@@ -1219,7 +1219,7 @@ describe('JiraIssueWebview', () => {
 
             await jiraIssueWebview['onMessageReceived'](msg);
 
-            expect(Logger.error).toHaveBeenCalledWith(error, 'Error updating issue');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, error, 'Error updating issue');
             expect(formatErrorSpy).toHaveBeenCalledWith(error, 'Error updating issue');
             expect(postMessageSpy).toHaveBeenCalledWith({
                 type: 'error',
@@ -1613,6 +1613,7 @@ describe('JiraIssueWebview - Additional Method Tests', () => {
             expect(mockFetchMultipleIssuesWithTransitions).toHaveBeenCalledWith(['SUBTASK-1'], mockIssue.siteDetails);
 
             expect(Logger.error).toHaveBeenCalledWith(
+                undefined,
                 error,
                 'Error enhancing child and linked issues with transitions',
             );

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -198,7 +198,7 @@ export class JiraIssueWebview
                 }
             }
         } catch (error) {
-            Logger.error(error, 'Error enhancing child and linked issues with transitions');
+            Logger.error(undefined, error, 'Error enhancing child and linked issues with transitions');
         }
     }
 
@@ -266,7 +266,7 @@ export class JiraIssueWebview
                 rovoDevEnabled: Container.isRovoDevEnabled,
             });
         } catch (e) {
-            Logger.error(e, 'Error updating issue');
+            Logger.error(undefined, e, 'Error updating issue');
             this.postMessage({ type: 'error', reason: this.formatErrorReason(e) });
         } finally {
             this.isRefeshing = false;
@@ -477,7 +477,7 @@ export class JiraIssueWebview
                         );
                         await commands.executeCommand(Commands.RefreshCustomJqlExplorer, OnJiraEditedRefreshDelay);
                     } catch (e) {
-                        Logger.error(e, 'Error updating issue');
+                        Logger.error(undefined, e, 'Error updating issue');
                         this.postMessage({
                             type: 'error',
                             reason: this.formatErrorReason(e, 'Error updating issue'),
@@ -516,7 +516,7 @@ export class JiraIssueWebview
                         );
                         await commands.executeCommand(Commands.RefreshCustomJqlExplorer, OnJiraEditedRefreshDelay);
                     } catch (e) {
-                        Logger.error(e, 'Error updating child issue');
+                        Logger.error(undefined, e, 'Error updating child issue');
                         this.postMessage({
                             type: 'error',
                             reason: this.formatErrorReason(e, 'Error updating child issue'),
@@ -549,7 +549,7 @@ export class JiraIssueWebview
                             throw new Error(`No transition found for status: ${statusName}`);
                         }
                     } catch (e) {
-                        Logger.error(e, 'Error transitioning child issue');
+                        Logger.error(undefined, e, 'Error transitioning child issue');
                         this.postMessage({
                             type: 'error',
                             reason: this.formatErrorReason(e, 'Error transitioning child issue'),
@@ -585,7 +585,7 @@ export class JiraIssueWebview
                                 fieldValues: { comment: this._editUIData.fieldValues['comment'], nonce: msg.nonce },
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error posting comment');
+                            Logger.error(undefined, e, 'Error posting comment');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error posting comment'),
@@ -612,7 +612,7 @@ export class JiraIssueWebview
                                 fieldValues: { comment: this._editUIData.fieldValues['comment'], nonce: msg.nonce },
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error deleting comment');
+                            Logger.error(undefined, e, 'Error deleting comment');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error deleting comment'),
@@ -659,7 +659,7 @@ export class JiraIssueWebview
                             commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
                             commands.executeCommand(Commands.RefreshCustomJqlExplorer);
                         } catch (e) {
-                            Logger.error(e, 'Error creating issue');
+                            Logger.error(undefined, e, 'Error creating issue');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error creating issue'),
@@ -698,7 +698,7 @@ export class JiraIssueWebview
                             commands.executeCommand(Commands.RefreshAssignedWorkItemsExplorer);
                             commands.executeCommand(Commands.RefreshCustomJqlExplorer);
                         } catch (e) {
-                            Logger.error(e, 'Error creating issue issue link');
+                            Logger.error(undefined, e, 'Error creating issue issue link');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error creating issue issue link'),
@@ -752,7 +752,7 @@ export class JiraIssueWebview
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error deleting issuelink');
+                            Logger.error(undefined, e, 'Error deleting issuelink');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error deleting issuelink'),
@@ -794,7 +794,7 @@ export class JiraIssueWebview
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error creating worklog');
+                            Logger.error(undefined, e, 'Error creating worklog');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error creating worklog'),
@@ -839,7 +839,7 @@ export class JiraIssueWebview
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error adding watcher');
+                            Logger.error(undefined, e, 'Error adding watcher');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error adding watcher'),
@@ -889,7 +889,7 @@ export class JiraIssueWebview
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error removing watcher');
+                            Logger.error(undefined, e, 'Error removing watcher');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error removing watcher'),
@@ -933,7 +933,7 @@ export class JiraIssueWebview
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error adding vote');
+                            Logger.error(undefined, e, 'Error adding vote');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error adding vote'),
@@ -981,7 +981,7 @@ export class JiraIssueWebview
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error removing vote');
+                            Logger.error(undefined, e, 'Error removing vote');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error removing vote'),
@@ -1036,7 +1036,7 @@ export class JiraIssueWebview
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error adding attachments');
+                            Logger.error(undefined, e, 'Error adding attachments');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error adding attachments'),
@@ -1080,7 +1080,7 @@ export class JiraIssueWebview
                                 Container.analyticsClient.sendTrackEvent(e);
                             });
                         } catch (e) {
-                            Logger.error(e, 'Error deleting attachments');
+                            Logger.error(undefined, e, 'Error deleting attachments');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error deleting attachments'),
@@ -1101,7 +1101,7 @@ export class JiraIssueWebview
                             // we need to force an update in case any new tranisitions are available
                             await this.forceUpdateIssue(true);
                         } catch (e) {
-                            Logger.error(e, 'Error transitioning issue');
+                            Logger.error(undefined, e, 'Error transitioning issue');
                             this.postMessage({
                                 type: 'error',
                                 reason: this.formatErrorReason(e, 'Error transitioning issue'),
@@ -1116,7 +1116,7 @@ export class JiraIssueWebview
                     try {
                         await this.forceUpdateIssue(true);
                     } catch (e) {
-                        Logger.error(e, 'Error refeshing issue');
+                        Logger.error(undefined, e, 'Error refeshing issue');
                         this.postMessage({ type: 'error', reason: this.formatErrorReason(e, 'Error refeshing issue') });
                     }
                     break;
@@ -1147,6 +1147,7 @@ export class JiraIssueWebview
                             );
                         } else {
                             Logger.error(
+                                undefined,
                                 new Error(`error opening pullrequest: ${msg.prHref}`),
                                 'Error opening pullrequest',
                             );
@@ -1199,7 +1200,7 @@ export class JiraIssueWebview
                                 nonce: msg.nonce,
                             });
                         } catch (e) {
-                            Logger.error(e, `Error fetching image: ${msg.url}`);
+                            Logger.error(undefined, e, `Error fetching image: ${msg.url}`);
                             this.postMessage({
                                 type: 'getImageDone',
                                 imgData: '',
@@ -1232,7 +1233,7 @@ export class JiraIssueWebview
                 currentParentKey = parent.parentKey;
             }
         } catch (e) {
-            Logger.error(e, 'Error fetching issue hierarchy');
+            Logger.error(undefined, e, 'Error fetching issue hierarchy');
         } finally {
             this.postMessage({ type: 'hierarchyUpdate', hierarchy });
         }

--- a/src/webviews/startWorkOnIssueWebview.test.ts
+++ b/src/webviews/startWorkOnIssueWebview.test.ts
@@ -308,7 +308,7 @@ describe('StartWorkOnIssueWebview', () => {
 
             await startWorkOnIssueWebview.invalidate();
 
-            expect(Logger.error).toHaveBeenCalledWith(error, 'StartWorkOnIssueWebview.forceUpdateIssue');
+            expect(Logger.error).toHaveBeenCalledWith(undefined, error, 'StartWorkOnIssueWebview.forceUpdateIssue');
             expect(formatErrorSpy).toHaveBeenCalledWith(error);
             expect(postMessageSpy).toHaveBeenCalledWith({ type: 'error', reason: 'Formatted error' });
         });

--- a/src/webviews/startWorkOnIssueWebview.ts
+++ b/src/webviews/startWorkOnIssueWebview.ts
@@ -262,7 +262,7 @@ export class StartWorkOnIssueWebview
             };
             this.postMessage(msg);
         } catch (e) {
-            Logger.error(e, 'StartWorkOnIssueWebview.updateIssue');
+            Logger.error(undefined, e, 'StartWorkOnIssueWebview.updateIssue');
             this.postMessage({ type: 'error', reason: this.formatErrorReason(e) });
         } finally {
             this.isRefeshing = false;
@@ -276,7 +276,7 @@ export class StartWorkOnIssueWebview
                 const issue = await fetchMinimalIssue(key, this._state.siteDetails);
                 this.updateIssue(issue);
             } catch (e) {
-                Logger.error(e, 'StartWorkOnIssueWebview.forceUpdateIssue');
+                Logger.error(undefined, e, 'StartWorkOnIssueWebview.forceUpdateIssue');
                 this.postMessage({ type: 'error', reason: this.formatErrorReason(e) });
             }
         }


### PR DESCRIPTION
### What Is This Change?

The `Logger.error` signature was temporarily hacked to allow being overloaded with and without the first argument of type ProductArea.

This is leading to some incorrect error data when the error (when passed as first param) is of type `string` instead of `Error`, which ideally it shouldn't happen.

This refactoring makes sure the only correct signature is being called.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`