### PR TITLE
Fix Logger.error signature and some incorrect Error data (alt version)

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -29,7 +29,7 @@ import { ConfigTarget } from './lib/ipc/models/config';
 import { SectionChangeMessage, SectionV3ChangeMessage } from './lib/ipc/toUI/config';
 import { StartWorkIssueMessage } from './lib/ipc/toUI/startWork';
 import { CommonActionMessageHandler } from './lib/webview/controller/common/commonActionMessageHandler';
-import { Logger } from './logger';
+import { Logger, RovoDevLogger } from './logger';
 import OnboardingProvider from './onboarding/onboardingProvider';
 import { registerQuickAuthCommand } from './onboarding/quickFlow';
 import { Pipeline } from './pipelines/model';
@@ -274,7 +274,7 @@ export class Container {
             this.pushFeatureUpdatesToUI();
             return true;
         } catch (err) {
-            Logger.error('RovoDev', err, "FeatureFlagClient: Failed to update user's tenantId");
+            RovoDevLogger.error(err, "FeatureFlagClient: Failed to update user's tenantId");
             return false;
         }
     }
@@ -295,7 +295,7 @@ export class Container {
                 // Already enabled
                 await RovoDevProcessManager.refreshRovoDevCredentials(context);
             } catch (error) {
-                Logger.error('RovoDev', error, 'Refreshing Rovo Dev credentials');
+                RovoDevLogger.error(error, 'Refreshing Rovo Dev credentials');
                 return;
             }
         } else {
@@ -313,7 +313,7 @@ export class Container {
 
                 context.subscriptions.push(this._rovodevDisposable);
             } catch (error) {
-                Logger.error('RovoDev', error, 'Enabling Rovo Dev');
+                RovoDevLogger.error(error, 'Enabling Rovo Dev');
             }
         }
 
@@ -321,7 +321,7 @@ export class Container {
             // Refresh all issue views to show the secret button
             this.jiraIssueViewManager.refreshAll();
         } catch (error) {
-            Logger.error('RovoDev', error, 'Refreshing Jira issue views');
+            RovoDevLogger.error(error, 'Refreshing Jira issue views');
             return;
         }
     }
@@ -338,14 +338,14 @@ export class Container {
             this._rovodevDisposable = undefined;
             RovoDevProcessManager.deactivateRovoDevProcessManager();
         } catch (error) {
-            Logger.error('RovoDev', error, 'Disabling Rovo Dev');
+            RovoDevLogger.error(error, 'Disabling Rovo Dev');
         }
 
         try {
             // Refresh all issue views to show the secret button
             this.jiraIssueViewManager.refreshAll();
         } catch (error) {
-            Logger.error('RovoDev', error, 'Refreshing Jira issue views');
+            RovoDevLogger.error(error, 'Refreshing Jira issue views');
             return;
         }
     }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,0 @@
-export interface Logger {
-    info(message?: any, ...params: any[]): void;
-    debug(message?: any, ...params: any[]): void;
-    warn(message?: any, ...params: any[]): void;
-    error(ex: Error, errorMessage?: string): void;
-}

--- a/src/lib/webview/controller/config/configV3WebviewController.test.ts
+++ b/src/lib/webview/controller/config/configV3WebviewController.test.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import * as vscode from 'vscode';
@@ -13,7 +14,6 @@ import { WebViewID } from '../../../ipc/models/common';
 import { ConfigTarget, ConfigV3Section } from '../../../ipc/models/config';
 import { CommonMessageType } from '../../../ipc/toUI/common';
 import { ConfigMessageType, SectionV3ChangeMessage } from '../../../ipc/toUI/config';
-import { Logger } from '../../../logger';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { ConfigActionApi } from './configActionApi';
 import { ConfigV3WebviewController, id } from './configV3WebviewController';

--- a/src/lib/webview/controller/config/configV3WebviewController.ts
+++ b/src/lib/webview/controller/config/configV3WebviewController.ts
@@ -1,6 +1,7 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import Axios from 'axios';
 import { ConfigV3Section } from 'src/lib/ipc/models/config';
+import { Logger } from 'src/logger';
 import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import { env } from 'vscode';
@@ -15,7 +16,6 @@ import { ConfigAction, ConfigActionType } from '../../../ipc/fromUI/config';
 import { WebViewID } from '../../../ipc/models/common';
 import { CommonMessage, CommonMessageType } from '../../../ipc/toUI/common';
 import { ConfigMessageType, ConfigResponse, ConfigV3Message, SectionV3ChangeMessage } from '../../../ipc/toUI/config';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';

--- a/src/lib/webview/controller/config/configWebviewController.test.ts
+++ b/src/lib/webview/controller/config/configWebviewController.test.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import * as vscode from 'vscode';
@@ -13,7 +14,6 @@ import { WebViewID } from '../../../ipc/models/common';
 import { ConfigSection, ConfigTarget } from '../../../ipc/models/config';
 import { CommonMessageType } from '../../../ipc/toUI/common';
 import { ConfigMessageType, SectionChangeMessage } from '../../../ipc/toUI/config';
-import { Logger } from '../../../logger';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { ConfigActionApi } from './configActionApi';
 import { ConfigWebviewController, id } from './configWebviewController';

--- a/src/lib/webview/controller/config/configWebviewController.ts
+++ b/src/lib/webview/controller/config/configWebviewController.ts
@@ -1,5 +1,6 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Features } from 'src/util/features';
 import { v4 } from 'uuid';
 import { env } from 'vscode';
@@ -14,7 +15,6 @@ import { ConfigAction, ConfigActionType } from '../../../ipc/fromUI/config';
 import { WebViewID } from '../../../ipc/models/common';
 import { CommonMessage, CommonMessageType } from '../../../ipc/toUI/common';
 import { ConfigMessage, ConfigMessageType, ConfigResponse, SectionChangeMessage } from '../../../ipc/toUI/config';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';

--- a/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.test.ts
+++ b/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.test.ts
@@ -1,3 +1,5 @@
+import { Logger } from 'src/logger';
+
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import {
     Pipeline,
@@ -11,14 +13,13 @@ import { AnalyticsApi } from '../../../analyticsApi';
 import { CommonActionType } from '../../../ipc/fromUI/common';
 import { PipelineSummaryAction, PipelineSummaryActionType } from '../../../ipc/fromUI/pipelineSummary';
 import { PipelineSummaryMessageType } from '../../../ipc/toUI/pipelineSummary';
-import { Logger } from '../../../logger';
 import { MessagePoster } from '../webviewController';
 import { PipelinesSummaryActionApi } from './pipelinesSummaryActionApi';
 import { PipelineSummaryWebviewController } from './pipelineSummaryWebviewController';
 
 // Mock dependencies
-jest.mock('../../../logger');
 jest.mock('../../../analyticsApi');
+jest.mock('src/logger');
 
 describe('PipelineSummaryWebviewController', () => {
     let controller: PipelineSummaryWebviewController;

--- a/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.ts
+++ b/src/lib/webview/controller/pipelines/pipelineSummaryWebviewController.ts
@@ -1,3 +1,5 @@
+import { Logger } from 'src/logger';
+
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import {
     Pipeline,
@@ -11,7 +13,6 @@ import { CommonActionType } from '../../../ipc/fromUI/common';
 import { PipelineSummaryAction, PipelineSummaryActionType } from '../../../ipc/fromUI/pipelineSummary';
 import { CommonMessage } from '../../../ipc/toUI/common';
 import { PipelineSummaryMessage, PipelineSummaryMessageType } from '../../../ipc/toUI/pipelineSummary';
-import { Logger } from '../../../logger';
 import { MessagePoster, WebviewController } from '../webviewController';
 import { PipelinesSummaryActionApi } from './pipelinesSummaryActionApi';
 

--- a/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.test.ts
+++ b/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.test.ts
@@ -1,5 +1,6 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
 import { Commit, FileDiff, FileStatus, PullRequest, User, WorkspaceRepo } from '../../../../bitbucket/model';
@@ -17,16 +18,15 @@ import {
 import { WebViewID } from '../../../ipc/models/common';
 import { CommonMessageType } from '../../../ipc/toUI/common';
 import { CreatePullRequestMessageType, RepoData } from '../../../ipc/toUI/createPullRequest';
-import { Logger } from '../../../logger';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster } from '../webviewController';
 import { CreatePullRequestActionApi } from './createPullRequestActionApi';
 import { CreatePullRequestWebviewController } from './createPullRequestWebviewController';
 
 // Mock dependencies
-jest.mock('../../../logger');
 jest.mock('../../../analyticsApi');
 jest.mock('../common/commonActionMessageHandler');
+jest.mock('src/logger');
 jest.mock('axios');
 
 // Helper functions to create mock objects

--- a/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.ts
+++ b/src/lib/webview/controller/pullrequest/createPullRequestWebviewController.ts
@@ -1,5 +1,6 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 
 import { Registry } from '../../../../analytics';
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
@@ -14,7 +15,6 @@ import {
     CreatePullRequestMessageType,
     CreatePullRequestResponse,
 } from '../../../ipc/toUI/createPullRequest';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';

--- a/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.test.ts
+++ b/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.test.ts
@@ -1,5 +1,6 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Uri } from 'vscode';
 
 import { DetailedSiteInfo } from '../../../../atlclients/authInfo';
@@ -23,7 +24,6 @@ import {
     emptyPullRequestDetailsInitMessage,
     PullRequestDetailsMessageType,
 } from '../../../ipc/toUI/pullRequestDetails';
-import { Logger } from '../../../logger';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster } from '../webviewController';
 import { PullRequestDetailsActionApi } from './pullRequestDetailsActionApi';
@@ -31,9 +31,9 @@ import { PullRequestDetailsWebviewController } from './pullRequestDetailsWebview
 
 // Mock dependencies
 jest.mock('../../../../views/notifications/notificationManager');
-jest.mock('../../../logger');
 jest.mock('../../../analyticsApi');
 jest.mock('../common/commonActionMessageHandler');
+jest.mock('src/logger');
 jest.mock('axios');
 
 // Helper functions to create mock objects

--- a/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.ts
+++ b/src/lib/webview/controller/pullrequest/pullRequestDetailsWebviewController.ts
@@ -1,6 +1,7 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import Axios from 'axios';
+import { Logger } from 'src/logger';
 import { Uri } from 'vscode';
 
 import { DetailedSiteInfo } from '../../../../atlclients/authInfo';
@@ -27,7 +28,6 @@ import {
     PullRequestDetailsMessageType,
     PullRequestDetailsResponse,
 } from '../../../ipc/toUI/pullRequestDetails';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.test.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.test.ts
@@ -1,5 +1,6 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import { createEmptyMinimalIssue, MinimalIssue, Transition } from '@atlassianlabs/jira-pi-common-models';
+import { Logger } from 'src/logger';
 
 import { DetailedSiteInfo, emptySiteInfo, ProductBitbucket } from '../../../../atlclients/authInfo';
 import { BitbucketBranchingModel, WorkspaceRepo } from '../../../../bitbucket/model';
@@ -16,7 +17,6 @@ import {
     StartWorkInitMessage,
     StartWorkMessageType,
 } from '../../../ipc/toUI/startWork';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster } from '../webviewController';

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -1,5 +1,6 @@
 import { defaultActionGuard } from '@atlassianlabs/guipi-core-controller';
 import { ConfigSection, ConfigSubSection, ConfigV3Section, ConfigV3SubSection } from 'src/lib/ipc/models/config';
+import { Logger } from 'src/logger';
 import * as vscode from 'vscode';
 
 import { ProductBitbucket } from '../../../../atlclients/authInfo';
@@ -24,7 +25,6 @@ import {
     StartWorkMessageType,
     StartWorkResponse,
 } from '../../../ipc/toUI/startWork';
-import { Logger } from '../../../logger';
 import { formatError } from '../../formatError';
 import { CommonActionMessageHandler } from '../common/commonActionMessageHandler';
 import { MessagePoster, WebviewController } from '../webviewController';

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'src/logger';
+import { RovoDevLogger } from 'src/logger';
 import { RovoDevViewResponse } from 'src/react/atlascode/rovo-dev/rovoDevViewMessages';
 import { v4 } from 'uuid';
 import { Event, Webview } from 'vscode';
@@ -389,7 +389,7 @@ export class RovoDevChatProvider {
     }
 
     private processError(error: Error, isRetriable: boolean, isProcessTerminated?: boolean) {
-        Logger.error('RovoDev', error);
+        RovoDevLogger.error(error);
 
         const webview = this._webView!;
         return webview.postMessage({

--- a/src/rovo-dev/rovoDevFeedbackManager.test.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.test.ts
@@ -1,6 +1,6 @@
 import { Container } from 'src/container';
 import { getAxiosInstance } from 'src/jira/jira-client/providers';
-import { Logger } from 'src/logger';
+import { RovoDevLogger } from 'src/logger';
 import * as vscode from 'vscode';
 
 import { RovoDevFeedbackManager } from './rovoDevFeedbackManager';
@@ -162,7 +162,7 @@ describe('RovoDevFeedbackManager', () => {
 
             await RovoDevFeedbackManager.submitFeedback(feedback);
 
-            expect(Logger.error).toHaveBeenCalledWith(error, 'Error submitting Rovo Dev feedback');
+            expect(RovoDevLogger.error).toHaveBeenCalledWith(error, 'Error submitting Rovo Dev feedback');
             expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
                 'There was an error submitting your feedback. Please try again later.',
             );

--- a/src/rovo-dev/rovoDevFeedbackManager.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.ts
@@ -1,7 +1,7 @@
 import { truncate } from 'lodash';
 import { Container } from 'src/container';
 import { getAxiosInstance } from 'src/jira/jira-client/providers';
-import { Logger } from 'src/logger';
+import { RovoDevLogger } from 'src/logger';
 import * as vscode from 'vscode';
 
 import { MIN_SUPPORTED_ROVODEV_VERSION } from './rovoDevProcessManager';
@@ -94,7 +94,7 @@ export class RovoDevFeedbackManager {
                 data: payload,
             });
         } catch (error) {
-            Logger.error(error as Error, 'Error submitting Rovo Dev feedback');
+            RovoDevLogger.error(error, 'Error submitting Rovo Dev feedback');
             vscode.window.showErrorMessage('There was an error submitting your feedback. Please try again later.');
             return;
         }

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import net from 'net';
 import packageJson from 'package.json';
 import path from 'path';
-import { Logger } from 'src/logger';
+import { RovoDevLogger } from 'src/logger';
 import { downloadAndUnzip } from 'src/util/downloadFile';
 import { getFsPromise } from 'src/util/fsPromises';
 import { Disposable, ExtensionContext, Terminal, Uri, window, workspace } from 'vscode';
@@ -116,7 +116,7 @@ async function getCloudCredentials(): Promise<{ username: string; key: string; h
         const results = (await Promise.all(promises)).filter((result) => result !== undefined);
         return results.length > 0 ? results[0] : undefined;
     } catch (error) {
-        Logger.error('RovoDev', error, 'Error fetching cloud credentials for Rovo Dev');
+        RovoDevLogger.error(error, 'Error fetching cloud credentials for Rovo Dev');
         return undefined;
     }
 }

--- a/src/rovo-dev/rovoDevPullRequestHandler.ts
+++ b/src/rovo-dev/rovoDevPullRequestHandler.ts
@@ -1,5 +1,5 @@
 import { exec } from 'child_process';
-import { Logger } from 'src/logger';
+import { Logger, RovoDevLogger } from 'src/logger';
 import { GitExtension, Repository } from 'src/typings/git';
 import { promisify } from 'util';
 import { env, extensions, Uri } from 'vscode';
@@ -106,7 +106,7 @@ export class RovoDevPullRequestHandler {
                 repo.state.mergeChanges.length === 0
             );
         } catch (error) {
-            Logger.error(error, 'Error checking git state');
+            RovoDevLogger.error(error, 'Error checking git state');
             return true; // If we can't determine the state, assume it's clean
         }
     }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -25,7 +25,7 @@ import {
 } from 'vscode';
 
 import { Container } from '../../src/container';
-import { Logger } from '../../src/logger';
+import { RovoDevLogger } from '../../src/logger';
 import { Commands, rovodevInfo } from '../constants';
 import {
     ModifiedFile,
@@ -136,7 +136,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
         const onTelemetryError = Container.isDebugging
             ? (error: Error) => this.processError(error, false)
-            : (error: Error) => Logger.error(error);
+            : (error: Error) => RovoDevLogger.error(error);
 
         this._telemetryProvider = new RovoDevTelemetryProvider(
             this.isBoysenberry ? 'Boysenberry' : 'IDE',
@@ -426,7 +426,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         isRetriable: boolean,
         isProcessTerminated?: boolean,
     ) {
-        Logger.error('RovoDev', error);
+        RovoDevLogger.error(error);
 
         const webview = this._webView!;
         return webview.postMessage({


### PR DESCRIPTION
### What Is This Change?

The `Logger.error` signature was temporarily hacked to allow being overloaded with and without the first argument of type ProductArea.

This is leading to some incorrect error data when the error (when passed as first param) is of type `string` instead of `Error`, which ideally it shouldn't happen.

This refactoring makes sure the only correct signature is being called.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`