### PR TITLE
FLOW-626 Fix image error loop if fallback fails

### DIFF
--- a/src/react/imageErrorHandler.tsx
+++ b/src/react/imageErrorHandler.tsx
@@ -3,6 +3,12 @@ export const attachImageErrorHandler = () => {
         'error',
         (ee: ErrorEvent) => {
             const targetEL = ee.target as HTMLElement;
+
+            // Prevent re-processing the same image and avoid loops if the fallback fails
+            if (targetEL.getAttribute('src') === 'images/no-image.svg') {
+                return;
+            }
+
             if (ee && targetEL && targetEL.nodeName === 'IMG') {
                 const originalSrc = targetEL.getAttribute('src');
                 targetEL.setAttribute('atlascode-original-src', `${originalSrc}`);

--- a/src/webviews/components/index.tsx
+++ b/src/webviews/components/index.tsx
@@ -33,6 +33,12 @@ window.addEventListener(
     'error',
     (ee: ErrorEvent) => {
         const targetEL = ee.target as HTMLElement;
+
+        // Prevent re-processing the same image and avoid loops if the fallback fails
+        if (targetEL.getAttribute('src') === 'images/no-image.svg') {
+            return;
+        }
+
         if (ee && targetEL && targetEL.nodeName === 'IMG') {
             const originalSrc = targetEL.getAttribute('src');
             targetEL.setAttribute('atlascode-original-src', `${originalSrc}`);


### PR DESCRIPTION
### What Is This Change?

The `attachImageErrorHandler` attempts to load a fallback image `images/no-image.svg` if an image fails to load. However if `images/no-image.svg` also fails to load then it gets into a loop where 10s-100s of errors start flooding the console.

<img width="1041" height="716" alt="Screenshot 2025-09-24 at 9 37 39 PM" src="https://github.com/user-attachments/assets/90b1b99a-db07-4631-9ea7-3c84a433efb2" />

These errors were observed in Boysenberry embedded in an iframe. Attempting to load `no-image.svg` returns a `401 Unauthorized`.
I can try and fix the root cause for why the image fails in a different PR, but for now this should at least stop it from getting into a loop.

### How Has This Been Tested?

Tested locally.

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [X] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [X] Update the CHANGELOG if making a user facing change