### PR TITLE
Revert "AXON-1099: fix error while connecting cloud sites with api token"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
-## What's new in 3.8.18
-
-### Bug Fixes
-
-- Fix error while connecting several jira sites with an API token
-
 ## What's new in 3.8.17
 
 ### Features

--- a/src/siteManager.test.ts
+++ b/src/siteManager.test.ts
@@ -150,32 +150,6 @@ describe('SiteManager', () => {
             expect(updatedSites[0].credentialId).toBe(`${ProductJira.key}-user1`);
             expect(updatedSites).toHaveLength(2);
         });
-
-        it('should not rewrite credentialId for site added via API token', () => {
-            const apiTokenSite = createDetailedSiteInfo(ProductJira, 'mock-site.atlassian.net', 'user1', true);
-            apiTokenSite.name = 'mock-site.atlassian.net';
-            apiTokenSite.host = 'mock-site.atlassian.net';
-            apiTokenSite.credentialId = 'api-token-credential-id';
-
-            storedSites.set(`${ProductJira.key}Sites`, [apiTokenSite]);
-
-            const oauthSite = createDetailedSiteInfo(ProductJira, 'oauth-site', 'user2', true);
-            oauthSite.name = 'mock-oauth';
-
-            siteManager.addSites([oauthSite]);
-
-            const updatedSites = siteManager.getSitesAvailable(ProductJira);
-
-            // The API token site should keep its original credential ID
-            const apiTokenSiteInResult = updatedSites.find((site) => site.name === 'mock-site.atlassian.net');
-            expect(apiTokenSiteInResult?.credentialId).toBe('api-token-credential-id');
-
-            // The OAuth site should get the standard credential ID
-            const oauthSiteInResult = updatedSites.find((site) => site.name === 'mock-oauth');
-            expect(oauthSiteInResult?.credentialId).toBe(`${ProductJira.key}-user2`);
-
-            expect(updatedSites).toHaveLength(2);
-        });
     });
 
     describe('updateSite', () => {

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -98,10 +98,6 @@ export class SiteManager extends Disposable {
         }
     }
 
-    public isSiteAddedViaOauth(site: DetailedSiteInfo): boolean {
-        return site.isCloud && site.name !== site.host && !site.contextPath;
-    }
-
     public addSites(newSites: DetailedSiteInfo[]) {
         if (newSites.length === 0) {
             return;
@@ -113,7 +109,7 @@ export class SiteManager extends Disposable {
         if (allSites) {
             // Ensure all cloud sites use the per account credential ID
             allSites.forEach((site) => {
-                if (this.isSiteAddedViaOauth(site)) {
+                if (site.isCloud) {
                     site.credentialId = CredentialManager.generateCredentialId(site.product.key, site.userId);
                 }
             });


### PR DESCRIPTION
Reverts atlassian/atlascode#1026

Additional work is required to allow multiple Jira sites authenticated with API token.
Unfortunately, this change needs to be reverted in the meantime.