### PR TITLE
[AXON-826] Add issue suggestions feedback analytics event

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,7 +1,7 @@
 import { Uri } from 'vscode';
 
 import { ScreenEvent, TrackEvent, UIEvent } from './analytics-node-client/src/types';
-import { CreatePrTerminalSelection, ErrorProductArea, UIErrorInfo } from './analyticsTypes';
+import { CreatePrTerminalSelection, ErrorProductArea, FeedbackSentEvent, UIErrorInfo } from './analyticsTypes';
 import {
     DetailedSiteInfo,
     isEmptySiteInfo,
@@ -537,6 +537,10 @@ export async function viewScreenEvent(
 }
 
 // UI Events
+
+export async function feedbackSentEvent(event: FeedbackSentEvent): Promise<TrackEvent> {
+    return trackEvent('feedbackSent', 'atlascode', { attributes: { ...event } });
+}
 
 export async function quickFlowEvent(event: QuickFlowAnalyticsEvent): Promise<TrackEvent> {
     return trackEvent('statusUpdated', 'quickFlow', { attributes: { ...event } });

--- a/src/analyticsTypes.ts
+++ b/src/analyticsTypes.ts
@@ -67,3 +67,8 @@ export enum CreatePrTerminalSelection {
 // in the future we may use this to classify where the error is coming from:
 // e.g., Jira, Bitbucket, Authentication, Notifications, etc
 export type ErrorProductArea = 'RovoDev' | undefined;
+
+export type FeedbackSentEvent = {
+    feature: 'issueSuggestions'; // | 'otherFeature' - this is generic
+    feedbackType: 'positive' | 'negative';
+};

--- a/src/commands/jira/issueSuggestionManager.ts
+++ b/src/commands/jira/issueSuggestionManager.ts
@@ -86,7 +86,10 @@ export class IssueSuggestionManager {
             : `Negative feedback for issue suggestion: ${data.summary}`;
         console.log('Sending feedback:', feedback);
         try {
-            // TODO: actually send an analytics event
+            await Container.analyticsApi.fireFeedbackSentEvent({
+                feature: 'issueSuggestions',
+                feedbackType: isPositive ? 'positive' : 'negative',
+            });
             window.showInformationMessage(`Thank you for your feedback!`);
         } catch (error) {
             Logger.error(error, 'Error sending feedback');

--- a/src/lib/analyticsApi.ts
+++ b/src/lib/analyticsApi.ts
@@ -1,7 +1,7 @@
 import { QuickFlowAnalyticsEvent } from 'src/onboarding/quickFlow/types';
 
 import { DeepLinkEventErrorType } from '../analytics';
-import { UIErrorInfo } from '../analyticsTypes';
+import { FeedbackSentEvent, UIErrorInfo } from '../analyticsTypes';
 import { DetailedSiteInfo, Product, SiteInfo } from '../atlclients/authInfo';
 
 export interface AnalyticsApi {
@@ -56,4 +56,5 @@ export interface AnalyticsApi {
     firePipelineRerunEvent(site: DetailedSiteInfo, source: string): Promise<void>;
     fireUIErrorEvent(errorInfo: UIErrorInfo): Promise<void>;
     fireQuickFlowEvent(event: QuickFlowAnalyticsEvent): Promise<void>;
+    fireFeedbackSentEvent(event: FeedbackSentEvent): Promise<void>;
 }

--- a/src/vscAnalyticsApi.ts
+++ b/src/vscAnalyticsApi.ts
@@ -9,6 +9,7 @@ import {
     exploreFeaturesButtonEvent,
     externalLinkEvent,
     featureChangeEvent,
+    feedbackSentEvent,
     focusCreateIssueEvent,
     focusCreatePullRequestEvent,
     focusIssueEvent,
@@ -46,7 +47,7 @@ import {
     viewScreenEvent,
 } from './analytics';
 import { AnalyticsClient } from './analytics-node-client/src/client.min.js';
-import { UIErrorInfo } from './analyticsTypes';
+import { FeedbackSentEvent, UIErrorInfo } from './analyticsTypes';
 import { DetailedSiteInfo, Product, SiteInfo } from './atlclients/authInfo';
 import { AnalyticsApi } from './lib/analyticsApi';
 import { QuickFlowAnalyticsEvent } from './onboarding/quickFlow/types';
@@ -341,6 +342,12 @@ export class VSCAnalyticsApi implements AnalyticsApi {
 
     public async fireQuickFlowEvent(event: QuickFlowAnalyticsEvent): Promise<void> {
         return quickFlowEvent(event).then((e) => {
+            this._analyticsClient.sendTrackEvent(e);
+        });
+    }
+
+    public async fireFeedbackSentEvent(event: FeedbackSentEvent): Promise<void> {
+        return feedbackSentEvent(event).then((e) => {
             this._analyticsClient.sendTrackEvent(e);
         });
     }


### PR DESCRIPTION
### What Is This Change?

Analytics event for issue suggestion feedback

### How Has This Been Tested?

Actual testing and iteration would need to happen once the event goes to amplitude

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`