### PR TITLE
Axon 1181 better auth nudge

### DIFF
--- a/src/webviews/components/aiCreateIssue/AISuggestionHeader.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionHeader.tsx
@@ -1,6 +1,6 @@
 import Checkbox from '@atlaskit/checkbox';
 import { HelperMessage } from '@atlaskit/form';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { IssueSuggestionContextLevel, IssueSuggestionSettings } from 'src/config/model';
 
 interface VsCodeApi {
@@ -28,6 +28,10 @@ const AISuggestionHeader: React.FC<{
         vscodeApi.postMessage({
             action: 'webviewReady',
         });
+    }, [vscodeApi]);
+
+    const onLoginClick = useCallback(() => {
+        vscodeApi.postMessage({ action: 'addApiToken' });
     }, [vscodeApi]);
 
     const updateIdeSettings = (newState: IssueSuggestionSettings) =>
@@ -114,8 +118,8 @@ const AISuggestionHeader: React.FC<{
         </div>
     ) : (
         <HelperMessage>
-            <div style={{ marginTop: '24px' }}>
-                <div>
+            <div style={{ marginTop: '24px', display: 'flex', alignItems: 'center', gap: '16px' }}>
+                <span>
                     <a
                         href="https://id.atlassian.com/manage-profile/security/api-tokens"
                         target="_blank"
@@ -123,12 +127,9 @@ const AISuggestionHeader: React.FC<{
                     >
                         Create an API token
                     </a>{' '}
-                    and then add it here to use AI-powered issue suggestions
-                </div>
-                <button
-                    style={{ marginTop: '8px' }}
-                    onClick={() => vscodeApi.postMessage({ action: 'addRovoDevToken' })}
-                >
+                    and add it here to use AI issue suggestions
+                </span>
+                <button type={'button'} style={{ marginTop: '0', fontSize: '12px' }} onClick={onLoginClick}>
                     Add API Token
                 </button>
             </div>

--- a/src/webviews/components/aiCreateIssue/AISuggestionHeader.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionHeader.tsx
@@ -114,8 +114,24 @@ const AISuggestionHeader: React.FC<{
         </div>
     ) : (
         <HelperMessage>
-            Did you know you can use AI to generate issues? Please add an API key in the settings to enable this
-            feature.
+            <div style={{ marginTop: '24px' }}>
+                <div>
+                    <a
+                        href="https://id.atlassian.com/manage-profile/security/api-tokens"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Create an API token
+                    </a>{' '}
+                    and then add it here to use AI-powered issue suggestions
+                </div>
+                <button
+                    style={{ marginTop: '8px' }}
+                    onClick={() => vscodeApi.postMessage({ action: 'addRovoDevToken' })}
+                >
+                    Add API Token
+                </button>
+            </div>
         </HelperMessage>
     );
 };

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -759,6 +759,12 @@ export class CreateIssueWebview
                     break;
                 }
 
+                case 'addApiToken': {
+                    handled = true;
+                    commands.executeCommand(Commands.JiraAPITokenLogin);
+                    break;
+                }
+
                 case 'generateIssueSuggestions': {
                     handled = true;
                     if (isGenerateIssueSuggestions(msg)) {


### PR DESCRIPTION
### What Is This Change?

Add API token authentication nudge to the create issue page, in line with how we do it in rovodev

|Before|After|
|------|------|
|<img width="590" height="133" alt="image" src="https://github.com/user-attachments/assets/34106930-a4c8-4a16-aad0-a8ffc3e4e055" />|<img width="595" height="139" alt="image" src="https://github.com/user-attachments/assets/411b8d45-076b-44ae-b95a-567b2a7b0cad" />|


Notably, this _doesn't_ refresh the page with the new credentials, that will be a separate PR


### How Has This Been Tested?

Manually! Also, more changes to come, turns out the logic where we check for token availability is a bit janky

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`