### PR TITLE
[AXON-1811] chore: use direct call instead of command when possible

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,6 +24,7 @@ import { transitionIssue } from './jira/transitionIssue';
 import { knownLinkIdMap } from './lib/ipc/models/common';
 import { ConfigSection, ConfigSubSection, ConfigV3Section, ConfigV3SubSection } from './lib/ipc/models/config';
 import { Logger } from './logger';
+import { runQuickAuth } from './onboarding/quickFlow';
 import { AuthenticationType } from './onboarding/quickFlow/authentication/types';
 import { RovoDevProcessManager } from './rovo-dev/rovoDevProcessManager';
 import { RovoDevContextItem } from './rovo-dev/rovoDevTypes';
@@ -220,7 +221,7 @@ export function registerCommands(vscodeContext: ExtensionContext) {
             commands.registerCommand(Commands.JiraLogin, () => {
                 const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
                 if (useNewAuthFlow) {
-                    commands.executeCommand(Commands.QuickAuth, { product: ProductJira }, 'assigned to me');
+                    runQuickAuth({ initialState: { product: ProductJira }, origin: 'settings' });
                 } else {
                     commands.executeCommand(Commands.ShowConfigPage);
                 }
@@ -228,9 +229,9 @@ export function registerCommands(vscodeContext: ExtensionContext) {
             commands.registerCommand(Commands.JiraAPITokenLogin, () => {
                 const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
                 if (useNewAuthFlow) {
-                    commands.executeCommand(Commands.QuickAuth, {
-                        product: ProductJira,
-                        authenticationType: AuthenticationType.ApiToken,
+                    runQuickAuth({
+                        initialState: { product: ProductJira, authenticationType: AuthenticationType.ApiToken },
+                        origin: 'nudge',
                     });
                 } else {
                     Container.settingsWebviewFactory.createOrShow({
@@ -435,7 +436,7 @@ export function registerCommands(vscodeContext: ExtensionContext) {
             commands.registerCommand(Commands.JiraLogin, () => {
                 const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
                 if (useNewAuthFlow) {
-                    commands.executeCommand(Commands.QuickAuth, { product: ProductJira }, 'assigned to me');
+                    runQuickAuth({ initialState: { product: ProductJira }, origin: 'settings' });
                 } else {
                     commands.executeCommand(Commands.ShowConfigPage);
                 }
@@ -443,9 +444,9 @@ export function registerCommands(vscodeContext: ExtensionContext) {
             commands.registerCommand(Commands.JiraAPITokenLogin, () => {
                 const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
                 if (useNewAuthFlow) {
-                    commands.executeCommand(Commands.QuickAuth, {
-                        product: ProductJira,
-                        authenticationType: AuthenticationType.ApiToken,
+                    runQuickAuth({
+                        initialState: { product: ProductJira, authenticationType: AuthenticationType.ApiToken },
+                        origin: 'nudge',
                     });
                 } else {
                     Container.settingsWebviewFactory.createOrShow({

--- a/src/onboarding/quickFlow/index.ts
+++ b/src/onboarding/quickFlow/index.ts
@@ -3,25 +3,38 @@ import { Commands } from 'src/constants';
 import { commands, Disposable, window } from 'vscode';
 
 import { AuthFlow, AuthFlowData } from './authentication';
+import { QuickFlowStatus } from './types';
+
+type QuickAuthOrigin = 'settings' | 'nudge' | 'command';
+
+export async function runQuickAuth({
+    initialState,
+    origin = 'command',
+}: {
+    initialState: Partial<AuthFlowData>;
+    origin?: QuickAuthOrigin;
+}): Promise<QuickFlowStatus> {
+    if (initialState?.product === ProductBitbucket) {
+        // Unsupported for now, shouldn't ever end up here
+        window.showErrorMessage('Quick Auth is only supported for Jira at the moment.');
+        return QuickFlowStatus.Cancelled;
+    }
+
+    const flow = new AuthFlow({
+        origin,
+    });
+    return await flow.run({
+        ...initialState,
+        product: ProductJira,
+    });
+}
 
 export function registerQuickAuthCommand(): Disposable {
     return Disposable.from(
         commands.registerCommand(
             Commands.QuickAuth,
-            async (initialState: Partial<AuthFlowData>, origin: string = 'command') => {
-                if (initialState?.product === ProductBitbucket) {
-                    // Unsupported for now, shouldn't ever end up here
-                    window.showErrorMessage('Quick Auth is only supported for Jira at the moment.');
-                    return;
-                }
-
-                const flow = new AuthFlow({
-                    origin,
-                });
-                await flow.run({
-                    ...initialState,
-                    product: ProductJira,
-                });
+            async (initialState: Partial<AuthFlowData>, origin: QuickAuthOrigin) => {
+                await runQuickAuth({ initialState, origin });
             },
         ),
     );


### PR DESCRIPTION
### What Is This Change?

Small PR tangentially related to the #1030 - for authentication, use direct call when possible if triggering quick flow commands

Ran into a type safety issue which was a bit unpleasant to debug because commands don't do argument type validation

### How Has This Been Tested?

Manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`