### PR TITLE
[AXON-1215] Migrate to the Rovo Dev v3 APIs, still in YOLO mode

### DIFF
--- a/src/rovo-dev/responseParser.ts
+++ b/src/rovo-dev/responseParser.ts
@@ -89,7 +89,7 @@ interface RovoDevWarningChunk {
     data: RovoDevWarningResponseRaw;
 }
 
-// ??
+// https://bitbucket.org/atlassian/acra-python/src/9ce5910e61d00e91f70c7978e067bde2690a1c97/packages/cli-rovodev/docs/serve/streaming-events.md?at=RDA-307-emit-warning-events-related-to-rate-limits-and-other-api-request-problems#:~:text=Server%20Error%20Warnings
 interface RovoDevClearResponseRaw {
     message: string;
 }
@@ -99,7 +99,7 @@ interface RovoDevClearChunk {
     data: RovoDevClearResponseRaw;
 }
 
-// ??
+// https://bitbucket.org/atlassian/acra-python/src/9ce5910e61d00e91f70c7978e067bde2690a1c97/packages/cli-rovodev/docs/serve/streaming-events.md?at=RDA-307-emit-warning-events-related-to-rate-limits-and-other-api-request-problems#:~:text=Server%20Error%20Warnings
 interface RovoDevPruneResponseRaw {
     message: string;
 }
@@ -109,7 +109,7 @@ interface RovoDevPruneChunk {
     data: RovoDevPruneResponseRaw;
 }
 
-// ??
+// https://bitbucket.org/atlassian/acra-python/src/9ce5910e61d00e91f70c7978e067bde2690a1c97/packages/cli-rovodev/docs/serve/streaming-events.md?at=RDA-307-emit-warning-events-related-to-rate-limits-and-other-api-request-problems#:~:text=Server%20Error%20Warnings
 interface RovoDevOnCallToolStartResponseRaw {
     parts: RovoDevToolCallResponseRaw[];
 }
@@ -119,7 +119,7 @@ interface RovoDevOnCallToolStartChunk {
     data: RovoDevOnCallToolStartResponseRaw;
 }
 
-// ??
+// https://bitbucket.org/atlassian/acra-python/src/9ce5910e61d00e91f70c7978e067bde2690a1c97/packages/cli-rovodev/docs/serve/streaming-events.md?at=RDA-307-emit-warning-events-related-to-rate-limits-and-other-api-request-problems#:~:text=Server%20Error%20Warnings
 interface RovoDevCloseChunk {
     event_kind: 'close';
 }

--- a/src/rovo-dev/rovoDevApiClient.test.ts
+++ b/src/rovo-dev/rovoDevApiClient.test.ts
@@ -131,7 +131,7 @@ describe('RovoDevApiClient', () => {
 
             const result = await client.cancel();
 
-            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v2/cancel', {
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/cancel', {
                 method: 'POST',
                 headers: {
                     accept: 'text/event-stream',
@@ -167,42 +167,7 @@ describe('RovoDevApiClient', () => {
 
             mockFetch.mockResolvedValue(mockResponse);
 
-            await expect(client.cancel()).rejects.toThrow("Failed to fetch '/v2/cancel API: HTTP 500");
-        });
-    });
-
-    describe('reset method', () => {
-        it('should make successful reset request', async () => {
-            const mockResponse = {
-                status: 200,
-                json: jest.fn().mockResolvedValue({}),
-                headers: mockStandardResponseHeaders(),
-            } as unknown as Response;
-
-            mockFetch.mockResolvedValue(mockResponse);
-
-            await client.reset();
-
-            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v2/reset', {
-                method: 'POST',
-                headers: {
-                    accept: 'text/event-stream',
-                    'Content-Type': 'application/json',
-                },
-                body: undefined,
-            });
-        });
-
-        it('should throw error when reset fails', async () => {
-            const mockResponse = {
-                status: 400,
-                statusText: 'Bad Request',
-                headers: mockStandardResponseHeaders(),
-            } as Response;
-
-            mockFetch.mockResolvedValue(mockResponse);
-
-            await expect(client.reset()).rejects.toThrow("Failed to fetch '/v2/reset API: HTTP 400");
+            await expect(client.cancel()).rejects.toThrow("Failed to fetch '/v3/cancel API: HTTP 500");
         });
     });
 
@@ -218,7 +183,7 @@ describe('RovoDevApiClient', () => {
             const message = 'Hello, how can I help?';
             const response = await client.chat(message);
 
-            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v2/chat', {
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/set_chat_message', {
                 method: 'POST',
                 headers: {
                     accept: 'text/event-stream',
@@ -227,6 +192,52 @@ describe('RovoDevApiClient', () => {
                 body: JSON.stringify({ message, context: [] }),
             });
             expect(response).toBe(mockResponse);
+
+            // after the POST /v3/set_chat_message, we expect a GET /v3/stream_chat to be called
+            expect(mockFetch).toHaveBeenCalledWith(
+                'http://localhost:8080/v3/stream_chat?pause_on_call_tools_start=false',
+                {
+                    method: 'GET',
+                    headers: {
+                        accept: 'text/event-stream',
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
+        });
+
+        it('should send chat message successfully, pasing on call tools', async () => {
+            const mockResponse = {
+                status: 200,
+                headers: mockStandardResponseHeaders(),
+            } as Response;
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const message = 'Hello, how can I help?';
+            const response = await client.chat(message, true);
+
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/set_chat_message', {
+                method: 'POST',
+                headers: {
+                    accept: 'text/event-stream',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ message, context: [] }),
+            });
+            expect(response).toBe(mockResponse);
+
+            // after the POST /v3/set_chat_message, we expect a GET /v3/stream_chat to be called
+            expect(mockFetch).toHaveBeenCalledWith(
+                'http://localhost:8080/v3/stream_chat?pause_on_call_tools_start=true',
+                {
+                    method: 'GET',
+                    headers: {
+                        accept: 'text/event-stream',
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
         });
 
         it('should request a deep plan successfully', async () => {
@@ -244,7 +255,7 @@ describe('RovoDevApiClient', () => {
                 context: [],
             });
 
-            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v2/chat', {
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/set_chat_message', {
                 method: 'POST',
                 headers: {
                     accept: 'text/event-stream',
@@ -253,6 +264,18 @@ describe('RovoDevApiClient', () => {
                 body: JSON.stringify({ message, enable_deep_plan: true, context: [] }),
             });
             expect(response).toBe(mockResponse);
+
+            // after the POST /v3/set_chat_message, we expect a GET /v3/stream_chat to be called
+            expect(mockFetch).toHaveBeenCalledWith(
+                'http://localhost:8080/v3/stream_chat?pause_on_call_tools_start=false',
+                {
+                    method: 'GET',
+                    headers: {
+                        accept: 'text/event-stream',
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
         });
 
         it('should handle empty message', async () => {
@@ -265,7 +288,7 @@ describe('RovoDevApiClient', () => {
 
             const response = await client.chat('');
 
-            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v2/chat', {
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/set_chat_message', {
                 method: 'POST',
                 headers: {
                     accept: 'text/event-stream',
@@ -274,6 +297,18 @@ describe('RovoDevApiClient', () => {
                 body: JSON.stringify({ message: '', context: [] }),
             });
             expect(response).toBe(mockResponse);
+
+            // after the POST /v3/set_chat_message, we expect a GET /v3/stream_chat to be called
+            expect(mockFetch).toHaveBeenCalledWith(
+                'http://localhost:8080/v3/stream_chat?pause_on_call_tools_start=false',
+                {
+                    method: 'GET',
+                    headers: {
+                        accept: 'text/event-stream',
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
         });
 
         it('should handle special characters in message', async () => {
@@ -287,7 +322,7 @@ describe('RovoDevApiClient', () => {
             const message = 'Test with "quotes" and \n newlines';
             const response = await client.chat(message);
 
-            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v2/chat', {
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/set_chat_message', {
                 method: 'POST',
                 headers: {
                     accept: 'text/event-stream',
@@ -296,6 +331,18 @@ describe('RovoDevApiClient', () => {
                 body: JSON.stringify({ message, context: [] }),
             });
             expect(response).toBe(mockResponse);
+
+            // after the POST /v3/set_chat_message, we expect a GET /v3/stream_chat to be called
+            expect(mockFetch).toHaveBeenCalledWith(
+                'http://localhost:8080/v3/stream_chat?pause_on_call_tools_start=false',
+                {
+                    method: 'GET',
+                    headers: {
+                        accept: 'text/event-stream',
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
         });
     });
 
@@ -334,24 +381,6 @@ describe('RovoDevApiClient', () => {
         });
     });
 
-    describe('getTools method', () => {
-        it('should throw not implemented error', () => {
-            expect(() => client.getTools()).toThrow('Method not implemented: tools');
-        });
-    });
-
-    describe('tool method', () => {
-        it('should throw not implemented error', () => {
-            expect(() => client.tool('test-tool', { arg1: 'value1' })).toThrow('Method not implemented: tool');
-        });
-    });
-
-    describe('invalidateFileCache method', () => {
-        it('should throw not implemented error', () => {
-            expect(() => client.invalidateFileCache()).toThrow('Method not implemented: invalidate-file-cache');
-        });
-    });
-
     describe('getCacheFilePath method', () => {
         it('should return cached file path', async () => {
             const mockResponse = {
@@ -366,7 +395,7 @@ describe('RovoDevApiClient', () => {
             const result = await client.getCacheFilePath(filePath);
 
             expect(mockFetch).toHaveBeenCalledWith(
-                `http://localhost:8080/v2/cache-file-path?file_path=${encodeURIComponent(filePath)}`,
+                `http://localhost:8080/v3/cache-file-path?file_path=${encodeURIComponent(filePath)}`,
                 {
                     method: 'GET',
                     headers: {
@@ -392,7 +421,7 @@ describe('RovoDevApiClient', () => {
             const result = await client.getCacheFilePath(filePath);
 
             expect(mockFetch).toHaveBeenCalledWith(
-                `http://localhost:8080/v2/cache-file-path?file_path=${encodeURIComponent(filePath)}`,
+                `http://localhost:8080/v3/cache-file-path?file_path=${encodeURIComponent(filePath)}`,
                 {
                     method: 'GET',
                     headers: {
@@ -415,7 +444,7 @@ describe('RovoDevApiClient', () => {
             mockFetch.mockResolvedValue(mockResponse);
 
             await expect(client.getCacheFilePath('/path/to/file.txt')).rejects.toThrow(
-                "Failed to fetch '/v2/cache-file-path?file_path=%2Fpath%2Fto%2Ffile.txt API: HTTP 404",
+                "Failed to fetch '/v3/cache-file-path?file_path=%2Fpath%2Fto%2Ffile.txt API: HTTP 404",
             );
         });
     });
@@ -432,7 +461,7 @@ describe('RovoDevApiClient', () => {
             mockFetch.mockResolvedValue(mockResponse);
             const sessionId = await client.createSession();
 
-            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v2/sessions/create', {
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/sessions/create', {
                 method: 'POST',
                 headers: {
                     accept: 'text/event-stream',
@@ -466,7 +495,7 @@ describe('RovoDevApiClient', () => {
             } as Response;
 
             mockFetch.mockResolvedValue(mockResponse);
-            await expect(client.createSession()).rejects.toThrow("Failed to fetch '/v2/sessions/create API: HTTP 500");
+            await expect(client.createSession()).rejects.toThrow("Failed to fetch '/v3/sessions/create API: HTTP 500");
         });
     });
 
@@ -641,6 +670,133 @@ describe('RovoDevApiClient', () => {
             await expect(client.acceptMcpTerms(true)).rejects.toThrow(
                 "Failed to fetch '/accept-mcp-terms API: HTTP 500",
             );
+        });
+    });
+
+    describe('resumeToolCall method', () => {
+        it('should send resume request with array of tool call IDs', async () => {
+            const mockResponse = {
+                status: 200,
+                headers: mockStandardResponseHeaders(),
+            } as Response;
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const toolCallIds = ['tool1', 'tool2', 'tool3'];
+            await expect(client.resumeToolCall(toolCallIds)).resolves.toBeUndefined();
+
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/resume_tool_calls', {
+                method: 'POST',
+                headers: {
+                    accept: 'text/event-stream',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    decisions: [{ tool_call_id: 'tool1' }, { tool_call_id: 'tool2' }, { tool_call_id: 'tool3' }],
+                }),
+            });
+        });
+
+        it('should send resume request with single tool call ID', async () => {
+            const mockResponse = {
+                status: 200,
+                headers: mockStandardResponseHeaders(),
+            } as Response;
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const toolCallId = 'tool1';
+            await expect(client.resumeToolCall(toolCallId)).resolves.toBeUndefined();
+
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/resume_tool_calls', {
+                method: 'POST',
+                headers: {
+                    accept: 'text/event-stream',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    decisions: [{ tool_call_id: 'tool1', deny_message: undefined }],
+                }),
+            });
+        });
+
+        it('should send resume request with single tool call ID and deny message', async () => {
+            const mockResponse = {
+                status: 200,
+                headers: mockStandardResponseHeaders(),
+            } as Response;
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const toolCallId = 'tool1';
+            const denyMessage = 'Access denied';
+            await expect(client.resumeToolCall(toolCallId, denyMessage)).resolves.toBeUndefined();
+
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/resume_tool_calls', {
+                method: 'POST',
+                headers: {
+                    accept: 'text/event-stream',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    decisions: [{ tool_call_id: 'tool1', deny_message: 'Access denied' }],
+                }),
+            });
+        });
+
+        it('should throw error when API call fails', async () => {
+            const mockResponse = {
+                status: 500,
+                statusText: 'Internal Server Error',
+                headers: mockStandardResponseHeaders(),
+            } as Response;
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            await expect(client.resumeToolCall('tool1')).rejects.toThrow(
+                "Failed to fetch '/v3/resume_tool_calls API: HTTP 500",
+            );
+        });
+    });
+
+    describe('shutdown method', () => {
+        it('should send shutdown request successfully', async () => {
+            const mockResponse = {
+                status: 200,
+                headers: mockStandardResponseHeaders(),
+            } as Response;
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            await expect(client.shutdown()).resolves.toBeUndefined();
+
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/shutdown', {
+                method: 'POST',
+                headers: {
+                    accept: 'text/event-stream',
+                    'Content-Type': 'application/json',
+                },
+                body: undefined,
+            });
+        });
+
+        it('should throw error when shutdown fails', async () => {
+            const mockResponse = {
+                status: 503,
+                statusText: 'Service Unavailable',
+                headers: mockStandardResponseHeaders(),
+            } as Response;
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            await expect(client.shutdown()).rejects.toThrow("Failed to fetch '/shutdown API: HTTP 503");
+        });
+
+        it('should handle network errors during shutdown', async () => {
+            const networkError = new Error('Network error');
+            mockFetch.mockRejectedValue(networkError);
+
+            await expect(client.shutdown()).rejects.toThrow("Failed to fetch '/shutdown API: Network error");
         });
     });
 });

--- a/src/rovo-dev/rovoDevApiClient.test.ts
+++ b/src/rovo-dev/rovoDevApiClient.test.ts
@@ -357,7 +357,7 @@ describe('RovoDevApiClient', () => {
 
             const response = await client.replay();
 
-            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v2/replay', {
+            expect(mockFetch).toHaveBeenCalledWith('http://localhost:8080/v3/replay', {
                 method: 'POST',
                 headers: {
                     accept: 'text/event-stream',
@@ -377,7 +377,7 @@ describe('RovoDevApiClient', () => {
 
             mockFetch.mockResolvedValue(mockResponse);
 
-            await expect(client.replay()).rejects.toThrow("Failed to fetch '/v2/replay API: HTTP 503");
+            await expect(client.replay()).rejects.toThrow("Failed to fetch '/v3/replay API: HTTP 503");
         });
     });
 

--- a/src/rovo-dev/rovoDevApiClient.ts
+++ b/src/rovo-dev/rovoDevApiClient.ts
@@ -61,11 +61,12 @@ export class RovoDevApiClient {
         this._baseApiUrl = `http://${hostnameOrIp}:${port}`;
     }
 
-    private async fetchApi(restApi: string, method: 'GET' | 'POST'): Promise<Response>;
-    private async fetchApi(restApi: string, method: 'POST', body: BodyInit | null): Promise<Response>;
+    private async fetchApi(restApi: string, method: 'GET'): Promise<Response>;
+    private async fetchApi(restApi: string, method: 'POST', body?: BodyInit | null): Promise<Response>;
     private async fetchApi(restApi: string, method: 'GET' | 'POST', body?: BodyInit | null): Promise<Response> {
+        let response: Response;
         try {
-            const response = await fetch(this._baseApiUrl + restApi, {
+            response = await fetch(this._baseApiUrl + restApi, {
                 method,
                 headers: {
                     accept: 'text/event-stream',
@@ -73,54 +74,51 @@ export class RovoDevApiClient {
                 },
                 body,
             });
-
-            if (statusIsSuccessful(response.status)) {
-                return response;
-            } else {
-                throw new RovoDevApiError(
-                    `Failed to fetch '${restApi} API: HTTP ${response.status}`,
-                    response.status,
-                    response,
-                );
-            }
         } catch (error) {
             const reason = error.cause?.code || error.message || error;
             throw new RovoDevApiError(`Failed to fetch '${restApi} API: ${reason}`, 0, undefined);
         }
+
+        if (statusIsSuccessful(response.status)) {
+            return response;
+        } else {
+            throw new RovoDevApiError(
+                `Failed to fetch '${restApi} API: HTTP ${response.status}`,
+                response.status,
+                response,
+            );
+        }
     }
 
-    /** Invokes the POST `/v2/cancel` API.
+    /** Invokes the POST `/v3/cancel` API.
      * @returns {Promise<RovoDevCancelResponse>} An object representing the API response.
      */
     public async cancel(): Promise<RovoDevCancelResponse> {
-        const response = await this.fetchApi('/v2/cancel', 'POST');
+        const response = await this.fetchApi('/v3/cancel', 'POST');
         return await response.json();
     }
 
-    /** Invokes the POST `/v2/reset` API. */
-    public async reset(): Promise<void> {
-        await this.fetchApi('/v2/reset', 'POST');
-    }
-
-    /** Invokes the POST `/v2/sessions/create` API
+    /** Invokes the POST `/v3/sessions/create` API
      * @returns {Promise<string>} A value representing the new session id.
      */
     public async createSession(): Promise<string | null> {
-        const response = await this.fetchApi('/v2/sessions/create', 'POST');
+        const response = await this.fetchApi('/v3/sessions/create', 'POST');
         return response.headers.get('x-session-id');
     }
 
-    /** Invokes the POST `/v2/chat` API.
+    /** Invokes the POST `/v3/set_chat_message` API, then the GET `/v3/stream_chat` API.
      * @param {string} message The message (prompt) to send to Rovo Dev.
+     * @param {boolean?} pause_on_call_tools_start Set to `true` to pause before every tool execution. Defaults to `false`.
      * @returns {Promise<Response>} An object representing the API response.
      */
-    public chat(message: string): Promise<Response>;
-    /** Invokes the POST `/v2/chat` API.
+    public chat(message: string, pause_on_call_tools_start?: boolean): Promise<Response>;
+    /** Invokes the POST `/v3/set_chat_message` API, then the GET `/v3/stream_chat` API.
      * @param {RovoDevChatRequest} message The chat payload to send to Rovo Dev.
+     * @param {boolean?} pause_on_call_tools_start Set to `true` to pause before every tool execution. Defaults to `false`.
      * @returns {Promise<Response>} An object representing the API response.
      */
-    public chat(message: RovoDevChatRequest): Promise<Response>;
-    public chat(message: string | RovoDevChatRequest): Promise<Response> {
+    public chat(message: RovoDevChatRequest, pause_on_call_tools_start?: boolean): Promise<Response>;
+    public async chat(message: string | RovoDevChatRequest, pause_on_call_tools_start?: boolean): Promise<Response> {
         if (typeof message === 'string') {
             message = {
                 message: message,
@@ -128,7 +126,36 @@ export class RovoDevApiClient {
             };
         }
 
-        return this.fetchApi('/v2/chat', 'POST', JSON.stringify(message));
+        await this.fetchApi('/v3/set_chat_message', 'POST', JSON.stringify(message));
+
+        const qs = `pause_on_call_tools_start=${pause_on_call_tools_start ? 'true' : 'false'}`;
+        return await this.fetchApi(`/v3/stream_chat?${qs}`, 'GET');
+    }
+
+    /** Invokes the POST `/v3/resume_tool_calls` API.
+     * @param {string[]} toolCallIds A list of tool call IDs to allow.
+     */
+    public async resumeToolCall(toolCallIds: string[]): Promise<void>;
+    /** Invokes the POST `/v3/resume_tool_calls` API.
+     * @param {string} toolCallId The ID of the tool call to either allow or deny.
+     * @param {string?} denyMessage The deny message for this tool call, or `undefined` to allow the tool call. Defaults to `undefined`.
+     */
+    public async resumeToolCall(toolCallId: string, denyMessage?: string): Promise<void>;
+    public async resumeToolCall(toolCallId: string | string[], denyMessage?: string): Promise<void> {
+        const message = Array.isArray(toolCallId)
+            ? {
+                  decisions: toolCallId.map((tool_call_id) => ({ tool_call_id })),
+              }
+            : {
+                  decisions: [
+                      {
+                          tool_call_id: toolCallId,
+                          deny_message: denyMessage || undefined,
+                      },
+                  ],
+              };
+
+        await this.fetchApi('/v3/resume_tool_calls', 'POST', JSON.stringify(message));
     }
 
     /** Invokes the POST `/v2/replay` API
@@ -138,56 +165,15 @@ export class RovoDevApiClient {
         return this.fetchApi('/v2/replay', 'POST');
     }
 
-    /** Invokes the GET `/v2/tools` API
-     * @not_implemented
-     */
-    public getTools() {
-        throw new Error('Method not implemented: tools');
-    }
-
-    /** Invokes the POST `/v2/tool` API
-     * @param {string} tool_name The name of the tool we want to invoke.
-     * @param {Record<string, string>} args The arguments for the tool.
-     * @not_implemented
-     */
-    public tool(tool_name: string, args: Record<string, string>) {
-        throw new Error('Method not implemented: tool');
-    }
-
-    /** Invokes the POST `/v2/clear` API
-     * @returns {Promise<string>} The message returned by the clear API.
-     */
-    public async clear(): Promise<string> {
-        const response = await this.fetchApi('/v2/clear', 'POST');
-        const responseJson = await response.json();
-        return responseJson.message;
-    }
-
-    /** Invokes the POST `/v2/prune` API
-     * @returns {Promise<string>} The message returned by the prune API.
-     */
-    public async prune(): Promise<string> {
-        const response = await this.fetchApi('/v2/prune', 'POST');
-        const responseJson = await response.json();
-        return responseJson.message;
-    }
-
-    /** Invokes the GET `/v2/cache-file-path` API.
+    /** Invokes the GET `/v3/cache-file-path` API.
      * @param {string} file_path
      * @returns {Promise<string>} The file path for the cached version without Rovo Dev changes.
      */
     public async getCacheFilePath(file_path: string): Promise<string> {
         const qs = `file_path=${encodeURIComponent(file_path)}`;
-        const response = await this.fetchApi(`/v2/cache-file-path?${qs}`, 'GET');
+        const response = await this.fetchApi(`/v3/cache-file-path?${qs}`, 'GET');
         const data = await response.json();
         return data.cached_file_path;
-    }
-
-    /** Invokes the POST `/v2/invalidate-file-cache` API.
-     * @not_implemented
-     */
-    public invalidateFileCache() {
-        throw new Error('Method not implemented: invalidate-file-cache');
     }
 
     /** Invokes the GET `/healthcheck` API.

--- a/src/rovo-dev/rovoDevApiClient.ts
+++ b/src/rovo-dev/rovoDevApiClient.ts
@@ -158,11 +158,11 @@ export class RovoDevApiClient {
         await this.fetchApi('/v3/resume_tool_calls', 'POST', JSON.stringify(message));
     }
 
-    /** Invokes the POST `/v2/replay` API
+    /** Invokes the POST `/v3/replay` API
      * @returns {Promise<Response>} An object representing the API response.
      */
     public replay(): Promise<Response> {
-        return this.fetchApi('/v2/replay', 'POST');
+        return this.fetchApi('/v3/replay', 'POST');
     }
 
     /** Invokes the GET `/v3/cache-file-path` API.

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -119,7 +119,7 @@ export class RovoDevChatProvider {
         this.beginNewPrompt();
 
         const fetchOp = async (client: RovoDevApiClient) => {
-            const response = await client.chat(requestPayload);
+            const response = await client.chat(requestPayload, true);
 
             this._telemetryProvider.fireTelemetryEvent(
                 'rovoDevPromptSentEvent',
@@ -258,7 +258,7 @@ export class RovoDevChatProvider {
         }
     }
 
-    private processRovoDevResponse(sourceApi: StreamingApi, response: RovoDevResponse): Thenable<boolean> {
+    private processRovoDevResponse(sourceApi: StreamingApi, response: RovoDevResponse): Thenable<unknown> {
         // if (this._processState === RovoDevProcessState.Disabled) {
         //     return Promise.resolve(false);
         // }
@@ -358,8 +358,17 @@ export class RovoDevChatProvider {
                     },
                 });
 
+            case 'on_call_tools_start':
+                // simulate YOLO mode
+                return this._rovoDevApiClient!.resumeToolCall(response.tools.map((x) => x.tool_call_id));
+
+            case 'close':
+                // response terminated
+                return Promise.resolve(true);
+
             default:
-                return Promise.resolve(false);
+                // @ts-expect-error ts(2339) - response here should be 'never'
+                throw new Error(`Rovo Dev response error: unknown event kind: ${response.event_kind}`);
         }
     }
 


### PR DESCRIPTION
### What Is This Change?

Consume the /v3 APIs instead of the /v2, which offer the ability to pause the streaming before every tool call to request user confirmation before executing them.

With this change, we automatically allow every tool call, which keeps the logic equivalent to the YOLO mode.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`