### PR TITLE
AXON-1191: Fixed code block contrast issue on the high contrast

### DIFF
--- a/src/webviews/components/issue/common/AtlaskitEditor/AtlaskitEditor.css
+++ b/src/webviews/components/issue/common/AtlaskitEditor/AtlaskitEditor.css
@@ -23,3 +23,8 @@
 [class*="Select__menu"] {
     z-index: 1000;
 }
+
+/* Fix for code blocks in ProseMirror editor */
+.ProseMirror code {
+    background-color: rgba(255, 255, 255, 0.1);
+}


### PR DESCRIPTION
### What Is This Change?

Before:
<img width="845" height="521" alt="Screenshot 2025-09-23 at 11 30 15-20250923-083018" src="https://github.com/user-attachments/assets/3208b98b-8458-4038-b0c0-f60ba0e9fcdc" />

After:
<img width="1541" height="484" alt="Screenshot 2025-09-25 at 14 28 11" src="https://github.com/user-attachments/assets/ea986012-50e9-40e6-a057-26193a42a9fc" />


<img width="1541" height="484" alt="Screenshot 2025-09-25 at 14 27 14" src="https://github.com/user-attachments/assets/1c524e11-bdbb-4cd3-a1e8-c999d9503001" />

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change