### PR TITLE
[AXON-1181] Update suggestion availability on credential change

### DIFF
--- a/src/webviews/abstractWebview.test.ts
+++ b/src/webviews/abstractWebview.test.ts
@@ -32,6 +32,14 @@ jest.mock('../container', () => ({
         analyticsApi: {
             fireUIErrorEvent: jest.fn(),
         },
+        credentialManager: {
+            onDidAuthChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+        },
+        siteManager: {
+            onDidSitesAvailableChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+            getSiteForId: jest.fn(),
+            getSitesAvailable: jest.fn().mockReturnValue([]),
+        },
     },
 }));
 


### PR DESCRIPTION
### What Is This Change?

Whenever authentication or available site list changes, update the create issue page
This is particularly relevant to make the authentication nudge work as expected (you authenticate -> you get the new shiny feature right away :D)

### How Has This Been Tested?

Manually, see loom:
https://www.loom.com/share/036976c0a4254e28808903c899c888dc

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
