### PR TITLE
FLOW-344 Adds analytic event for rovodev create PR button clicked

### DIFF
--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -1330,6 +1330,22 @@ describe('analytics', () => {
             expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
             expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
         });
+
+        it.each(RovoDevEnvironments)('should create rovoDevCreatePrButtonClickedEvent', async (rovoDevEnv) => {
+            const event = await analytics.rovoDevCreatePrButtonClickedEvent(
+                rovoDevEnv,
+                appInstanceId,
+                mockSessionId,
+                mockPromptId,
+            );
+
+            expect(event.trackEvent.action).toEqual('clicked');
+            expect(event.trackEvent.actionSubject).toEqual('rovoDevCreatePrButton');
+            expect(event.trackEvent.attributes.rovoDevEnv).toEqual(rovoDevEnv);
+            expect(event.trackEvent.attributes.appInstanceId).toEqual(appInstanceId);
+            expect(event.trackEvent.attributes.sessionId).toEqual(mockSessionId);
+            expect(event.trackEvent.attributes.promptId).toEqual(mockPromptId);
+        });
     });
 
     // Platform detection tests

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -329,6 +329,17 @@ export function rovoDevDetailsExpandedEvent(
     });
 }
 
+export function rovoDevCreatePrButtonClickedEvent(
+    rovoDevEnv: RovoDevEnv,
+    appInstanceId: string,
+    sessionId: string,
+    promptId: string,
+) {
+    return trackEvent('clicked', 'rovoDevCreatePrButton', {
+        attributes: { rovoDevEnv, appInstanceId, sessionId, promptId },
+    });
+}
+
 export function rovoDevAiResultViewedEvent(
     rovoDevEnv: RovoDevEnv,
     appInstanceId: string,

--- a/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
+++ b/src/react/atlascode/rovo-dev/create-pr/PullRequestForm.tsx
@@ -36,7 +36,7 @@ interface PullRequestFormProps {
 
 export const PullRequestForm: React.FC<PullRequestFormProps> = ({
     onCancel,
-    messagingApi: { postMessagePromise },
+    messagingApi: { postMessage, postMessagePromise },
     onPullRequestCreated,
     isFormVisible = false,
     setFormVisible,
@@ -58,6 +58,7 @@ export const PullRequestForm: React.FC<PullRequestFormProps> = ({
 
     const handleToggleForm = async (event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
+        postMessage({ type: RovoDevViewResponseType.ReportCreatePrButtonClicked });
         await getCurrentBranchName();
         setFormVisible?.(true);
     };

--- a/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevViewMessages.tsx
@@ -19,6 +19,7 @@ export const enum RovoDevViewResponseType {
     ReportChangedFilesPanelShown = 'reportChangedFilesPanelShown',
     ReportChangesGitPushed = 'reportChangesGitPushed',
     ReportThinkingDrawerExpanded = 'reportThinkingDrawerExpanded',
+    ReportCreatePrButtonClicked = 'reportCreatePrButtonClicked',
     CheckGitChanges = 'checkGitChanges',
     WebviewReady = 'webviewReady',
     GetAgentMemory = 'getAgentMemory',
@@ -51,6 +52,7 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.ReportChangedFilesPanelShown, { filesCount: number }>
     | ReducerAction<RovoDevViewResponseType.ReportChangesGitPushed, { pullRequestCreated: boolean }>
     | ReducerAction<RovoDevViewResponseType.ReportThinkingDrawerExpanded>
+    | ReducerAction<RovoDevViewResponseType.ReportCreatePrButtonClicked>
     | ReducerAction<RovoDevViewResponseType.CheckGitChanges>
     | ReducerAction<RovoDevViewResponseType.WebviewReady>
     | ReducerAction<RovoDevViewResponseType.GetAgentMemory>

--- a/src/rovo-dev/rovoDevTelemetryProvider.ts
+++ b/src/rovo-dev/rovoDevTelemetryProvider.ts
@@ -3,6 +3,7 @@ import { Logger } from 'src/logger';
 
 import {
     rovoDevAiResultViewedEvent,
+    rovoDevCreatePrButtonClickedEvent,
     rovoDevDetailsExpandedEvent,
     RovoDevEnv,
     rovoDevFileChangedActionEvent,
@@ -25,6 +26,7 @@ const rovoDevTelemetryEvents = {
     rovoDevTechnicalPlanningShownEvent,
     rovoDevDetailsExpandedEvent,
     rovoDevAiResultViewedEvent,
+    rovoDevCreatePrButtonClickedEvent,
 };
 
 type ParametersSkip3<T extends (...args: any) => any> =
@@ -77,7 +79,7 @@ export class RovoDevTelemetryProvider {
         this._firedTelemetryForCurrentPrompt = {};
     }
 
-    // This function esures that the same telemetry event is not sent twice for the same prompt
+    // This function ensures that the same telemetry event is not sent twice for the same prompt
     public fireTelemetryEvent<T extends TelemetryFunction>(
         funcName: T,
         ...params: ParametersSkip3<(typeof rovoDevTelemetryEvents)[T]>
@@ -94,6 +96,7 @@ export class RovoDevTelemetryProvider {
 
         // the following events can be fired multiple times during the same prompt
         delete this._firedTelemetryForCurrentPrompt['rovoDevFileChangedActionEvent'];
+        delete this._firedTelemetryForCurrentPrompt['rovoDevCreatePrButtonClickedEvent'];
 
         if (!this._firedTelemetryForCurrentPrompt[funcName]) {
             this._firedTelemetryForCurrentPrompt[funcName] = true;

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -281,6 +281,12 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                             this._chatProvider.currentPromptId,
                         );
                         break;
+                    case RovoDevViewResponseType.ReportCreatePrButtonClicked:
+                        this._telemetryProvider.fireTelemetryEvent(
+                            'rovoDevCreatePrButtonClickedEvent',
+                            this._chatProvider.currentPromptId,
+                        );
+                        break;
 
                     case RovoDevViewResponseType.WebviewReady:
                         this._webviewReady = true;


### PR DESCRIPTION
### What Is This Change?

Fire an analytic even when a user clicks the Rovodev "Create Pull Request" button.
https://www.loom.com/share/e47330bdbd4c42cebd5f2bf0f219205d?sid=ec4fe507-62d1-45dc-a8d3-6012f18696a2


### How Has This Been Tested?

- Tested locally and basic unit tests added
https://www.loom.com/share/e47330bdbd4c42cebd5f2bf0f219205d?sid=ec4fe507-62d1-45dc-a8d3-6012f18696a2

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change