### PR TITLE
AXON-1181 use any available key

### DIFF
--- a/src/atlclients/issueBuilder.test.ts
+++ b/src/atlclients/issueBuilder.test.ts
@@ -1,0 +1,87 @@
+import { AuthInfoState, BasicAuthInfo } from './authInfo';
+import { findApiTokenForSite } from './issueBuilder';
+
+jest.mock('../container', () => {
+    const actual = jest.requireActual('../container');
+    return {
+        ...actual,
+        Container: {
+            siteManager: {
+                getSiteForId: jest.fn(),
+                getSitesAvailable: jest.fn(),
+            },
+            credentialManager: {
+                getAuthInfo: jest.fn(),
+            },
+        },
+    };
+});
+
+import { Container } from '../container';
+
+describe('findApiTokenForSite', () => {
+    const basicAuthInfo: BasicAuthInfo = {
+        username: 'user',
+        password: 'pass',
+        user: { email: 'test@domain.com', id: 'id', displayName: 'Test User', avatarUrl: '' },
+        state: AuthInfoState.Valid,
+    };
+
+    const makeSite = (host: string, email: string): any => ({
+        host,
+        id: 'site-id',
+        name: 'Test Site',
+        avatarUrl: '',
+        baseLinkUrl: '',
+        product: 'jira',
+        user: { email, id: 'id', displayName: 'Test User', avatarUrl: '' },
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns undefined if site is not found', async () => {
+        (Container.siteManager.getSiteForId as jest.Mock).mockReturnValue(undefined);
+        const result = await findApiTokenForSite('site-id');
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if site host is not .atlassian.net', async () => {
+        (Container.siteManager.getSiteForId as jest.Mock).mockReturnValue(makeSite('example.com', 'test@domain.com'));
+        const result = await findApiTokenForSite('site-id');
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if no matching authInfo found', async () => {
+        const site = makeSite('test.atlassian.net', 'a@b.com');
+        (Container.siteManager.getSiteForId as jest.Mock).mockReturnValue(site);
+        (Container.siteManager.getSitesAvailable as jest.Mock).mockReturnValue([site]);
+        (Container.credentialManager.getAuthInfo as jest.Mock).mockResolvedValueOnce({
+            user: { email: 'a@b.com', id: 'id', displayName: '', avatarUrl: '' },
+        });
+        (Container.credentialManager.getAuthInfo as jest.Mock).mockResolvedValueOnce(undefined);
+        const result = await findApiTokenForSite('site-id');
+        expect(result).toBeUndefined();
+    });
+
+    it('returns BasicAuthInfo if matching site and authInfo found', async () => {
+        const site = makeSite('test.atlassian.net', 'test@domain.com');
+        (Container.siteManager.getSiteForId as jest.Mock).mockReturnValue(site);
+        (Container.siteManager.getSitesAvailable as jest.Mock).mockReturnValue([site]);
+        // First call returns an object with a user property, second returns BasicAuthInfo
+        (Container.credentialManager.getAuthInfo as jest.Mock).mockResolvedValueOnce({ user: site.user });
+        (Container.credentialManager.getAuthInfo as jest.Mock).mockResolvedValueOnce(basicAuthInfo);
+        const result = await findApiTokenForSite('site-id');
+        expect(result).toEqual(basicAuthInfo);
+    });
+
+    it('works when site is passed as DetailedSiteInfo', async () => {
+        const site = makeSite('test.atlassian.net', 'test@domain.com');
+        (Container.siteManager.getSitesAvailable as jest.Mock).mockReturnValue([site]);
+        (Container.credentialManager.getAuthInfo as jest.Mock).mockResolvedValueOnce({ user: site.user });
+        (Container.credentialManager.getAuthInfo as jest.Mock).mockResolvedValueOnce(basicAuthInfo);
+        const result = await findApiTokenForSite(site);
+        expect(result).toEqual(basicAuthInfo);
+    });
+});

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -389,6 +389,12 @@ export class CreateIssueWebview
             return;
         }
 
+        this._partialIssue = {
+            ...this._partialIssue,
+            summary: fieldValues?.summary || this._partialIssue?.summary,
+            description: fieldValues?.description || this._partialIssue?.description,
+        };
+
         const createData: CreateIssueData = this._screenData.issueTypeUIs[this._selectedIssueTypeId] as CreateIssueData;
         createData.fieldValues = {
             ...createData.fieldValues,


### PR DESCRIPTION
### What Is This Change?

This change rewrites how we resolve API token availability for the purpose of issue suggestions

|  | Before | After |
|--|------|-------|
| When deciding if suggestions are available | Check for API token credential on specific site | Check for an API token applicable to the selected site (via matching email) |
| When making the API call | Use first available cloud site with an API token | Use the exact site the user has selected in the `Create Issue` page |

Also featuring: fix to a very annoying bug where the generated values would reset when switching sites

### How Has This Been Tested?

Manually :)
https://www.loom.com/share/3302b30e620947eeb9d3d7a1d58254b8

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`