### PR TITLE
chore: move API token lookup to credential manager + more tests

### DIFF
--- a/src/commands/jira/issueSuggestionManager.ts
+++ b/src/commands/jira/issueSuggestionManager.ts
@@ -3,7 +3,7 @@ import { Container } from 'src/container';
 import { Logger } from 'src/logger';
 import { window, workspace } from 'vscode';
 
-import { fetchIssueSuggestions, findApiTokenForSite } from '../../atlclients/issueBuilder';
+import { fetchIssueSuggestions } from '../../atlclients/issueBuilder';
 import { IssueSuggestionContextLevel, IssueSuggestionSettings, SimplifiedTodoIssueData } from '../../config/model';
 import { Features } from '../../util/featureFlags';
 
@@ -147,5 +147,5 @@ async function getSuggestionAvailable(): Promise<boolean> {
         return false;
     }
 
-    return (await findApiTokenForSite(selectedSite)) !== undefined;
+    return (await Container.credentialManager.findApiTokenForSite(selectedSite)) !== undefined;
 }


### PR DESCRIPTION
### What Is This Change?

No functional change, small follow-up from #1041:
 * Move `findApiTokenForSite` into `credentialManager` per @bwieger-atlassian-com's suggestion
 * Add some more unit tests (and move the existing tests accordingly)

### How Has This Been Tested?

N/A

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
