### PR TITLE
[AXON-825] bring issue suggestion UI (somewhat) in line with design

### DIFF
--- a/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
@@ -1,4 +1,9 @@
+import 'src/react/atlascode/rovo-dev/RovoDev.css';
+
 import { HelperMessage } from '@atlaskit/form';
+import ThumbsDownIcon from '@atlaskit/icon/core/thumbs-down';
+import ThumbsUpIcon from '@atlaskit/icon/core/thumbs-up';
+import Tooltip from '@atlaskit/tooltip';
 import React, { useState } from 'react';
 import { SimplifiedTodoIssueData } from 'src/config/model';
 
@@ -28,19 +33,42 @@ const AISuggestionFooter: React.FC<{
 
     return (
         (isAvailable && isEnabled && (
-            <HelperMessage>
-                <div style={{ marginTop: '8px', display: 'flex', gap: '8px' }}>
-                    <span>AI-generated results may vary. Please provide feedback</span>
-                    <div style={{ marginLeft: 'auto', display: 'flex', gap: '8px' }}>
-                        <span style={{ cursor: 'pointer' }} onClick={() => handleFeedback(true)}>
-                            👍
-                        </span>
-                        <span style={{ cursor: 'pointer' }} onClick={() => handleFeedback(false)}>
-                            👎
-                        </span>
-                    </div>
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    minWidth: '100%',
+                }}
+            >
+                <HelperMessage style={{ flex: 1 }}>
+                    Please provide feedback to improve AI work item generation
+                </HelperMessage>
+                <div className="chat-message-actions" style={{ display: 'flex', gap: '2px', marginTop: '10px' }}>
+                    <div style={{ flex: 1 }}></div>
+                    <Tooltip content="Helpful">
+                        <button
+                            onClick={() => handleFeedback(true)}
+                            type="button"
+                            aria-label="like-response-button"
+                            className="chat-message-action"
+                        >
+                            <ThumbsUpIcon label="thumbs-up" spacing="none" />
+                        </button>
+                    </Tooltip>
+                    <Tooltip content="Unhelpful">
+                        <button
+                            onClick={() => handleFeedback(false)}
+                            type="button"
+                            aria-label="dislike-response-button"
+                            className="chat-message-action"
+                        >
+                            <ThumbsDownIcon label="thumbs-down" spacing="none" />
+                        </button>
+                    </Tooltip>
                 </div>
-            </HelperMessage>
+            </div>
         )) ||
         null
     );

--- a/src/webviews/components/aiCreateIssue/AISuggestionHeader.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionHeader.tsx
@@ -1,5 +1,6 @@
 import Checkbox from '@atlaskit/checkbox';
 import { HelperMessage } from '@atlaskit/form';
+import StatusInformationIcon from '@atlaskit/icon/core/status-information';
 import React, { useCallback, useEffect, useState } from 'react';
 import { IssueSuggestionContextLevel, IssueSuggestionSettings } from 'src/config/model';
 
@@ -90,26 +91,19 @@ const AISuggestionHeader: React.FC<{
     }
 
     return isAvailable ? (
-        <div>
+        <div style={{ marginBottom: '15px' }}>
             <hr className="ac-form-separator" />
-            <Checkbox label="Use AI to create issue" isChecked={isEnabled} onChange={handleCheckboxChange} />
+            <Checkbox
+                label="Use AI to create summary and description"
+                isChecked={isEnabled}
+                onChange={handleCheckboxChange}
+            />
             <HelperMessage>
-                <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                    <span>AI will analyze your TODO and code context to suggest issue titles and descriptions.</span>
-                    <span title="AI suggestions use your code and TODO comments to generate issue details.">
-                        <svg
-                            width="16"
-                            height="16"
-                            viewBox="0 0 16 16"
-                            fill="none"
-                            aria-label="Info"
-                            style={{ verticalAlign: 'middle', cursor: 'pointer' }}
-                        >
-                            <circle cx="8" cy="8" r="7" stroke="#6B778C" strokeWidth="1.5" fill="#DEEBFF" />
-                            <rect x="7.25" y="7" width="1.5" height="4" rx="0.75" fill="#6B778C" />
-                            <rect x="7.25" y="4" width="1.5" height="1.5" rx="0.75" fill="#6B778C" />
-                        </svg>
+                <span style={{ display: 'flex', alignItems: 'center' }}>
+                    <span style={{ marginLeft: '6px', marginRight: '6px' }}>
+                        <StatusInformationIcon label="info" size="small" />
                     </span>
+                    <span>Uses AI. Verify results.</span>
                 </span>
             </HelperMessage>
         </div>


### PR DESCRIPTION
### What Is This Change?

Small changes to the header and footer of the issue suggestion UI to bring them in line with design - at least as much as possible, without reworking the page as a whole

<img width="300" alt="image" src="https://github.com/user-attachments/assets/68102025-56e3-41fc-9cf6-c55b65cf718e" />

### How Has This Been Tested?

This is purely cosmetic - please see the image above :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`