### PR TITLE
AXON-1142: added context to prompt is not an anchor link

### DIFF
--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -80,7 +80,7 @@ export const renderChatHistory = (
             );
         case 'RovoDev':
         case 'User':
-            return <ChatMessageItem msg={msg} />;
+            return <ChatMessageItem msg={msg} openFile={openFile} />;
         case 'RovoDevRetry':
             const retryMsg: DefaultMessage = {
                 text: msg.content,
@@ -90,6 +90,7 @@ export const renderChatHistory = (
                 <ChatMessageItem
                     msg={retryMsg}
                     icon={<StatusErrorIcon color="var(--ds-icon-danger)" label="error-icon" spacing="none" />}
+                    openFile={openFile}
                 />
             );
         default:

--- a/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatMessageItem.tsx
@@ -5,7 +5,7 @@ import ThumbsUpIcon from '@atlaskit/icon/core/thumbs-up';
 import Tooltip from '@atlaskit/tooltip';
 import React, { useCallback, useState } from 'react';
 
-import { MarkedDown } from '../common/common';
+import { MarkedDown, OpenFileFunc } from '../common/common';
 import { PromptContextCollection } from '../prompt-box/promptContext/promptContextCollection';
 import { DefaultMessage } from '../utils';
 
@@ -15,9 +15,9 @@ export const ChatMessageItem: React.FC<{
     enableActions?: boolean;
     onCopy?: (text: string) => void;
     onFeedback?: (isPositive: boolean) => void;
-}> = ({ msg, icon, enableActions, onCopy, onFeedback }) => {
+    openFile?: OpenFileFunc;
+}> = ({ msg, icon, enableActions, onCopy, onFeedback, openFile }) => {
     const [isCopied, setIsCopied] = useState(false);
-
     const messageTypeStyles = msg.source === 'User' ? 'user-message' : 'agent-message';
 
     const handleCopyClick = useCallback(() => {
@@ -46,7 +46,13 @@ export const ChatMessageItem: React.FC<{
             </div>
             {msg.source === 'User' && msg.context && (
                 <div className="message-context">
-                    <PromptContextCollection content={msg.context} direction="column" align="right" inChat={true} />
+                    <PromptContextCollection
+                        content={msg.context}
+                        direction="column"
+                        align="right"
+                        inChat={true}
+                        openFile={openFile}
+                    />
                 </div>
             )}
             {msg.source === 'RovoDev' && enableActions && (

--- a/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
@@ -262,6 +262,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                                     }
                                     onCopy={handleCopyResponse}
                                     onFeedback={handleFeedbackTrigger}
+                                    openFile={renderProps.openFile}
                                 />
                             );
                         } else if (block.source === 'ToolReturn') {

--- a/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextCollection.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextCollection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { RovoDevContextItem } from 'src/rovo-dev/rovoDevTypes';
 
+import { OpenFileFunc } from '../../common/common';
 import { PromptContextItem } from './promptContextItem';
 
 // PromptContextCollection: displays a row or column of PromptContextItem
@@ -12,7 +13,17 @@ export const PromptContextCollection: React.FC<{
     readonly?: boolean;
     onRemoveContext?: (item: RovoDevContextItem) => void;
     inChat?: boolean;
-}> = ({ content, direction = 'row', align = 'left', onToggleActiveItem, readonly = true, onRemoveContext, inChat }) => {
+    openFile?: OpenFileFunc;
+}> = ({
+    content,
+    direction = 'row',
+    align = 'left',
+    onToggleActiveItem,
+    readonly = true,
+    onRemoveContext,
+    inChat,
+    openFile,
+}) => {
     if (content.length === 0) {
         return null;
     }
@@ -46,6 +57,7 @@ export const PromptContextCollection: React.FC<{
                     selection={focusedItem.selection}
                     enabled={focusedItem.enabled}
                     onToggle={onToggleActiveItem}
+                    openFile={openFile}
                 />
             )}
             {addedItems.map((item, index) => (
@@ -56,6 +68,7 @@ export const PromptContextCollection: React.FC<{
                     selection={item.selection}
                     enabled={item.enabled}
                     onRemove={!readonly && onRemoveContext ? () => onRemoveContext(item) : undefined}
+                    openFile={openFile}
                 />
             ))}
         </div>

--- a/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextItem.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/promptContext/promptContextItem.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { RovoDevContextItem } from 'src/rovo-dev/rovoDevTypes';
 
+import { OpenFileFunc } from '../../common/common';
+
 const isHighContrastTheme = (): boolean => {
     return (
         document.body.classList.contains('vscode-high-contrast') ||
@@ -75,9 +77,13 @@ export type PromptContextItemRemoveProps = {
     onRemove?: () => void;
 };
 
+export type PromptContextItemOpenFileProps = {
+    openFile?: OpenFileFunc;
+};
+
 export const PromptContextItem: React.FC<
-    RovoDevContextItem & PromptContextItemToggleProps & PromptContextItemRemoveProps
-> = ({ file: openFile, selection, enabled, onToggle, onRemove }) => {
+    RovoDevContextItem & PromptContextItemToggleProps & PromptContextItemRemoveProps & PromptContextItemOpenFileProps
+> = ({ file: openFile, selection, enabled, onToggle, onRemove, openFile: openFileFunc }) => {
     // Calculate line numbers if selection is present
     let lineInfo: string | null = null;
     if (selection) {
@@ -101,7 +107,16 @@ export const PromptContextItem: React.FC<
                         whiteSpace: 'nowrap',
                         maxWidth: 110,
                         marginRight: 4,
+                        cursor: openFileFunc ? 'pointer' : 'default',
                     }}
+                    onClick={() => {
+                        if (openFileFunc && selection) {
+                            openFileFunc(openFile.absolutePath, false, [selection.start + 1, selection.end + 1]);
+                        } else if (openFileFunc) {
+                            openFileFunc(openFile.absolutePath);
+                        }
+                    }}
+                    title={openFile.absolutePath}
                 >
                     {openFile.name}
                 </span>

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -783,6 +783,7 @@ const RovoDevView: React.FC = () => {
                                     }
                                 });
                             }}
+                            openFile={openFile}
                         />
                         <PromptInputBox
                             disabled={currentState.state === 'ProcessTerminated'}


### PR DESCRIPTION
**Ticket:**
https://softwareteams.atlassian.net/browse/AXON-1142

**What Is This Change?**
Added context to prompt is not an anchor link

**Demo:**
https://www.loom.com/share/25435474ff4e4ac7823a25367efa0f8f

### How Has This Been Tested?



Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change