### PR TITLE
chore: use new design guidelines in issue suggesions

### DIFF
--- a/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
@@ -1,6 +1,7 @@
 import 'src/react/atlascode/rovo-dev/RovoDev.css';
 
 import { HelperMessage } from '@atlaskit/form';
+import StatusInformationIcon from '@atlaskit/icon/core/status-information';
 import ThumbsDownIcon from '@atlaskit/icon/core/thumbs-down';
 import ThumbsUpIcon from '@atlaskit/icon/core/thumbs-up';
 import Tooltip from '@atlaskit/tooltip';
@@ -33,40 +34,52 @@ const AISuggestionFooter: React.FC<{
 
     return (
         (isAvailable && isEnabled && (
-            <div
-                style={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    minWidth: '100%',
-                }}
-            >
-                <HelperMessage style={{ flex: 1 }}>
-                    Please provide feedback to improve AI work item generation
+            <div style={{ marginTop: '12px' }}>
+                <HelperMessage>
+                    <span style={{ display: 'flex', alignItems: 'center' }}>
+                        <span style={{ marginLeft: '6px', marginRight: '6px' }}>
+                            <StatusInformationIcon label="info" size="small" />
+                        </span>
+                        <span>
+                            <a href="https://www.atlassian.com/trust/atlassian-intelligence">
+                                Uses AI. Verify results.
+                            </a>
+                        </span>
+                    </span>
                 </HelperMessage>
-                <div className="chat-message-actions" style={{ display: 'flex', gap: '2px', marginTop: '10px' }}>
-                    <div style={{ flex: 1 }}></div>
-                    <Tooltip content="Helpful">
-                        <button
-                            onClick={() => handleFeedback(true)}
-                            type="button"
-                            aria-label="like-response-button"
-                            className="chat-message-action"
-                        >
-                            <ThumbsUpIcon label="thumbs-up" spacing="none" />
-                        </button>
-                    </Tooltip>
-                    <Tooltip content="Unhelpful">
-                        <button
-                            onClick={() => handleFeedback(false)}
-                            type="button"
-                            aria-label="dislike-response-button"
-                            className="chat-message-action"
-                        >
-                            <ThumbsDownIcon label="thumbs-down" spacing="none" />
-                        </button>
-                    </Tooltip>
+                <div
+                    style={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        minWidth: '100%',
+                    }}
+                >
+                    <HelperMessage> Please provide feedback to improve Rovo Dev work item generation</HelperMessage>
+                    <div className="chat-message-actions" style={{ display: 'flex', gap: '2px', marginTop: '10px' }}>
+                        <div style={{ flex: 1 }}></div>
+                        <Tooltip content="Helpful">
+                            <button
+                                onClick={() => handleFeedback(true)}
+                                type="button"
+                                aria-label="like-response-button"
+                                className="chat-message-action"
+                            >
+                                <ThumbsUpIcon label="thumbs-up" spacing="none" />
+                            </button>
+                        </Tooltip>
+                        <Tooltip content="Unhelpful">
+                            <button
+                                onClick={() => handleFeedback(false)}
+                                type="button"
+                                aria-label="dislike-response-button"
+                                className="chat-message-action"
+                            >
+                                <ThumbsDownIcon label="thumbs-down" spacing="none" />
+                            </button>
+                        </Tooltip>
+                    </div>
                 </div>
             </div>
         )) ||

--- a/src/webviews/components/aiCreateIssue/AISuggestionHeader.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionHeader.tsx
@@ -1,6 +1,6 @@
 import Checkbox from '@atlaskit/checkbox';
 import { HelperMessage } from '@atlaskit/form';
-import StatusInformationIcon from '@atlaskit/icon/core/status-information';
+import LightbulbIcon from '@atlaskit/icon/core/lightbulb';
 import React, { useCallback, useEffect, useState } from 'react';
 import { IssueSuggestionContextLevel, IssueSuggestionSettings } from 'src/config/model';
 
@@ -94,16 +94,16 @@ const AISuggestionHeader: React.FC<{
         <div style={{ marginBottom: '15px' }}>
             <hr className="ac-form-separator" />
             <Checkbox
-                label="Use AI to create summary and description"
+                label="Use Rovo Dev to generate the summary and description"
                 isChecked={isEnabled}
                 onChange={handleCheckboxChange}
             />
             <HelperMessage>
                 <span style={{ display: 'flex', alignItems: 'center' }}>
                     <span style={{ marginLeft: '6px', marginRight: '6px' }}>
-                        <StatusInformationIcon label="info" size="small" />
+                        <LightbulbIcon label="info" size="small" />
                     </span>
-                    <span>Uses AI. Verify results.</span>
+                    <span>Rovo Dev reads the TODO comment and surrounding code for context</span>
                 </span>
             </HelperMessage>
         </div>
@@ -111,6 +111,9 @@ const AISuggestionHeader: React.FC<{
         <HelperMessage>
             <div style={{ marginTop: '24px', display: 'flex', alignItems: 'center', gap: '16px' }}>
                 <span>
+                    <span style={{ marginLeft: '6px', marginRight: '6px' }}>
+                        <LightbulbIcon label="info" size="small" />
+                    </span>
                     <a
                         href="https://id.atlassian.com/manage-profile/security/api-tokens"
                         target="_blank"
@@ -118,7 +121,7 @@ const AISuggestionHeader: React.FC<{
                     >
                         Create an API token
                     </a>{' '}
-                    and add it here to use AI issue suggestions
+                    and add it here to use Rovo Dev issue suggestions
                 </span>
                 <button type={'button'} style={{ marginTop: '0', fontSize: '12px' }} onClick={onLoginClick}>
                     Add API Token


### PR DESCRIPTION
### What Is This Change?

Iterating on the issue suggestion design based on the new guidelines

| Before | After |
|-----|-----|
|  <img width="618" height="396" alt="image" src="https://github.com/user-attachments/assets/c641f0e9-1adf-44a5-9434-32c564d74b6e" /> |  <img width="601" height="445" alt="image" src="https://github.com/user-attachments/assets/4f981b9c-cb43-4e29-9e74-01afc055bdfb" />

No footer when the checkbox is disabled:
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/ccb1f74b-c381-4778-a67e-079d1f6e1ce1" />

### How Has This Been Tested?

See images above

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`