### PR TITLE
[AXON-1271] Remove the link to create an API token in Rovo Dev landing page

### DIFF
--- a/src/react/atlascode/rovo-dev/landing-page/disabled-messages/DisabledMessage.tsx
+++ b/src/react/atlascode/rovo-dev/landing-page/disabled-messages/DisabledMessage.tsx
@@ -18,16 +18,7 @@ export const DisabledMessage: React.FC<{
     if (currentState.state === 'Disabled' && currentState.subState === 'NeedAuth') {
         return (
             <div style={messageOuterStyles}>
-                <div>
-                    <a
-                        href="https://id.atlassian.com/manage-profile/security/api-tokens"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Create an API token
-                    </a>{' '}
-                    and then add it here to use RovoDev beta
-                </div>
+                <div>Create an API token and add it here to use Rovo Dev beta</div>
                 <button style={{ ...inChatButtonStyles, marginTop: '8px' }} onClick={onLoginClick}>
                     Add API Token
                 </button>


### PR DESCRIPTION
### What Is This Change?

After the change:
<img width="447" height="506" alt="image" src="https://github.com/user-attachments/assets/f075419d-f493-410a-9f38-b367f675517b" />

### How Has This Been Tested?

- [x] `npm run lint`
- [x] `npm run test`
- [x] `manual tests`