### PR TITLE
Handle Rovo Dev healthcheck in BBY

### DIFF
--- a/src/react/atlascode/rovo-dev/landing-page/disabled-messages/DisabledMessage.tsx
+++ b/src/react/atlascode/rovo-dev/landing-page/disabled-messages/DisabledMessage.tsx
@@ -39,7 +39,7 @@ export const DisabledMessage: React.FC<{
 
     if (currentState.state === 'Disabled' && currentState.subState === 'EntitlementCheckFailed') {
         return (
-            <div style={messageOuterStyles}>
+            <div style={{ ...messageOuterStyles, width: '100%' }}>
                 <DialogMessageItem
                     msg={{
                         source: 'RovoDevDialog',

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -8,16 +8,12 @@ import { detectLanguage } from '@speed-highlight/core/detect';
 import { useCallback, useState } from 'react';
 import * as React from 'react';
 import { ToolPermissionChoice } from 'src/rovo-dev/rovoDevApiClientInterfaces';
-import { DisabledState, RovoDevContextItem, State } from 'src/rovo-dev/rovoDevTypes';
+import { RovoDevContextItem, State } from 'src/rovo-dev/rovoDevTypes';
 import { v4 } from 'uuid';
 
 import { DetailedSiteInfo } from '../../../atlclients/authInfo';
 import { RovoDevResponse } from '../../../rovo-dev/responseParser';
-import {
-    RovoDevDisabledReason,
-    RovoDevProviderMessage,
-    RovoDevProviderMessageType,
-} from '../../../rovo-dev/rovoDevWebviewProviderMessages';
+import { RovoDevProviderMessage, RovoDevProviderMessageType } from '../../../rovo-dev/rovoDevWebviewProviderMessages';
 import { createRovoDevTemplate } from '../../../util/rovoDevTemplate';
 import { useMessagingApi } from '../messagingApi';
 import { FeedbackType } from './feedback-form/FeedbackForm';
@@ -43,22 +39,6 @@ import {
 } from './utils';
 
 const DEFAULT_LOADING_MESSAGE: string = 'Rovo dev is working';
-
-function mapRovoDevDisabledReasonToSubState(reason: RovoDevDisabledReason): DisabledState['subState'] {
-    switch (reason) {
-        case 'needAuth':
-            return 'NeedAuth';
-        case 'noOpenFolder':
-            return 'NoWorkspaceOpen';
-        case 'other':
-            return 'Other';
-        case 'entitlementCheckFailed':
-            return 'EntitlementCheckFailed';
-        default:
-            // @ts-expect-error ts(2339) - reason here should be 'never'
-            throw new Error(reason.toString());
-    }
-}
 
 const IsBoysenberry = process.env.ROVODEV_BBY === 'true';
 
@@ -370,17 +350,16 @@ const RovoDevView: React.FC = () => {
                         finalizeResponse();
                     }
 
-                    const subState = mapRovoDevDisabledReasonToSubState(event.reason);
-                    if (subState === 'EntitlementCheckFailed') {
+                    if (event.reason === 'EntitlementCheckFailed') {
                         setCurrentState({
                             state: 'Disabled',
-                            subState,
+                            subState: event.reason,
                             detail: event.detail!,
                         });
                     } else {
                         setCurrentState({
                             state: 'Disabled',
-                            subState,
+                            subState: event.reason,
                         });
                     }
                     break;

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -341,7 +341,7 @@ export abstract class RovoDevProcessManager {
 
     private static async sendErrorToChat(rovoDevWebViewProvider: RovoDevWebviewProvider, error: Error) {
         if (error instanceof ProcessManagerError && error.type === 'needAuth') {
-            await rovoDevWebViewProvider.signalRovoDevDisabled('needAuth');
+            await rovoDevWebViewProvider.signalRovoDevDisabled('NeedAuth');
         } else {
             await rovoDevWebViewProvider.signalProcessFailedToInitialize(error.message);
         }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -299,7 +299,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         this.refreshDebugPanel(true);
                         if (!this.isBoysenberry && !this.isDisabled) {
                             if (!workspace.workspaceFolders?.length) {
-                                await this.signalRovoDevDisabled('noOpenFolder');
+                                await this.signalRovoDevDisabled('NoWorkspaceOpen');
                                 return;
                             } else {
                                 await webview.postMessage({
@@ -316,7 +316,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                             const rovoDevApiClient = new RovoDevApiClient(rovoDevHost, fixedPort);
                             await this.initializeWithHealthcheck(rovoDevApiClient);
                         } else if (this.isBoysenberry) {
-                            await this.signalRovoDevDisabled('other');
+                            await this.signalRovoDevDisabled('Other');
                             throw new Error('Rovo Dev port not set');
                         } else {
                             this._processState = RovoDevProcessState.Starting;
@@ -1049,22 +1049,48 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         // if result is undefined, it means we didn't manage to contact Rovo Dev within the allotted time
         // TODO - this scenario needs a better handling
         if (!result || result.status === 'unknown') {
-            await this.signalProcessFailedToInitialize(
-                `Service at at "${this._rovoDevApiClient.baseApiUrl}" wasn't ready within ${timeout} ms`,
-            );
+            if (this.isBoysenberry) {
+                const msg = result ? 'Rovo Dev service is unhealthy/unknown.' : 'Rovo Dev service is unreachable.';
+                await this.processError(
+                    new Error(`${msg}\rTry closing and reopening the Boysenberry session to retry.`),
+                    { title: 'Failed to initialize Rovo Dev' },
+                );
+                this.signalRovoDevDisabled('Other');
+            } else {
+                await this.signalProcessFailedToInitialize(
+                    `Service at at "${this._rovoDevApiClient.baseApiUrl}" wasn't ready within ${timeout} ms`,
+                );
+            }
             return;
         }
 
         // if result is unhealthy, it means Rovo Dev has failed during initialization (e.g., some MCP servers failed to start)
         // we can't continue - shutdown and set the process as terminated so the user can try again.
         if (result.status === 'unhealthy') {
-            await this.signalProcessFailedToInitialize();
+            if (this.isBoysenberry) {
+                await this.processError(
+                    new Error(
+                        `Rovo Dev service is unhealthy.\nTry closing and reopening the Boysenberry session to retry.`,
+                    ),
+                    { title: 'Failed to initialize Rovo Dev' },
+                );
+                this.signalRovoDevDisabled('Other');
+            } else {
+                await this.signalProcessFailedToInitialize();
+            }
             return;
         }
 
         // this scenario is when the user is not allowed to run Rovo Dev because it's disabled by the Jira administrator
         if (result.status === 'entitlement check failed') {
-            await this.signalRovoDevDisabled('entitlementCheckFailed', result.detail);
+            if (this.isBoysenberry) {
+                await this.processError(new Error(`${result.detail.message}\nCode: ${result.detail.payload.status}`), {
+                    title: result.detail.title,
+                });
+                this.signalRovoDevDisabled('Other');
+            } else {
+                await this.signalRovoDevDisabled('EntitlementCheckFailed', result.detail);
+            }
             return;
         }
 
@@ -1073,16 +1099,24 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             const mcp_servers = result.mcp_servers || {};
             const serversToReview = Object.keys(mcp_servers).filter((x) => mcp_servers[x] === 'pending user review');
 
-            if (serversToReview.length === 0) {
-                await this.signalProcessFailedToInitialize(
-                    'Failed to initialize Rovo Dev, something went wrong with the MCP servers acceptance flow.',
+            if (this.isBoysenberry) {
+                await this.processError(
+                    new Error(`Cannot start third party MCP servers: ${serversToReview.join(', ')}.`),
+                    { title: 'Failed to initialize Rovo Dev' },
                 );
+                this.signalRovoDevDisabled('Other');
             } else {
-                await webView.postMessage({
-                    type: RovoDevProviderMessageType.SetMcpAcceptanceRequired,
-                    isPromptPending: this._chatProvider.isPromptPending,
-                    mcpIds: serversToReview,
-                });
+                if (serversToReview.length === 0) {
+                    await this.signalProcessFailedToInitialize(
+                        'Failed to initialize Rovo Dev, something went wrong with the MCP servers acceptance flow.',
+                    );
+                } else {
+                    await webView.postMessage({
+                        type: RovoDevProviderMessageType.SetMcpAcceptanceRequired,
+                        isPromptPending: this._chatProvider.isPromptPending,
+                        mcpIds: serversToReview,
+                    });
+                }
             }
 
             return;
@@ -1125,9 +1159,9 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         }
     }
 
-    public async signalRovoDevDisabled(reason: Exclude<RovoDevDisabledReason, 'entitlementCheckFailed'>): Promise<void>;
+    public async signalRovoDevDisabled(reason: Exclude<RovoDevDisabledReason, 'EntitlementCheckFailed'>): Promise<void>;
     public async signalRovoDevDisabled(
-        reason: 'entitlementCheckFailed',
+        reason: 'EntitlementCheckFailed',
         detail: RovoDevEntitlementCheckFailedDetail,
     ): Promise<void>;
     public async signalRovoDevDisabled(

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -5,7 +5,7 @@ import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { DialogMessage } from '../react/atlascode/rovo-dev/utils';
 import { RovoDevResponse } from './responseParser';
 import { EntitlementCheckRovoDevHealthcheckResponse } from './rovoDevApiClientInterfaces';
-import { RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
+import { DisabledState, RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
 
 export const enum RovoDevProviderMessageType {
     RovoDevDisabled = 'rovoDevDisabled',
@@ -49,7 +49,7 @@ interface NonFocusedContextRemovedResponse {
     context: RovoDevContextItem;
 }
 
-export type RovoDevDisabledReason = 'noOpenFolder' | 'needAuth' | 'other' | 'entitlementCheckFailed';
+export type RovoDevDisabledReason = DisabledState['subState'];
 
 export type RovoDevEntitlementCheckFailedDetail = EntitlementCheckRovoDevHealthcheckResponse['detail'];
 


### PR DESCRIPTION
### What Is This Change?

Handling the different healthcheck states of Rovo Dev in BBY.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`