### PR TITLE
AXON-1173 - fixed race conditions in Updated files list

### DIFF
--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.test.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.test.tsx
@@ -55,7 +55,7 @@ describe('UpdatedFilesComponent', () => {
                 actionsEnabled={true}
             />,
         );
-        expect(screen.getByText('3 Updated files')).toBeTruthy();
+        expect(screen.getByText('3 updated files')).toBeTruthy();
     });
 
     it('renders singular file text for single file', () => {
@@ -68,7 +68,7 @@ describe('UpdatedFilesComponent', () => {
                 actionsEnabled={true}
             />,
         );
-        expect(screen.getByText('1 Updated file')).toBeTruthy();
+        expect(screen.getByText('1 updated file')).toBeTruthy();
     });
 
     it('calls onUndo with all file paths when Undo All is clicked', () => {

--- a/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/updated-files/UpdatedFilesComponent.tsx
@@ -23,7 +23,7 @@ export const UpdatedFilesComponent: React.FC<{
                 <div>
                     <i className="codicon codicon-source-control" />
                     <span>
-                        {modifiedFiles.length} Updated file{modifiedFiles.length > 1 ? 's' : ''}
+                        {modifiedFiles.length} updated file{modifiedFiles.length > 1 ? 's' : ''}
                     </span>
                 </div>
                 <div>

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -174,12 +174,12 @@ const RovoDevView: React.FC = () => {
         setIsFeedbackFormVisible(false);
     }, [totalModifiedFiles, keepFiles]);
 
-    const handleAppendModifiedFileToolReturns = useCallback(
-        (toolReturn: ToolReturnGenericMessage) => {
-            if (isCodeChangeTool(toolReturn.tool_name)) {
-                const msg = parseToolReturnMessage(toolReturn).filter((msg) => msg.filePath !== undefined);
+    const handleAppendModifiedFileToolReturns = useCallback((toolReturn: ToolReturnGenericMessage) => {
+        if (isCodeChangeTool(toolReturn.tool_name)) {
+            const msg = parseToolReturnMessage(toolReturn).filter((msg) => msg.filePath !== undefined);
 
-                const filesMap = new Map([...totalModifiedFiles].map((item) => [item.filePath!, item]));
+            setTotalModifiedFiles((currentFiles) => {
+                const filesMap = new Map([...currentFiles].map((item) => [item.filePath!, item]));
 
                 // Logic for handling deletions and modifications
                 msg.forEach((file) => {
@@ -204,11 +204,10 @@ const RovoDevView: React.FC = () => {
                     }
                 });
 
-                setTotalModifiedFiles(Array.from(filesMap.values()));
-            }
-        },
-        [totalModifiedFiles],
-    );
+                return Array.from(filesMap.values());
+            });
+        }
+    }, []);
 
     const handleAppendResponse = useCallback(
         (response: Response) => {


### PR DESCRIPTION
### What Is This Change?
**Issues**:
AXON-1173:
Sometimes when Rovo dev responds with multiple modified file tool returns quickly, the updated files list does not include all modified files

AXON-1242:
Capitalisation on "1 Updated file" -> Can we please change to sentence case to align with Atlassian content standards? So this should be: "1 updated file"

**Recordings**:
Before:
https://www.loom.com/share/8a696b32fae849ad831762879e9942a6

After:
https://www.loom.com/share/811007e5339143d7af85fca6c17ee538

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change