### PR TITLE
AXON-1257: 'Start with Rovo Dev' should not be available when Rovo Dev is disabled

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 
 import { featureFlagClientInitializedEvent } from './analytics';
 import { AnalyticsClient, analyticsClient } from './analytics-node-client/src/client.min.js';
-import { Product, ProductJira } from './atlclients/authInfo';
+import { isBasicAuthInfo, Product, ProductJira } from './atlclients/authInfo';
 import { CredentialManager } from './atlclients/authStore';
 import { ClientManager } from './atlclients/clientManager';
 import { LoginManager } from './atlclients/loginManager';
@@ -481,6 +481,23 @@ export class Container {
     private static _isRovoDevEnabled: boolean;
     public static get isRovoDevEnabled() {
         return this._isRovoDevEnabled;
+    }
+
+    public static async hasValidRovoDevCredentials(): Promise<boolean> {
+        try {
+            const sites = this._siteManager.getSitesAvailable(ProductJira);
+
+            for (const site of sites) {
+                const authInfo = await this._credentialManager.getAuthInfo(site);
+                if (authInfo && isBasicAuthInfo(authInfo)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } catch {
+            return false;
+        }
     }
 
     private static _version: string;

--- a/src/lib/webview/controller/startwork/startWorkWebviewController.ts
+++ b/src/lib/webview/controller/startwork/startWorkWebviewController.ts
@@ -114,12 +114,14 @@ export class StartWorkWebviewController implements WebviewController<StartWorkIs
             this.logger.debug(`JS-1324 Webview Controller - Repo data Count: ${repoData.length}`);
             this.logger.debug(`JS-1324 ${JSON.stringify(repoData.map((r) => r.workspaceRepo.rootUri))}`);
 
+            const hasValidRovoDevCredentials = await Container.hasValidRovoDevCredentials();
+
             this.postMessage({
                 type: StartWorkMessageType.Init,
                 ...this.initData!,
                 repoData,
                 ...this.api.getStartWorkConfig(),
-                isRovoDevEnabled: Container.isRovoDevEnabled,
+                isRovoDevEnabled: Container.isRovoDevEnabled && hasValidRovoDevCredentials,
             });
         } catch (e) {
             this.logger.error(e, 'Error updating start work page');


### PR DESCRIPTION


### What Is This Change?



### How Has This Been Tested?


Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change