### PR TITLE
AXON-1256: [Start work page] When 'Create branch' is unchecked, the submit button should say 'Start work'

### DIFF
--- a/src/react/atlascode/startwork/v3/StartWorkPageV3.test.tsx
+++ b/src/react/atlascode/startwork/v3/StartWorkPageV3.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import StartWorkPageV3 from './StartWorkPageV3';
+
+jest.mock('../startWorkController', () => ({
+    useStartWorkController: jest.fn(),
+    StartWorkControllerContext: React.createContext({}),
+}));
+
+jest.mock('./hooks/useStartWorkFormState', () => ({
+    useStartWorkFormState: jest.fn(),
+}));
+
+jest.mock('../../common/errorController', () => ({
+    ErrorStateContext: React.createContext({ isErrorBannerOpen: false }),
+    ErrorControllerContext: React.createContext({}),
+}));
+
+jest.mock('src/analyticsTypes', () => ({
+    AnalyticsView: {
+        StartWorkPageV3: 'StartWorkPageV3',
+    },
+}));
+
+jest.mock('../../common/ErrorBoundary', () => ({
+    AtlascodeErrorBoundary: ({ children }: any) => <div data-testid="error-boundary">{children}</div>,
+}));
+
+jest.mock('../../common/ErrorDisplay', () => ({
+    ErrorDisplay: () => <div data-testid="error-display">Error Display</div>,
+}));
+
+// Mock all components used in StartWorkPageV3
+jest.mock('./components', () => ({
+    CreateBranchSection: () => <div data-testid="create-branch-section">Create Branch Section</div>,
+    RovoDevToggle: () => <div data-testid="rovo-dev-toggle">Rovo Dev Toggle</div>,
+    SnackbarNotification: () => <div data-testid="snackbar-notification">Snackbar</div>,
+    SuccessAlert: () => <div data-testid="success-alert">Success Alert</div>,
+    TaskInfoSection: () => <div data-testid="task-info-section">Task Info Section</div>,
+    UpdateStatusSection: () => <div data-testid="update-status-section">Update Status Section</div>,
+}));
+
+const mockController = {
+    postMessage: jest.fn(),
+    refresh: jest.fn(),
+    openLink: jest.fn(),
+    startWork: jest.fn(),
+    closePage: jest.fn(),
+    openJiraIssue: jest.fn(),
+    openSettings: jest.fn(),
+};
+
+const mockState = {
+    issue: {
+        key: 'TEST-123',
+        summary: 'Test Issue',
+        status: {
+            id: '1',
+            name: 'To Do',
+            statusCategory: {
+                key: 'new',
+                colorName: 'blue',
+            },
+        },
+        transitions: [],
+        issuetype: {
+            name: 'Task',
+            iconUrl: 'test-icon.png',
+        },
+    },
+    repoData: [],
+    customTemplate: '{{prefix}}/{{issueKey}}-{{summary}}',
+    customPrefixes: [],
+    isSomethingLoading: false,
+    isRovoDevEnabled: true,
+    rovoDevPreference: false,
+};
+
+describe('StartWorkPageV3', () => {
+    const mockUseStartWorkController = require('../startWorkController').useStartWorkController;
+    const mockUseStartWorkFormState = require('./hooks/useStartWorkFormState').useStartWorkFormState;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockUseStartWorkController.mockReturnValue([mockState, mockController]);
+    });
+
+    it('should display "Create branch" button text when branchSetupEnabled is true', () => {
+        mockUseStartWorkFormState.mockReturnValue({
+            formState: {
+                branchSetupEnabled: true,
+                startWithRovoDev: false,
+            },
+            formActions: {},
+            updateStatusFormState: {},
+            updateStatusFormActions: {},
+            handleCreateBranch: jest.fn(),
+            handleSnackbarClose: jest.fn(),
+            submitState: 'initial',
+            submitResponse: {},
+            snackbarOpen: false,
+        });
+
+        render(<StartWorkPageV3 />);
+
+        const button = screen.getByRole('button', { name: 'Create branch' });
+        expect(button).toBeDefined();
+    });
+
+    it('should display "Start work" button text when branchSetupEnabled is false', () => {
+        mockUseStartWorkFormState.mockReturnValue({
+            formState: {
+                branchSetupEnabled: false,
+                startWithRovoDev: false,
+            },
+            formActions: {},
+            updateStatusFormState: {},
+            updateStatusFormActions: {},
+            handleCreateBranch: jest.fn(),
+            handleSnackbarClose: jest.fn(),
+            submitState: 'initial',
+            submitResponse: {},
+            snackbarOpen: false,
+        });
+
+        render(<StartWorkPageV3 />);
+
+        const button = screen.getByRole('button', { name: 'Start work' });
+        expect(button).toBeDefined();
+    });
+});

--- a/src/react/atlascode/startwork/v3/StartWorkPageV3.tsx
+++ b/src/react/atlascode/startwork/v3/StartWorkPageV3.tsx
@@ -86,7 +86,7 @@ const StartWorkPageV3: React.FunctionComponent = () => {
                                     submitState === 'submitting' ? <CircularProgress color="inherit" size={20} /> : null
                                 }
                             >
-                                Create branch
+                                {formState.branchSetupEnabled ? 'Create branch' : 'Start work'}
                             </Button>
                         </Box>
                     )}


### PR DESCRIPTION
### What Is This Change?

| Checked | Unchecked |
|:--|:--|
| <img width="632" height="903" alt="image" src="https://github.com/user-attachments/assets/2d225ff9-0a66-4677-99c9-a8755298fb01" /> | <img width="628" height="411" alt="image" src="https://github.com/user-attachments/assets/057e357f-75d7-4042-aff1-e78951cb92d2" /> |

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change