### PR TITLE
[AXON-1262] Remove new session button/command in BBY

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
                     "light": "resources/light/add.svg"
                 },
                 "category": "Rovo Dev",
-                "enablement": "atlascode:rovoDevEnabled"
+                "enablement": "atlascode:rovoDevEnabled && !atlascode:bbyEnvironmentActive"
             },
             {
                 "command": "atlascode.rovodev.showTerminal",
@@ -620,7 +620,7 @@
             "view/title": [
                 {
                     "command": "atlascode.rovodev.newChatSession",
-                    "when": "view == atlascode.views.rovoDev.webView",
+                    "when": "view == atlascode.views.rovoDev.webView && !atlascode:bbyEnvironmentActive",
                     "group": "navigation@1"
                 },
                 {
@@ -842,7 +842,7 @@
                 },
                 {
                     "command": "atlascode.rovodev.newChatSession",
-                    "when": "atlascode:rovoDevEnabled"
+                    "when": "atlascode:rovoDevEnabled && !atlascode:bbyEnvironmentActive"
                 },
                 {
                     "command": "atlascode.rovodev.showTerminal",


### PR DESCRIPTION
### What Is This Change?

Remove the `+` button from rovodev tab in BBY

| Normal | BBY (don't mind the port error) |
|----|----|
| <img width="591" height="280" alt="image" src="https://github.com/user-attachments/assets/dcda6677-97dd-4614-b865-300ca241e4e0" /> | <img width="596" height="252" alt="image" src="https://github.com/user-attachments/assets/fac2a49b-9603-4913-a0bb-1adddde73313" />|

### How Has This Been Tested?

Just manually, see image above :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
