### PR TITLE
chore: fix broken loading image in rovodev tab

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -189,6 +189,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             enableCommandUris: true,
             enableScripts: true,
             localResourceRoots: [
+                Uri.file(path.join(this._extensionPath, 'images')),
                 Uri.file(path.join(this._extensionPath, 'build')),
                 Uri.file(path.join(this._extensionPath, 'node_modules', '@vscode', 'codicons', 'dist')),
             ],


### PR DESCRIPTION
### What Is This Change?

| Before | After |
|---|---|
|<img width="547" height="128" alt="image" src="https://github.com/user-attachments/assets/350e1154-5f16-4d64-9733-55e4c2f93896" />|<img width="618" height="613" alt="image" src="https://github.com/user-attachments/assets/d0e9b38c-3c3f-4b12-b4b9-ff474eac1763" />

Turns out we were missing content root for images which is present in all other webviews :)

### How Has This Been Tested?

See images above :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`