### PR TITLE
[AXON-1269] Rovo Dev without open folder shouldn't display the auth screen

### DIFF
--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -345,7 +345,11 @@ export abstract class RovoDevProcessManager {
     }
 
     private static async sendErrorToChat(rovoDevWebViewProvider: RovoDevWebviewProvider, error: Error) {
-        await rovoDevWebViewProvider.signalProcessFailedToInitialize(error.message);
+        if (error instanceof ProcessManagerError && error.type === 'needAuth') {
+            await rovoDevWebViewProvider.signalRovoDevDisabled('NeedAuth');
+        } else {
+            await rovoDevWebViewProvider.signalProcessFailedToInitialize(error.message);
+        }
     }
 }
 


### PR DESCRIPTION
### What Is This Change?

The "Open folder" screen should take priority over the "Add API Token" screen.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`