### PR TITLE
[AXON-1266] Fix dialog message overflow

### DIFF
--- a/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
@@ -59,6 +59,7 @@ export const DialogMessageItem: React.FC<{
                         paddingTop: '2px',
                         paddingLeft: '2px',
                         width: 'calc(100% - 24px)',
+                        overflowWrap: 'break-word',
                     }}
                 >
                     <div style={messageContentStyles}>{title}</div>


### PR DESCRIPTION
### What Is This Change?

Bug:
<img width="499" height="430" alt="image" src="https://github.com/user-attachments/assets/1dd64392-cbba-40d1-a7e5-891357075237" />

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`