### PR TITLE
[AXON-1277] Fix tool permission dialog not disappearing, and update Rovo Dev tool-call interface

### DIFF
--- a/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
@@ -2,6 +2,7 @@ import StatusErrorIcon from '@atlaskit/icon/core/status-error';
 import StatusInfoIcon from '@atlaskit/icon/core/status-information';
 import StatusWarningIcon from '@atlaskit/icon/core/status-warning';
 import React from 'react';
+import { RovoDevToolName } from 'src/rovo-dev/responseParserInterfaces';
 import { ToolPermissionChoice } from 'src/rovo-dev/rovoDevApiClientInterfaces';
 
 import {
@@ -70,7 +71,7 @@ export const DialogMessageItem: React.FC<{
                     </div>
 
                     {msg.type === 'toolPermissionRequest' && (
-                        <ToolCall toolName={msg.toolName} toolArgs={msg.toolArgs} />
+                        <ToolCall toolName={msg.toolName} toolArgs={msg.toolArgs} mcpServer={msg.mcpServer} />
                     )}
 
                     {msg.type === 'error' &&
@@ -152,7 +153,7 @@ const fileListStyles: React.CSSProperties = {
     overflow: 'hidden',
 };
 
-const friendlyToolName: Record<string, string> = {
+const friendlyToolName: Record<RovoDevToolName, string> = {
     create_file: 'Create file',
     delete_file: 'Delete file',
     move_file: 'Move file',
@@ -163,12 +164,14 @@ const friendlyToolName: Record<string, string> = {
     grep: 'Search for',
     bash: 'Run command',
     create_technical_plan: 'Create a technical plan',
+    mcp_invoke_tool: "Invoke an MCP server's tool",
 };
 
 const ToolCall: React.FC<{
-    toolName: string;
+    toolName: RovoDevToolName;
     toolArgs: string;
-}> = ({ toolName, toolArgs }) => {
+    mcpServer?: string;
+}> = ({ toolName, toolArgs, mcpServer }) => {
     const jsonArgs = React.useMemo(() => {
         try {
             return toolArgs ? JSON.parse(toolArgs) : {};
@@ -182,7 +185,7 @@ const ToolCall: React.FC<{
     return (
         <div>
             <div style={{ fontWeight: '600' }}>{toolFriendlyName}</div>
-            <ToolCallBody toolName={toolName} jsonArgs={jsonArgs} toolArgs={toolArgs} />
+            <ToolCallBody toolName={toolName} jsonArgs={jsonArgs} toolArgs={toolArgs} mcpServer={mcpServer} />
         </div>
     );
 };
@@ -191,7 +194,8 @@ const ToolCallBody: React.FC<{
     toolName: string;
     jsonArgs: any;
     toolArgs: string;
-}> = ({ toolName, jsonArgs, toolArgs }) => {
+    mcpServer?: string;
+}> = ({ toolName, jsonArgs, toolArgs, mcpServer }) => {
     if (toolName === 'bash') {
         return (
             <pre style={{ margin: '0' }}>
@@ -202,6 +206,19 @@ const ToolCallBody: React.FC<{
         return <code style={toolCallCodeBlockStyles}>{jsonArgs.content_pattern}</code>;
     } else if (toolName === 'create_technical_plan') {
         return null;
+    } else if (toolName === 'mcp_invoke_tool') {
+        return (
+            <table style={{ border: '0' }}>
+                <tr>
+                    <td style={{ paddingLeft: '8px' }}>Server:</td>
+                    <td style={{ paddingLeft: '8px' }}>{mcpServer}</td>
+                </tr>
+                <tr>
+                    <td style={{ paddingLeft: '8px' }}>Tool:</td>
+                    <td style={{ paddingLeft: '8px' }}>{jsonArgs.tool_name}</td>
+                </tr>
+            </table>
+        );
     } else if (Array.isArray(jsonArgs.file_paths)) {
         return (
             <ul style={fileListStyles}>

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -7,12 +7,12 @@ import { highlightElement } from '@speed-highlight/core';
 import { detectLanguage } from '@speed-highlight/core/detect';
 import { useCallback, useState } from 'react';
 import * as React from 'react';
+import { RovoDevResponse } from 'src/rovo-dev/responseParserInterfaces';
 import { ToolPermissionChoice } from 'src/rovo-dev/rovoDevApiClientInterfaces';
 import { RovoDevContextItem, State } from 'src/rovo-dev/rovoDevTypes';
 import { v4 } from 'uuid';
 
 import { DetailedSiteInfo } from '../../../atlclients/authInfo';
-import { RovoDevResponse } from '../../../rovo-dev/responseParser';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from '../../../rovo-dev/rovoDevWebviewProviderMessages';
 import { createRovoDevTemplate } from '../../../util/rovoDevTemplate';
 import { useMessagingApi } from '../messagingApi';
@@ -231,6 +231,7 @@ const RovoDevView: React.FC = () => {
                     ) {
                         finalizeResponse();
                     }
+                    setModalDialogs([]);
                     break;
 
                 case RovoDevProviderMessageType.ToolCall:

--- a/src/react/atlascode/rovo-dev/tools/ToolCallItem.test.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolCallItem.test.tsx
@@ -14,7 +14,7 @@ function validateMessage(
 
 describe('ToolCallItem', () => {
     it('invalid tool call message is empty', () => {
-        const toolMessage = parseToolCallMessage('');
+        const toolMessage = parseToolCallMessage('' as any);
         expect(toolMessage).toBe('');
     });
 
@@ -91,7 +91,7 @@ describe('ToolCallItem', () => {
     });
 
     it('renders the tool name for unknown tools', () => {
-        const toolMessage = parseToolCallMessage('unknown_tool');
+        const toolMessage = parseToolCallMessage('unknown_tool' as any);
         const { getByText } = render(
             <ToolCallItem toolMessage={toolMessage} currentState={{ state: 'WaitingForPrompt' }} />,
         );

--- a/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { RovoDevToolName } from 'src/rovo-dev/responseParserInterfaces';
 import { InitializingDownladingState, InitializingState, State } from 'src/rovo-dev/rovoDevTypes';
 
 export const ToolCallItem: React.FC<{
@@ -29,12 +30,12 @@ export const ToolCallItem: React.FC<{
     );
 };
 
-export function parseToolCallMessage(msgToolName: string): string {
+export function parseToolCallMessage(msgToolName: RovoDevToolName): string {
+    if (!msgToolName) {
+        return '';
+    }
+
     switch (msgToolName) {
-        case '':
-        case null:
-        case undefined:
-            return '';
         case 'create_file':
             return 'Creating file';
         case 'delete_file':
@@ -55,8 +56,11 @@ export function parseToolCallMessage(msgToolName: string): string {
             return `Executing bash command`;
         case 'create_technical_plan':
             return 'Creating technical plan';
+        case 'mcp_invoke_tool':
+            return "Invoking MCP server's tool";
         default:
-            return msgToolName;
+            // @ts-expect-error ts(2339) - msgToolName here should be 'never'
+            return msgToolName.toString();
     }
 }
 

--- a/src/react/atlascode/rovo-dev/utils.test.tsx
+++ b/src/react/atlascode/rovo-dev/utils.test.tsx
@@ -48,7 +48,7 @@ describe('appendResponse', () => {
 
     it('should group ToolReturn with previous message when groupable', () => {
         const prev: Response[] = [
-            { tool_name: 'test', source: 'ToolReturn', content: 'prev result', args: 'args', tool_call_id: 'id' },
+            { tool_name: 'grep', source: 'ToolReturn', content: 'prev result', args: 'args', tool_call_id: 'id' },
         ];
         const response: ToolReturnGenericMessage = {
             tool_name: 'bash',
@@ -144,8 +144,8 @@ describe('appendResponse', () => {
 
     it('should merge with existing thinking group', () => {
         const existingGroup: ChatMessage[] = [
-            { tool_name: 'tool1', source: 'ToolReturn', content: 'result', tool_call_id: 'id1' },
-            { tool_name: 'tool1', source: 'ToolReturn', content: 'result1', tool_call_id: 'id1' },
+            { tool_name: 'grep', source: 'ToolReturn', content: 'result', tool_call_id: 'id1' },
+            { tool_name: 'grep', source: 'ToolReturn', content: 'result1', tool_call_id: 'id1' },
         ];
         const prev: Response[] = [existingGroup];
         const response: ToolReturnGenericMessage = {
@@ -194,8 +194,8 @@ describe('appendResponse', () => {
     it('should handle array response when latest exists', () => {
         const prev: Response[] = [{ text: 'previous', source: 'User' }];
         const response: ChatMessage[] = [
-            { tool_name: 'tool1', source: 'ToolCall', args: 'args1', tool_call_id: 'id1' },
-            { tool_name: 'tool1', source: 'ToolReturn', content: 'result1', tool_call_id: 'id1' },
+            { tool_name: 'grep', source: 'ToolCall', args: 'args1', tool_call_id: 'id1' },
+            { tool_name: 'grep', source: 'ToolReturn', content: 'result1', tool_call_id: 'id1' },
         ] as const;
 
         const result = appendResponse(

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -1,3 +1,5 @@
+import { RovoDevToolName } from 'src/rovo-dev/responseParserInterfaces';
+
 import { RovoDevContextItem, TechnicalPlan } from '../../../../src/rovo-dev/rovoDevTypes';
 
 export type ToolReturnMessage =
@@ -35,8 +37,9 @@ export interface WarningInfoDialogMessage extends AbstractDialogMessage {
 
 export interface ToolPermissionDialogMessage extends AbstractDialogMessage {
     type: 'toolPermissionRequest';
-    toolName: string;
+    toolName: RovoDevToolName;
     toolArgs: string;
+    mcpServer?: string;
     toolCallId: string;
 }
 
@@ -83,7 +86,7 @@ export interface ToolReturnTechnicalPlanMessage {
 }
 
 export interface ToolReturnGenericMessage {
-    tool_name: string;
+    tool_name: RovoDevToolName;
     source: 'ToolReturn' | 'ModifiedFile' | 'RovoDevRetry';
     content: string;
     parsedContent?: object | undefined;

--- a/src/rovo-dev/responseParser.test.ts
+++ b/src/rovo-dev/responseParser.test.ts
@@ -1,4 +1,5 @@
-import { RovoDevResponse, RovoDevResponseParser } from './responseParser';
+import { RovoDevResponseParser } from './responseParser';
+import { RovoDevResponse } from './responseParserInterfaces';
 
 describe('RovoDevResponseParser', () => {
     let parser: RovoDevResponseParser;
@@ -132,8 +133,9 @@ describe('RovoDevResponseParser', () => {
                 expect(results).toHaveLength(1);
                 expect(results[0]).toEqual({
                     event_kind: 'tool-call',
-                    tool_name: '',
+                    tool_name: undefined,
                     args: '',
+                    mcp_server: undefined,
                     tool_call_id: 'call_123',
                 });
             });
@@ -235,7 +237,7 @@ describe('RovoDevResponseParser', () => {
                 expect(results[0]).toEqual({
                     event_kind: 'retry-prompt',
                     content: '',
-                    tool_name: '',
+                    tool_name: undefined,
                     tool_call_id: 'call_123',
                     timestamp: '2025-07-02T12:00:00Z',
                 });

--- a/src/rovo-dev/responseParserInterfaces.ts
+++ b/src/rovo-dev/responseParserInterfaces.ts
@@ -1,0 +1,98 @@
+// abstracted responses' interfaces
+
+export interface RovoDevUserPromptResponse {
+    event_kind: 'user-prompt';
+    content: string;
+    timestamp: string;
+}
+
+export interface RovoDevTextResponse {
+    event_kind: 'text';
+    index: number;
+    content: string;
+}
+
+export interface RovoDevToolCallResponse {
+    event_kind: 'tool-call';
+    tool_name: RovoDevToolName;
+    args: string;
+    /** sets when the tool is being exposed by an MCP server */
+    mcp_server?: string;
+    tool_call_id: string;
+}
+
+export interface RovoDevToolReturnResponse {
+    event_kind: 'tool-return';
+    tool_name: RovoDevToolName;
+    content?: string;
+    parsedContent?: object;
+    tool_call_id: string;
+    timestamp: string;
+    toolCallMessage: RovoDevToolCallResponse;
+}
+
+export interface RovoDevRetryPromptResponse {
+    event_kind: 'retry-prompt';
+    content: string;
+    tool_name: RovoDevToolName;
+    tool_call_id: string;
+    timestamp: string;
+}
+
+export interface RovoDevExceptionResponse {
+    event_kind: 'exception';
+    message: string;
+    title?: string;
+    type: string;
+}
+
+export interface RovoDevWarningResponse {
+    event_kind: 'warning';
+    message: string;
+    title?: string;
+}
+
+export interface RovoDevClearResponse {
+    event_kind: 'clear';
+    message: string;
+}
+
+export interface RovoDevPruneResponse {
+    event_kind: 'prune';
+    message: string;
+}
+
+export interface RovoDevOnCallToolStartResponse {
+    event_kind: 'on_call_tools_start';
+    tools: RovoDevToolCallResponse[];
+}
+
+export interface RovoDevCloseResponse {
+    event_kind: 'close';
+}
+
+export type RovoDevResponse =
+    | RovoDevUserPromptResponse
+    | RovoDevTextResponse
+    | RovoDevToolCallResponse
+    | RovoDevToolReturnResponse
+    | RovoDevRetryPromptResponse
+    | RovoDevExceptionResponse
+    | RovoDevWarningResponse
+    | RovoDevClearResponse
+    | RovoDevPruneResponse
+    | RovoDevOnCallToolStartResponse
+    | RovoDevCloseResponse;
+
+export type RovoDevToolName =
+    | 'create_file'
+    | 'delete_file'
+    | 'move_file'
+    | 'find_and_replace_code'
+    | 'open_files'
+    | 'expand_code_chunks'
+    | 'expand_folder'
+    | 'grep'
+    | 'bash'
+    | 'create_technical_plan'
+    | 'mcp_invoke_tool';

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -3,7 +3,8 @@ import { RovoDevViewResponse } from 'src/react/atlascode/rovo-dev/rovoDevViewMes
 import { v4 } from 'uuid';
 import { Event, Webview } from 'vscode';
 
-import { RovoDevResponse, RovoDevResponseParser } from './responseParser';
+import { RovoDevResponseParser } from './responseParser';
+import { RovoDevResponse } from './responseParserInterfaces';
 import { RovoDevApiClient } from './rovoDevApiClient';
 import {
     RovoDevChatRequest,
@@ -396,6 +397,7 @@ export class RovoDevChatProvider {
                                 source: 'RovoDevDialog',
                                 toolName: tool.tool_name,
                                 toolArgs: tool.args,
+                                mcpServer: tool.mcp_server,
                                 text: 'To do this I will need to',
                                 toolCallId: tool.tool_call_id,
                             },

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -3,7 +3,7 @@ import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 
 import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { DialogMessage } from '../react/atlascode/rovo-dev/utils';
-import { RovoDevResponse } from './responseParser';
+import { RovoDevResponse } from './responseParserInterfaces';
 import { EntitlementCheckRovoDevHealthcheckResponse } from './rovoDevApiClientInterfaces';
 import { DisabledState, RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
 


### PR DESCRIPTION
### What Is This Change?

The new tool call interface includes the `mcp_server` field when the tool is invoked from an MCP server.

Rovo Dev also introduced a new tool call named `mcp_invoke_tool` which represent the invocation of a tool from an MCP server:
<img width="400" height="769" alt="image" src="https://github.com/user-attachments/assets/9a9261ec-b746-457e-ad6a-0b3241675f61" />

This change also fixes the issue:
[AXON-1277] Update Rovo Dev tool-call interface, and small refactoring

This change also refactors the parser interfaces into their own file, and creates the `RovoDevToolName` type enumerating all possible tool call names.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`

[AXON-1277]: https://softwareteams.atlassian.net/browse/AXON-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ