### PR TITLE
AXON-1274: [Start Work Page] Align blocks in Update Status section

### DIFF
--- a/src/react/atlascode/startwork/v3/components/UpdateStatusSection.tsx
+++ b/src/react/atlascode/startwork/v3/components/UpdateStatusSection.tsx
@@ -76,9 +76,11 @@ export const UpdateStatusSection: React.FC<UpdateStatusSectionProps> = ({
                             {state.issue.status.name}
                         </Lozenge>
                     </Grid>
-                    <Box display="flex" alignItems="center">
-                        <ArrowRightAltIcon />
-                    </Box>
+                    <Grid item>
+                        <Box display="flex" alignItems="center">
+                            <ArrowRightAltIcon />
+                        </Box>
+                    </Grid>
                     <Grid item>
                         <Box minWidth={150}>
                             <TextField


### PR DESCRIPTION
### What Is This Change?

| Before | After |
|:--|:--|
| <img width="287" height="151" alt="image" src="https://github.com/user-attachments/assets/eaf5036a-9715-4ab1-9452-1801ff101179" /> | <img width="277" height="142" alt="image" src="https://github.com/user-attachments/assets/204d6741-f56a-4ea2-8d2d-b3c9355af341" /> |

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change