### PR TITLE
AXON-1253: [Start Work Page] New state should default to "In progress"

### DIFF
--- a/src/react/atlascode/startwork/v3/components/UpdateStatusSection.test.tsx
+++ b/src/react/atlascode/startwork/v3/components/UpdateStatusSection.test.tsx
@@ -1,3 +1,4 @@
+import { emptyTransition } from '@atlassianlabs/jira-pi-common-models';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -173,5 +174,52 @@ describe('UpdateStatusSection', () => {
         expect(screen.getByText('To Do')).toBeDefined();
         expect(screen.getByRole('checkbox')).toBeDefined();
         expect(screen.getByRole('combobox')).toBeDefined();
+    });
+
+    it('should select transition with "progress" in name as default', () => {
+        const mockStateWithProgress = {
+            ...mockState,
+            issue: {
+                ...mockState.issue,
+                transitions: [
+                    {
+                        id: 'transition-1',
+                        name: 'Start Progress',
+                        to: {
+                            id: '2',
+                            name: 'In Progress',
+                            statusCategory: { key: 'indeterminate', colorName: 'yellow' },
+                        },
+                        isInitial: false,
+                    },
+                    {
+                        id: 'transition-2',
+                        name: 'Skip to Done',
+                        to: { id: '3', name: 'Done', statusCategory: { key: 'done', colorName: 'green' } },
+                        isInitial: false,
+                    },
+                ],
+            },
+        };
+
+        const mockFormStateWithEmptyTransition = {
+            ...mockFormState,
+            selectedTransition: emptyTransition,
+        };
+
+        render(
+            <UpdateStatusSection
+                {...mockProps}
+                state={mockStateWithProgress}
+                formState={mockFormStateWithEmptyTransition}
+            />,
+        );
+
+        expect(mockFormActions.onSelectedTransitionChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 'transition-1',
+                to: expect.objectContaining({ name: 'In Progress' }),
+            }),
+        );
     });
 });

--- a/src/react/atlascode/startwork/v3/components/UpdateStatusSection.tsx
+++ b/src/react/atlascode/startwork/v3/components/UpdateStatusSection.tsx
@@ -1,5 +1,5 @@
 import Lozenge from '@atlaskit/lozenge';
-import { emptyTransition } from '@atlassianlabs/jira-pi-common-models';
+import { emptyTransition, Transition } from '@atlassianlabs/jira-pi-common-models';
 import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt';
 import { Box, Checkbox, FormControlLabel, Grid, MenuItem, TextField, Typography } from '@mui/material';
 import React, { useCallback, useEffect } from 'react';
@@ -33,7 +33,7 @@ export const UpdateStatusSection: React.FC<UpdateStatusSectionProps> = ({
             // 2. Fallback to first non-initial transition (works for any workflow)
             // 3. Fallback to first available transition (guarantees something is selected)
             // 4. Final fallback to emptyTransition
-            const inProgressTransitionGuess =
+            const inProgressTransitionGuess: Transition =
                 availableTransitions.find((t) => !t.isInitial && t.to.name.toLowerCase().includes('progress')) ||
                 availableTransitions.find((t) => !t.isInitial) ||
                 availableTransitions[0] ||

--- a/src/react/atlascode/startwork/v3/components/UpdateStatusSection.tsx
+++ b/src/react/atlascode/startwork/v3/components/UpdateStatusSection.tsx
@@ -1,5 +1,5 @@
 import Lozenge from '@atlaskit/lozenge';
-import { emptyTransition, Transition } from '@atlassianlabs/jira-pi-common-models';
+import { emptyTransition } from '@atlassianlabs/jira-pi-common-models';
 import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt';
 import { Box, Checkbox, FormControlLabel, Grid, MenuItem, TextField, Typography } from '@mui/material';
 import React, { useCallback, useEffect } from 'react';
@@ -16,18 +16,6 @@ export const UpdateStatusSection: React.FC<UpdateStatusSectionProps> = ({
     const { transitionIssueEnabled, selectedTransition } = formState;
     const { onTransitionIssueEnabledChange, onSelectedTransitionChange } = formActions;
 
-    useEffect(() => {
-        const availableTransitions = state.issue.transitions.filter((t) => t.to.id !== state.issue.status.id);
-
-        const inProgressTransitionGuess: Transition =
-            availableTransitions.find((t) => !t.isInitial && t.to.name.toLocaleLowerCase().includes('progress')) ||
-            availableTransitions.find((t) => !t.isInitial) ||
-            availableTransitions[0] ||
-            emptyTransition;
-
-        onSelectedTransitionChange(inProgressTransitionGuess);
-    }, [state.issue, onSelectedTransitionChange]);
-
     const availableTransitions = state.issue.transitions.filter(
         (transition) => transition.to.id !== state.issue.status.id,
     );
@@ -35,8 +23,23 @@ export const UpdateStatusSection: React.FC<UpdateStatusSectionProps> = ({
     const isValidSelectedTransition = availableTransitions.some((t) => t.id === selectedTransition.id);
 
     useEffect(() => {
-        if (!isValidSelectedTransition && availableTransitions.length > 0) {
-            onSelectedTransitionChange(availableTransitions[0]);
+        if (availableTransitions.length === 0) {
+            return;
+        }
+
+        if (!isValidSelectedTransition) {
+            // Use the same logic as the previous version of the start work page:
+            // 1. Try to find a transition with "progress" in the name (covers most cases)
+            // 2. Fallback to first non-initial transition (works for any workflow)
+            // 3. Fallback to first available transition (guarantees something is selected)
+            // 4. Final fallback to emptyTransition
+            const inProgressTransitionGuess =
+                availableTransitions.find((t) => !t.isInitial && t.to.name.toLowerCase().includes('progress')) ||
+                availableTransitions.find((t) => !t.isInitial) ||
+                availableTransitions[0] ||
+                emptyTransition;
+
+            onSelectedTransitionChange(inProgressTransitionGuess);
         }
     }, [availableTransitions, isValidSelectedTransition, onSelectedTransitionChange]);
 


### PR DESCRIPTION
### What Is This Change?

It seems that it was just a conflict between two `useEffects`.

| Before | After |
|:--|:--|
| <img width="242" height="107" alt="image" src="https://github.com/user-attachments/assets/3995c99b-2121-400c-9db5-53f3d8c040f7" /> | https://www.loom.com/share/62d38eee2b3d402189f645337bd72885 |

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change