### PR TITLE
[AXON-830] Add feedback collection from issue suggestions

### DIFF
--- a/src/commands/jira/issueSuggestionManager.ts
+++ b/src/commands/jira/issueSuggestionManager.ts
@@ -1,5 +1,6 @@
 import { DetailedSiteInfo, ProductJira } from 'src/atlclients/authInfo';
 import { Container } from 'src/container';
+import { AxonFeedbackSubmitter } from 'src/feedback/JSDSubmitter';
 import { Logger } from 'src/logger';
 import { Uri, window, workspace } from 'vscode';
 
@@ -89,7 +90,11 @@ export class IssueSuggestionManager {
             : this.generateDummyIssueSuggestion(data);
     }
 
-    async sendFeedback(isPositive: boolean, data: SimplifiedTodoIssueData) {
+    async sendFeedback(
+        isPositive: boolean,
+        data: SimplifiedTodoIssueData,
+        feedbackData?: { description: string; contactMe: boolean },
+    ) {
         const feedback = isPositive
             ? `Positive feedback for issue suggestion: ${data.summary}`
             : `Negative feedback for issue suggestion: ${data.summary}`;
@@ -99,6 +104,14 @@ export class IssueSuggestionManager {
                 feature: 'issueSuggestions',
                 feedbackType: isPositive ? 'positive' : 'negative',
             });
+            if (feedbackData) {
+                await AxonFeedbackSubmitter.send({
+                    feature: 'issueSuggestions',
+                    description: feedbackData.description,
+                    canContact: feedbackData.contactMe,
+                    email: (await getUserEmail()) ?? 'placeholder@email.com',
+                });
+            }
             window.showInformationMessage(`Thank you for your feedback!`);
         } catch (error) {
             Logger.error(error, 'Error sending feedback');
@@ -152,4 +165,14 @@ async function getSuggestionAvailable(): Promise<boolean> {
     }
 
     return (await Container.credentialManager.findApiTokenForSite(selectedSite)) !== undefined;
+}
+
+async function getUserEmail(): Promise<string | undefined> {
+    const selectedSite = getSelectedSite();
+    if (!selectedSite) {
+        return undefined;
+    }
+
+    const client = await Container.credentialManager.getAuthInfo(selectedSite);
+    return client?.user.email;
 }

--- a/src/feedback/JSDSubmitter.ts
+++ b/src/feedback/JSDSubmitter.ts
@@ -1,0 +1,110 @@
+import truncate from 'lodash.truncate';
+import { version } from 'vscode';
+
+import { ProductBitbucket, ProductJira } from '../atlclients/authInfo';
+import { Container } from '../container';
+import { getAgent, getAxiosInstance } from '../jira/jira-client/providers';
+
+type FeatureFeedbackData = {
+    description: string;
+    feature: string;
+    email: string;
+};
+
+type FeedbackPayload = {
+    summary?: string;
+    context?: string;
+};
+
+class JSDSubmitter<FeedbackData extends FeatureFeedbackData, FullPayload = FeedbackData & FeedbackPayload> {
+    private readonly widgetId: string;
+    private readonly requestTypeId: number;
+    private readonly fieldMapper: Record<keyof FullPayload, string>;
+    private readonly valueMapper?: Partial<Record<keyof FullPayload, (value: FullPayload[keyof FullPayload]) => any>>;
+
+    constructor({
+        widgetId,
+        requestTypeId,
+        fieldMapper: fieldMappings,
+        valueMapper,
+    }: {
+        widgetId: string;
+        requestTypeId: number;
+        fieldMapper: Record<keyof FullPayload, string>;
+        valueMapper: Partial<Record<keyof FullPayload, (value: any) => any>>;
+    }) {
+        this.widgetId = widgetId;
+        this.requestTypeId = requestTypeId;
+        this.fieldMapper = fieldMappings as Record<keyof FullPayload, string>;
+        this.valueMapper = valueMapper;
+    }
+
+    public get url(): string {
+        return `https://jsd-widget.atlassian.com/api/embeddable/${this.widgetId}/request?requestTypeId=${this.requestTypeId}`;
+    }
+
+    async send(feedback: FeedbackData) {
+        const fullFeedback = {
+            summary: `[${feedback.feature}] ${truncate(feedback.description.trim().split('\n', 1)[0])}`,
+            context: JSON.stringify(this.buildContext(), undefined, 4),
+            ...feedback,
+        };
+
+        const payload = {
+            fields: Object.entries(fullFeedback).map(([key, value]) => {
+                const mapper = (this.valueMapper && this.valueMapper[key as keyof FullPayload]) ?? ((v) => v);
+                return {
+                    id: this.fieldMapper[key as keyof FullPayload],
+                    value: mapper(value as any),
+                };
+            }),
+        };
+
+        const transport = getAxiosInstance();
+
+        await transport(this.url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            data: JSON.stringify(payload),
+            ...getAgent(),
+        });
+    }
+
+    buildContext() {
+        return {
+            extensionVersion: Container.version,
+            vscodeVersion: version,
+            platform: process.platform,
+            jiraCloud: Container.siteManager.getSitesAvailable(ProductJira).find((site) => site.isCloud) !== undefined,
+            jiraServer:
+                Container.siteManager.getSitesAvailable(ProductJira).find((site) => !site.isCloud) !== undefined,
+            bitbucketCloud:
+                Container.siteManager.getSitesAvailable(ProductBitbucket).find((site) => site.isCloud) !== undefined,
+            bitbucketServer:
+                Container.siteManager.getSitesAvailable(ProductBitbucket).find((site) => !site.isCloud) !== undefined,
+        };
+    }
+}
+
+export const AxonFeedbackSubmitter = new JSDSubmitter<{
+    description: string;
+    feature: string;
+    email: string;
+    canContact: boolean;
+}>({
+    widgetId: 'd76bb212-7451-4a04-8644-19fa2aec2181',
+    requestTypeId: 11826,
+    fieldMapper: {
+        description: 'description',
+        summary: 'summary',
+        email: 'email',
+        canContact: 'customfield_11560',
+        feature: 'customfield_11529',
+        context: 'customfield_11528',
+    },
+    valueMapper: {
+        canContact: (value: boolean) => (value ? { id: '11709' } : { id: '11710' }),
+    },
+});

--- a/src/ipc/issueActions.ts
+++ b/src/ipc/issueActions.ts
@@ -184,6 +184,10 @@ export interface AiSuggeestionFeedbackAction extends Action {
     action: 'aiSuggestionFeedback';
     isPositive: boolean;
     todoData: SimplifiedTodoIssueData;
+    feedbackData?: {
+        description: string;
+        contactMe: boolean;
+    };
 }
 
 export function isGetImage(a: Action): a is GetImageAction {

--- a/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
@@ -1,12 +1,19 @@
 import 'src/react/atlascode/rovo-dev/RovoDev.css';
 
+import { Checkbox } from '@atlaskit/checkbox';
 import { HelperMessage } from '@atlaskit/form';
 import StatusInformationIcon from '@atlaskit/icon/core/status-information';
 import ThumbsDownIcon from '@atlaskit/icon/core/thumbs-down';
 import ThumbsUpIcon from '@atlaskit/icon/core/thumbs-up';
+import TextArea from '@atlaskit/textarea';
 import Tooltip from '@atlaskit/tooltip';
 import React, { useState } from 'react';
 import { SimplifiedTodoIssueData } from 'src/config/model';
+
+type FeedbackData = {
+    description: string;
+    contactMe: boolean;
+};
 
 const AISuggestionFooter: React.FC<{
     vscodeApi: any;
@@ -14,6 +21,7 @@ const AISuggestionFooter: React.FC<{
     const [isAvailable, setIsAvailable] = useState(false);
     const [isEnabled, setIsEnabled] = useState(false);
     const [todoData, setTodoData] = useState<SimplifiedTodoIssueData | null>(null);
+    const [showFeedbackOverlay, setShowFeedbackOverlay] = useState(false);
 
     window.addEventListener('message', (event) => {
         const message = event.data;
@@ -24,17 +32,28 @@ const AISuggestionFooter: React.FC<{
         }
     });
 
-    const handleFeedback = (isPositive: boolean) => {
+    const handleFeedback = (isPositive: boolean, feedbackData?: FeedbackData) => {
         vscodeApi.postMessage({
             action: 'aiSuggestionFeedback',
             isPositive,
             todoData,
+            feedbackData,
         });
     };
 
     return (
         (isAvailable && isEnabled && (
             <div style={{ marginTop: '12px' }}>
+                {showFeedbackOverlay && (
+                    <FeedbackOverlay
+                        message="Please provide feedback to improve Rovo Dev work item generation"
+                        onSubmit={(fd) => {
+                            setShowFeedbackOverlay(false);
+                            handleFeedback(false, fd);
+                        }}
+                        onCancel={() => setShowFeedbackOverlay(false)}
+                    />
+                )}
                 <HelperMessage>
                     <span style={{ display: 'flex', alignItems: 'center' }}>
                         <span style={{ marginLeft: '6px', marginRight: '6px' }}>
@@ -71,7 +90,9 @@ const AISuggestionFooter: React.FC<{
                         </Tooltip>
                         <Tooltip content="Unhelpful">
                             <button
-                                onClick={() => handleFeedback(false)}
+                                onClick={() => {
+                                    setShowFeedbackOverlay(true);
+                                }}
                                 type="button"
                                 aria-label="dislike-response-button"
                                 className="chat-message-action"
@@ -84,6 +105,162 @@ const AISuggestionFooter: React.FC<{
             </div>
         )) ||
         null
+    );
+};
+
+/**
+ * Largely auto-generated feedback form. Not an actual <Form> to avoid nesting.
+ * Not reusing rovodev styles here since they are pretty different from the CreateIssuePage
+ */
+const FeedbackOverlay: React.FC<{
+    message: string;
+    onSubmit: (fd: FeedbackData) => void;
+    onCancel: () => void;
+}> = ({ message, onSubmit, onCancel }) => {
+    const [description, setDescription] = useState('');
+    const [contactMe, setContactMe] = useState(false);
+
+    const handleSubmit = (e: React.FormEvent) => {
+        const data = { description: description.trim(), contactMe };
+
+        // Handle form submission - send feedback data
+        console.log('Feedback submitted:', data);
+        onSubmit(data);
+    };
+    return (
+        <div
+            style={{
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                zIndex: 1000,
+            }}
+            onClick={() => onCancel()}
+        >
+            <div
+                style={{
+                    backgroundColor: 'var(--vscode-editor-background)',
+                    color: 'var(--vscode-editor-foreground)',
+                    padding: '24px',
+                    borderRadius: '8px',
+                    maxWidth: '500px',
+                    width: '90%',
+                    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+                    border: '1px solid var(--vscode-panel-border)',
+                }}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <h3
+                    style={{
+                        marginTop: 0,
+                        marginBottom: '16px',
+                        color: 'var(--vscode-editor-foreground)',
+                    }}
+                >
+                    Provide Feedback
+                </h3>
+                <p
+                    style={{
+                        marginBottom: '20px',
+                        color: 'var(--vscode-descriptionForeground)',
+                    }}
+                >
+                    {message}
+                </p>
+
+                <div>
+                    <div style={{ marginBottom: '16px' }}>
+                        <label
+                            style={{
+                                display: 'block',
+                                marginBottom: '8px',
+                                color: 'var(--vscode-editor-foreground)',
+                                fontSize: '13px',
+                                fontWeight: '500',
+                            }}
+                        >
+                            What went wrong? How can we improve? *
+                        </label>
+                        <TextArea
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder="Please describe the issue or suggestion for improvement..."
+                            minimumRows={4}
+                            resize="auto"
+                        />
+                    </div>
+
+                    <div style={{ marginBottom: '20px' }}>
+                        <Checkbox
+                            isChecked={contactMe}
+                            onChange={(e: any) => setContactMe(e.currentTarget.checked)}
+                            label="I'd like to be contacted about this feedback"
+                        />
+                    </div>
+
+                    <div
+                        style={{
+                            display: 'flex',
+                            justifyContent: 'flex-end',
+                            gap: '8px',
+                            paddingTop: '16px',
+                            borderTop: '1px solid var(--vscode-panel-border)',
+                        }}
+                    >
+                        <button
+                            type="button"
+                            onClick={onCancel}
+                            style={{
+                                backgroundColor: 'transparent',
+                                color: 'var(--vscode-button-secondaryForeground)',
+                                border: '1px solid var(--vscode-button-secondaryBorder)',
+                                borderRadius: '4px',
+                                padding: '8px 16px',
+                                cursor: 'pointer',
+                                fontSize: '13px',
+                                fontFamily: 'inherit',
+                            }}
+                            onMouseEnter={(e) => {
+                                e.currentTarget.style.backgroundColor = 'var(--vscode-button-secondaryHoverBackground)';
+                            }}
+                            onMouseLeave={(e) => {
+                                e.currentTarget.style.backgroundColor = 'transparent';
+                            }}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleSubmit}
+                            style={{
+                                backgroundColor: 'var(--vscode-button-background)',
+                                color: 'var(--vscode-button-foreground)',
+                                border: 'none',
+                                borderRadius: '4px',
+                                padding: '8px 16px',
+                                cursor: 'pointer',
+                                fontSize: '13px',
+                                fontFamily: 'inherit',
+                            }}
+                            onMouseEnter={(e) => {
+                                e.currentTarget.style.backgroundColor = 'var(--vscode-button-hoverBackground)';
+                            }}
+                            onMouseLeave={(e) => {
+                                e.currentTarget.style.backgroundColor = 'var(--vscode-button-background)';
+                            }}
+                        >
+                            Submit Feedback
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
     );
 };
 

--- a/src/webviews/createIssueWebview.ts
+++ b/src/webviews/createIssueWebview.ts
@@ -859,10 +859,10 @@ export class CreateIssueWebview
                 case 'aiSuggestionFeedback': {
                     handled = true;
                     if (isAiSuggestionFeedback(msg)) {
-                        const { isPositive, todoData } = msg;
+                        const { isPositive, todoData, feedbackData } = msg;
 
                         const suggestionManager = new IssueSuggestionManager(this._issueSuggestionSettings!);
-                        suggestionManager.sendFeedback(isPositive, todoData);
+                        suggestionManager.sendFeedback(isPositive, todoData, feedbackData);
                     }
                     break;
                 }


### PR DESCRIPTION
### What Is This Change?

* Implement a somewhat generic JSD sender for feeature feedback that works with a new queue
<img width="515" height="135" alt="image" src="https://github.com/user-attachments/assets/be32dbba-c496-4f54-8afb-12704e53c4d5" />

* Add feedback form to the create issue page, in line with Slack design
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/49bf6441-f1e4-415f-822b-2de7c676d590" />

Coming in a follow-up:
 * some rewords
 * hiding the thumbs buttons after feedback is sent
 * using an actual queue instead of a test one (only requires some ID chages)

### How Has This Been Tested?

See images above :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`