### PR TITLE
feat: add in-place feedback acknowledgement

### DIFF
--- a/src/commands/jira/issueSuggestionManager.ts
+++ b/src/commands/jira/issueSuggestionManager.ts
@@ -112,10 +112,8 @@ export class IssueSuggestionManager {
                     email: (await getUserEmail()) ?? 'placeholder@email.com',
                 });
             }
-            window.showInformationMessage(`Thank you for your feedback!`);
         } catch (error) {
             Logger.error(error, 'Error sending feedback');
-            window.showErrorMessage('Error sending feedback: ' + error.message);
         }
     }
 }

--- a/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
@@ -22,6 +22,7 @@ const AISuggestionFooter: React.FC<{
     const [isEnabled, setIsEnabled] = useState(false);
     const [todoData, setTodoData] = useState<SimplifiedTodoIssueData | null>(null);
     const [showFeedbackOverlay, setShowFeedbackOverlay] = useState(false);
+    const [feedbackSent, setFeedbackSent] = useState(false);
 
     window.addEventListener('message', (event) => {
         const message = event.data;
@@ -39,6 +40,7 @@ const AISuggestionFooter: React.FC<{
             todoData,
             feedbackData,
         });
+        setFeedbackSent(true);
     };
 
     return (
@@ -75,7 +77,11 @@ const AISuggestionFooter: React.FC<{
                         minWidth: '100%',
                     }}
                 >
-                    <HelperMessage> Please provide feedback to improve Rovo Dev work item generation</HelperMessage>
+                    <HelperMessage style={{ marginTop: '10px' }}>
+                        {feedbackSent
+                            ? 'Thank you for your feedback! Your input helps us improve Rovo Dev.'
+                            : 'Please provide feedback to improve Rovo Dev work item generation'}
+                    </HelperMessage>
                     <div className="chat-message-actions" style={{ display: 'flex', gap: '2px', marginTop: '10px' }}>
                         <div style={{ flex: 1 }}></div>
                         <Tooltip content="Helpful">
@@ -84,6 +90,7 @@ const AISuggestionFooter: React.FC<{
                                 type="button"
                                 aria-label="like-response-button"
                                 className="chat-message-action"
+                                style={{ visibility: feedbackSent ? 'hidden' : 'visible' }}
                             >
                                 <ThumbsUpIcon label="thumbs-up" spacing="none" />
                             </button>
@@ -96,6 +103,7 @@ const AISuggestionFooter: React.FC<{
                                 type="button"
                                 aria-label="dislike-response-button"
                                 className="chat-message-action"
+                                style={{ visibility: feedbackSent ? 'hidden' : 'visible' }}
                             >
                                 <ThumbsDownIcon label="thumbs-down" spacing="none" />
                             </button>


### PR DESCRIPTION
### What Is This Change?

We now have an in-place acknowlegement when users submit feedback:
<img width="715" height="442" alt="image" src="https://github.com/user-attachments/assets/ce30e21a-ec87-4095-9c15-b80536d41fff" />

### How Has This Been Tested?

By sending a bunch of feedback :D

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`