### PR TITLE
[AXON-1292] Gracefully handle parsing errors, and hide certain errors from the user

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -440,7 +440,7 @@ export class Container {
             } catch {}
         }
 
-        return this._isDebugging;
+        return !!this._isDebugging;
     }
 
     // Container for all rovodev components that might get toggled by feature flags

--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -21,6 +21,10 @@ body {
     max-width: 800px;
 }
 
+.rovoDevChat:not(.debugEnabled) .debugOnly {
+    display: none !important;
+}
+
 #rovoDevLogo > path {
     fill: #6A9A23;
 }

--- a/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
@@ -48,7 +48,7 @@ export const DialogMessageItem: React.FC<{
         }
     }, [msg.type, msg.title]);
 
-    const showInDebugOnly = React.useMemo(() => msg.type === 'error' && msg.showInDebugOnly, [msg]);
+    const showInDebugOnly = React.useMemo(() => msg.type === 'error' && msg.showOnlyInDebug, [msg]);
 
     return (
         <div className={showInDebugOnly ? 'debugOnly' : ''} style={{ ...chatMessageStyles, ...errorMessageStyles }}>

--- a/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
@@ -48,8 +48,10 @@ export const DialogMessageItem: React.FC<{
         }
     }, [msg.type, msg.title]);
 
+    const showInDebugOnly = React.useMemo(() => msg.type === 'error' && msg.showInDebugOnly, [msg]);
+
     return (
-        <div style={{ ...chatMessageStyles, ...errorMessageStyles }}>
+        <div className={showInDebugOnly ? 'debugOnly' : ''} style={{ ...chatMessageStyles, ...errorMessageStyles }}>
             <div style={{ display: 'flex', flexDirection: 'row' }}>
                 {icon}
                 <div

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -690,7 +690,7 @@ const RovoDevView: React.FC = () => {
         (currentState.state === 'Initializing' && currentState.subState === 'MCPAcceptance');
 
     return (
-        <div className="rovoDevChat">
+        <div className={debugPanelEnabled ? 'rovoDevChat debugEnabled' : 'rovoDevChat'}>
             {debugPanelEnabled && (
                 <DebugPanel
                     currentState={currentState}

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -28,7 +28,7 @@ export interface ErrorDialogMessage extends AbstractDialogMessage {
     type: 'error';
     isRetriable?: boolean;
     isProcessTerminated?: boolean;
-    showInDebugOnly?: boolean;
+    showOnlyInDebug?: boolean;
     uid: string;
 }
 

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -28,6 +28,7 @@ export interface ErrorDialogMessage extends AbstractDialogMessage {
     type: 'error';
     isRetriable?: boolean;
     isProcessTerminated?: boolean;
+    showInDebugOnly?: boolean;
     uid: string;
 }
 

--- a/src/rovo-dev/responseParserInterfaces.ts
+++ b/src/rovo-dev/responseParserInterfaces.ts
@@ -1,5 +1,10 @@
 // abstracted responses' interfaces
 
+export interface RovoDevParsingError {
+    event_kind: '_parsing_error';
+    error: Error;
+}
+
 export interface RovoDevUserPromptResponse {
     event_kind: 'user-prompt';
     content: string;
@@ -72,6 +77,7 @@ export interface RovoDevCloseResponse {
 }
 
 export type RovoDevResponse =
+    | RovoDevParsingError
     | RovoDevUserPromptResponse
     | RovoDevTextResponse
     | RovoDevToolCallResponse

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -342,7 +342,7 @@ export class RovoDevChatProvider {
                 return Promise.resolve(false);
 
             case '_parsing_error':
-                return this.processError(response.error, { showInDebugOnly: !this.isDebugging });
+                return this.processError(response.error, { showOnlyInDebug: true });
 
             case 'exception':
                 const msg = response.title ? `${response.title} - ${response.message}` : response.message;
@@ -472,10 +472,15 @@ export class RovoDevChatProvider {
         {
             isRetriable,
             isProcessTerminated,
-            showInDebugOnly,
-        }: { isRetriable?: boolean; isProcessTerminated?: boolean; showInDebugOnly?: boolean } = {},
+            showOnlyInDebug,
+        }: { isRetriable?: boolean; isProcessTerminated?: boolean; showOnlyInDebug?: boolean } = {},
     ) {
         RovoDevLogger.error(error);
+
+        if (this.isDebugging) {
+            // since we are running in debug mode, make this always visible
+            showOnlyInDebug = false;
+        }
 
         const webview = this._webView!;
         await webview.postMessage({
@@ -486,7 +491,7 @@ export class RovoDevChatProvider {
                 source: 'RovoDevDialog',
                 isRetriable,
                 isProcessTerminated,
-                showInDebugOnly,
+                showOnlyInDebug,
                 uid: v4(),
             },
         });

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -1,3 +1,4 @@
+import { Container } from 'src/container';
 import { RovoDevLogger } from 'src/logger';
 import { RovoDevViewResponse } from 'src/react/atlascode/rovo-dev/rovoDevViewMessages';
 import { v4 } from 'uuid';
@@ -23,6 +24,8 @@ interface TypedWebview<MessageOut, MessageIn> extends Webview {
 type StreamingApi = 'chat' | 'replay';
 
 export class RovoDevChatProvider {
+    private readonly isDebugging = Container.isDebugging;
+
     private _pendingToolConfirmation: Record<string, ToolPermissionChoice | 'undecided'> = {};
     private _pendingToolConfirmationLeft = 0;
     private _pendingPrompt: RovoDevPrompt | undefined;
@@ -189,7 +192,7 @@ export class RovoDevChatProvider {
                 const cancelResponse = await this._rovoDevApiClient.cancel();
                 success = cancelResponse.cancelled || cancelResponse.message === 'No chat in progress';
             } catch {
-                await this.processError(new Error('Failed to cancel the current response. Please try again.'), false);
+                await this.processError(new Error('Failed to cancel the current response. Please try again.'));
                 success = false;
             }
 
@@ -338,9 +341,12 @@ export class RovoDevChatProvider {
                 }
                 return Promise.resolve(false);
 
+            case '_parsing_error':
+                return this.processError(response.error, { showInDebugOnly: !this.isDebugging });
+
             case 'exception':
                 const msg = response.title ? `${response.title} - ${response.message}` : response.message;
-                return this.processError(new Error(msg), false);
+                return this.processError(new Error(msg));
 
             case 'warning':
                 return webview.postMessage({
@@ -448,10 +454,10 @@ export class RovoDevChatProvider {
                 await func(this._rovoDevApiClient);
             } catch (error) {
                 // the error is retriable only when it happens during the streaming of a 'chat' response
-                await this.processError(error, sourceApi === 'chat');
+                await this.processError(error, { isRetriable: sourceApi === 'chat' });
             }
         } else {
-            await this.processError(new Error('RovoDev client not initialized'), false);
+            await this.processError(new Error('RovoDev client not initialized'));
         }
 
         // whatever happens, at the end of the streaming API we need to tell the webview
@@ -461,11 +467,18 @@ export class RovoDevChatProvider {
         });
     }
 
-    private processError(error: Error, isRetriable: boolean, isProcessTerminated?: boolean) {
+    private async processError(
+        error: Error,
+        {
+            isRetriable,
+            isProcessTerminated,
+            showInDebugOnly,
+        }: { isRetriable?: boolean; isProcessTerminated?: boolean; showInDebugOnly?: boolean } = {},
+    ) {
         RovoDevLogger.error(error);
 
         const webview = this._webView!;
-        return webview.postMessage({
+        await webview.postMessage({
             type: RovoDevProviderMessageType.ShowDialog,
             message: {
                 type: 'error',
@@ -473,6 +486,7 @@ export class RovoDevChatProvider {
                 source: 'RovoDevDialog',
                 isRetriable,
                 isProcessTerminated,
+                showInDebugOnly,
                 uid: v4(),
             },
         });


### PR DESCRIPTION
### What Is This Change?

In case of parsing errors, we should not stop processing the returned stream.
Errors are going to be returned as a new type of messages, and handled appropriately.

Also, errors can now specify if they should be visible in debug mode only.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`