### PR TITLE
chore: switch to a new feature flag for issue suggestions

### DIFF
--- a/src/util/features.ts
+++ b/src/util/features.ts
@@ -4,7 +4,7 @@ export enum Features {
     StartWorkV3 = 'atlascode-start-work-v3',
     RovoDevEnabled = 'rovo_dev_ff',
     UseNewAuthFlow = 'atlascode-use-new-auth-flow',
-    EnableAiSuggestions = 'atlascode-enable-ai-suggestions',
+    EnableAiSuggestions = 'atlascode-enable-ai-suggestions-new',
     AtlaskitEditor = 'atlascode-use-new-atlaskit-editor',
 }
 


### PR DESCRIPTION
### What Is This Change?

This changes the issue suggestions feature flag to a new one, to prevent the old UI from rolling with the older versions when we toggle the feature. No material change otherwise, the flag configuration is identical

### How Has This Been Tested?

Manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`