### PR TITLE
[AXON-1299, AXON-1300] Design alignment for Rovo Dev dialogs

### DIFF
--- a/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
@@ -95,7 +95,7 @@ export const DialogMessageItem: React.FC<{
                                 justifyContent: 'flex-end',
                                 width: '100%',
                                 marginTop: '8px',
-                                gap: '4px',
+                                gap: '8px',
                             }}
                         >
                             <button

--- a/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
@@ -66,11 +66,14 @@ export const DialogMessageItem: React.FC<{
                     }}
                 >
                     <div style={messageContentStyles}>{title}</div>
-                    <div style={messageContentStyles}>
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                            <MarkedDown value={msg.text} />
+
+                    {msg.text && (
+                        <div style={messageContentStyles}>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                                <MarkedDown value={msg.text} />
+                            </div>
                         </div>
-                    </div>
+                    )}
 
                     {msg.type === 'toolPermissionRequest' && (
                         <ToolCall toolName={msg.toolName} toolArgs={msg.toolArgs} mcpServer={msg.mcpServer} />

--- a/src/react/atlascode/rovo-dev/landing-page/disabled-messages/DisabledMessage.tsx
+++ b/src/react/atlascode/rovo-dev/landing-page/disabled-messages/DisabledMessage.tsx
@@ -3,7 +3,7 @@ import { State } from 'src/rovo-dev/rovoDevTypes';
 
 import { DialogMessageItem } from '../../common/DialogMessage';
 import { McpConsentChoice } from '../../rovoDevViewMessages';
-import { inChatButtonStyles } from '../../rovoDevViewStyles';
+import { inChatButtonStyles, inChatSecondaryButtonStyles } from '../../rovoDevViewStyles';
 
 const messageOuterStyles: React.CSSProperties = {
     marginTop: '24px',
@@ -69,14 +69,22 @@ export const DisabledMessage: React.FC<{
                     {currentState.mcpIds.map((serverName) => (
                         <tr>
                             <td style={{ width: '100%' }}>{serverName}</td>
-                            <td>
+                            <td
+                                style={{
+                                    display: 'flex',
+                                    justifyContent: 'flex-end',
+                                    width: '100%',
+                                    gap: '8px',
+                                }}
+                            >
+                                <button
+                                    style={inChatSecondaryButtonStyles}
+                                    onClick={() => onMcpChoice('deny', serverName)}
+                                >
+                                    Deny
+                                </button>
                                 <button style={inChatButtonStyles} onClick={() => onMcpChoice('accept', serverName)}>
                                     Allow
-                                </button>
-                            </td>
-                            <td>
-                                <button style={inChatButtonStyles} onClick={() => onMcpChoice('deny', serverName)}>
-                                    Deny
                                 </button>
                             </td>
                         </tr>

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -395,7 +395,7 @@ export class RovoDevChatProvider {
                                 toolName: tool.tool_name,
                                 toolArgs: tool.args,
                                 mcpServer: tool.mcp_server,
-                                text: 'To do this I will need to',
+                                text: '',
                                 toolCallId: tool.tool_call_id,
                             },
                         });


### PR DESCRIPTION
### What Is This Change?

| Before | After |
|-----|-----|
| <img width="359" height="219" alt="image" src="https://github.com/user-attachments/assets/52e0c9f1-1592-4d2b-a044-58ab8c8a8754" /> | <img width="372" height="221" alt="image" src="https://github.com/user-attachments/assets/582a8735-b1fa-433e-a668-34d8243fca1c" /> |
| <img width="375" height="204" alt="image" src="https://github.com/user-attachments/assets/3160d1af-4398-4117-b98c-d3822ad1ba2d" /> | <img width="375" height="178" alt="image" src="https://github.com/user-attachments/assets/a7f8874f-c8aa-4caa-9c04-565dc01ce984" /> |

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`