### PR TITLE
[AXON-1301] retain API token credentials through OAuth

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -570,6 +570,10 @@ export async function apiTokenNudgeClickedEvent(source: string): Promise<TrackEv
     return trackEvent('clicked', 'apiTokenNudge', { attributes: { source } });
 }
 
+export async function apiTokenRetainedEvent() {
+    return trackEvent('retained', 'apiToken');
+}
+
 export async function quickFlowEvent(event: QuickFlowAnalyticsEvent): Promise<TrackEvent> {
     return trackEvent('statusUpdated', 'quickFlow', { attributes: { ...event } });
 }

--- a/src/atlclients/loginManager.ts
+++ b/src/atlclients/loginManager.ts
@@ -130,7 +130,7 @@ export class LoginManager {
             const sitesToAdd = promises.filter((p) => p !== undefined) as DetailedSiteInfo[];
 
             // Add all sites at once to prevent race condition
-            this._siteManager.addSites(sitesToAdd);
+            await this._siteManager.addSites(sitesToAdd);
 
             this.fireExplicitSiteChangeEvent(sitesToAdd);
         } catch (e) {
@@ -331,7 +331,7 @@ export class LoginManager {
 
         await this._credentialManager.saveAuthInfo(siteDetails, credentials);
 
-        this._siteManager.addOrUpdateSite(siteDetails);
+        await this._siteManager.addOrUpdateSite(siteDetails);
 
         return siteDetails;
     }

--- a/src/atlclients/loginManager.ts
+++ b/src/atlclients/loginManager.ts
@@ -103,19 +103,36 @@ export class LoginManager {
                 resp.accessibleResources,
             );
 
-            await Promise.all(
+            const promises = await Promise.all(
                 siteDetails.map(async (siteInfo) => {
+                    // If an API token is already provided for the site, retain it
+                    const tokenAuthInfo = await this._credentialManager.getApiTokenIfExists(siteInfo);
+                    if (
+                        tokenAuthInfo &&
+                        tokenAuthInfo.state === AuthInfoState.Valid &&
+                        tokenAuthInfo.username === oauthInfo.user.email
+                    ) {
+                        // Discard the incoming OAuth info since token is preferred
+                        Logger.debug(`Retaining existing API token for ${siteInfo.host}`);
+                        Container.analyticsApi.fireApiTokenRetainedEvent();
+                        return undefined;
+                    }
+
                     await this._credentialManager.saveAuthInfo(siteInfo, oauthInfo);
                     authenticatedEvent(siteInfo, isOnboarding, source).then((e) => {
                         this._analyticsClient.sendTrackEvent(e);
                     });
+
+                    return siteInfo;
                 }),
             );
 
-            // Add all sites at once to prevent race condition
-            this._siteManager.addSites(siteDetails);
+            const sitesToAdd = promises.filter((p) => p !== undefined) as DetailedSiteInfo[];
 
-            this.fireExplicitSiteChangeEvent(siteDetails);
+            // Add all sites at once to prevent race condition
+            this._siteManager.addSites(sitesToAdd);
+
+            this.fireExplicitSiteChangeEvent(sitesToAdd);
         } catch (e) {
             Logger.error(e, `Error authenticating with provider '${provider}'`);
             vscode.window.showErrorMessage(`There was an error authenticating with provider '${provider}': ${e}`);

--- a/src/lib/analyticsApi.ts
+++ b/src/lib/analyticsApi.ts
@@ -65,4 +65,6 @@ export interface AnalyticsApi {
     fireIssueSuggestionGeneratedEvent(): Promise<void>;
     fireIssueSuggestionFailedEvent(attributes: { error: string }): Promise<void>;
     fireIssueSuggestionSettingsChangeEvent(newSettings: IssueSuggestionSettings): Promise<void>;
+
+    fireApiTokenRetainedEvent(): Promise<void>;
 }

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -88,17 +88,28 @@ export class SiteManager extends Disposable {
         this._onDidSitesAvailableChange.dispose();
     }
 
-    public addOrUpdateSite(newSite: DetailedSiteInfo) {
+    public async addOrUpdateSite(newSite: DetailedSiteInfo) {
         const allSites = this.readSitesFromGlobalStore(newSite.product.key);
         const oldSite = allSites?.find((site) => site.id === newSite.id && site.userId === newSite.userId);
         if (oldSite) {
             this.updateSite(oldSite, newSite);
         } else {
-            this.addSites([newSite]);
+            await this.addSites([newSite]);
         }
     }
 
-    public addSites(newSites: DetailedSiteInfo[]) {
+    async getSitesWithApiToken() {
+        const promises = await Promise.all(
+            this.getSitesAvailable(ProductJira).map(async (site) => ({
+                token: await Container.credentialManager.getApiTokenIfExists(site),
+                site: site,
+            })),
+        );
+
+        return promises.filter((s) => s.token !== undefined).map((s) => s.site);
+    }
+
+    public async addSites(newSites: DetailedSiteInfo[]) {
         if (newSites.length === 0) {
             return;
         }
@@ -107,14 +118,10 @@ export class SiteManager extends Disposable {
         let notify = true;
         let allSites = this.readSitesFromGlobalStore(productKey);
 
-        // Generally, we overwrite credential IDs on cloud sites to prevent
+        // Generally, we overwrite credentialId on cloud sites to prevent
         // several instances of OAuth credentials from existing at once.
         // However, we must NOT mix cloud API token credentials with OAuth credentials
-        const cloudCredentialIdsToKeep = new Set(
-            this.getSitesAvailable(ProductJira)
-                .filter((site) => Container.credentialManager.getApiTokenIfExists(site))
-                .map((s) => s.credentialId),
-        );
+        const cloudCredentialIdsToKeep = new Set((await this.getSitesWithApiToken()).map((s) => s.credentialId));
 
         if (allSites) {
             // Ensure all cloud sites use the per account credential ID

--- a/src/vscAnalyticsApi.ts
+++ b/src/vscAnalyticsApi.ts
@@ -1,5 +1,6 @@
 import {
     apiTokenNudgeClickedEvent,
+    apiTokenRetainedEvent,
     authenticateButtonEvent,
     authenticatedEvent,
     bbIssuesPaginationEvent,
@@ -374,6 +375,11 @@ export class VSCAnalyticsApi implements AnalyticsApi {
 
     async fireApiTokenNudgeClickedEvent({ source }: { source: string }) {
         const event = await apiTokenNudgeClickedEvent(source);
+        this._analyticsClient.sendTrackEvent(event);
+    }
+
+    async fireApiTokenRetainedEvent() {
+        const event = await apiTokenRetainedEvent();
         this._analyticsClient.sendTrackEvent(event);
     }
 }


### PR DESCRIPTION
### What Is This Change?

Up until now, we've been overwriting API tokens when logging in with OAuth. Our new way of doing things suggests that API token credential is actually preferred, so this change changes the logic so that the API token is retained, instead

Changes:
 * Exclude sites which are already using an API token from OAuth response
 * Fix the logic where we merge all cloud sites after OAuth login to exclude sites with API tokens
 * Add analytics

### How Has This Been Tested?

Manually - please see #axon for the demos

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`