### PR TITLE
AXON-1263 Design nits for the rovodev chat

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -536,7 +536,7 @@ body {
     display: block;
     overflow-y: auto;
     max-height: 100px;
-    padding: 4px 8px;
+    padding: 4px 0px;
     border-top: 1px solid var(--vscode-panel-border);
 }
 .modified-file-item {
@@ -545,7 +545,7 @@ body {
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
-    padding: 2px 8px;
+    padding: 2px 12px;
     width: 100%;
 }
 
@@ -626,6 +626,8 @@ body {
     gap: 8px;
     padding-top: 8px;
     border: solid 1px var(--vscode-dropdown-border);
+    border-left: none;
+    border-right: none;
     border-bottom: none;
     margin-bottom: -16px;
     padding-bottom: 16px;
@@ -638,7 +640,7 @@ body {
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    padding: 0 8px;
+    padding: 0 12px;
 }
 
 .updated-files-header div {
@@ -658,7 +660,7 @@ body {
     background-color: inherit;
     border: none;
     border-radius: 4px;
-    padding: 2px 6px;
+    padding: 2px 12px;
 }
 
 #bordered-button {
@@ -696,8 +698,12 @@ body {
 .input-section-container {
     width: 100%;
     background-color: var(--vscode-sideBar-background);
-    padding: 8px 16px 6px 16px;
+    padding: 8px 0px 6px 0px;
     border-radius: 12px 12px 0 0;
+}
+
+.prompt-container-container {
+    padding: 0px 16px;
 }
 
 .prompt-container {

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -739,44 +739,46 @@ const RovoDevView: React.FC = () => {
                         workspacePath={workspacePath}
                         homeDir={homeDir}
                     />
-                    <div className="prompt-container">
-                        <PromptContextCollection
-                            content={promptContextCollection}
-                            readonly={false}
-                            onRemoveContext={(item: RovoDevContextItem) => {
-                                setPromptContextCollection((prev) => {
-                                    return [...prev.filter((x) => x.file.absolutePath !== item.file.absolutePath)];
-                                });
-                            }}
-                            onToggleActiveItem={(enabled) => {
-                                setPromptContextCollection((prev) => {
-                                    const idx = prev.findIndex((x) => x.isFocus);
-                                    if (idx < 0) {
-                                        return prev;
-                                    } else {
-                                        prev[idx].enabled = enabled;
-                                        return [...prev];
-                                    }
-                                });
-                            }}
-                            openFile={openFile}
-                        />
-                        <PromptInputBox
-                            disabled={currentState.state === 'ProcessTerminated'}
-                            currentState={currentState}
-                            isDeepPlanEnabled={isDeepPlanToggled}
-                            isYoloModeEnabled={isYoloModeToggled}
-                            onDeepPlanToggled={() => setIsDeepPlanToggled((prev) => !prev)}
-                            onYoloModeToggled={IsBoysenberry ? undefined : () => onYoloModeToggled()}
-                            onSend={sendPrompt}
-                            onCancel={cancelResponse}
-                            onAddContext={onAddContext}
-                            onCopy={handleCopyResponse}
-                            handleMemoryCommand={executeGetAgentMemory}
-                            handleTriggerFeedbackCommand={handleShowFeedbackForm}
-                            promptText={promptText}
-                            onPromptTextSet={handlePromptTextSet}
-                        />
+                    <div className="prompt-container-container">
+                        <div className="prompt-container">
+                            <PromptContextCollection
+                                content={promptContextCollection}
+                                readonly={false}
+                                onRemoveContext={(item: RovoDevContextItem) => {
+                                    setPromptContextCollection((prev) => {
+                                        return [...prev.filter((x) => x.file.absolutePath !== item.file.absolutePath)];
+                                    });
+                                }}
+                                onToggleActiveItem={(enabled) => {
+                                    setPromptContextCollection((prev) => {
+                                        const idx = prev.findIndex((x) => x.isFocus);
+                                        if (idx < 0) {
+                                            return prev;
+                                        } else {
+                                            prev[idx].enabled = enabled;
+                                            return [...prev];
+                                        }
+                                    });
+                                }}
+                                openFile={openFile}
+                            />
+                            <PromptInputBox
+                                disabled={currentState.state === 'ProcessTerminated'}
+                                currentState={currentState}
+                                isDeepPlanEnabled={isDeepPlanToggled}
+                                isYoloModeEnabled={isYoloModeToggled}
+                                onDeepPlanToggled={() => setIsDeepPlanToggled((prev) => !prev)}
+                                onYoloModeToggled={IsBoysenberry ? undefined : () => onYoloModeToggled()}
+                                onSend={sendPrompt}
+                                onCancel={cancelResponse}
+                                onAddContext={onAddContext}
+                                onCopy={handleCopyResponse}
+                                handleMemoryCommand={executeGetAgentMemory}
+                                handleTriggerFeedbackCommand={handleShowFeedbackForm}
+                                promptText={promptText}
+                                onPromptTextSet={handlePromptTextSet}
+                            />
+                        </div>
                     </div>
                     <div className="ai-disclaimer">Uses AI. Verify results.</div>
                 </div>

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -309,7 +309,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         break;
 
                     case RovoDevViewResponseType.CheckGitChanges:
-                        const isClean = await this._prHandler!.isGitStateClean();
+                        const isClean = await this._prHandler?.isGitStateClean();
                         await webview.postMessage({
                             type: RovoDevProviderMessageType.CheckGitChangesComplete,
                             hasChanges: !isClean,
@@ -829,11 +829,14 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     }
 
     private async createPR(commitMessage?: string, branchName?: string): Promise<void> {
-        const prHandler = this._prHandler!;
+        const prHandler = this._prHandler;
 
         let prLink: string | undefined;
         const webview = this._webView!;
         try {
+            if (!prHandler) {
+                throw new Error('Pull Request handler not initialized');
+            }
             if (!commitMessage || !branchName) {
                 throw new Error('Commit message and branch name are required to create a PR');
             }
@@ -863,10 +866,16 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     }
 
     private async getCurrentBranchName(): Promise<void> {
-        const webview = this._webView!;
-        const prHandler = this._prHandler!;
+        const webview = this._webView;
+        const prHandler = this._prHandler;
 
         try {
+            if (!prHandler) {
+                throw new Error('Pull Request handler not initialized');
+            }
+            if (!webview) {
+                throw new Error('Webview not initialized');
+            }
             const branchName = await prHandler.getCurrentBranchName();
             await webview.postMessage({
                 type: RovoDevProviderMessageType.GetCurrentBranchNameComplete,


### PR DESCRIPTION
### What Is This Change?

Some design tweaks for the rovodev chat section.
- Align "X updated files" header vertically with the filenames
- Increase padding on "keep" / "undo" buttons
- Make the "files drawer" section full width of the chat window

I also fixed a bug where the prHandler was not initialized somehow, and it caused an infinite loop of errors. No idea how to reproduce but I've added a sanity check to throw an error instead of looping hopefully.

<img width="516" height="489" alt="Screenshot 2025-10-03 at 10 46 16 AM" src="https://github.com/user-attachments/assets/552c241d-fa0e-4d78-b4f2-faeb689dd4e5" />
<img width="497" height="716" alt="Screenshot 2025-10-03 at 10 31 58 AM" src="https://github.com/user-attachments/assets/37b5084a-d665-456b-beb4-af7db8c129db" />


### How Has This Been Tested?

Tested locally

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change