### PR TITLE
AXON-1258: [Start Work page] Properly reset branch prefix

### DIFF
--- a/src/react/atlascode/startwork/v3/components/BranchPrefixSelector.test.tsx
+++ b/src/react/atlascode/startwork/v3/components/BranchPrefixSelector.test.tsx
@@ -53,4 +53,35 @@ describe('BranchPrefixSelector', () => {
 
         expect(screen.getByText('Branch prefix')).toBeTruthy();
     });
+
+    it('should render with custom prefixes when no branch types', () => {
+        const repoWithoutBranchTypes = {
+            ...mockRepoData,
+            branchTypes: [],
+        };
+
+        render(
+            <BranchPrefixSelector
+                selectedRepository={repoWithoutBranchTypes}
+                selectedBranchType={{ kind: 'hotfix', prefix: 'hotfix/' }}
+                customPrefixes={['hotfix', 'chore']}
+                onBranchTypeChange={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Branch prefix')).toBeTruthy();
+    });
+
+    it('should render with both branch types and custom prefixes', () => {
+        render(
+            <BranchPrefixSelector
+                selectedRepository={mockRepoData}
+                selectedBranchType={{ kind: 'Feature', prefix: 'feature/' }}
+                customPrefixes={['hotfix', 'chore']}
+                onBranchTypeChange={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Branch prefix')).toBeTruthy();
+    });
 });

--- a/src/react/atlascode/startwork/v3/hooks/useStartWorkFormState.test.tsx
+++ b/src/react/atlascode/startwork/v3/hooks/useStartWorkFormState.test.tsx
@@ -1,0 +1,159 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { RepoData } from '../../../../../lib/ipc/toUI/startWork';
+import { useStartWorkFormState } from './useStartWorkFormState';
+
+// Mock dependencies
+jest.mock('../../../common/errorController', () => ({
+    ErrorControllerContext: {
+        Provider: ({ children }: any) => children,
+    },
+}));
+
+jest.mock('../../startWorkController', () => ({
+    useStartWorkController: jest.fn(),
+}));
+
+jest.mock('../utils/branchUtils', () => ({
+    getDefaultSourceBranch: jest.fn().mockReturnValue({ type: 0, name: 'main' }),
+    generateBranchName: jest.fn().mockReturnValue('generated-branch-name'),
+}));
+
+const mockGenerateBranchName = require('../utils/branchUtils').generateBranchName;
+
+describe('useStartWorkFormState', () => {
+    const mockController = {
+        postMessage: jest.fn(),
+        startWork: jest.fn(),
+    } as any;
+
+    const mockBitbucketRepo: RepoData = {
+        workspaceRepo: {
+            rootUri: '/test/bitbucket-repo',
+            mainSiteRemote: { site: undefined, remote: { name: 'origin', isReadOnly: false } },
+            siteRemotes: [],
+        },
+        localBranches: [],
+        remoteBranches: [],
+        branchTypes: [
+            { kind: 'Feature', prefix: 'feature/' },
+            { kind: 'Bugfix', prefix: 'bugfix/' },
+        ],
+        developmentBranch: 'main',
+        userName: 'test',
+        userEmail: 'test@example.com',
+        isCloud: false,
+    };
+
+    const mockGitHubRepo: RepoData = {
+        workspaceRepo: {
+            rootUri: '/test/github-repo',
+            mainSiteRemote: { site: undefined, remote: { name: 'origin', isReadOnly: false } },
+            siteRemotes: [],
+        },
+        localBranches: [],
+        remoteBranches: [],
+        branchTypes: [], // No branch types for GitHub
+        developmentBranch: 'main',
+        userName: 'test',
+        userEmail: 'test@example.com',
+        isCloud: false,
+    };
+
+    const mockState = {
+        repoData: [mockBitbucketRepo, mockGitHubRepo],
+        customPrefixes: [],
+        customTemplate: '{{prefix}}/{{issueKey}}-{{summary}}',
+        issue: { key: 'TEST-123', summary: 'Test issue' } as any,
+        rovoDevPreference: false,
+        isSomethingLoading: false,
+        isRovoDevEnabled: false,
+    } as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGenerateBranchName.mockReturnValue('generated-branch-name');
+    });
+
+    describe('handleRepositoryChange', () => {
+        it('should reset selectedBranchType to first branchType when switching to Bitbucket repo', () => {
+            const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
+
+            act(() => {
+                result.current.formActions.onRepositoryChange(mockBitbucketRepo);
+            });
+
+            expect(result.current.formState.selectedBranchType).toEqual({
+                kind: 'Feature',
+                prefix: 'feature/',
+            });
+        });
+
+        it('should reset selectedBranchType to empty when switching to non-Bitbucket repo without custom prefixes', () => {
+            const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
+
+            act(() => {
+                result.current.formActions.onRepositoryChange(mockGitHubRepo);
+            });
+
+            expect(result.current.formState.selectedBranchType).toEqual({
+                kind: '',
+                prefix: '',
+            });
+        });
+
+        it('should reset selectedBranchType to first custom prefix when switching to non-Bitbucket repo with custom prefixes', () => {
+            const stateWithCustomPrefixes = {
+                ...mockState,
+                customPrefixes: ['hotfix', 'chore'],
+            };
+
+            const { result } = renderHook(() => useStartWorkFormState(stateWithCustomPrefixes, mockController));
+
+            act(() => {
+                result.current.formActions.onRepositoryChange(mockGitHubRepo);
+            });
+
+            expect(result.current.formState.selectedBranchType).toEqual({
+                kind: 'hotfix',
+                prefix: 'hotfix/',
+            });
+        });
+    });
+
+    describe('branch name generation', () => {
+        it('should generate branch name with prefix when selectedBranchType has prefix', () => {
+            mockGenerateBranchName.mockReturnValue('feature/TEST-123-test-issue');
+
+            const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
+
+            act(() => {
+                result.current.formActions.onRepositoryChange(mockBitbucketRepo);
+            });
+
+            expect(mockGenerateBranchName).toHaveBeenCalledWith(
+                mockBitbucketRepo,
+                { kind: 'Feature', prefix: 'feature/' },
+                mockState.issue,
+                mockState.customTemplate,
+            );
+        });
+
+        it('should generate branch name without prefix when selectedBranchType has no prefix', () => {
+            mockGenerateBranchName.mockReturnValue('TEST-123-test-issue');
+
+            const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
+
+            act(() => {
+                result.current.formActions.onRepositoryChange(mockGitHubRepo);
+            });
+
+            expect(mockGenerateBranchName).toHaveBeenCalledWith(
+                mockGitHubRepo,
+                { kind: '', prefix: '' },
+                mockState.issue,
+                '{{issueKey}}-{{summary}}', // Template without prefix
+            );
+        });
+    });
+});

--- a/src/react/atlascode/startwork/v3/utils/branchUtils.test.ts
+++ b/src/react/atlascode/startwork/v3/utils/branchUtils.test.ts
@@ -135,5 +135,24 @@ describe('branchUtils', () => {
             const result = generateBranchName(mockRepo, mockBranchType, mockIssue, invalidTemplate);
             expect(result).toBe('Invalid template: please follow the format described above');
         });
+
+        it('should generate branch name without prefix when prefix is empty', () => {
+            mockMustacheRender.mockReturnValue('TEST-123-Test-issue-summary');
+            const emptyBranchType = {
+                kind: '',
+                prefix: '',
+            };
+            const templateWithoutPrefix = '{{issueKey}}-{{summary}}';
+            const result = generateBranchName(mockRepo, emptyBranchType, mockIssue, templateWithoutPrefix);
+            expect(mockMustacheRender).toHaveBeenCalledWith(
+                templateWithoutPrefix,
+                expect.objectContaining({
+                    prefix: '',
+                    issueKey: 'TEST-123',
+                    summary: 'test-issue-summary',
+                }),
+            );
+            expect(result).toBe('TEST-123-Test-issue-summary');
+        });
     });
 });


### PR DESCRIPTION
### What Is This Change?

I’ve fixed the field behavior: if a user has at least one custom prefix, they see the prefix field with a custom prefix selected by default (non-Bitbucket repo). If they have no custom prefixes and no branching model (as with non-Bitbucket repositories), the prefix field is hidden as unnecessary. In any case, the user can still type any prefix manually if they wish

| Before | After (with custom prefixes) | After (without custom prefixes) |
|:--|:--|:--|
| <img width="602" height="206" alt="image" src="https://github.com/user-attachments/assets/4819f2d9-9843-4a05-9e8f-428382381588" /> | <img width="353" height="279" alt="image" src="https://github.com/user-attachments/assets/756a0c1f-a010-4d1b-9403-b3fbddecc5ba" /> | <img width="355" height="212" alt="image" src="https://github.com/user-attachments/assets/b78cec27-3b23-4944-931d-11436f2bb1aa" /> |

Demo: https://www.loom.com/share/81bf6b0292294a84a2a0b9b2d201e65d

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change