### PR TITLE
[AXON-1310] Fix broken thinking block when parsing errors occur

### DIFF
--- a/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
@@ -48,10 +48,8 @@ export const DialogMessageItem: React.FC<{
         }
     }, [msg.type, msg.title]);
 
-    const showInDebugOnly = React.useMemo(() => msg.type === 'error' && msg.showOnlyInDebug, [msg]);
-
     return (
-        <div className={showInDebugOnly ? 'debugOnly' : ''} style={{ ...chatMessageStyles, ...errorMessageStyles }}>
+        <div style={{ ...chatMessageStyles, ...errorMessageStyles }}>
             <div style={{ display: 'flex', flexDirection: 'row' }}>
                 {icon}
                 <div

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -28,7 +28,6 @@ export interface ErrorDialogMessage extends AbstractDialogMessage {
     type: 'error';
     isRetriable?: boolean;
     isProcessTerminated?: boolean;
-    showOnlyInDebug?: boolean;
     uid: string;
 }
 


### PR DESCRIPTION
### What Is This Change?

Caused by #1086.

When non debugging, parsing errors were still rendered but hidden, causing the thinking block to split up.
Fix is to not render them at all.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`