### PR TITLE
[AXON-1313] Fix 'fetch error' right after denying an MCP server terms

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -641,6 +641,27 @@ const RovoDevView: React.FC = () => {
 
     const onMcpChoice = useCallback(
         (choice: McpConsentChoice, serverName?: string) => {
+            // removes the server name dialog, in case Rovo Dev is too slow responding back
+            setCurrentState((prev) => {
+                if (prev.state !== 'Initializing' || prev.subState !== 'MCPAcceptance') {
+                    return prev;
+                }
+
+                const otherIdsToAccept = prev.mcpIds.filter((x) => x !== serverName);
+                return otherIdsToAccept.length > 0
+                    ? {
+                          state: 'Initializing',
+                          subState: 'MCPAcceptance',
+                          mcpIds: otherIdsToAccept,
+                          isPromptPending: prev.isPromptPending,
+                      }
+                    : {
+                          state: 'Initializing',
+                          subState: 'Other',
+                          isPromptPending: prev.isPromptPending,
+                      };
+            });
+
             postMessage({
                 type: RovoDevViewResponseType.McpConsentChoiceSubmit,
                 choice,

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -1079,7 +1079,10 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         this._rovoDevApiClient = rovoDevApiClient;
 
         const result = await safeWaitFor({
-            condition: (info) => !!info && info.status !== 'unknown',
+            condition: (info) =>
+                !!info &&
+                info.status !== 'unknown' &&
+                (info.status !== 'healthy' || info.mcp_servers?.['filesystem-tools'] === 'started'),
             check: () => this.executeHealthcheckInfo(),
             timeout,
             interval: 500,


### PR DESCRIPTION
### What Is This Change?

Fixed this issue, which happens if you have a prompt pending before denying an MCP server:
<img width="394" height="200" alt="image" src="https://github.com/user-attachments/assets/ad7e242e-2deb-4b50-804c-fac41676ca55" />

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`