### PR TITLE
[AXON-1314] fix: updade help section w/ rovodev consistently

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -80,6 +80,7 @@ export class Container {
     private static _commonMessageHandler: CommonActionMessageHandler;
     private static _bitbucketHelper: CheckoutHelper;
     private static _assignedWorkItemsView: AssignedWorkItemsViewProvider;
+    private static _helpExplorer: HelpExplorer;
 
     static async initialize(context: ExtensionContext, version: string) {
         canFetchInternalUrl().then((success) => {
@@ -194,7 +195,8 @@ export class Container {
 
         this._loginManager = new LoginManager(this._credentialManager, this._siteManager, this._analyticsClient);
         this._bitbucketHelper = new BitbucketCheckoutHelper(context.globalState);
-        context.subscriptions.push(new HelpExplorer());
+        this._helpExplorer = new HelpExplorer();
+        context.subscriptions.push(this._helpExplorer);
 
         this._featureFlagClient = FeatureFlagClient.getInstance();
 
@@ -324,6 +326,9 @@ export class Container {
                 );
 
                 context.subscriptions.push(this._rovodevDisposable);
+
+                // Update help explorer to show Rovo Dev content
+                this._helpExplorer.refresh();
             } catch (error) {
                 RovoDevLogger.error(error, 'Enabling Rovo Dev');
             }
@@ -343,6 +348,9 @@ export class Container {
             // Already disabled
             return;
         }
+
+        // Update help explorer to hide Rovo Dev content
+        this._helpExplorer.refresh();
 
         try {
             await setCommandContext(CommandContext.RovoDevEnabled, false);

--- a/src/views/HelpExplorer.ts
+++ b/src/views/HelpExplorer.ts
@@ -28,4 +28,8 @@ export class HelpExplorer extends Explorer implements Disposable {
     async handleFocusEvent(e: FocusEvent) {
         //No focus available for now
     }
+
+    refresh() {
+        this.newTreeView();
+    }
 }


### PR DESCRIPTION
### What Is This Change?

Question time! What do these have in common?
 * Rovodev Help Section
 * Weeping Angels from Dr. Who 
 * SCP-173 

Answer - all of them only move if the user isn't looking :D

Up to now, there was a race condition in the behaviour of the rovodev button in our help section - it was only added if the help section got loaded before rovodev (e.g. if the user had the normal Atlassian tab open)


This forces the content to update every time 

### How Has This Been Tested?

Please refer to the videos on Axon channel

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`