### PR TITLE
[AXON-1322] Fixed process state transitions, chat history polluted after Disabled state, and bug during initialization

### DIFF
--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -136,17 +136,13 @@ const RovoDevView: React.FC = () => {
         [dispatch, removeModifiedFileToolReturns],
     );
 
-    const finalizeResponse = useCallback(() => {
-        setPendingToolCallMessage('');
-        setCurrentState({ state: 'WaitingForPrompt' });
-    }, []);
-
     const clearChatHistory = useCallback(() => {
-        setHistory([]);
         keepFiles(totalModifiedFiles);
+        setHistory([]);
         setTotalModifiedFiles([]);
         setIsDeepPlanCreated(false);
         setIsFeedbackFormVisible(false);
+        setPendingToolCallMessage('');
     }, [keepFiles, totalModifiedFiles]);
 
     const handleAppendModifiedFileToolReturns = useCallback((toolReturn: ToolReturnGenericMessage) => {
@@ -239,8 +235,9 @@ const RovoDevView: React.FC = () => {
                         currentState.state === 'ExecutingPlan' ||
                         currentState.state === 'CancellingResponse'
                     ) {
-                        finalizeResponse();
+                        setCurrentState({ state: 'WaitingForPrompt' });
                     }
+                    setPendingToolCallMessage('');
                     setModalDialogs([]);
                     break;
 
@@ -262,7 +259,6 @@ const RovoDevView: React.FC = () => {
 
                 case RovoDevProviderMessageType.ClearChat:
                     clearChatHistory();
-                    setPendingToolCallMessage('');
                     break;
 
                 case RovoDevProviderMessageType.ProviderReady:
@@ -322,13 +318,7 @@ const RovoDevView: React.FC = () => {
                     break;
 
                 case RovoDevProviderMessageType.RovoDevDisabled:
-                    if (
-                        currentState.state === 'GeneratingResponse' ||
-                        currentState.state === 'ExecutingPlan' ||
-                        currentState.state === 'CancellingResponse'
-                    ) {
-                        finalizeResponse();
-                    }
+                    clearChatHistory();
 
                     if (event.reason === 'EntitlementCheckFailed') {
                         setCurrentState({
@@ -411,7 +401,7 @@ const RovoDevView: React.FC = () => {
                     break;
             }
         },
-        [currentState.state, handleAppendResponse, clearChatHistory, finalizeResponse],
+        [currentState.state, handleAppendResponse, clearChatHistory],
     );
 
     const { postMessage, postMessagePromise } = useMessagingApi<


### PR DESCRIPTION
### What Is This Change?

Fixed:
- AXON-1322: Logging out from API token when Rovo Dev is in disabled states doesn't trigger the Login page
- Chat history was not cleaned up when Rovo Dev transitioned to disabled state
- Incorrect condition during initialization caused Rovo Dev to initialize with some delay

Also:
- Some clean ups
- Renamed the ugly `Service at at "${baseApiUrl}" wasn't ready within ${timeout} ms` error message to a simpler `Rovo Dev service is unreachable.`

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`