### PR TITLE
[AXON-1319, AXON-1254]: [Start Work Page] Custom Branch Template rule is not correctly applied 

### DIFF
--- a/src/react/atlascode/startwork/v3/hooks/useStartWorkFormState.test.tsx
+++ b/src/react/atlascode/startwork/v3/hooks/useStartWorkFormState.test.tsx
@@ -17,9 +17,11 @@ jest.mock('../../startWorkController', () => ({
 jest.mock('../utils/branchUtils', () => ({
     getDefaultSourceBranch: jest.fn().mockReturnValue({ type: 0, name: 'main' }),
     generateBranchName: jest.fn().mockReturnValue('generated-branch-name'),
+    getBranchTypeForRepo: jest.fn(),
 }));
 
 const mockGenerateBranchName = require('../utils/branchUtils').generateBranchName;
+const mockGetBranchTypeForRepo = require('../utils/branchUtils').getBranchTypeForRepo;
 
 describe('useStartWorkFormState', () => {
     const mockController = {
@@ -73,103 +75,63 @@ describe('useStartWorkFormState', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockGenerateBranchName.mockReturnValue('generated-branch-name');
+
+        mockGetBranchTypeForRepo.mockImplementation((repo: RepoData, customPrefixes: string[]) => {
+            if (repo.branchTypes?.length > 0) {
+                return repo.branchTypes[0];
+            } else if (customPrefixes.length > 0) {
+                return { kind: customPrefixes[0], prefix: customPrefixes[0] + '/' };
+            } else {
+                return { kind: '', prefix: '' };
+            }
+        });
     });
 
-    describe('initialization', () => {
-        it('should initialize with first branchType when default repo has branchTypes', () => {
+    describe('hook behavior', () => {
+        it('should initialize with correct branch type from utils', () => {
             const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
 
+            // Hook should use the result from getBranchTypeForRepo
             expect(result.current.formState.selectedBranchType).toEqual({
                 kind: 'Feature',
                 prefix: 'feature/',
             });
         });
 
-        it('should initialize with empty branchType when default repo has no branchTypes and no custom prefixes', () => {
-            const stateWithGitHubFirst = {
-                ...mockState,
-                repoData: [mockGitHubRepo, mockBitbucketRepo],
-            };
-
-            const { result } = renderHook(() => useStartWorkFormState(stateWithGitHubFirst, mockController));
-
-            expect(result.current.formState.selectedBranchType).toEqual({
-                kind: '',
-                prefix: '',
-            });
-        });
-
-        it('should initialize with first custom prefix when default repo has no branchTypes but has custom prefixes', () => {
-            const stateWithCustomPrefixes = {
-                ...mockState,
-                repoData: [mockGitHubRepo, mockBitbucketRepo],
-                customPrefixes: ['hotfix', 'chore'],
-            };
-
-            const { result } = renderHook(() => useStartWorkFormState(stateWithCustomPrefixes, mockController));
-
-            expect(result.current.formState.selectedBranchType).toEqual({
-                kind: 'hotfix',
-                prefix: 'hotfix/',
-            });
-        });
-    });
-
-    describe('handleRepositoryChange', () => {
-        it('should reset selectedBranchType to first branchType when switching to Bitbucket repo', () => {
-            const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
-
-            act(() => {
-                result.current.formActions.onRepositoryChange(mockBitbucketRepo);
-            });
-
-            expect(result.current.formState.selectedBranchType).toEqual({
-                kind: 'Feature',
-                prefix: 'feature/',
-            });
-        });
-
-        it('should reset selectedBranchType to empty when switching to non-Bitbucket repo without custom prefixes', () => {
+        it('should update branch type when repository changes', () => {
             const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
 
             act(() => {
                 result.current.formActions.onRepositoryChange(mockGitHubRepo);
             });
 
+            // Hook should call utils and update state accordingly
             expect(result.current.formState.selectedBranchType).toEqual({
                 kind: '',
                 prefix: '',
             });
         });
+    });
 
-        it('should reset selectedBranchType to first custom prefix when switching to non-Bitbucket repo with custom prefixes', () => {
-            const stateWithCustomPrefixes = {
-                ...mockState,
-                customPrefixes: ['hotfix', 'chore'],
-            };
+    describe('integration with utils', () => {
+        it('should call getBranchTypeForRepo with correct parameters on initialization', () => {
+            renderHook(() => useStartWorkFormState(mockState, mockController));
 
-            const { result } = renderHook(() => useStartWorkFormState(stateWithCustomPrefixes, mockController));
+            expect(mockGetBranchTypeForRepo).toHaveBeenCalledWith(mockBitbucketRepo, mockState.customPrefixes);
+        });
+
+        it('should call getBranchTypeForRepo when repository changes', () => {
+            const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
 
             act(() => {
                 result.current.formActions.onRepositoryChange(mockGitHubRepo);
             });
 
-            expect(result.current.formState.selectedBranchType).toEqual({
-                kind: 'hotfix',
-                prefix: 'hotfix/',
-            });
+            expect(mockGetBranchTypeForRepo).toHaveBeenCalledWith(mockGitHubRepo, mockState.customPrefixes);
         });
-    });
 
-    describe('branch name generation', () => {
-        it('should generate branch name with prefix when selectedBranchType has prefix', () => {
-            mockGenerateBranchName.mockReturnValue('feature/TEST-123-test-issue');
-
+        it('should call generateBranchName when repository or branch type changes', () => {
             const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
-
-            act(() => {
-                result.current.formActions.onRepositoryChange(mockBitbucketRepo);
-            });
 
             expect(mockGenerateBranchName).toHaveBeenCalledWith(
                 mockBitbucketRepo,
@@ -177,12 +139,6 @@ describe('useStartWorkFormState', () => {
                 mockState.issue,
                 mockState.customTemplate,
             );
-        });
-
-        it('should generate branch name using custom template even when selectedBranchType has no prefix', () => {
-            mockGenerateBranchName.mockReturnValue('TEST-123-test-issue');
-
-            const { result } = renderHook(() => useStartWorkFormState(mockState, mockController));
 
             act(() => {
                 result.current.formActions.onRepositoryChange(mockGitHubRepo);
@@ -192,7 +148,7 @@ describe('useStartWorkFormState', () => {
                 mockGitHubRepo,
                 { kind: '', prefix: '' },
                 mockState.issue,
-                mockState.customTemplate, // Always use custom template from settings
+                mockState.customTemplate,
             );
         });
     });

--- a/src/react/atlascode/startwork/v3/hooks/useStartWorkFormState.ts
+++ b/src/react/atlascode/startwork/v3/hooks/useStartWorkFormState.ts
@@ -6,7 +6,7 @@ import { RepoData } from '../../../../../lib/ipc/toUI/startWork';
 import { Branch } from '../../../../../typings/git';
 import { ErrorControllerContext } from '../../../common/errorController';
 import { useStartWorkController } from '../../startWorkController';
-import { generateBranchName, getDefaultSourceBranch } from '../utils/branchUtils';
+import { generateBranchName, getBranchTypeForRepo, getDefaultSourceBranch } from '../utils/branchUtils';
 
 export function useStartWorkFormState(
     state: ReturnType<typeof useStartWorkController>[0],
@@ -34,6 +34,10 @@ export function useStartWorkFormState(
     }>({});
     const [snackbarOpen, setSnackbarOpen] = useState(false);
     const [startWithRovoDev, setStartWithRovoDev] = useState(state.rovoDevPreference || false);
+    const getBranchTypeForCurrentRepo = useCallback(
+        (repo: RepoData) => getBranchTypeForRepo(repo, state.customPrefixes),
+        [state.customPrefixes],
+    );
 
     useEffect(() => {
         controller.postMessage({
@@ -55,33 +59,20 @@ export function useStartWorkFormState(
             setSourceBranch(getDefaultSourceBranch(defaultRepo));
 
             // Set branch type based on repo's branch types or custom prefixes
-            if (defaultRepo.branchTypes?.length > 0) {
-                setSelectedBranchType(defaultRepo.branchTypes[0]);
-            } else {
-                const convertedCustomPrefixes = state.customPrefixes.map((prefix) => {
-                    const normalizedCustomPrefix = prefix.endsWith('/') ? prefix : prefix + '/';
-                    return { prefix: normalizedCustomPrefix, kind: prefix };
-                });
-
-                if (convertedCustomPrefixes.length > 0) {
-                    setSelectedBranchType(convertedCustomPrefixes[0]);
-                } else {
-                    setSelectedBranchType({ kind: '', prefix: '' });
-                }
-            }
+            setSelectedBranchType(getBranchTypeForCurrentRepo(defaultRepo));
 
             if (!upstream) {
                 setUpstream(defaultRepo.workspaceRepo.mainSiteRemote.remote.name);
             }
         }
-    }, [state.repoData, upstream, state.customPrefixes]);
+    }, [state.repoData, upstream, getBranchTypeForCurrentRepo]);
 
     // useEffect: auto-generate branch name
     useEffect(() => {
         if (selectedRepository) {
-            const branchTypeToUse = selectedBranchType.prefix ? selectedBranchType : { kind: '', prefix: '' };
-
-            setLocalBranch(generateBranchName(selectedRepository, branchTypeToUse, state.issue, state.customTemplate));
+            setLocalBranch(
+                generateBranchName(selectedRepository, selectedBranchType, state.issue, state.customTemplate),
+            );
         }
     }, [selectedRepository, selectedBranchType, state.issue, state.customTemplate]);
 
@@ -89,27 +80,13 @@ export function useStartWorkFormState(
         (repository: RepoData) => {
             setSelectedRepository(repository);
             setSourceBranch(getDefaultSourceBranch(repository));
-
-            if (repository.branchTypes?.length > 0) {
-                setSelectedBranchType(repository.branchTypes[0]);
-            } else {
-                const convertedCustomPrefixes = state.customPrefixes.map((prefix) => {
-                    const normalizedCustomPrefix = prefix.endsWith('/') ? prefix : prefix + '/';
-                    return { prefix: normalizedCustomPrefix, kind: prefix };
-                });
-
-                if (convertedCustomPrefixes.length > 0) {
-                    setSelectedBranchType(convertedCustomPrefixes[0]);
-                } else {
-                    setSelectedBranchType({ kind: '', prefix: '' });
-                }
-            }
+            setSelectedBranchType(getBranchTypeForCurrentRepo(repository));
 
             if (!upstream) {
                 setUpstream(repository.workspaceRepo.mainSiteRemote.remote.name);
             }
         },
-        [upstream, state.customPrefixes],
+        [upstream, getBranchTypeForCurrentRepo],
     );
 
     const handleBranchTypeChange = useCallback((branchType: { kind: string; prefix: string }) => {

--- a/src/react/atlascode/startwork/v3/utils/branchUtils.test.ts
+++ b/src/react/atlascode/startwork/v3/utils/branchUtils.test.ts
@@ -7,7 +7,7 @@ jest.mock('mustache', () => ({
 
 const mockMustacheRender = require('mustache').default.render;
 
-import { generateBranchName, getAllBranches, getDefaultSourceBranch } from './branchUtils';
+import { generateBranchName, getAllBranches, getBranchTypeForRepo, getDefaultSourceBranch } from './branchUtils';
 
 describe('branchUtils', () => {
     const mockRepoData = {
@@ -173,6 +173,62 @@ describe('branchUtils', () => {
                 }),
             );
             expect(result).toBe('test.user/TEST-123-Test-issue-summary');
+        });
+    });
+
+    describe('getBranchTypeForRepo', () => {
+        const mockRepoWithBranchTypes = {
+            branchTypes: [
+                { kind: 'Feature', prefix: 'feature/' },
+                { kind: 'Bugfix', prefix: 'bugfix/' },
+            ],
+        } as any;
+
+        const mockRepoWithoutBranchTypes = {
+            branchTypes: [],
+        } as any;
+
+        const mockRepoWithUndefinedBranchTypes = {
+            branchTypes: undefined,
+        } as any;
+
+        it('should return first branch type when repo has branch types', () => {
+            const result = getBranchTypeForRepo(mockRepoWithBranchTypes, []);
+            expect(result).toEqual({ kind: 'Feature', prefix: 'feature/' });
+        });
+
+        it('should return first custom prefix when repo has no branch types', () => {
+            const customPrefixes = ['hotfix', 'release'];
+            const result = getBranchTypeForRepo(mockRepoWithoutBranchTypes, customPrefixes);
+            expect(result).toEqual({ kind: 'hotfix', prefix: 'hotfix/' });
+        });
+
+        it('should normalize custom prefix by adding slash', () => {
+            const customPrefixes = ['hotfix'];
+            const result = getBranchTypeForRepo(mockRepoWithoutBranchTypes, customPrefixes);
+            expect(result).toEqual({ kind: 'hotfix', prefix: 'hotfix/' });
+        });
+
+        it('should not add slash if custom prefix already ends with slash', () => {
+            const customPrefixes = ['hotfix/'];
+            const result = getBranchTypeForRepo(mockRepoWithoutBranchTypes, customPrefixes);
+            expect(result).toEqual({ kind: 'hotfix/', prefix: 'hotfix/' });
+        });
+
+        it('should return empty branch type when no branch types and no custom prefixes', () => {
+            const result = getBranchTypeForRepo(mockRepoWithoutBranchTypes, []);
+            expect(result).toEqual({ kind: '', prefix: '' });
+        });
+
+        it('should return empty branch type when branch types is undefined and no custom prefixes', () => {
+            const result = getBranchTypeForRepo(mockRepoWithUndefinedBranchTypes, []);
+            expect(result).toEqual({ kind: '', prefix: '' });
+        });
+
+        it('should prioritize repo branch types over custom prefixes', () => {
+            const customPrefixes = ['hotfix', 'release'];
+            const result = getBranchTypeForRepo(mockRepoWithBranchTypes, customPrefixes);
+            expect(result).toEqual({ kind: 'Feature', prefix: 'feature/' });
         });
     });
 });

--- a/src/react/atlascode/startwork/v3/utils/branchUtils.ts
+++ b/src/react/atlascode/startwork/v3/utils/branchUtils.ts
@@ -27,13 +27,15 @@ export const generateBranchName = (
     issue: MinimalIssue<any>,
     customTemplate: string,
 ): string => {
+    // Use branchType if it has a prefix, otherwise use empty prefix
+    const branchTypeToUse = branchType.prefix ? branchType : { kind: '', prefix: '' };
     const usernameBase = repo.userEmail
         ? repo.userEmail
               .split('@')[0]
               .normalize('NFD') // Convert accented characters to two characters where the accent is separated out
               .replace(/[\u0300-\u036f]/g, '') // Remove the separated accent marks
         : 'username';
-    const prefixBase = branchType.prefix.replace(/ /g, '-');
+    const prefixBase = branchTypeToUse.prefix.replace(/ /g, '-');
     const summaryBase = issue.summary
         .substring(0, 50)
         .trim()
@@ -63,5 +65,22 @@ export const generateBranchName = (
         return Mustache.render(customTemplate, view);
     } catch {
         return 'Invalid template: please follow the format described above';
+    }
+};
+
+export const getBranchTypeForRepo = (repo: RepoData, customPrefixes: string[]): { kind: string; prefix: string } => {
+    if (repo.branchTypes?.length > 0) {
+        return repo.branchTypes[0];
+    } else {
+        const convertedCustomPrefixes = customPrefixes.map((prefix) => {
+            const normalizedCustomPrefix = prefix.endsWith('/') ? prefix : prefix + '/';
+            return { prefix: normalizedCustomPrefix, kind: prefix };
+        });
+
+        if (convertedCustomPrefixes.length > 0) {
+            return convertedCustomPrefixes[0];
+        } else {
+            return { kind: '', prefix: '' };
+        }
     }
 };


### PR DESCRIPTION
### What Is This Change?

It seems that we fixed the `AXON-1254` bug as part of `AXON-1258` (already merged), so the fix for this PR is more relevant to `AXON-1319`. Nevertheless, this PR branch is perfect for testing both fixes (`AXON-1254`, `AXON-1319`).

Demo: https://www.loom.com/share/ba40e0d4225a4770b1d3e89a3c7c81a3

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change