### PR TITLE
[AXON-1328] Re-introduce rovodev feature flag check

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -290,9 +290,11 @@ export class Container {
     }
 
     private static async refreshRovoDev(context: ExtensionContext) {
-        const isJiraEnabledAndAtlassianUser = this.config.jira.enabled && (await this.isAtlassianUser(ProductJira));
+        const isJiraAndRovodevEnabled =
+            this.config.jira.enabled &&
+            (this.featureFlagClient.checkGate(Features.RovoDevEnabled) || (await this.isAtlassianUser(ProductJira)));
         const isBoysenberryMode = !!process.env.ROVODEV_BBY;
-        const shouldEnableRovoDev = isJiraEnabledAndAtlassianUser || isBoysenberryMode;
+        const shouldEnableRovoDev = isJiraAndRovodevEnabled || isBoysenberryMode;
 
         if (shouldEnableRovoDev) {
             this._isRovoDevEnabled = true;


### PR DESCRIPTION
### What Is This Change?

Re-introduce rovodev feature flag check to work as an alternative condition to the internal user check.
Effectively returns what was removed here:
https://github.com/atlassian/atlascode/pull/1069

### How Has This Been Tested?

TBD

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`