### PR TITLE
[AXON-1324] Update Rovo Dev, adjust tool permission flow, and enablement strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ],
     "main": "./build/extension/extension",
     "rovoDev": {
-        "version": "0.12.0"
+        "version": "0.12.1"
     },
     "scripts": {
         "vscode:uninstall": "node ./build/extension/uninstall.js",

--- a/src/react/atlascode/rovo-dev/landing-page/disabled-messages/DisabledMessage.tsx
+++ b/src/react/atlascode/rovo-dev/landing-page/disabled-messages/DisabledMessage.tsx
@@ -44,8 +44,8 @@ export const DisabledMessage: React.FC<{
                     msg={{
                         source: 'RovoDevDialog',
                         type: 'error',
-                        title: currentState.detail.title,
-                        text: currentState.detail.message,
+                        title: currentState.detail.payload.title,
+                        text: currentState.detail.payload.message,
                         statusCode: `Failure code: ${currentState.detail.payload.status}`,
                         uid: '',
                     }}

--- a/src/rovo-dev/responseParser.ts
+++ b/src/rovo-dev/responseParser.ts
@@ -11,6 +11,7 @@ import {
     RovoDevTextResponse,
     RovoDevToolCallResponse,
     RovoDevToolName,
+    RovoDevToolPemissionScenario,
     RovoDevToolReturnResponse,
     RovoDevUserPromptResponse,
     RovoDevWarningResponse,
@@ -128,6 +129,8 @@ interface RovoDevPruneChunk {
 // https://bitbucket.org/atlassian/acra-python/src/9ce5910e61d00e91f70c7978e067bde2690a1c97/packages/cli-rovodev/docs/serve/streaming-events.md?at=RDA-307-emit-warning-events-related-to-rate-limits-and-other-api-request-problems#:~:text=Server%20Error%20Warnings
 interface RovoDevOnCallToolStartResponseRaw {
     parts: RovoDevToolCallResponseRaw[];
+    permission_required?: boolean;
+    permissions?: Record<string, RovoDevToolPemissionScenario>;
 }
 
 interface RovoDevOnCallToolStartChunk {
@@ -302,6 +305,8 @@ function parseOnCallToolStart(data: RovoDevOnCallToolStartResponseRaw): RovoDevO
     return {
         event_kind: 'on_call_tools_start',
         tools: data.parts.map((part) => parseResponseToolCall(part)),
+        permission_required: !!data.permission_required,
+        permissions: data.permissions ?? {},
     };
 }
 

--- a/src/rovo-dev/responseParserInterfaces.ts
+++ b/src/rovo-dev/responseParserInterfaces.ts
@@ -70,6 +70,8 @@ export interface RovoDevPruneResponse {
 export interface RovoDevOnCallToolStartResponse {
     event_kind: 'on_call_tools_start';
     tools: RovoDevToolCallResponse[];
+    permission_required: boolean;
+    permissions: Record<string, RovoDevToolPemissionScenario>;
 }
 
 export interface RovoDevCloseResponse {
@@ -102,3 +104,5 @@ export type RovoDevToolName =
     | 'bash'
     | 'create_technical_plan'
     | 'mcp_invoke_tool';
+
+export type RovoDevToolPemissionScenario = 'ASK' | 'ALLOWED' | 'DENIED';

--- a/src/rovo-dev/rovoDevApiClientInterfaces.ts
+++ b/src/rovo-dev/rovoDevApiClientInterfaces.ts
@@ -41,10 +41,9 @@ export interface EntitlementCheckRovoDevHealthcheckResponse {
     status: 'entitlement check failed';
     version: string;
     detail: {
-        title: string;
-        message: string;
         payload: {
             status: EntitlementFailedStatus;
+            title?: string;
             message: string;
             userCreditLimits: {
                 user: {

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -395,7 +395,15 @@ class RovoDevTerminalInstance extends Disposable {
 
                 try {
                     const siteUrl = `https://${credentials.host}`;
-                    const shellArgs = ['serve', `${port}`, '--xid', 'rovodev-ide-vscode', '--site-url', siteUrl];
+                    const shellArgs = [
+                        'serve',
+                        `${port}`,
+                        '--xid',
+                        'rovodev-ide-vscode',
+                        '--site-url',
+                        siteUrl,
+                        '--respect-configured-permissions',
+                    ];
 
                     if (credentials.isStaging) {
                         shellArgs.push('--server-env', 'staging');

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -1158,9 +1158,12 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         // this scenario is when the user is not allowed to run Rovo Dev because it's disabled by the Jira administrator
         if (result.status === 'entitlement check failed') {
             if (this.isBoysenberry) {
-                await this.processError(new Error(`${result.detail.message}\nCode: ${result.detail.payload.status}`), {
-                    title: result.detail.title,
-                });
+                await this.processError(
+                    new Error(`${result.detail.payload.message}\nCode: ${result.detail.payload.status}`),
+                    {
+                        title: result.detail.payload.title || 'Entitlement check failed',
+                    },
+                );
                 this.signalRovoDevDisabled('Other');
             } else {
                 await this.signalRovoDevDisabled('EntitlementCheckFailed', result.detail);


### PR DESCRIPTION
### What Is This Change?

Upgraded Rovo Dev to 0.12.1.

This new version includes breaking changes in:

- The tool permissions, adding
  - A field to indicate if permissions are required
  - A map to indicate which tools requires permission, which ones are auto-allowed, and which ones are auto-denied
  - A new arg to specify the permissions in settings should be respected
  - NOTE: now the message `on_call_tools_start` is always coming for every `tool-call`

- Entitlement strings
  - Moved the strings inside the data's payload

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`