### PR TITLE
Remove github release from pipelines

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -98,16 +98,3 @@ jobs:
           git tag -a $RELEASE_TAG -m "Nightly build for $(date +'%Y-%m-%d %H:%M')"
           git push origin $RELEASE_TAG
 
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: Release ${{ env.RELEASE_TAG }}
-          draft: false
-          prerelease: true
-          files: |
-            atlascode-${{ env.PACKAGE_VERSION }}.vsix
-          fail_on_unmatched_files: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,16 +96,3 @@ jobs:
              -p ${{ secrets.OPENVSX_KEY }} \
             "atlascode-${PACKAGE_VERSION}.vsix"
 
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: Release ${{ env.RELEASE_TAG }}
-          draft: false
-          prerelease: false
-          files: |
-            atlascode-${{ env.PACKAGE_VERSION }}.vsix
-          fail_on_unmatched_files: true


### PR DESCRIPTION
### What Is This Change?
Removes release publishing to github because its failing due to new change from GitHub 