### PR TITLE
Reintroduce GitHub release task

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -108,3 +108,6 @@ jobs:
           name: Release ${{ env.RELEASE_TAG }}
           draft: false
           prerelease: true
+          files: |
+            atlascode-${{ env.PACKAGE_VERSION }}.vsix
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,3 +106,6 @@ jobs:
           name: Release ${{ env.RELEASE_TAG }}
           draft: false
           prerelease: false
+          files: |
+            atlascode-${{ env.PACKAGE_VERSION }}.vsix
+          fail_on_unmatched_files: true


### PR DESCRIPTION
### What Is This Change?

Reintroduce the GitHub release task, for both nightly and release, but without uploading the VSIX file.
