### PR TITLE
remove bby from error message strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
-## What's new in 4.0.0
+## What's new in 4.0.1
 ### Bug Fixes
 - Cleaned up user facing error messages 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
 ## What's new in 4.0.0
+### Bug Fixes
+- Cleaned up user facing error messages 
+
+
+## What's new in 4.0.0
 
 ### Features
 - **Rovo Dev: Atlassian AI Agent** is now available in beta

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -1127,10 +1127,9 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         if (!result || result.status === 'unknown') {
             const msg = result ? 'Rovo Dev service is unhealthy/unknown.' : 'Rovo Dev service is unreachable.';
             if (this.isBoysenberry) {
-                await this.processError(
-                    new Error(`${msg}\rTry closing and reopening the Boysenberry session to retry.`),
-                    { title: 'Failed to initialize Rovo Dev' },
-                );
+                await this.processError(new Error(`${msg}\rTry closing and reopening the session to retry.`), {
+                    title: 'Failed to initialize Rovo Dev',
+                });
                 this.signalRovoDevDisabled('Other');
             } else {
                 await this.signalProcessFailedToInitialize(msg);
@@ -1143,9 +1142,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         if (result.status === 'unhealthy') {
             if (this.isBoysenberry) {
                 await this.processError(
-                    new Error(
-                        `Rovo Dev service is unhealthy.\nTry closing and reopening the Boysenberry session to retry.`,
-                    ),
+                    new Error(`Rovo Dev service is unhealthy.\nTry closing and reopening the session to retry.`),
                     { title: 'Failed to initialize Rovo Dev' },
                 );
                 this.signalRovoDevDisabled('Other');


### PR DESCRIPTION
### What Is This Change?
Remove the "Boysenberry" word from user facing messages 

From: https://atlassian.slack.com/archives/C08HHS3DQTU/p1759840263147819 

### How Has This Been Tested?
Manual


Recommendations:
- [x] Update the CHANGELOG if making a user facing change