### PR TITLE
Fix Rovo Dev initialization errors when webview is not ready

### DIFF
--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -295,6 +295,12 @@ export abstract class RovoDevProcessManager {
             return;
         }
 
+        // don't do anything if the provider isn't ready yet - the initialization will be called
+        // by the provider when it becomes ready
+        if (!this.rovoDevWebviewProvider || !this.rovoDevWebviewProvider.isReady) {
+            return;
+        }
+
         if (this.rovoDevInstance) {
             this.asyncLocked = true;
 

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -137,6 +137,10 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         await this._context.workspaceState.update(key, enabled);
     }
 
+    public get isReady(): boolean {
+        return !!this._webviewReady;
+    }
+
     public get isVisible(): boolean {
         return this._webviewView?.visible ?? false;
     }


### PR DESCRIPTION
### What Is This Change?

If the Rovo Dev panel hasn't been opened yet, its webview has not been initialized.
If we try to call `enableRovoDev` in Container while the webview has not been initialized yet, the process manager will try to set a new state in the webview failing.

This change prevents this scenario to happen.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`