### PR TITLE
AXON-1213 - Fix Rovo Dev Refreshing Credentials error 

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -26,7 +26,7 @@ import {
 } from 'vscode';
 
 import { Container } from '../../src/container';
-import { RovoDevLogger } from '../../src/logger';
+import { Logger, RovoDevLogger } from '../../src/logger';
 import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { Commands, rovodevInfo } from '../constants';
 import {
@@ -1252,8 +1252,11 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
         this.setRovoDevTerminated(RovoDevProcessState.Disabled, reason);
 
-        const webView = this._webView!;
-        await webView.postMessage({
+        if (!this._webView) {
+            Logger.warn('signalRovoDevDisabled called but webView is not initialized');
+            return;
+        }
+        await this._webView.postMessage({
             type: RovoDevProviderMessageType.RovoDevDisabled,
             reason,
             detail,

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -26,7 +26,7 @@ import {
 } from 'vscode';
 
 import { Container } from '../../src/container';
-import { Logger, RovoDevLogger } from '../../src/logger';
+import { RovoDevLogger } from '../../src/logger';
 import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { Commands, rovodevInfo } from '../constants';
 import {
@@ -1253,7 +1253,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         this.setRovoDevTerminated(RovoDevProcessState.Disabled, reason);
 
         if (!this._webView) {
-            Logger.warn('signalRovoDevDisabled called but webView is not initialized');
+            RovoDevLogger.warn('signalRovoDevDisabled called but webView is not initialized');
             return;
         }
         await this._webView.postMessage({


### PR DESCRIPTION
### What Is This Change?
Address these types of errors: 

```

TypeError: Cannot read properties of undefined (reading 'postMessage')
    at RovoDevWebviewProvider.signalRovoDevDisabled (/Users/<user>/.vscode/extensions/atlassian.atlascode-4.0.0/build/extension/extension.js:34:150259)
    at RovoDevProcessManager.internalInitializeRovoDev (/Users/<user>/.vscode/extensions/atlassian.atlascode-4.0.0/build/extension/extension.js:34:80248)
    at RovoDevProcessManager.initializeRovoDev (/Users/<user>/.vscode/extensions/atlassian.atlascode-4.0.0/build/extension/extension.js:34:81355)
    at RovoDevProcessManager.refreshRovoDevCredentials (/Users/<user>/.vscode/extensions/atlassian.atlascode-4.0.0/build/extension/extension.js:34:81797)
    at container_Container.enableRovoDev (/Users/<user>/.vscode/extensions/atlassian.atlascode-4.0.0/build/extension/extension.js:34:353463)
    at container_Container.refreshRovoDev (/Users/<user>/.vscode/extensions/atlassian.atlascode-4.0.0/build/extension/extension.js:34:353317)
    at od.value (/Users/<user>/.vscode/extensions/atlassian.atla
```

### How Has This Been Tested?
Manual 

https://www.loom.com/share/ab85fa792b2448779e28b2b7e86a0f9f?sid=0c354c76-872c-4b12-ae0a-1dc20b2171d1
