### PR TITLE
AXON-1282: actions should just fill the prompt

### DIFF
--- a/src/react/atlascode/rovo-dev/landing-page/RovoDevLanding.tsx
+++ b/src/react/atlascode/rovo-dev/landing-page/RovoDevLanding.tsx
@@ -33,7 +33,7 @@ export const RovoDevLanding: React.FC<{
     onLoginClick: () => void;
     onOpenFolder: () => void;
     onMcpChoice: (choice: McpConsentChoice, serverName?: string) => void;
-    onSendMessage: (message: string) => void;
+    setPromptText: (context: string) => void;
     jiraWorkItems: MinimalIssue<DetailedSiteInfo>[] | undefined;
     onJiraItemClick: (issue: MinimalIssue<DetailedSiteInfo>) => void;
 }> = ({
@@ -42,7 +42,7 @@ export const RovoDevLanding: React.FC<{
     onLoginClick,
     onOpenFolder,
     onMcpChoice,
-    onSendMessage,
+    setPromptText,
     jiraWorkItems,
     onJiraItemClick,
 }) => {
@@ -77,7 +77,7 @@ export const RovoDevLanding: React.FC<{
 
             {!shouldHideSuggestions && (
                 <>
-                    <RovoDevActions onSendMessage={onSendMessage} />
+                    <RovoDevActions setPromptText={setPromptText} />
                     <RovoDevJiraWorkItems jiraWorkItems={jiraWorkItems} onJiraItemClick={onJiraItemClick} />
                 </>
             )}

--- a/src/react/atlascode/rovo-dev/landing-page/RovoDevSuggestions.tsx
+++ b/src/react/atlascode/rovo-dev/landing-page/RovoDevSuggestions.tsx
@@ -15,8 +15,8 @@ const titleStyles: React.CSSProperties = {
 };
 
 export const RovoDevActions: React.FC<{
-    onSendMessage: (message: string) => void;
-}> = ({ onSendMessage }) => {
+    setPromptText: (context: string) => void;
+}> = ({ setPromptText }) => {
     return (
         <div style={{ marginTop: '32px', width: '100%', maxWidth: '270px' }}>
             <div style={titleStyles}>Actions</div>
@@ -25,17 +25,17 @@ export const RovoDevActions: React.FC<{
                 <ActionItem
                     icon={<AiChatIcon size="small" spacing="none" label="Explain this repository" />}
                     text="Explain this repository"
-                    onClick={() => onSendMessage('Explain this repository')}
+                    onClick={() => setPromptText('Explain this repository')}
                 />
                 <ActionItem
                     icon={<AiChatIcon size="small" spacing="none" label="Find bugs in this repository" />}
                     text="Find bugs in this repository"
-                    onClick={() => onSendMessage('Find bugs in this repository')}
+                    onClick={() => setPromptText('Find bugs in this repository')}
                 />
                 <ActionItem
                     icon={<AiChatIcon size="small" spacing="none" label="List my assigned Jira work items" />}
                     text="List my assigned Jira work items"
-                    onClick={() => onSendMessage('List my assigned Jira work items')}
+                    onClick={() => setPromptText('List my assigned Jira work items')}
                 />
             </div>
         </div>

--- a/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
@@ -45,7 +45,7 @@ interface ChatStreamProps {
     onLoginClick: () => void;
     onOpenFolder: () => void;
     onMcpChoice: (choice: McpConsentChoice, serverName?: string) => void;
-    onSendMessage: (message: string) => void;
+    setPromptText: (context: string) => void;
     jiraWorkItems: MinimalIssue<DetailedSiteInfo>[] | undefined;
     onJiraItemClick: (issue: MinimalIssue<DetailedSiteInfo>) => void;
     onToolPermissionChoice: (toolCallId: string, choice: ToolPermissionChoice) => void;
@@ -68,7 +68,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
     onLoginClick,
     onOpenFolder,
     onMcpChoice,
-    onSendMessage,
+    setPromptText,
     jiraWorkItems,
     onJiraItemClick,
     onToolPermissionChoice,
@@ -241,7 +241,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                     onLoginClick={onLoginClick}
                     onOpenFolder={onOpenFolder}
                     onMcpChoice={onMcpChoice}
-                    onSendMessage={onSendMessage}
+                    setPromptText={setPromptText}
                     jiraWorkItems={jiraWorkItems}
                     onJiraItemClick={onJiraItemClick}
                 />

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -666,6 +666,10 @@ const RovoDevView: React.FC = () => {
         setPromptText(template);
     }, []);
 
+    const setPromptTextFromAction = useCallback((context: string) => {
+        setPromptText(context);
+    }, []);
+
     const onToolPermissionChoice = useCallback(
         (toolCallId: string, choice: ToolPermissionChoice) => {
             // remove the dialog after the choice is submitted
@@ -734,7 +738,7 @@ const RovoDevView: React.FC = () => {
                 onLoginClick={onLoginClick}
                 onOpenFolder={onOpenFolder}
                 onMcpChoice={onMcpChoice}
-                onSendMessage={sendPrompt}
+                setPromptText={setPromptTextFromAction}
                 jiraWorkItems={jiraWorkItems}
                 onJiraItemClick={onJiraItemClick}
                 onToolPermissionChoice={onToolPermissionChoice}


### PR DESCRIPTION
### What Is This Change?
Change actions to fill the prompt box instead of sending the context


**Current behavior ( sending the context ):** 

https://github.com/user-attachments/assets/0b01b073-6fce-4db3-b766-0ca48d61f71b


**Fix ( filling the prompt box ):**


https://github.com/user-attachments/assets/ea0ab6f6-a8b2-4692-bbda-ee74cc03ec6e



<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change