### PR TITLE
AXON-1317: [Start Work page] Prefix can be reset

### DIFF
--- a/src/react/atlascode/startwork/v3/components/BranchPrefixSelector.test.tsx
+++ b/src/react/atlascode/startwork/v3/components/BranchPrefixSelector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { RepoData } from '../../../../../lib/ipc/toUI/startWork';
@@ -83,5 +83,24 @@ describe('BranchPrefixSelector', () => {
         );
 
         expect(screen.getByText('Branch prefix')).toBeTruthy();
+    });
+
+    it('should clear selection when clear button is clicked', () => {
+        const mockOnBranchTypeChange = jest.fn();
+
+        render(
+            <BranchPrefixSelector
+                selectedRepository={mockRepoData}
+                selectedBranchType={{ kind: 'Feature', prefix: 'feature/' }}
+                customPrefixes={[]}
+                onBranchTypeChange={mockOnBranchTypeChange}
+            />,
+        );
+
+        const clearButton = screen.getByLabelText('Clear');
+
+        fireEvent.click(clearButton);
+
+        expect(mockOnBranchTypeChange).toHaveBeenCalledWith({ kind: '', prefix: '' });
     });
 });

--- a/src/react/atlascode/startwork/v3/components/BranchPrefixSelector.tsx
+++ b/src/react/atlascode/startwork/v3/components/BranchPrefixSelector.tsx
@@ -22,10 +22,23 @@ export const BranchPrefixSelector: React.FC<BranchPrefixSelectorProps> = ({
         return { prefix: normalizedCustomPrefix, kind: prefix };
     });
 
+    const allOptions = [...(selectedRepository?.branchTypes || []), ...convertedCustomPrefixes];
+
+    const getOptionGroup = useCallback(
+        (option: { kind: string; prefix: string }) => {
+            const repoBranchTypes = selectedRepository?.branchTypes || [];
+            const isRepoBranchType = repoBranchTypes.some((type) => type.kind === option.kind);
+            return isRepoBranchType ? 'Repo Branch Type' : 'Custom Prefix';
+        },
+        [selectedRepository?.branchTypes],
+    );
+
     const handleBranchTypeChange = useCallback(
         (event: React.ChangeEvent<{}>, value: { kind: string; prefix: string } | null) => {
             if (value) {
                 onBranchTypeChange(value);
+            } else {
+                onBranchTypeChange({ kind: '', prefix: '' });
             }
         },
         [onBranchTypeChange],
@@ -41,16 +54,11 @@ export const BranchPrefixSelector: React.FC<BranchPrefixSelectorProps> = ({
         <Grid item xs={6}>
             <Typography variant="body2">Branch prefix</Typography>
             <Autocomplete
-                options={[...(selectedRepository?.branchTypes || []), ...convertedCustomPrefixes]}
-                groupBy={(option) =>
-                    (selectedRepository?.branchTypes || []).map((type) => type.kind).includes(option.kind)
-                        ? 'Repo Branch Type'
-                        : 'Custom Prefix'
-                }
+                options={allOptions}
+                groupBy={getOptionGroup}
                 getOptionLabel={(option) => option.kind}
                 renderInput={(params) => <TextField {...params} size="small" variant="outlined" />}
                 size="small"
-                disableClearable
                 value={selectedBranchType}
                 onChange={handleBranchTypeChange}
             />


### PR DESCRIPTION
### What Is This Change?

Demo: https://www.loom.com/share/13006439b20a4b26baf0f2463a0bf2a7

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change