### PR TITLE
AXON-1305: update disclaimer

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -836,6 +836,11 @@ body {
 }
 
 .ai-disclaimer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: row;
+    gap: 4px;
     text-align: center;
     font-size: 11px;
     color: var(--vscode-descriptionForeground);

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -1,6 +1,7 @@
 import './RovoDev.css';
 import './RovoDevCodeHighlighting.css';
 
+import InformationCircleIcon from '@atlaskit/icon/core/information-circle';
 import { setGlobalTheme } from '@atlaskit/tokens';
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import { highlightElement } from '@speed-highlight/core';
@@ -805,7 +806,10 @@ const RovoDevView: React.FC = () => {
                             />
                         </div>
                     </div>
-                    <div className="ai-disclaimer">Uses AI. Verify results.</div>
+                    <div className="ai-disclaimer">
+                        <InformationCircleIcon label="Disclaimer logo" size="small" />
+                        Uses AI. Verify results.
+                    </div>
                 </div>
             )}
         </div>


### PR DESCRIPTION
### What Is This Change?

Update AI disclaimer to relfect designs

<img width="320" height="126" alt="Screenshot 2025-10-09 at 2 47 53 PM" src="https://github.com/user-attachments/assets/788cb50c-2b61-4477-8e93-e814600c55b5" />


### How Has This Been Tested?

manual
Basic checks:

- [x] `npm run lint`
- [x] `npm run test`