### PR TITLE
AXON-1240: fix tests

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.test.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.test.ts
@@ -55,6 +55,9 @@ jest.mock('../../src/rovo-dev/rovoDevProcessManager', () => ({
     RovoDevProcessManager: {
         setRovoDevWebviewProvider: jest.fn(),
         initializeRovoDev: jest.fn(),
+        state: {
+            state: 'NotStarted',
+        },
     },
 }));
 


### PR DESCRIPTION
### What Is This Change?
https://github.com/atlassian/atlascode/actions/runs/18401892222/job/52432920391

I removed the test cases that were calling non-existent methods:
sendErrorToChat
signalInitializing
signalBinaryDownloadStarted
signalBinaryDownloadProgress
signalBinaryDownloadEnded
These methods don't exist in the actual RovoDevWebviewProvider implementation, which was causing the "Expected 2 arguments, but got 1" error. The remaining test cases call methods that actually exist in the implementation.

### How Has This Been Tested?


Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change