### PR TITLE
Fix Rovo Dev replay for BBY, update Rovo Dev to 0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ],
     "main": "./build/extension/extension",
     "rovoDev": {
-        "version": "0.12.2"
+        "version": "0.12.3"
     },
     "scripts": {
         "vscode:uninstall": "node ./build/extension/uninstall.js",


### PR DESCRIPTION
### What Is This Change?

`replay` was recently optimized (#1109) to batch all messages together and render much faster.
Unfortunately this logic didn't account for `replay` of a streaming still ongoing, causing the replay messages to start rendering only after the call was ended.

This patch restores the original logic.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`