### PR TITLE
Fix error-state messages in Boysenberry

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -318,6 +318,11 @@ export class Container {
                 // this enables the Rovo Dev activity bar
                 await setCommandContext(CommandContext.RovoDevEnabled, true);
 
+                // only in Boysenberry, we auto-focus the Rovo Dev view
+                if (this.isBoysenberryMode) {
+                    await vscode.commands.executeCommand('atlascode.views.rovoDev.webView.focus');
+                }
+
                 this._rovodevDisposable = vscode.Disposable.from(
                     languages.registerCodeActionsProvider({ scheme: 'file' }, new RovoDevCodeActionProvider(), {
                         providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,8 @@ import { Features } from './util/featureFlags';
 import Performance from './util/perf';
 import { NotificationManagerImpl } from './views/notifications/notificationManager';
 
+const IsBoysenberry = process.env.ROVODEV_BBY === 'true';
+
 const AnalyticDelay = 5000;
 const PerfStartMarker = 'extension.start';
 
@@ -49,8 +51,8 @@ export async function activate(context: ExtensionContext) {
     Configuration.configure(context);
     Logger.configure(context);
 
-    // this disables the main Atlassian activity bar when we are in BBY
-    setCommandContext(CommandContext.BbyEnvironmentActive, !!process.env.ROVODEV_BBY);
+    // this disables the main Atlassian activity bar when we are in Boysenberry,
+    setCommandContext(CommandContext.BbyEnvironmentActive, IsBoysenberry);
 
     // Mark ourselves as the PID in charge of refreshing credentials and start listening for pings.
     context.globalState.update('rulingPid', pid);
@@ -61,7 +63,7 @@ export async function activate(context: ExtensionContext) {
         activateErrorReporting();
         registerRovoDevCommands(context);
 
-        if (!process.env.ROVODEV_BBY) {
+        if (!IsBoysenberry) {
             registerCommands(context);
             activateCodebucket(context);
 
@@ -84,7 +86,7 @@ export async function activate(context: ExtensionContext) {
         Container.clientManager.requestSite(site);
     });
 
-    if (!process.env.ROVODEV_BBY) {
+    if (!IsBoysenberry) {
         if (previousVersion === undefined) {
             commands.executeCommand(Commands.ShowOnboardingFlow);
         } else {
@@ -97,7 +99,7 @@ export async function activate(context: ExtensionContext) {
         sendAnalytics(atlascodeVersion, context.globalState);
     }, delay);
 
-    if (!process.env.ROVODEV_BBY) {
+    if (!IsBoysenberry) {
         context.subscriptions.push(languages.registerCodeLensProvider({ scheme: 'file' }, { provideCodeLenses }));
 
         // Following are async functions called without await so that they are run
@@ -209,7 +211,7 @@ async function sendAnalytics(version: string, globalState: Memento) {
 
 // this method is called when your extension is deactivated
 export function deactivate() {
-    if (!process.env.ROVODEV_BBY) {
+    if (!IsBoysenberry) {
         RovoDevProcessManager.deactivateRovoDevProcessManager();
         NotificationManagerImpl.getInstance().stopListening();
     }

--- a/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatStream.tsx
@@ -18,6 +18,8 @@ import { DialogMessage, PullRequestMessage, Response, scrollToEnd } from '../uti
 import { ChatStreamMessageRenderer } from './ChatStreamMessageRenderer';
 import { DropdownButton } from './dropdown-button/DropdownButton';
 
+const IsBoysenberry = process.env.ROVODEV_BBY === 'true';
+
 interface ChatStreamProps {
     chatHistory: Response[];
     modalDialogs: DialogMessage[];
@@ -192,16 +194,18 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
     ]);
 
     // Other state management effect
-    React.useEffect(() => {
-        if (process.env.ROVODEV_BBY && currentState.state === 'WaitingForPrompt') {
-            const canCreatePR = chatHistory.length > 0;
-            setCanCreatePR(canCreatePR);
-            if (canCreatePR) {
-                // Only check git changes if there's something in the chat
-                checkGitChanges();
+    if (IsBoysenberry) {
+        React.useEffect(() => {
+            if (currentState.state === 'WaitingForPrompt') {
+                const canCreatePR = chatHistory.length > 0;
+                setCanCreatePR(canCreatePR);
+                if (canCreatePR) {
+                    // Only check git changes if there's something in the chat
+                    checkGitChanges();
+                }
             }
-        }
-    }, [currentState, chatHistory, isFormVisible, checkGitChanges]);
+        }, [currentState, chatHistory, isFormVisible, checkGitChanges]);
+    }
 
     const handleCopyResponse = React.useCallback((text: string) => {
         if (!navigator.clipboard) {
@@ -231,7 +235,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
 
     return (
         <div ref={chatEndRef} className="chat-message-container">
-            {!process.env.ROVODEV_BBY && (
+            {!IsBoysenberry && (
                 <RovoDevLanding
                     currentState={currentState}
                     isHistoryEmpty={chatHistory.length === 0}


### PR DESCRIPTION
### What Is This Change?

Error state messages displayed when the Rovo Dev healtcheck is not healthy were hidden by the `signalRovoDevDisabled` function.
Fixed that.

Also, re-introduced the `.focus` command to auto-focus Rovo Dev in Boysenberry.

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`