### PR TITLE
Renamed StartWorkV3 feature flag

### DIFF
--- a/src/util/features.ts
+++ b/src/util/features.ts
@@ -1,7 +1,7 @@
 export enum Features {
     EnableErrorTelemetry = 'atlascode-send-error-telemetry',
     AtlassianNotifications = 'atlascode-atlassian-notifications-v2',
-    StartWorkV3 = 'atlascode-start-work-v3',
+    StartWorkV3 = 'atlascode-start-work-v3-new',
     RovoDevEnabled = 'rovo_dev_ff',
     UseNewAuthFlow = 'atlascode-use-new-auth-flow',
     EnableAiSuggestions = 'atlascode-enable-ai-suggestions-new',


### PR DESCRIPTION
### What Is This Change?

To prevent activating the feature in old releases where it was bugged.