### PR TITLE
AXON-1028: removed slash command logo in popup menu

### DIFF
--- a/src/react/atlascode/rovo-dev/RovoDev.css
+++ b/src/react/atlascode/rovo-dev/RovoDev.css
@@ -751,6 +751,13 @@ body {
     background-color: var(--vscode-input-background) !important;
 }
 
+.monaco-list .monaco-list-row .codicon {
+    display: none !important;
+}
+
+.monaco-list .monaco-list-row {
+    padding-left: 4px;
+}
 .prompt-container:focus-within {
     outline: var(--vscode-focusBorder) solid 1px;
 }


### PR DESCRIPTION
### What Is This Change?

Removed the monaco logo for the slash commands popup menu

Before: 
<img width="382" height="117" alt="Screenshot 2025-10-15 at 1 27 56 PM" src="https://github.com/user-attachments/assets/09266682-246b-491f-9074-4510ad6ecb13" />

After: 
<img width="378" height="109" alt="Screenshot 2025-10-15 at 1 28 23 PM" src="https://github.com/user-attachments/assets/a8362164-1f76-4d9f-9aae-c744dabee45e" />


### How Has This Been Tested?

Manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`