### PR TITLE
AXON-1381: handle yolo command

### DIFF
--- a/src/react/atlascode/rovo-dev/prompt-box/prompt-input/utils.tsx
+++ b/src/react/atlascode/rovo-dev/prompt-box/prompt-input/utils.tsx
@@ -101,6 +101,12 @@ export const SLASH_COMMANDS: SlashCommand[] = [
         command: { title: 'Agent Memory', id: 'rovo-dev.agentMemory', tooltip: 'Show agent memory' },
     },
     {
+        label: '/yolo',
+        insertText: '/yolo',
+        description: 'Toggle tool confirmations',
+        command: { title: 'Yolo Mode', id: 'rovo-dev.toggleYoloMode', tooltip: 'Toggle tool confirmations' },
+    },
+    {
         label: '/status',
         insertText: '/status',
         description: 'Show Rovo Dev CLI status including version, account details and model',
@@ -118,7 +124,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
     },
 ];
 
-export const createSlashCommandProvider = (): monaco.languages.CompletionItemProvider => {
+export const createSlashCommandProvider = (commands: SlashCommand[]): monaco.languages.CompletionItemProvider => {
     return {
         triggerCharacters: ['/'],
         provideCompletionItems: (model, position) => {
@@ -142,7 +148,7 @@ export const createSlashCommandProvider = (): monaco.languages.CompletionItemPro
 
             const startColumn = position.column - match[0].length;
 
-            const suggestions: monaco.languages.CompletionItem[] = SLASH_COMMANDS.map((command, index) => ({
+            const suggestions: monaco.languages.CompletionItem[] = commands.map((command, index) => ({
                 label: command.label,
                 kind: monaco.languages.CompletionItemKind.Method,
                 insertText: command.insertText,
@@ -182,6 +188,7 @@ export function setupMonacoCommands(
     onCopy: () => void,
     handleMemoryCommand: () => void,
     handleTriggerFeedbackCommand: () => void,
+    onYoloModeToggled?: () => void,
 ) {
     monaco.editor.registerCommand('rovo-dev.clearChat', () => {
         if (onSend('/clear')) {
@@ -210,6 +217,13 @@ export function setupMonacoCommands(
             editor.setValue('');
         }
     });
+
+    if (onYoloModeToggled) {
+        monaco.editor.registerCommand('rovo-dev.toggleYoloMode', () => {
+            onYoloModeToggled();
+            editor.setValue('');
+        });
+    }
 
     monaco.editor.registerCommand('rovo-dev.triggerFeedback', () => {
         handleTriggerFeedbackCommand();


### PR DESCRIPTION
### What Is This Change?

Added `/yolo` command to slash commands _only_ for IDE. This does not appear for boysenberry environments

<img width="403" height="236" alt="Screenshot 2025-10-15 at 2 14 17 PM" src="https://github.com/user-attachments/assets/2e1d056b-e212-49e1-9d75-91216d573435" />

<img width="400" height="107" alt="Screenshot 2025-10-15 at 2 14 27 PM" src="https://github.com/user-attachments/assets/2157fa72-b261-405b-b1fe-bad73d42cffe" />

### How Has This Been Tested?

Manually

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`