### PR TITLE
[AXON-1239, AXON-1326, AXON-1368] Force git status to fix missing PR button in BBY

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -7,5 +7,12 @@ module.exports = {
             writeText: jest.fn(),
             readText: jest.fn(),
         },
-    }
+    },
+    extensions: {
+        getExtension: jest.fn(() => ({
+            isActive: true,
+            exports: {},
+            activate: jest.fn().mockResolvedValue({}),
+        })),
+    },    
 }

--- a/src/rovo-dev/rovoDevPullRequestHandler.test.ts
+++ b/src/rovo-dev/rovoDevPullRequestHandler.test.ts
@@ -1,41 +1,52 @@
 import { RovoDevPullRequestHandler } from './rovoDevPullRequestHandler';
 
+jest.mock('src/logger', () => ({
+    RovoDevLogger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+    },
+}));
+
 describe('RovoDevPullRequestHandler', () => {
     let handler: RovoDevPullRequestHandler;
+    let findPRLink: (output: string) => string | undefined;
 
     beforeEach(() => {
         handler = new RovoDevPullRequestHandler();
+        findPRLink = (output) => handler['findPRLink'](output);
     });
 
     describe('findPRLink', () => {
         it('Should match the link in GitHub push output', () => {
-            const link = handler.findPRLink(`
+            const link = findPRLink(`
 remote:      https://github.com/my-org/my-repo/pull/new/my-branch
 remote:`);
             expect(link).toBe('https://github.com/my-org/my-repo/pull/new/my-branch');
         });
 
         it('Should match the link in Bitbucket push output', () => {
-            const link = handler.findPRLink(`
+            const link = findPRLink(`
 remote:      https://bitbucket.org/my-org/my-repo/pull-requests/new?source=my-branch
 remote:`);
             expect(link).toBe('https://bitbucket.org/my-org/my-repo/pull-requests/new?source=my-branch');
         });
 
         it('Should match the link in generic push output', () => {
-            const link = handler.findPRLink(`
+            const link = findPRLink(`
                 remote:      https://example.com/my-org/my-repo/pull/new/my-branch
 remote:`);
             expect(link).toBe('https://example.com/my-org/my-repo/pull/new/my-branch');
         });
 
         it('Should return undefined for empty output', () => {
-            const link = handler.findPRLink('');
+            const link = findPRLink('');
             expect(link).toBeUndefined();
         });
 
         it('Should not match anything to odd links', () => {
-            const link = handler.findPRLink(`
+            const link = findPRLink(`
                 remote:      https://example.com/my-org/my-repo/not-a-pr-link
 remote:`);
             expect(link).toBeUndefined();


### PR DESCRIPTION
### What Is This Change?

The Pull Request button isn't showing up because git didn't detect the changes before the prompt finished.
Forcing a `git status` before checking if there are pending changes should solve the issue.

This change also optimize the `rovoDevPullRequestHandler.ts` by:
- caching the Git API object instead of recreating it every time
- invoking `hasUnpushedCommits` only if `hasUncommittedChanges` returns false

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`