### PR TITLE
AXON-1175: [Rovo Dev] Markdown is having trouble parsing complex URLs with encoded characters and parentheses

### DIFF
--- a/src/react/atlascode/rovo-dev/common/common.test.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.test.tsx
@@ -1,0 +1,72 @@
+import { decodeUriComponentSafely, normalizeLinks } from './common';
+
+describe('decodeUriComponentSafely', () => {
+    it('should decode valid URI components', () => {
+        expect(decodeUriComponentSafely('hello%20world')).toBe('hello world');
+        expect(decodeUriComponentSafely('test%3Dvalue')).toBe('test=value');
+    });
+
+    it('should return original string for invalid URI components', () => {
+        const invalid = 'invalid%';
+        expect(decodeUriComponentSafely(invalid)).toBe(invalid);
+
+        const malformed = 'test%GG';
+        expect(decodeUriComponentSafely(malformed)).toBe(malformed);
+    });
+});
+
+describe('normalizeLinks', () => {
+    it('should encode JQL query with spaces and parentheses', () => {
+        const input = 'https://softwareteams.atlassian.net/issues/?jql=assignee = currentUser()';
+        const result = normalizeLinks(input);
+
+        expect(result).toContain('jql=');
+        expect(result).not.toContain('assignee = currentUser()');
+        expect(result).toContain('assignee%20');
+        expect(result).toContain('currentUser%28%29');
+    });
+
+    it('should handle complex JQL with already encoded parts', () => {
+        const input =
+            'https://softwareteams.atlassian.net/issues/?jql=assignee WAS currentUser() DURING (startOfDay(-30d)%2C now())%20ORDER%20BY%20updated%20DESC';
+        const result = normalizeLinks(input);
+
+        expect(result.startsWith('https://softwareteams.atlassian.net/issues/?jql=')).toBe(true);
+        expect(result).toContain('assignee%20WAS');
+        expect(result).toContain('currentUser%28%29');
+        expect(result).not.toContain('assignee WAS');
+        expect(result).not.toContain('currentUser()');
+    });
+
+    it('should encode parentheses in regular URLs', () => {
+        const input = 'https://example.com/page(with)parentheses';
+        const result = normalizeLinks(input);
+
+        expect(result).toBe('https://example.com/page%28with%29parentheses');
+    });
+
+    it('should handle mixed content with JQL and regular URLs', () => {
+        const input = `Here is a JQL link: https://site.atlassian.net/issues/?jql=assignee = me()
+And a regular link: https://example.com/page(test)
+And some text`;
+        const result = normalizeLinks(input);
+
+        expect(result).not.toContain('assignee = me()');
+        expect(result).toContain('jql=');
+        expect(result).toContain('page%28test%29');
+        expect(result).toContain('And some text');
+    });
+
+    it('should handle multiple JQL links in text', () => {
+        const input = `Check these links:
+https://site1.atlassian.net/issues/?jql=assignee = currentUser()
+and also
+https://site2.atlassian.net/issues/?jql=status = "In Progress"`;
+        const result = normalizeLinks(input);
+        const jqlLinks = result.match(/https:\/\/[^\n\r]+\/issues\/\?jql=[^\n\r]+/g);
+
+        expect(jqlLinks).toHaveLength(2);
+        expect(result).not.toContain('assignee = currentUser()');
+        expect(result).not.toContain('status = "In Progress"');
+    });
+});

--- a/src/react/atlascode/rovo-dev/common/common.tsx
+++ b/src/react/atlascode/rovo-dev/common/common.tsx
@@ -16,6 +16,8 @@ const mdParser = new MarkdownIt({
 
 mdParser.linkify.set({ fuzzyLink: false });
 
+mdParser.validateLink = (url) => /^(https?):/i.test(url);
+
 mdParser.renderer.rules.link_open = function (tokens, idx, options, env, self) {
     const token = tokens[idx];
     const hrefIndex = token.attrIndex('href');
@@ -35,11 +37,44 @@ mdParser.renderer.rules.link_open = function (tokens, idx, options, env, self) {
     return self.renderToken(tokens, idx, options);
 };
 
+export const decodeUriComponentSafely = (value: string) => {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+};
+
+const strictEncodeUrl = (url: string) => {
+    const decoded = decodeUriComponentSafely(url);
+    const encoded = encodeURI(decoded);
+
+    return encoded.replace(/\(/g, '%28').replace(/\)/g, '%29');
+};
+
+// Normalizes URLs before Markdown rendering:
+// 1) Encodes the entire Atlassian JQL query (everything after "jql=" to end of line)
+// so spaces, commas, and parentheses don't break the link.
+// 2) Strict-encodes any http/https URL (encodeURI + () -> %28/%29) to prevent
+// linkify from truncating at closing parentheses.
+// Keep validateLink to allow only http/https.
+export const normalizeLinks = (messageText: string) => {
+    let processed = messageText.replace(
+        /(https?:\/\/[^\s]+\/issues\/\?jql=)(.*?)(?=$|\n|\r)/gi,
+        (_match, prefix: string, jqlTail: string) => prefix + encodeURIComponent(decodeUriComponentSafely(jqlTail)),
+    );
+
+    processed = processed.replace(/https?:\/\/[^\n\r]+/g, (rawUrl) => strictEncodeUrl(rawUrl));
+
+    return processed;
+};
+
 export const MarkedDown: React.FC<{ value: string; onLinkClick?: (href: string) => void }> = ({
     value,
     onLinkClick,
 }) => {
     const spanRef = React.useRef<HTMLSpanElement>(null);
+    const html = React.useMemo(() => mdParser.render(normalizeLinks(value)), [value]);
 
     React.useEffect(() => {
         if (!spanRef.current) {
@@ -64,8 +99,9 @@ export const MarkedDown: React.FC<{ value: string; onLinkClick?: (href: string) 
             currentSpan.removeEventListener('click', handleClick);
         };
     }, [onLinkClick]);
+
     // eslint-disable-next-line react-dom/no-dangerously-set-innerhtml -- necessary to apply MarkDown formatting
-    return <span ref={spanRef} dangerouslySetInnerHTML={{ __html: mdParser.render(value) }} />;
+    return <span ref={spanRef} dangerouslySetInnerHTML={{ __html: html }} />;
 };
 
 export interface OpenFileFunc {


### PR DESCRIPTION
### What Is This Change?

| Before | After |
|:--|:--|
| <img width="694" height="1020" alt="image" src="https://github.com/user-attachments/assets/291638d4-6629-45ee-94b1-7d4c2a6162b8" /> | <img width="418" height="563" alt="image" src="https://github.com/user-attachments/assets/e0797bac-2a1b-4829-80a5-9f47e53150d5" /> |

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change