### PR TITLE
from GH #1169 re-apply color to text input fields

### DIFF
--- a/src/webviews/components/issue/common/JiraIssueTextArea.tsx
+++ b/src/webviews/components/issue/common/JiraIssueTextArea.tsx
@@ -67,6 +67,7 @@ const JiraIssueTextAreaEditor: React.FC<Props> = ({
                 <TextArea
                     style={{
                         background: 'var(--vscode-input-background)',
+                        color: 'var(--vscode-input-foreground)',
                         border: '1px solid var(--vscode-input-border)',
                         caretColor: 'var(--vscode-editorCursor-background)',
                         minHeight: isDescription ? '175px' : '100px',


### PR DESCRIPTION
### What Is This Change?
The user raised an issue with low contrast. In their case, it was literally impossible to see. I couldn't repro this. However, the change that caused this was suspicious, and reverting the change did increase the contrast. 

The suspicious change: https://github.com/atlassian/atlascode/commit/6418d430ef0a8d8a8c15cfe49a89f275e79e332c#r168114670

Manual tested 

See Screenshots of before and after 

** BEFORE **
<img width="936" height="181" alt="image" src="https://github.com/user-attachments/assets/23fdd22b-23ff-4ec2-a41f-e992a386758b" />

** AFTER **
<img width="824" height="181" alt="image" src="https://github.com/user-attachments/assets/3e83525c-8b48-4201-bac0-610850b0e7b2" />

Address GH issue #1169 

Root Cause: code deleted by mistake