### PR TITLE
AXON-1412: [Create issue] The state of the attachments field is reset when the user collapse Advanced Options section

### DIFF
--- a/src/webviews/components/App.css
+++ b/src/webviews/components/App.css
@@ -1934,6 +1934,9 @@ pre {
 .ac-attachment-thumb-img-inline {
     width: 34px;
     height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .ac-attachment-overlay-container {

--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -1854,6 +1854,7 @@ export abstract class AbstractIssueEditorPage<
                             isInline={true}
                             field={field}
                             onFilesChanged={this.handleCreateModeAttachments}
+                            initialFiles={this.state.fieldValues[field.key]}
                         />
                     </div>
                 );

--- a/src/webviews/components/issue/AttachmentForm.test.tsx
+++ b/src/webviews/components/issue/AttachmentForm.test.tsx
@@ -1,0 +1,95 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { disableConsole } from 'testsutil';
+
+import { AttachmentForm } from './AttachmentForm';
+
+describe('AttachmentForm - persisting files when reopening advanced options', () => {
+    const mockOnFilesChanged = jest.fn();
+
+    // Helper to create serialized file (as saved in state)
+    const createSerializedFile = (name: string, type: string) => {
+        const content = btoa('test content');
+        return {
+            name,
+            size: 12,
+            type,
+            lastModified: Date.now(),
+            fileContent: content,
+            path: `/path/to/${name}`,
+        };
+    };
+
+    beforeAll(() => {
+        disableConsole('warn', 'error');
+        global.URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+        global.URL.revokeObjectURL = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('restores a single file from saved state', () => {
+        const savedFiles = [createSerializedFile('document.pdf', 'application/pdf')];
+
+        const { container } = render(
+            <AttachmentForm onFilesChanged={mockOnFilesChanged} isInline={true} initialFiles={savedFiles} />,
+        );
+
+        expect(container.textContent).toContain('document.pdf');
+    });
+
+    it('restores multiple files from saved state', () => {
+        const savedFiles = [
+            createSerializedFile('file1.txt', 'text/plain'),
+            createSerializedFile('file2.pdf', 'application/pdf'),
+            createSerializedFile('image.png', 'image/png'),
+        ];
+
+        const { container } = render(
+            <AttachmentForm onFilesChanged={mockOnFilesChanged} isInline={true} initialFiles={savedFiles} />,
+        );
+
+        expect(container.textContent).toContain('file1.txt');
+        expect(container.textContent).toContain('file2.pdf');
+        expect(container.textContent).toContain('image.png');
+    });
+
+    it('calls onFilesChanged with restored files', async () => {
+        const savedFiles = [createSerializedFile('test.txt', 'text/plain')];
+
+        render(<AttachmentForm onFilesChanged={mockOnFilesChanged} isInline={true} initialFiles={savedFiles} />);
+
+        await waitFor(() => {
+            expect(mockOnFilesChanged).toHaveBeenCalled();
+            const calledFiles = mockOnFilesChanged.mock.calls[0][0];
+            expect(calledFiles).toHaveLength(1);
+            expect(calledFiles[0].name).toBe('test.txt');
+        });
+    });
+
+    it('creates preview URL for images', () => {
+        const savedFiles = [createSerializedFile('image.png', 'image/png')];
+
+        render(<AttachmentForm onFilesChanged={mockOnFilesChanged} isInline={true} initialFiles={savedFiles} />);
+
+        expect(global.URL.createObjectURL).toHaveBeenCalled();
+    });
+
+    it('does not create preview URL for non-images', () => {
+        const savedFiles = [createSerializedFile('document.pdf', 'application/pdf')];
+
+        render(<AttachmentForm onFilesChanged={mockOnFilesChanged} isInline={true} initialFiles={savedFiles} />);
+
+        expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('handles empty files array correctly', () => {
+        const { getByText } = render(
+            <AttachmentForm onFilesChanged={mockOnFilesChanged} isInline={true} initialFiles={[]} />,
+        );
+
+        expect(getByText('Drop files or click to browse')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
### What Is This Change?

Demo: https://www.loom.com/share/21068099eadc4437a3d68c304a05c539

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change