### PR TITLE
AXON-1413: [Create Issue] The state of the 'Due date' field is reset when the user collapse Advanced Options section

### DIFF
--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -678,6 +678,7 @@ export abstract class AbstractIssueEditorPage<
                                 <div>
                                     <DatePicker
                                         {...fieldArgs.fieldProps}
+                                        defaultValue={this.coerceToString(this.state.fieldValues[field.key])}
                                         isDisabled={this.state.isSomethingLoading}
                                         className="ac-select-container"
                                         selectProps={{
@@ -743,6 +744,7 @@ export abstract class AbstractIssueEditorPage<
                                 <div>
                                     <DateTimePicker
                                         {...fieldArgs.fieldProps}
+                                        defaultValue={this.coerceToString(this.state.fieldValues[field.key])}
                                         isDisabled={this.state.isSomethingLoading}
                                         className="ac-select-container"
                                         datePickerSelectProps={{


### PR DESCRIPTION
### What Is This Change?

Demo: https://www.loom.com/share/da8b98f10351417389f6664454aca2f9

Basic checks:

- [ ] `yarn lint`
- [ ] `yarn test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change