### PR TITLE
chore: revert to using npm version directly

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: yarn-cache-
 
       - name: Set version in package.json
-        run: yarn version $PACKAGE_VERSION --immediate
+        run: npm version $PACKAGE_VERSION --no-git-tag-version --allow-same-version -f
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           restore-keys: yarn-cache-
 
       - name: Set version in package.json
-        run: yarn version $PACKAGE_VERSION --immediate
+        run: npm version $PACKAGE_VERSION --no-git-tag-version --allow-same-version -f
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
### What Is This Change?

Revert the use of `yarn version` in release scripts

This is what we're seeing in a `release` job today:

<img width="1320" height="220" alt="image" src="https://github.com/user-attachments/assets/8241914f-1092-46ce-8aa5-f3be0776bb22" />

We can repro this locally by doing a shallow checkout, like the one that `release` job does by default:
```sh
git clone --depth 1 -b v4.0.5 git@github.com:atlassian/atlascode.git
```

`yarn version` fails in an environment like that, `npm version` works as expected

IMO we should just revert to using `npm` for versioning.  Based on the [docs](https://classic.yarnpkg.com/lang/en/docs/cli/version/), `yarn version` is pretty opinionated, and intended for more complex usage than what we want here.

Notably, `yarn version` works in nightly builds. I didn't spend the time to properly investigate this - but it's probably one of the 2 differences at play:
 * In nightly, we do `git fetch --tags --force -q` as a first action, via `get-next-nightly.sh`
 * The pipeline is triggered differently, meaning there could be a different setup for `git clone` in the checkout action

In a quick local test, I couldn't get `yarn version` to work even after `git fetch --tags --force -q` though - so I'm not proposing that as a solution here 😛 

### How Has This Been Tested?

Tried `npm version` in a shallow copy, it worked as expected. Also, this is literally what we had before

Basic checks:

- [x] `yarn lint`
- [x] `yarn test`
