### PR TITLE
AXON-1420: stream now checks last response for summary block

### DIFF
--- a/src/react/atlascode/rovo-dev/messaging/ChatItem.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ToolPermissionChoice } from 'src/rovo-dev/rovoDevApiClientInterfaces';
-import { State } from 'src/rovo-dev/rovoDevTypes';
 
 import { CheckFileExistsFunc, OpenFileFunc, OpenJiraFunc } from '../common/common';
 import { DialogMessageItem } from '../common/DialogMessage';
@@ -24,7 +23,6 @@ interface ChatItemProps {
         isRetryAfterErrorButtonEnabled: (uid: string) => boolean;
         retryPromptAfterError: () => void;
     };
-    currentState: State;
     drawerOpen: boolean;
     onLinkClick: (href: string) => void;
 }
@@ -37,7 +35,6 @@ export const ChatItem = React.memo<ChatItemProps>(
         onToolPermissionChoice,
         onCollapsiblePanelExpanded,
         renderProps,
-        currentState,
         drawerOpen,
         onLinkClick,
     }) => {
@@ -58,7 +55,7 @@ export const ChatItem = React.memo<ChatItemProps>(
             return (
                 <ChatMessageItem
                     msg={block}
-                    enableActions={block.event_kind === 'text' && currentState.state === 'WaitingForPrompt'}
+                    enableActions={block.event_kind === 'text' && block.isSummary === true}
                     onCopy={handleCopyResponse}
                     onFeedback={handleFeedbackTrigger}
                     openFile={renderProps.openFile}
@@ -115,7 +112,6 @@ export const ChatItem = React.memo<ChatItemProps>(
         return (
             prevProps.block === nextProps.block &&
             !isAppendedMessages() &&
-            prevProps.currentState === nextProps.currentState &&
             prevProps.drawerOpen === nextProps.drawerOpen
         );
     },

--- a/src/react/atlascode/rovo-dev/messaging/ChatStreamMessageRenderer.tsx
+++ b/src/react/atlascode/rovo-dev/messaging/ChatStreamMessageRenderer.tsx
@@ -60,7 +60,6 @@ export const ChatStreamMessageRenderer = React.memo<ChatStreamMessageRendererPro
                     onToolPermissionChoice={onToolPermissionChoice}
                     onCollapsiblePanelExpanded={onCollapsiblePanelExpanded}
                     renderProps={renderProps}
-                    currentState={currentState}
                     drawerOpen={idx === openDrawerIdx}
                     onLinkClick={onLinkClick}
                 />

--- a/src/react/atlascode/rovo-dev/rovoDevView.tsx
+++ b/src/react/atlascode/rovo-dev/rovoDevView.tsx
@@ -206,6 +206,18 @@ const RovoDevView: React.FC = () => {
         }
     }, []);
 
+    const setSummaryMessageInHistory = useCallback(() => {
+        setHistory((prev) => {
+            const lastMessage = prev[prev.length - 1];
+
+            if (lastMessage && !Array.isArray(lastMessage) && lastMessage.event_kind === 'text') {
+                const summaryMessage = { ...lastMessage, isSummary: true };
+                return [...prev.slice(0, -1), summaryMessage];
+            }
+            return prev;
+        });
+    }, []);
+
     const handleAppendResponse = useCallback(
         (response: Response | Response[]) => {
             setHistory((prev) => {
@@ -267,6 +279,7 @@ const RovoDevView: React.FC = () => {
                     ) {
                         setCurrentState({ state: 'WaitingForPrompt' });
                     }
+                    setSummaryMessageInHistory();
                     setPendingToolCallMessage('');
                     setModalDialogs([]);
                     break;
@@ -428,7 +441,7 @@ const RovoDevView: React.FC = () => {
                     break;
             }
         },
-        [currentState.state, handleAppendResponse, clearChatHistory],
+        [handleAppendResponse, currentState.state, setSummaryMessageInHistory, clearChatHistory],
     );
 
     const { postMessage, postMessagePromise } = useMessagingApi<

--- a/src/rovo-dev/responseParserInterfaces.ts
+++ b/src/rovo-dev/responseParserInterfaces.ts
@@ -15,6 +15,7 @@ export interface RovoDevTextResponse {
     event_kind: 'text';
     index: number;
     content: string;
+    isSummary?: boolean;
 }
 
 export interface RovoDevToolCallResponse {


### PR DESCRIPTION
### What Is This Change?

Before, feedback buttons were shown to any text response outside of a thinking block

Now, when the webview recieves a `CompleteMessage` signal, it looks at the last response. If it is a text response, it is counted as the summary message and the feedback buttons are appended only to those messages.

<img width="422" height="465" alt="Screenshot 2025-10-23 at 2 44 36 PM" src="https://github.com/user-attachments/assets/fbcf05d6-400b-47df-8163-b92d606ad769" />


### How Has This Been Tested?

manually

Basic checks:

- [x] `yarn lint`
- [x] `yarn test`