### PR TITLE
AXON-1419: fix issue with linked issues display

### DIFF
--- a/src/webviews/components/issue/IssueList.tsx
+++ b/src/webviews/components/issue/IssueList.tsx
@@ -45,7 +45,7 @@ export default class IssueList extends React.Component<
         return (
             <TableTree
                 columns={[IssueKey, Summary, Priority, AssigneeColumn, StatusColumn]}
-                columnWidths={['100px', '100%', '20px', '100%', '150px']}
+                columnWidths={['100%', '100%', '20px', '100%', '150px']}
                 items={this.props.issues.map((issue) => {
                     return {
                         id: issue.key,

--- a/src/webviews/components/issue/LinkedIssues.tsx
+++ b/src/webviews/components/issue/LinkedIssues.tsx
@@ -59,7 +59,7 @@ export const LinkedIssues: React.FunctionComponent<LinkedIssuesProps> = ({
     return (
         <TableTree
             columns={[IssueKey, Summary, Priority, AssigneeColumn, StatusColumn]}
-            columnWidths={['100px', '100%', '20px', '100%', '150px']}
+            columnWidths={['100%', '100%', '20px', '100%', '150px']}
             items={issuelinks.map((issuelink) => {
                 return {
                     id: issuelink.id,


### PR DESCRIPTION
### What Is This Change?

**Current behaviour when the space key is too long:**
<img width="859" height="660" alt="Screenshot 2025-10-24 at 17 32 12" src="https://github.com/user-attachments/assets/e45c9811-471a-43a0-9fe2-63a127bc4ec4" />

**Fixed behaviour:** 
<img width="853" height="772" alt="Screenshot 2025-10-24 at 17 27 24" src="https://github.com/user-attachments/assets/34adcd95-4e21-4e85-9854-78be0e102d08" />


<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `yarn lint`
- [ ] `yarn test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change