### PR TITLE
AXON-1424: Add rendering for expanded_folder and known mcp tools

### DIFF
--- a/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
+++ b/src/react/atlascode/rovo-dev/common/DialogMessage.tsx
@@ -162,6 +162,9 @@ const friendlyToolName: Record<RovoDevToolName, string> = {
     bash: 'Run command',
     create_technical_plan: 'Create a technical plan',
     mcp_invoke_tool: "Invoke an MCP server's tool",
+    mcp__atlassian__invoke_tool: "Invoke an Atlassian MCP server's tool",
+    mcp__atlassian__get_tool_schema: "Get an Atlassian MCP server's tool schema",
+    mcp__scout__invoke_tool: "Invoke an MCP server's tool",
 };
 
 const ToolCall: React.FC<{

--- a/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
+++ b/src/react/atlascode/rovo-dev/tools/ToolCallItem.tsx
@@ -57,6 +57,9 @@ export function parseToolCallMessage(msgToolName: RovoDevToolName): string {
         case 'create_technical_plan':
             return 'Creating technical plan';
         case 'mcp_invoke_tool':
+        case 'mcp__atlassian__invoke_tool':
+        case 'mcp__atlassian__get_tool_schema':
+        case 'mcp__scout__invoke_tool':
             return "Invoking MCP server's tool";
         default:
             // @ts-expect-error ts(2339) - msgToolName here should be 'never'

--- a/src/react/atlascode/rovo-dev/utils.tsx
+++ b/src/react/atlascode/rovo-dev/utils.tsx
@@ -194,6 +194,16 @@ export function parseToolReturnMessage(msg: RovoDevToolReturnResponse): ToolRetu
             }
             break;
 
+        case 'mcp__atlassian__invoke_tool':
+        case 'mcp__atlassian__get_tool_schema':
+        case 'mcp__scout__invoke_tool':
+            const mcpToolCallArgs = msg.toolCallMessage.args;
+            const mcpToolData = mcpToolCallArgs ? JSON.parse(mcpToolCallArgs) : undefined;
+            resp.push({
+                content: `Invoked MCP tool: \`${mcpToolData?.tool_name || 'unknown tool'}\``,
+                type: 'bash',
+            });
+            break;
         default:
             // For other tool names, we just return the raw content
             resp.push({

--- a/src/rovo-dev/responseParserInterfaces.ts
+++ b/src/rovo-dev/responseParserInterfaces.ts
@@ -120,6 +120,9 @@ export type RovoDevToolName =
     | 'grep'
     | 'bash'
     | 'create_technical_plan'
-    | 'mcp_invoke_tool';
+    | 'mcp_invoke_tool'
+    | 'mcp__atlassian__invoke_tool'
+    | 'mcp__atlassian__get_tool_schema'
+    | 'mcp__scout__invoke_tool';
 
 export type RovoDevToolPemissionScenario = 'ASK' | 'ALLOWED' | 'DENIED';


### PR DESCRIPTION
### What Is This Change?

Added rendering for `expanded_folder` tool call as well as know `mcp` tool calls
<img width="317" height="44" alt="Screenshot 2025-10-24 at 10 44 09 AM" src="https://github.com/user-attachments/assets/27cf366c-8da7-4cfd-9c61-6385ec03af80" />

<img width="214" height="41" alt="Screenshot 2025-10-24 at 10 45 19 AM" src="https://github.com/user-attachments/assets/560fd115-2fb3-4f2d-9ee5-682689329886" />

### How Has This Been Tested?

manually

Basic checks:

- [x] `yarn lint`
- [x] `yarn test`