### PR TITLE
AXON-1473: Retain artifacts on job failure to enable partial workflow reruns

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,7 +126,7 @@ jobs:
     needs: [build-extension]
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target:
           - jira-cloud


### PR DESCRIPTION
### What Is This Change?

- Only delete artifacts on success to enable partial workflow reruns
  - artifacts retained for 1 day when jobs fail or are cancelled
  - allows rerunning failed jobs without rebuilding dependencies
  - reduces CI time for retries

- Disable fail-fast for e2e matrix tests
  - all e2e targets run to completion even if one fails
  - provides complete test results in a single run
  - better visibility into which targets are passing/failing

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change