### PR TITLE
[AXON-1477, AXON-1478] Fix some errors while enabling Rovo Dev

### DIFF
--- a/src/util/waitFor.ts
+++ b/src/util/waitFor.ts
@@ -38,7 +38,7 @@ export async function waitFor<T>({
     abortIf?: () => boolean;
 }): Promise<T> {
     if (abortIf?.()) {
-        throw new WaitForError('aborted', undefined);
+        throw new WaitForError('waitFor aborted', undefined);
     }
 
     let result = await check();
@@ -49,7 +49,7 @@ export async function waitFor<T>({
         timeout -= interval;
 
         if (abortIf?.()) {
-            throw new WaitForError('aborted', result);
+            throw new WaitForError('waitFor aborted', result);
         }
 
         result = await check();
@@ -57,7 +57,7 @@ export async function waitFor<T>({
     }
 
     if (!checkPassed) {
-        throw new WaitForError('failed', result);
+        throw new WaitForError('waitFor failed', result);
     }
 
     return result;


### PR DESCRIPTION
### What Is This Change?

This change fixes the following errors:
`Error: Rovo Dev instance is already running.`
`Error: Multiple initialization of Rovo Dev attempted`

These were happening because of a race condition between `enableRovoDev()` and `disableRovoDev()` when they were called one after the other.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`