### PR TITLE
[AXON-1483] add dedicated stylesheet for issue suggestions

### DIFF
--- a/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
+++ b/src/webviews/components/aiCreateIssue/AISuggestionFooter.tsx
@@ -1,5 +1,4 @@
-// TODO: extract the relevant bits, decouple from Rovo Dev styles
-import 'src/rovo-dev/ui/RovoDev.css';
+import './Suggestions.css';
 
 import { Checkbox } from '@atlaskit/checkbox';
 import { HelperMessage } from '@atlaskit/form';
@@ -83,14 +82,17 @@ const AISuggestionFooter: React.FC<{
                             ? 'Thank you for your feedback! Your input helps us improve Rovo Dev.'
                             : 'Please provide feedback to improve Rovo Dev work item generation'}
                     </HelperMessage>
-                    <div className="chat-message-actions" style={{ display: 'flex', gap: '2px', marginTop: '10px' }}>
+                    <div
+                        className="ai-suggestion-feedback-actions"
+                        style={{ display: 'flex', gap: '2px', marginTop: '10px' }}
+                    >
                         <div style={{ flex: 1 }}></div>
                         <Tooltip content="Helpful">
                             <button
                                 onClick={() => handleFeedback(true)}
                                 type="button"
                                 aria-label="like-response-button"
-                                className="chat-message-action"
+                                className="ai-suggestion-feedback-action"
                                 style={{ visibility: feedbackSent ? 'hidden' : 'visible' }}
                             >
                                 <ThumbsUpIcon label="thumbs-up" spacing="none" />
@@ -103,7 +105,7 @@ const AISuggestionFooter: React.FC<{
                                 }}
                                 type="button"
                                 aria-label="dislike-response-button"
-                                className="chat-message-action"
+                                className="ai-suggestion-feedback-action"
                                 style={{ visibility: feedbackSent ? 'hidden' : 'visible' }}
                             >
                                 <ThumbsDownIcon label="thumbs-down" spacing="none" />

--- a/src/webviews/components/aiCreateIssue/Suggestions.css
+++ b/src/webviews/components/aiCreateIssue/Suggestions.css
@@ -1,0 +1,23 @@
+/* Styles for AI suggestion feedback buttons */
+
+.ai-suggestion-feedback-actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0;
+    margin-bottom: 8px;
+}
+
+.ai-suggestion-feedback-action {
+    display: flex;
+    align-items: center;
+    background: transparent;
+    border: none;
+    color: var(--vscode-editor-foreground);
+    cursor: pointer;
+    border-radius: 2px;
+}
+
+.ai-suggestion-feedback-action:hover {
+    background: var(--vscode-button-secondaryHoverBackground);
+}


### PR DESCRIPTION
### What Is This Change?

Stop using rovodev stylesheets in issue suggestions by creating a new dedicated stylesheet with relevant stuff from `Rovodev.css`. Renamed the classes so that they match the purpose :)

This should cause no visual or logical changes :)

### How Has This Been Tested?

Made sure the styles didn't go crazy in the footer where then old css was used:

<img width="695" height="106" alt="image" src="https://github.com/user-attachments/assets/5a70a2d1-1cb0-49dc-923d-588ac5e3f540" />


Basic checks:

- [x] `npm run lint`
- [x] `npm run test`