### PR TITLE
[AXON-1487] decouple timeout definition for rovodev

### DIFF
--- a/src/rovo-dev/ui/create-pr/PullRequestForm.tsx
+++ b/src/rovo-dev/ui/create-pr/PullRequestForm.tsx
@@ -1,12 +1,11 @@
 import PullRequestIcon from '@atlaskit/icon/core/pull-request';
 import React from 'react';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
-import { ConnectionTimeout } from 'src/util/time';
 
 import { useMessagingApi } from '../../../react/atlascode/messagingApi';
 import { MarkedDown } from '../common/common';
 import { RovoDevViewResponse, RovoDevViewResponseType } from '../rovoDevViewMessages';
-import { PullRequestMessage } from '../utils';
+import { ConnectionTimeout, PullRequestMessage } from '../utils';
 
 const PullRequestButton: React.FC<{
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -2,7 +2,6 @@ import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import * as React from 'react';
 import { State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
-import { ConnectionTimeout } from 'src/util/time';
 
 import { DetailedSiteInfo } from '../../../atlclients/authInfo';
 import { useMessagingApi } from '../../../react/atlascode/messagingApi';
@@ -14,7 +13,7 @@ import { RovoDevLanding } from '../landing-page/RovoDevLanding';
 import { McpConsentChoice, RovoDevViewResponse, RovoDevViewResponseType } from '../rovoDevViewMessages';
 import { CodePlanButton } from '../technical-plan/CodePlanButton';
 import { ToolCallItem } from '../tools/ToolCallItem';
-import { DialogMessage, PullRequestMessage, Response, scrollToEnd } from '../utils';
+import { ConnectionTimeout, DialogMessage, PullRequestMessage, Response, scrollToEnd } from '../utils';
 import { ChatStreamMessageRenderer } from './ChatStreamMessageRenderer';
 import { DropdownButton } from './dropdown-button/DropdownButton';
 

--- a/src/rovo-dev/ui/utils.tsx
+++ b/src/rovo-dev/ui/utils.tsx
@@ -8,6 +8,18 @@ import {
 
 import { RovoDevContextItem, TechnicalPlan } from '../rovoDevTypes';
 
+export enum Time {
+    SECONDS = 1000,
+    MINUTES = 60000,
+    HOURS = 3600000,
+    DAYS = 86400000,
+    WEEKS = 604800000,
+    MONTHS = 2592000000,
+    FOREVER = Infinity,
+}
+
+export const ConnectionTimeout = 30 * Time.SECONDS;
+
 export type ChatMessage =
     | UserPromptMessage
     | PullRequestMessage


### PR DESCRIPTION
### What Is This Change?

This is part of the continued effort to reduce coupling between rovodev and the rest of the extension.
Here, we introduce a local definition for timeout

<img width="403" height="364" alt="image" src="https://github.com/user-attachments/assets/b05594b4-c043-4f8a-a838-c3d6d118b8e8" />


### How Has This Been Tested?

`npm run extension:install` -> everything still works :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`