### PR TITLE
fix: don't call API if issues are found in cache

### DIFF
--- a/src/rovo-dev/rovoDevJiraItemsProvider.ts
+++ b/src/rovo-dev/rovoDevJiraItemsProvider.ts
@@ -77,7 +77,7 @@ export class RovoDevJiraItemsProvider extends Disposable {
 
         // Filter to only include MinimalIssue items (not IssueLinkIssue)
         let assignedIssuesForSite = this.fetchJiraIssuesFromCache(this.jiraSiteHostname);
-        if (!assignedIssuesForSite || assignedIssuesForSite.length === 0) {
+        if (assignedIssuesForSite.length === 0) {
             assignedIssuesForSite = await this.fetchJiraIssuesFromAPI(this.jiraSiteHostname);
         }
 


### PR DESCRIPTION
### What Is This Change?

Noticed a small broken conditional, restored what was probably the intended logic here - go to API if cache doesn't return anything. We probably missed it on introduction [here](https://github.com/atlassian/atlascode/pull/1068/files#diff-6dd5455adc5e4421d8e6ef6722c03b39255364f53133fe9c640ff2b39aaa5f39R63-R66)

### How Has This Been Tested?

`npm run dev` - poked around with breakpoints, with and without cache. Looks the same - but skipping the call makes the loading a bit faster

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`