### PR TITLE
[AXON-1010] Replay should render instantly instead of being streamed

### DIFF
--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -356,7 +356,7 @@ export class RovoDevChatProvider {
 
                 default:
                     await flush();
-                    this.processRovoDevResponse('replay', response);
+                    await this.processRovoDevResponse('replay', response);
                     break;
             }
         }


### PR DESCRIPTION
## **This change is currently blocked on a new release from Rovo Dev**

### What Is This Change?

With this change, the `replay` messages are rendered in bulk instead of being rendered one by one.
This should drastically improve the performance of `replay` and render it almost instantaneously. 

This change relies on a new message `replay_end` sent by Rovo Dev when the `replay` API finishes streaming the buffered messages and starts streaming live messages.

### How Has This Been Tested?

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`