### PR TITLE
chore: bump glob -> `^11.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34823,6 +34823,13 @@
             "dev": true,
             "license": "Unlicense"
         },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/fsevents/-/fsevents-2.3.3.tgz",
@@ -35800,6 +35807,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/inherits/-/inherits-2.0.4.tgz",
@@ -36729,6 +36748,28 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-merge/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/istanbul-merge/node_modules/locate-path": {
@@ -39678,6 +39719,28 @@
                 "node": ">=8"
             }
         },
+        "node_modules/nyc/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/nyc/node_modules/istanbul-lib-source-maps": {
             "version": "4.0.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
@@ -40494,6 +40557,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
@@ -43916,6 +43989,28 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rimraf/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/rope-sequence": {
             "version": "1.3.4",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -45627,6 +45722,28 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/test-exclude/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -1789,6 +1789,17 @@
             "react": "^18.3.1"
         },
         "js-yaml": "^4.1.1",
-        "glob": "^11.1.0"
+        "@jest/core": {
+            "glob": "^11.1.0"
+        },
+        "@jest/reporters": {
+            "glob": "^11.1.0"
+        },
+        "jest-config": {
+            "glob": "^11.1.0"
+        },
+        "jest-runtime": {
+            "glob": "^11.1.0"
+        }
     }
 }


### PR DESCRIPTION
### What Is This Change?

Addresses [GHSA-5j98-mcp5-4vw2](https://github.com/advisories/GHSA-5j98-mcp5-4vw2):
 * bump `vsce`
 * override `^11.1.0` elsewhere

We only have this in dev dependencies, so everything should still run w/o changes

```
❯ npm ls glob
atlascode@0.0.0 /Users/sdzhumaev/work/atlascode
├─┬ @vscode/vsce@3.7.0
│ └── glob@11.1.0
├─┬ istanbul-merge@2.0.0
│ └── glob@7.2.3
├─┬ jest@30.2.0
│ └─┬ @jest/core@30.2.0 overridden
│   ├─┬ @jest/reporters@30.2.0 overridden
│   │ └── glob@11.1.0 deduped
│   ├─┬ jest-config@30.2.0 overridden
│   │ └── glob@11.1.0 deduped
│   └─┬ jest-runtime@30.2.0 overridden
│     └── glob@11.1.0 deduped
└─┬ nyc@17.1.0
  ├── glob@7.2.3
  ├─┬ rimraf@3.0.2
  │ └── glob@7.2.3
  └─┬ test-exclude@6.0.0
    └── glob@7.2.3
```

### How Has This Been Tested?

```
❯ npx audit-ci --config=".audit-ci.json"
# ...
# ...
Modules to allowlist: pdfjs-dist.
Found vulnerable allowlisted modules: pdfjs-dist.
Passed npm security audit.
```

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`