### PR TITLE
[AXON-1488] chore: export types in rovodev via extension API

### DIFF
--- a/src/rovo-dev/api/extensionApi.test.ts
+++ b/src/rovo-dev/api/extensionApi.test.ts
@@ -1,7 +1,6 @@
-import { ProductJira } from 'src/atlclients/authInfo';
 import { Container } from 'src/container';
 
-import { ExtensionApi, JiraApi } from './extensionApi';
+import { ExtensionApi, JiraApi, ProductJira } from './extensionApi';
 
 // Create a mutable primarySite property for testing
 const mockSiteManager = {

--- a/src/rovo-dev/api/extensionApi.ts
+++ b/src/rovo-dev/api/extensionApi.ts
@@ -1,8 +1,12 @@
 import { isMinimalIssue, MinimalIssue, readSearchResults } from '@atlassianlabs/jira-pi-common-models';
-import { AuthInfo, DetailedSiteInfo, ProductJira } from 'src/atlclients/authInfo';
 import { ValidBasicAuthSiteData } from 'src/atlclients/clientManager';
 import { Container } from 'src/container';
 import { SearchJiraHelper } from 'src/views/jira/searchJiraHelper';
+
+import { AuthInfo, DetailedSiteInfo, ProductJira } from './extensionApiTypes';
+
+// Re-export types for convenience
+export * from './extensionApiTypes';
 
 export class JiraApi {
     public getSites = (): DetailedSiteInfo[] => {
@@ -74,7 +78,7 @@ export class ExtensionApi {
     };
 
     public readonly auth = {
-        // TODO: rectify these 2 methods
+        // TODO [AXON-1531]: rectify these 2 methods
 
         /**
          * Get valid credentials for the 1st available cloud site with an API token,

--- a/src/rovo-dev/api/extensionApiTypes.ts
+++ b/src/rovo-dev/api/extensionApiTypes.ts
@@ -1,0 +1,3 @@
+// Placeholder for simple types from the extension that might need to be copied later
+// This file is kept separate to use in `tsx` files
+export { AuthInfo, DetailedSiteInfo, ProductJira } from '../../atlclients/authInfo';

--- a/src/rovo-dev/rovoDevJiraItemsProvider.ts
+++ b/src/rovo-dev/rovoDevJiraItemsProvider.ts
@@ -1,8 +1,7 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import { Disposable, Event, EventEmitter } from 'vscode';
 
-import { DetailedSiteInfo } from '../atlclients/authInfo';
-import { ExtensionApi } from './api/extensionApi';
+import { DetailedSiteInfo, ExtensionApi } from './api/extensionApi';
 
 export class RovoDevJiraItemsProvider extends Disposable {
     private extensionApi = new ExtensionApi();

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -10,8 +10,7 @@ import { getFsPromise } from 'src/rovo-dev/util/fsPromises';
 import { waitFor } from 'src/rovo-dev/util/waitFor';
 import { Disposable, Event, EventEmitter, ExtensionContext, Terminal, Uri, window, workspace } from 'vscode';
 
-import { DetailedSiteInfo } from '../atlclients/authInfo';
-import { ExtensionApi } from './api/extensionApi';
+import { DetailedSiteInfo, ExtensionApi } from './api/extensionApi';
 import { RovoDevApiClient } from './client';
 import { RovoDevDisabledReason, RovoDevEntitlementCheckFailedDetail } from './rovoDevWebviewProviderMessages';
 import { RovoDevLogger } from './util/rovoDevLogger';

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -26,11 +26,10 @@ import {
     workspace,
 } from 'vscode';
 
-import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { Commands } from '../constants';
 import { GitErrorCodes } from '../typings/git';
 import { getHtmlForView } from '../webview/common/getHtmlForView';
-import { ExtensionApi } from './api/extensionApi';
+import { DetailedSiteInfo, ExtensionApi } from './api/extensionApi';
 import { RovoDevApiClient, RovoDevHealthcheckResponse } from './client';
 import { RovoDevChatContextProvider } from './rovoDevChatContextProvider';
 import { RovoDevChatProvider } from './rovoDevChatProvider';

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -1,7 +1,7 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 
-import { DetailedSiteInfo } from '../atlclients/authInfo';
 import { ReducerAction } from '../ipc/messaging';
+import { DetailedSiteInfo } from './api/extensionApi';
 import {
     EntitlementCheckRovoDevHealthcheckResponse,
     RovoDevRetryPromptResponse,

--- a/src/rovo-dev/ui/landing-page/RovoDevLanding.tsx
+++ b/src/rovo-dev/ui/landing-page/RovoDevLanding.tsx
@@ -2,7 +2,7 @@ import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import * as React from 'react';
 import { State } from 'src/rovo-dev/rovoDevTypes';
 
-import { DetailedSiteInfo } from '../../../atlclients/authInfo';
+import { DetailedSiteInfo } from '../../api/extensionApiTypes';
 import { McpConsentChoice } from '../rovoDevViewMessages';
 import { DisabledMessage } from './disabled-messages/DisabledMessage';
 import { RovoDevActions, RovoDevJiraWorkItems } from './RovoDevSuggestions';

--- a/src/rovo-dev/ui/landing-page/RovoDevSuggestions.tsx
+++ b/src/rovo-dev/ui/landing-page/RovoDevSuggestions.tsx
@@ -1,8 +1,8 @@
 import AiChatIcon from '@atlaskit/icon/core/ai-chat';
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import * as React from 'react';
-import { DetailedSiteInfo } from 'src/atlclients/authInfo';
 
+import { DetailedSiteInfo } from '../../api/extensionApiTypes';
 import { ActionItem } from './action-item/ActionItem';
 import { JiraWorkItem } from './jira-work-item/JiraWorkItem';
 

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
-import { DetailedSiteInfo } from '../../../atlclients/authInfo';
 import { useMessagingApi } from '../../../react/atlascode/messagingApi';
+import { DetailedSiteInfo } from '../../api/extensionApiTypes';
 import { CheckFileExistsFunc, FollowUpActionFooter, OpenFileFunc, OpenJiraFunc } from '../common/common';
 import { DialogMessageItem } from '../common/DialogMessage';
 import { PullRequestForm } from '../create-pr/PullRequestForm';

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -12,8 +12,8 @@ import { RovoDevToolReturnResponse } from 'src/rovo-dev/client';
 import { RovoDevContextItem, State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { v4 } from 'uuid';
 
-import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { useMessagingApi } from '../../react/atlascode/messagingApi';
+import { DetailedSiteInfo } from '../api/extensionApiTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from '../rovoDevWebviewProviderMessages';
 import { FeedbackType } from './feedback-form/FeedbackForm';
 import { ChatStream } from './messaging/ChatStream';


### PR DESCRIPTION
### What Is This Change?

This PR identifies the types we use in rovodev related to authentication (`AuthInfo`, `DetailedSiteInfo`, `ProductJira`), and consolidates the imports - so that we could easily copy the underlying data structures later

No changes in behaviour or presentation, refactoring only

### How Has This Been Tested?

`npm run extension:install` -> small sanity checks to make sure things still run as expected

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`