### PR TITLE
[AXON-1488] chore: minor cleanup

### DIFF
--- a/src/rovo-dev/api/extensionApi.ts
+++ b/src/rovo-dev/api/extensionApi.ts
@@ -1,15 +1,21 @@
 import { isMinimalIssue, MinimalIssue, readSearchResults } from '@atlassianlabs/jira-pi-common-models';
 import { ValidBasicAuthSiteData } from 'src/atlclients/clientManager';
 import { showIssueForURL } from 'src/commands/jira/showIssue';
+import { configuration } from 'src/config/configuration';
 import { Commands } from 'src/constants';
 import { Container } from 'src/container';
 import { SearchJiraHelper } from 'src/views/jira/searchJiraHelper';
-import { commands, Uri } from 'vscode';
+import { getHtmlForView } from 'src/webview/common/getHtmlForView';
+import { commands, ConfigurationChangeEvent, Uri } from 'vscode';
 
 import { AuthInfo, DetailedSiteInfo, ProductJira } from './extensionApiTypes';
 
 // Re-export types for convenience
 export * from './extensionApiTypes';
+
+// TODO: getAxiosInstance is being re-exported for now, to not break compatability with curl logging
+//       in the future, we'd need to re-implement it, or just use the library directly
+export { getAxiosInstance } from 'src/jira/jira-client/providers';
 
 export class JiraApi {
     public getSites = (): DetailedSiteInfo[] => {
@@ -82,6 +88,12 @@ export class ExtensionApi {
         isThinkingBlockEnabled: (): boolean => {
             return Container.config.rovodev.thinkingBlockEnabled;
         },
+        onDidChange: (listener: (e: ConfigurationChangeEvent) => any, thisArg?: any) => {
+            return configuration.onDidChange(listener, thisArg);
+        },
+        changed(e: ConfigurationChangeEvent, section: string, resource?: Uri | null): boolean {
+            return configuration.changed(e, section, resource);
+        },
     };
 
     public readonly auth = {
@@ -152,4 +164,21 @@ export class ExtensionApi {
     };
 
     public readonly jira = new JiraApi();
+
+    // Not technically part of the ExtensionApi, but convenient to have here for now
+    public getHtmlForView({
+        extensionPath,
+        cspSource,
+        viewId,
+        baseUri,
+        stylesUri,
+    }: {
+        extensionPath: string;
+        baseUri: Uri;
+        cspSource: string;
+        viewId: string;
+        stylesUri?: Uri;
+    }): string {
+        return getHtmlForView(extensionPath, baseUri, cspSource, viewId, stylesUri);
+    }
 }

--- a/src/rovo-dev/api/extensionApiTypes.ts
+++ b/src/rovo-dev/api/extensionApiTypes.ts
@@ -1,3 +1,4 @@
 // Placeholder for simple types from the extension that might need to be copied later
 // This file is kept separate to use in `tsx` files
 export { AuthInfo, DetailedSiteInfo, ProductJira } from '../../atlclients/authInfo';
+export { ValidBasicAuthSiteData } from 'src/atlclients/clientManager';

--- a/src/rovo-dev/rovoDevFeedbackManager.test.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.test.ts
@@ -1,4 +1,3 @@
-jest.mock('src/jira/jira-client/providers');
 jest.mock('./util/rovoDevLogger');
 jest.mock('vscode');
 
@@ -12,6 +11,7 @@ const mockExtensionApiInstance = {
 };
 
 jest.mock('./api/extensionApi', () => ({
+    getAxiosInstance: jest.fn(),
     ExtensionApi: jest.fn().mockImplementation(() => mockExtensionApiInstance),
 }));
 
@@ -20,9 +20,9 @@ jest.mock('lodash', () => ({
     truncate: jest.fn((str, options) => str),
 }));
 
-import { getAxiosInstance } from 'src/jira/jira-client/providers';
 import * as vscode from 'vscode';
 
+import { getAxiosInstance } from './api/extensionApi';
 import { RovoDevFeedbackManager } from './rovoDevFeedbackManager';
 import { RovoDevLogger } from './util/rovoDevLogger';
 

--- a/src/rovo-dev/rovoDevFeedbackManager.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.ts
@@ -1,8 +1,7 @@
 import { truncate } from 'lodash';
-import { getAxiosInstance } from 'src/jira/jira-client/providers';
 import * as vscode from 'vscode';
 
-import { ExtensionApi } from './api/extensionApi';
+import { ExtensionApi, getAxiosInstance } from './api/extensionApi';
 import { MIN_SUPPORTED_ROVODEV_VERSION } from './rovoDevProcessManager';
 import { RovoDevLogger } from './util/rovoDevLogger';
 

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -4,13 +4,12 @@ import fs from 'fs';
 import net from 'net';
 import packageJson from 'package.json';
 import path from 'path';
-import { ValidBasicAuthSiteData } from 'src/atlclients/clientManager';
 import { downloadAndUnzip } from 'src/rovo-dev/util/downloadFile';
 import { getFsPromise } from 'src/rovo-dev/util/fsPromises';
 import { waitFor } from 'src/rovo-dev/util/waitFor';
 import { Disposable, Event, EventEmitter, ExtensionContext, Terminal, Uri, window, workspace } from 'vscode';
 
-import { DetailedSiteInfo, ExtensionApi } from './api/extensionApi';
+import { DetailedSiteInfo, ExtensionApi, ValidBasicAuthSiteData } from './api/extensionApi';
 import { RovoDevApiClient } from './client';
 import { RovoDevDisabledReason, RovoDevEntitlementCheckFailedDetail } from './rovoDevWebviewProviderMessages';
 import { RovoDevLogger } from './util/rovoDevLogger';

--- a/src/rovo-dev/rovoDevWebviewProvider.test.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.test.ts
@@ -37,6 +37,7 @@ jest.mock('./api/extensionApi', () => ({
         config: {
             isDebugPanelEnabled: jest.fn(() => false),
             isThinkingBlockEnabled: jest.fn(() => false),
+            onDidChange: jest.fn(),
         },
         analytics: {
             sendTrackEvent: jest.fn(),
@@ -71,12 +72,6 @@ import { RovoDevWebviewProvider } from './rovoDevWebviewProvider';
 jest.mock('./util/rovoDevLogger', () => ({
     RovoDevLogger: {
         error: jest.fn(),
-    },
-}));
-
-jest.mock('../../src/config/configuration', () => ({
-    configuration: {
-        onDidChange: jest.fn(),
     },
 }));
 


### PR DESCRIPTION
### What Is This Change?

> **NOTE** no changes to behaviour or presentation, refactoring only

Minor cleanup:

 * Consolidated Rovo Dev's access to extension functionality through the ExtensionApi layer
 * Added `config.onDidChange()`, `config.changed()`, and `getHtmlForView()` methods
 * Components now import through the API (e.g., `ValidBasicAuthSiteData`, `getAxiosInstance`) instead of directly from extension modules, improving encapsulation and modularity.

(thank you mr copilot for the summary)

### How Has This Been Tested?

`npm run dev` -> sanity checks

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`