### PR TITLE
Randomize Rovo Dev http port to reduce chances of collision

### DIFF
--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -94,11 +94,25 @@ async function shutdownRovoDev(port: number) {
     }
 }
 
+function getRandomInt(min: number, max: number): number {
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min)) + min;
+}
+
 async function getOrAssignPortForWorkspace(): Promise<number> {
     const portStart = RovoDevInfo.portRange.start;
     const portEnd = RovoDevInfo.portRange.end;
 
-    for (let port = portStart; port <= portEnd; ++port) {
+    const len = portEnd - portStart + 1;
+    const a = getRandomInt(3, len);
+    const b = getRandomInt(3, len);
+
+    // use a bijective function to "randomize" the next port without picking the same port twice
+    const pickPort = (x: number) => ((a * x + b) % len) + portStart;
+
+    for (let i = 0; i < len; ++i) {
+        const port = pickPort(i);
         if (await isPortAvailable(port)) {
             return port;
         }


### PR DESCRIPTION
### What Is This Change?

Randomizes the http port that Rovo Dev is going to try to use.
It still checks if the port is available before using it, but it now picks "random" ports to try, in the range of 40000..41000 instead of always trying 40000 to 41000 in order.

This should reduce the Rovo Dev error `exited with code 1` in case it's happening due to port collision.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`