### PR TITLE
Fix for the new Jira filters when the new Settings page is enabled

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,9 +38,141 @@ import { IssueNode } from './views/nodes/issueNode';
 import { PipelineNode } from './views/pipelines/PipelinesTree';
 
 export function registerCommands(vscodeContext: ExtensionContext) {
+    // here, add any setting that doesn't depend on which settings page is enabled
+    vscodeContext.subscriptions.push(
+        commands.registerCommand(
+            Commands.ViewInWebBrowser,
+            async (prNode: AbstractBaseNode, source?: string, linkId?: string) => {
+                if (source && linkId && knownLinkIdMap.has(linkId)) {
+                    Container.analyticsApi.fireExternalLinkEvent(source, linkId);
+                }
+                const uri = (await prNode.getTreeItem()).resourceUri;
+                if (uri) {
+                    env.openExternal(uri);
+                }
+            },
+        ),
+        commands.registerCommand(Commands.CreateIssue, (data: any, source?: string) => createIssue(data, source)),
+        commands.registerCommand(
+            Commands.ShowIssue,
+            async (issueOrKeyAndSite: MinimalIssueOrKeyAndSite<DetailedSiteInfo>) => await showIssue(issueOrKeyAndSite),
+        ),
+        commands.registerCommand(
+            Commands.ShowIssueForKey,
+            async (issueKey?: string) => await showIssueForKey(issueKey),
+        ),
+        commands.registerCommand(
+            Commands.ShowIssueForSiteIdAndKey,
+            async (siteId: string, issueKey: string) => await showIssueForSiteIdAndKey(siteId, issueKey),
+        ),
+        commands.registerCommand(Commands.ShowIssueForURL, async (issueURL: string) => await showIssueForURL(issueURL)),
+        commands.registerCommand(Commands.ToDoIssue, (issueNode) =>
+            commands.executeCommand(Commands.ShowIssue, issueNode.issue),
+        ),
+        commands.registerCommand(Commands.InProgressIssue, (issueNode) =>
+            commands.executeCommand(Commands.ShowIssue, issueNode.issue),
+        ),
+        commands.registerCommand(Commands.DoneIssue, (issueNode) =>
+            commands.executeCommand(Commands.ShowIssue, issueNode.issue),
+        ),
+        commands.registerCommand(Commands.AssignIssueToMe, (issueNode: IssueNode) => assignIssue(issueNode)),
+        commands.registerCommand(Commands.TransitionIssue, async (issueNode: IssueNode) => {
+            if (!isMinimalIssue(issueNode.issue)) {
+                // Should be unreachable, but let's fail gracefully
+                return;
+            }
+
+            const issue = issueNode.issue as MinimalIssue<DetailedSiteInfo>;
+            Container.analyticsApi.fireViewScreenEvent('atlascodeTransitionQuickPick', issue.siteDetails, ProductJira);
+            window
+                .showQuickPick(
+                    issue.transitions.map((x) => ({
+                        label: x.name,
+                        detail: x.name !== x.to.name ? `${x.to.name}` : '',
+                    })),
+                    {
+                        placeHolder: `Select a transition for ${issue.key}`,
+                    },
+                )
+                .then(async (transition) => {
+                    if (!transition) {
+                        return;
+                    }
+
+                    const target = issue.transitions.find((x) => x.name === transition.label);
+                    if (!target) {
+                        window.showErrorMessage(`Transition ${transition.label} not found`);
+                        Logger.error(new Error('Transition not found'));
+                        return;
+                    }
+
+                    await transitionIssue(issue, target, { source: 'quickPick' });
+                });
+        }),
+        commands.registerCommand(
+            Commands.StartWorkOnIssue,
+            (issueNodeOrMinimalIssue: IssueNode | MinimalIssue<DetailedSiteInfo>) =>
+                startWorkOnIssue(
+                    isMinimalIssue(issueNodeOrMinimalIssue) ? issueNodeOrMinimalIssue : issueNodeOrMinimalIssue.issue,
+                ),
+        ),
+        commands.registerCommand(Commands.ViewDiff, async (...diffArgs: [() => {}, Uri, Uri, string]) => {
+            viewScreenEvent(Registry.screen.pullRequestDiffScreen, undefined, ProductBitbucket).then((e) => {
+                Container.analyticsClient.sendScreenEvent(e);
+            });
+            diffArgs[0]();
+            commands.executeCommand('vscode.diff', ...diffArgs.slice(1));
+        }),
+        commands.registerCommand(Commands.RerunPipeline, (node: PipelineNode) => {
+            rerunPipeline(node.pipeline);
+        }),
+        commands.registerCommand(Commands.RunPipelineForBranch, () => {
+            runPipeline();
+        }),
+        commands.registerCommand(Commands.ShowPipeline, (pipelineInfo: any) => {
+            Container.pipelinesSummaryWebview.createOrShow(pipelineInfo.uuid, pipelineInfo);
+        }),
+        commands.registerCommand(Commands.DebugBitbucketSites, showBitbucketDebugInfo),
+        commands.registerCommand(Commands.WorkbenchOpenRepository, (source: string) => {
+            openWorkbenchRepositoryButtonEvent(source).then((event) => Container.analyticsClient.sendUIEvent(event));
+            commands.executeCommand('workbench.action.addRootFolder');
+        }),
+        commands.registerCommand(Commands.WorkbenchOpenWorkspace, (source: string) => {
+            openWorkbenchWorkspaceButtonEvent(source).then((event) => Container.analyticsClient.sendUIEvent(event));
+            commands.executeCommand('workbench.action.openWorkspace');
+        }),
+        commands.registerCommand(Commands.CloneRepository, async (source: string, repoUrl?: string) => {
+            cloneRepositoryButtonEvent(source).then((event) => Container.analyticsClient.sendUIEvent(event));
+            await commands.executeCommand('git.clone', repoUrl);
+        }),
+        commands.registerCommand(Commands.DisableHelpExplorer, () => {
+            configuration.updateEffective('helpExplorerEnabled', false, null, true);
+        }),
+        commands.registerCommand(Commands.BitbucketOpenPullRequest, (data: { pullRequestUrl: string }) => {
+            Container.openPullRequestHandler(data.pullRequestUrl);
+        }),
+        commands.registerCommand(Commands.ShowOnboardingFlow, () => Container.onboardingProvider.start()),
+        commands.registerCommand(Commands.JiraFilter, () => FilterProvider.createFilterQuickPick()),
+        commands.registerCommand(Commands.JiraLogin, () => {
+            const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
+            if (useNewAuthFlow) {
+                runQuickAuth({ initialState: { product: ProductJira }, origin: 'settings' });
+            } else {
+                commands.executeCommand(Commands.ShowConfigPage);
+            }
+        }),
+        commands.registerCommand(Commands.AddRecommendedExtension, addAtlascodeAsRecommendedExtension),
+        commands.registerCommand(Commands.ExpandCreateWorkItemWebview, () => {
+            Container.createIssueWebview.createOrShow();
+            setCommandContext('atlascode:showCreateWorkItemWebview', false);
+        }),
+    );
+
     const settingsFeatureValue = Container.featureFlagClient.checkExperimentValue(
         Experiments.AtlascodeNewSettingsExperiment,
     );
+
+    // here, add any setting for which their implementation depends on which settings page is enabled
     if (settingsFeatureValue) {
         vscodeContext.subscriptions.push(
             commands.registerCommand(Commands.AddJiraSite, () =>
@@ -93,140 +225,6 @@ export function registerCommands(vscodeContext: ExtensionContext) {
             commands.registerCommand(Commands.ShowPipelineSettings, () =>
                 commands.executeCommand('workbench.action.openSettings', '@ext:atlassian.atlascode pipeline'),
             ),
-            // -----------------------------------
-            commands.registerCommand(
-                Commands.ViewInWebBrowser,
-                async (prNode: AbstractBaseNode, source?: string, linkId?: string) => {
-                    if (source && linkId && knownLinkIdMap.has(linkId)) {
-                        Container.analyticsApi.fireExternalLinkEvent(source, linkId);
-                    }
-                    const uri = (await prNode.getTreeItem()).resourceUri;
-                    if (uri) {
-                        env.openExternal(uri);
-                    }
-                },
-            ),
-            commands.registerCommand(Commands.CreateIssue, (data: any, source?: string) => createIssue(data, source)),
-            commands.registerCommand(
-                Commands.ShowIssue,
-                async (issueOrKeyAndSite: MinimalIssueOrKeyAndSite<DetailedSiteInfo>) =>
-                    await showIssue(issueOrKeyAndSite),
-            ),
-            commands.registerCommand(
-                Commands.ShowIssueForKey,
-                async (issueKey?: string) => await showIssueForKey(issueKey),
-            ),
-            commands.registerCommand(
-                Commands.ShowIssueForSiteIdAndKey,
-                async (siteId: string, issueKey: string) => await showIssueForSiteIdAndKey(siteId, issueKey),
-            ),
-            commands.registerCommand(
-                Commands.ShowIssueForURL,
-                async (issueURL: string) => await showIssueForURL(issueURL),
-            ),
-            commands.registerCommand(Commands.ToDoIssue, (issueNode) =>
-                commands.executeCommand(Commands.ShowIssue, issueNode.issue),
-            ),
-            commands.registerCommand(Commands.InProgressIssue, (issueNode) =>
-                commands.executeCommand(Commands.ShowIssue, issueNode.issue),
-            ),
-            commands.registerCommand(Commands.DoneIssue, (issueNode) =>
-                commands.executeCommand(Commands.ShowIssue, issueNode.issue),
-            ),
-            commands.registerCommand(Commands.AssignIssueToMe, (issueNode: IssueNode) => assignIssue(issueNode)),
-            commands.registerCommand(Commands.TransitionIssue, async (issueNode: IssueNode) => {
-                if (!isMinimalIssue(issueNode.issue)) {
-                    // Should be unreachable, but let's fail gracefully
-                    return;
-                }
-
-                const issue = issueNode.issue as MinimalIssue<DetailedSiteInfo>;
-                Container.analyticsApi.fireViewScreenEvent(
-                    'atlascodeTransitionQuickPick',
-                    issue.siteDetails,
-                    ProductJira,
-                );
-                window
-                    .showQuickPick(
-                        issue.transitions.map((x) => ({
-                            label: x.name,
-                            detail: x.name !== x.to.name ? `${x.to.name}` : '',
-                        })),
-                        {
-                            placeHolder: `Select a transition for ${issue.key}`,
-                        },
-                    )
-                    .then(async (transition) => {
-                        if (!transition) {
-                            return;
-                        }
-
-                        const target = issue.transitions.find((x) => x.name === transition.label);
-                        if (!target) {
-                            window.showErrorMessage(`Transition ${transition.label} not found`);
-                            Logger.error(new Error('Transition not found'));
-                            return;
-                        }
-
-                        await transitionIssue(issue, target, { source: 'quickPick' });
-                    });
-            }),
-            commands.registerCommand(
-                Commands.StartWorkOnIssue,
-                (issueNodeOrMinimalIssue: IssueNode | MinimalIssue<DetailedSiteInfo>) =>
-                    startWorkOnIssue(
-                        isMinimalIssue(issueNodeOrMinimalIssue)
-                            ? issueNodeOrMinimalIssue
-                            : issueNodeOrMinimalIssue.issue,
-                    ),
-            ),
-            commands.registerCommand(Commands.ViewDiff, async (...diffArgs: [() => {}, Uri, Uri, string]) => {
-                viewScreenEvent(Registry.screen.pullRequestDiffScreen, undefined, ProductBitbucket).then((e) => {
-                    Container.analyticsClient.sendScreenEvent(e);
-                });
-                diffArgs[0]();
-                commands.executeCommand('vscode.diff', ...diffArgs.slice(1));
-            }),
-            commands.registerCommand(Commands.RerunPipeline, (node: PipelineNode) => {
-                rerunPipeline(node.pipeline);
-            }),
-            commands.registerCommand(Commands.RunPipelineForBranch, () => {
-                runPipeline();
-            }),
-            commands.registerCommand(Commands.ShowPipeline, (pipelineInfo: any) => {
-                Container.pipelinesSummaryWebview.createOrShow(pipelineInfo.uuid, pipelineInfo);
-            }),
-            commands.registerCommand(Commands.DebugBitbucketSites, showBitbucketDebugInfo),
-            commands.registerCommand(Commands.WorkbenchOpenRepository, (source: string) => {
-                openWorkbenchRepositoryButtonEvent(source).then((event) =>
-                    Container.analyticsClient.sendUIEvent(event),
-                );
-                commands.executeCommand('workbench.action.addRootFolder');
-            }),
-            commands.registerCommand(Commands.WorkbenchOpenWorkspace, (source: string) => {
-                openWorkbenchWorkspaceButtonEvent(source).then((event) => Container.analyticsClient.sendUIEvent(event));
-                commands.executeCommand('workbench.action.openWorkspace');
-            }),
-            commands.registerCommand(Commands.CloneRepository, async (source: string, repoUrl?: string) => {
-                cloneRepositoryButtonEvent(source).then((event) => Container.analyticsClient.sendUIEvent(event));
-                await commands.executeCommand('git.clone', repoUrl);
-            }),
-            commands.registerCommand(Commands.DisableHelpExplorer, () => {
-                configuration.updateEffective('helpExplorerEnabled', false, null, true);
-            }),
-            commands.registerCommand(Commands.BitbucketOpenPullRequest, (data: { pullRequestUrl: string }) => {
-                Container.openPullRequestHandler(data.pullRequestUrl);
-            }),
-            commands.registerCommand(Commands.ShowOnboardingFlow, () => Container.onboardingProvider.start()),
-            commands.registerCommand(Commands.JiraFilter, () => FilterProvider.createFilterQuickPick()),
-            commands.registerCommand(Commands.JiraLogin, () => {
-                const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
-                if (useNewAuthFlow) {
-                    runQuickAuth({ initialState: { product: ProductJira }, origin: 'settings' });
-                } else {
-                    commands.executeCommand(Commands.ShowConfigPage);
-                }
-            }),
             commands.registerCommand(Commands.JiraAPITokenLogin, () => {
                 const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
                 if (useNewAuthFlow) {
@@ -242,7 +240,6 @@ export function registerCommands(vscodeContext: ExtensionContext) {
                     });
                 }
             }),
-            commands.registerCommand(Commands.AddRecommendedExtension, addAtlascodeAsRecommendedExtension),
         );
     } else {
         vscodeContext.subscriptions.push(
@@ -308,138 +305,6 @@ export function registerCommands(vscodeContext: ExtensionContext) {
                     subSection: undefined,
                 });
             }),
-            commands.registerCommand(
-                Commands.ViewInWebBrowser,
-                async (prNode: AbstractBaseNode, source?: string, linkId?: string) => {
-                    if (source && linkId && knownLinkIdMap.has(linkId)) {
-                        Container.analyticsApi.fireExternalLinkEvent(source, linkId);
-                    }
-                    const uri = (await prNode.getTreeItem()).resourceUri;
-                    if (uri) {
-                        env.openExternal(uri);
-                    }
-                },
-            ),
-            commands.registerCommand(Commands.CreateIssue, (data: any, source?: string) => createIssue(data, source)),
-            commands.registerCommand(
-                Commands.ShowIssue,
-                async (issueOrKeyAndSite: MinimalIssueOrKeyAndSite<DetailedSiteInfo>) =>
-                    await showIssue(issueOrKeyAndSite),
-            ),
-            commands.registerCommand(
-                Commands.ShowIssueForKey,
-                async (issueKey?: string) => await showIssueForKey(issueKey),
-            ),
-            commands.registerCommand(
-                Commands.ShowIssueForSiteIdAndKey,
-                async (siteId: string, issueKey: string) => await showIssueForSiteIdAndKey(siteId, issueKey),
-            ),
-            commands.registerCommand(
-                Commands.ShowIssueForURL,
-                async (issueURL: string) => await showIssueForURL(issueURL),
-            ),
-            commands.registerCommand(Commands.ToDoIssue, (issueNode) =>
-                commands.executeCommand(Commands.ShowIssue, issueNode.issue),
-            ),
-            commands.registerCommand(Commands.InProgressIssue, (issueNode) =>
-                commands.executeCommand(Commands.ShowIssue, issueNode.issue),
-            ),
-            commands.registerCommand(Commands.DoneIssue, (issueNode) =>
-                commands.executeCommand(Commands.ShowIssue, issueNode.issue),
-            ),
-            commands.registerCommand(Commands.AssignIssueToMe, (issueNode: IssueNode) => assignIssue(issueNode)),
-            commands.registerCommand(Commands.TransitionIssue, async (issueNode: IssueNode) => {
-                if (!isMinimalIssue(issueNode.issue)) {
-                    // Should be unreachable, but let's fail gracefully
-                    return;
-                }
-
-                const issue = issueNode.issue as MinimalIssue<DetailedSiteInfo>;
-                Container.analyticsApi.fireViewScreenEvent(
-                    'atlascodeTransitionQuickPick',
-                    issue.siteDetails,
-                    ProductJira,
-                );
-                window
-                    .showQuickPick(
-                        issue.transitions.map((x) => ({
-                            label: x.name,
-                            detail: x.name !== x.to.name ? `${x.to.name}` : '',
-                        })),
-                        {
-                            placeHolder: `Select a transition for ${issue.key}`,
-                        },
-                    )
-                    .then(async (transition) => {
-                        if (!transition) {
-                            return;
-                        }
-
-                        const target = issue.transitions.find((x) => x.name === transition.label);
-                        if (!target) {
-                            window.showErrorMessage(`Transition ${transition.label} not found`);
-                            Logger.error(new Error('Transition not found'));
-                            return;
-                        }
-
-                        await transitionIssue(issue, target, { source: 'quickPick' });
-                    });
-            }),
-            commands.registerCommand(
-                Commands.StartWorkOnIssue,
-                (issueNodeOrMinimalIssue: IssueNode | MinimalIssue<DetailedSiteInfo>) =>
-                    startWorkOnIssue(
-                        isMinimalIssue(issueNodeOrMinimalIssue)
-                            ? issueNodeOrMinimalIssue
-                            : issueNodeOrMinimalIssue.issue,
-                    ),
-            ),
-            commands.registerCommand(Commands.ViewDiff, async (...diffArgs: [() => {}, Uri, Uri, string]) => {
-                viewScreenEvent(Registry.screen.pullRequestDiffScreen, undefined, ProductBitbucket).then((e) => {
-                    Container.analyticsClient.sendScreenEvent(e);
-                });
-                diffArgs[0]();
-                commands.executeCommand('vscode.diff', ...diffArgs.slice(1));
-            }),
-            commands.registerCommand(Commands.RerunPipeline, (node: PipelineNode) => {
-                rerunPipeline(node.pipeline);
-            }),
-            commands.registerCommand(Commands.RunPipelineForBranch, () => {
-                runPipeline();
-            }),
-            commands.registerCommand(Commands.ShowPipeline, (pipelineInfo: any) => {
-                Container.pipelinesSummaryWebview.createOrShow(pipelineInfo.uuid, pipelineInfo);
-            }),
-            commands.registerCommand(Commands.DebugBitbucketSites, showBitbucketDebugInfo),
-            commands.registerCommand(Commands.WorkbenchOpenRepository, (source: string) => {
-                openWorkbenchRepositoryButtonEvent(source).then((event) =>
-                    Container.analyticsClient.sendUIEvent(event),
-                );
-                commands.executeCommand('workbench.action.addRootFolder');
-            }),
-            commands.registerCommand(Commands.WorkbenchOpenWorkspace, (source: string) => {
-                openWorkbenchWorkspaceButtonEvent(source).then((event) => Container.analyticsClient.sendUIEvent(event));
-                commands.executeCommand('workbench.action.openWorkspace');
-            }),
-            commands.registerCommand(Commands.CloneRepository, async (source: string, repoUrl?: string) => {
-                cloneRepositoryButtonEvent(source).then((event) => Container.analyticsClient.sendUIEvent(event));
-                await commands.executeCommand('git.clone', repoUrl);
-            }),
-            commands.registerCommand(Commands.DisableHelpExplorer, () => {
-                configuration.updateEffective('helpExplorerEnabled', false, null, true);
-            }),
-            commands.registerCommand(Commands.BitbucketOpenPullRequest, (data: { pullRequestUrl: string }) => {
-                Container.openPullRequestHandler(data.pullRequestUrl);
-            }),
-            commands.registerCommand(Commands.ShowOnboardingFlow, () => Container.onboardingProvider.start()),
-            commands.registerCommand(Commands.JiraLogin, () => {
-                const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
-                if (useNewAuthFlow) {
-                    runQuickAuth({ initialState: { product: ProductJira }, origin: 'settings' });
-                } else {
-                    commands.executeCommand(Commands.ShowConfigPage);
-                }
-            }),
             commands.registerCommand(Commands.JiraAPITokenLogin, () => {
                 const useNewAuthFlow = Container.featureFlagClient.checkGate(Features.UseNewAuthFlow);
                 if (useNewAuthFlow) {
@@ -454,11 +319,6 @@ export function registerCommands(vscodeContext: ExtensionContext) {
                         initiateApiTokenAuth: true,
                     });
                 }
-            }),
-            commands.registerCommand(Commands.AddRecommendedExtension, addAtlascodeAsRecommendedExtension),
-            commands.registerCommand(Commands.ExpandCreateWorkItemWebview, () => {
-                Container.createIssueWebview.createOrShow();
-                setCommandContext('atlascode:showCreateWorkItemWebview', false);
             }),
         );
     }

--- a/src/container.ts
+++ b/src/container.ts
@@ -18,7 +18,6 @@ import { registerDebugCommands } from './commands';
 import { openPullRequest } from './commands/bitbucket/pullRequest';
 import { configuration, IConfig } from './config/configuration';
 import { PmfStats } from './feedback/pmfStats';
-import { FilterProvider } from './filter/filterProvider';
 import { JQLManager } from './jira/jqlManager';
 import { JiraProjectManager } from './jira/projectManager';
 import { JiraSettingsManager } from './jira/settingsManager';
@@ -265,7 +264,6 @@ export class Container {
         );
 
         this._onboardingProvider = new OnboardingProvider();
-        FilterProvider.initialize();
 
         this.refreshRovoDev(context);
     }

--- a/src/filter/filterProvider.ts
+++ b/src/filter/filterProvider.ts
@@ -1,6 +1,5 @@
-import { commands, QuickPick, QuickPickItem, window } from 'vscode';
+import { QuickPick, QuickPickItem, window } from 'vscode';
 
-import { Commands } from '../constants';
 import { AssigneeFilterProvider } from './assignee/assigneeFilterProvider';
 
 interface FilterQuickPickItem extends QuickPickItem {
@@ -8,12 +7,6 @@ interface FilterQuickPickItem extends QuickPickItem {
 }
 
 export class FilterProvider {
-    public static initialize(): void {
-        commands.registerCommand(Commands.JiraFilter, () => {
-            this.createFilterQuickPick();
-        });
-    }
-
     public static createFilterQuickPick(): void {
         const quickPick = window.createQuickPick<FilterQuickPickItem>();
         quickPick.title = 'Filter Jira Issues';


### PR DESCRIPTION
### What Is This Change?

The root cause of the issue was the register command for `Filter` happening twice when the new Settings page is enabled, because the registration command was put in two different places.

This issue was likely caused by the bad organization of the register commands.

This change fixes the issue, and refactors the register commands to be cleaner and clearer.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`