### PR TITLE
[AXON-1569] Copy messaging logic into rovodev

### DIFF
--- a/src/rovo-dev/messaging/index.ts
+++ b/src/rovo-dev/messaging/index.ts
@@ -1,0 +1,1 @@
+export * from './messagingTypes';

--- a/src/rovo-dev/messaging/messagingTypes.ts
+++ b/src/rovo-dev/messaging/messagingTypes.ts
@@ -1,0 +1,9 @@
+export type ReducerAction<K, V = void> = V extends void ? { type: K } : { type: K } & V;
+
+export function defaultStateGuard<S>(state: S, a: never) {
+    return state;
+}
+
+export function defaultActionGuard(a: never) {
+    return;
+}

--- a/src/rovo-dev/rovoDevFeedbackManager.test.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.test.ts
@@ -18,7 +18,6 @@ jest.mock('lodash', () => ({
 }));
 
 import { UserInfo } from 'src/rovo-dev/api/extensionApiTypes';
-import { expansionCastTo } from 'testsutil/miscFunctions';
 import * as vscode from 'vscode';
 
 import { getAxiosInstance } from './api/extensionApi';
@@ -75,7 +74,7 @@ describe('RovoDevFeedbackManager', () => {
                 canContact: true,
             };
 
-            await RovoDevFeedbackManager.submitFeedback(feedback, expansionCastTo<UserInfo>(mockUser));
+            await RovoDevFeedbackManager.submitFeedback(feedback, mockUser as UserInfo);
 
             expect(mockTransport).toHaveBeenCalledWith(
                 expect.any(String),

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -1,6 +1,5 @@
 import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 
-import { ReducerAction } from '../ipc/messaging';
 import { DetailedSiteInfo } from './api/extensionApi';
 import {
     EntitlementCheckRovoDevHealthcheckResponse,
@@ -9,6 +8,7 @@ import {
     RovoDevToolCallResponse,
     RovoDevToolReturnResponse,
 } from './client';
+import { ReducerAction } from './messaging';
 import { DisabledState, RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
 import { ModifiedFile } from './ui/rovoDevViewMessages';
 import { ChatMessage, DialogMessage } from './ui/utils';

--- a/src/rovo-dev/ui/create-pr/PullRequestForm.tsx
+++ b/src/rovo-dev/ui/create-pr/PullRequestForm.tsx
@@ -2,8 +2,8 @@ import PullRequestIcon from '@atlaskit/icon/core/pull-request';
 import React from 'react';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
-import { useMessagingApi } from '../../../react/atlascode/messagingApi';
 import { MarkedDown } from '../common/common';
+import { useMessagingApi } from '../messagingApi';
 import { RovoDevViewResponse, RovoDevViewResponseType } from '../rovoDevViewMessages';
 import { ConnectionTimeout, PullRequestMessage } from '../utils';
 

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import { State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
-import { useMessagingApi } from '../../../react/atlascode/messagingApi';
 import { DetailedSiteInfo } from '../../api/extensionApiTypes';
 import { CheckFileExistsFunc, FollowUpActionFooter, OpenFileFunc, OpenJiraFunc } from '../common/common';
 import { DialogMessageItem } from '../common/DialogMessage';
 import { PullRequestForm } from '../create-pr/PullRequestForm';
 import { FeedbackForm, FeedbackType } from '../feedback-form/FeedbackForm';
 import { RovoDevLanding } from '../landing-page/RovoDevLanding';
+import { useMessagingApi } from '../messagingApi';
 import { McpConsentChoice, RovoDevViewResponse, RovoDevViewResponseType } from '../rovoDevViewMessages';
 import { CodePlanButton } from '../technical-plan/CodePlanButton';
 import { ToolCallItem } from '../tools/ToolCallItem';

--- a/src/rovo-dev/ui/messagingApi.tsx
+++ b/src/rovo-dev/ui/messagingApi.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { ReducerAction } from '../messaging';
+
+export type ExtractActionType<T> = T extends ReducerAction<infer K1> ? K1 : never;
+
+export type PostMessageFunc<T> = ReturnType<typeof useMessagingApi<T, any, any>>['postMessage'];
+export type ReceiveMessageFunc<M extends ReducerAction<any, any>> = (message: M) => void;
+
+interface VsCodeApi {
+    postMessage<T = {}>(msg: T): void;
+    setState(state: {}): void;
+    getState(): {};
+}
+declare function acquireVsCodeApi(): VsCodeApi;
+
+// This is taken from react/atlascode/messagingApi.ts, with some legacy part removed (pmf, errors)
+// TODO: refactor this whole implementation to make sure we're not dragging legacy code
+export function useMessagingApi<A, M extends ReducerAction<any, any>, R extends ReducerAction<any, any>>(
+    onMessageHandler: ReceiveMessageFunc<M>,
+) {
+    const apiRef = useMemo<VsCodeApi>(acquireVsCodeApi, [acquireVsCodeApi]);
+
+    const postMessage = useCallback(
+        (action: A): void => {
+            apiRef.postMessage<A>(action);
+        },
+        [apiRef],
+    );
+
+    const postMessagePromise = useCallback(
+        <Z extends ExtractActionType<R>>(
+            action: A,
+            waitForEvent: Z,
+            timeout: number,
+            nonce?: string,
+        ): Promise<Extract<R, { type: Z }>> => {
+            apiRef.postMessage(action);
+            return new Promise<Extract<R, { type: Z }>>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    window.removeEventListener('message', promiseListener);
+                    clearTimeout(timer);
+                    reject(`timeout waiting for event ${waitForEvent}`);
+                }, timeout);
+
+                const promiseListener = (e: MessageEvent): void => {
+                    if (
+                        e.data.type &&
+                        waitForEvent &&
+                        e.data.type === waitForEvent &&
+                        (!nonce || e.data.nonce === nonce)
+                    ) {
+                        clearTimeout(timer);
+                        window.removeEventListener('message', promiseListener);
+                        resolve(e.data);
+                    }
+                    if (e.data.type === 'error' && nonce && e.data.nonce === nonce) {
+                        window.removeEventListener('message', promiseListener);
+                        clearTimeout(timer);
+                        reject(e.data.reason);
+                    }
+                };
+
+                window.addEventListener('message', promiseListener);
+            });
+        },
+        [apiRef],
+    );
+
+    const internalMessageHandler = useCallback(
+        (msg: any): void => {
+            type M1 = {
+                type?: any;
+                showPMF?: any;
+                reason?: any;
+            } & M;
+            const message = msg.data as M1;
+            if (message && message.type) {
+                onMessageHandler(message);
+            }
+        },
+        [onMessageHandler],
+    );
+
+    const setState = useCallback(
+        (state: Record<string, any>): void => {
+            apiRef.setState(state);
+        },
+        [apiRef],
+    );
+
+    useEffect(() => {
+        window.addEventListener('message', internalMessageHandler);
+        apiRef.postMessage({ type: 'refresh' });
+
+        return () => {
+            window.removeEventListener('message', internalMessageHandler);
+        };
+    }, [onMessageHandler, internalMessageHandler, apiRef]);
+
+    return { postMessage, postMessagePromise, setState };
+}

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -12,11 +12,11 @@ import { RovoDevToolReturnResponse } from 'src/rovo-dev/client';
 import { RovoDevContextItem, State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { v4 } from 'uuid';
 
-import { useMessagingApi } from '../../react/atlascode/messagingApi';
 import { DetailedSiteInfo } from '../api/extensionApiTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from '../rovoDevWebviewProviderMessages';
 import { FeedbackType } from './feedback-form/FeedbackForm';
 import { ChatStream } from './messaging/ChatStream';
+import { useMessagingApi } from './messagingApi';
 import { PromptInputBox } from './prompt-box/prompt-input/PromptInput';
 import { PromptContextCollection } from './prompt-box/promptContext/promptContextCollection';
 import { UpdatedFilesComponent } from './prompt-box/updated-files/UpdatedFilesComponent';

--- a/src/rovo-dev/ui/rovoDevViewMessages.tsx
+++ b/src/rovo-dev/ui/rovoDevViewMessages.tsx
@@ -1,6 +1,6 @@
 import { RovoDevContextItem, RovoDevPrompt, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 
-import { ReducerAction } from '../../ipc/messaging';
+import { ReducerAction } from '../messaging';
 import { FeedbackType } from './feedback-form/FeedbackForm';
 
 export const enum RovoDevViewResponseType {


### PR DESCRIPTION
### What Is This Change?

> **Note:** no change to behaviour or presentation - refactoring only

Move or copy messagingApi-related stuff to rovodev, to be refactored later:
 * `ReducerAction` & relevant types -> `src/rovo-dev/messaging/messagingTypes`
 * `useMessagingApi` -> `src/rovo-dev/ui/messagingApi.tsx`
 * small unrelated change to get rid of a test dependency that snuck in :D

### How Has This Been Tested?

`npm run dev` -> standard set of sanity checks + dragged the panel around to make sure it preserves the state

Found out that weird things happens if you do that _during_ a response - but the same happens in base version too :(

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`