### PR TITLE
[AXON-1569] chore: rearrange MinimalIssue dependency in rovodev

### DIFF
--- a/src/rovo-dev/api/extensionApiTypes.ts
+++ b/src/rovo-dev/api/extensionApiTypes.ts
@@ -2,3 +2,4 @@
 // This file is kept separate to use in `tsx` files
 export { AuthInfo, UserInfo, DetailedSiteInfo, ProductJira } from '../../atlclients/authInfo';
 export { ValidBasicAuthSiteData } from 'src/atlclients/clientManager';
+export { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';

--- a/src/rovo-dev/rovoDevJiraItemsProvider.ts
+++ b/src/rovo-dev/rovoDevJiraItemsProvider.ts
@@ -1,7 +1,6 @@
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import { Disposable, Event, EventEmitter } from 'vscode';
 
-import { DetailedSiteInfo, ExtensionApi } from './api/extensionApi';
+import { DetailedSiteInfo, ExtensionApi, MinimalIssue } from './api/extensionApi';
 
 export class RovoDevJiraItemsProvider extends Disposable {
     private extensionApi = new ExtensionApi();

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -1,4 +1,3 @@
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import * as fs from 'fs';
 import path from 'path';
 import { Commands } from 'src/constants';
@@ -27,7 +26,7 @@ import {
 
 import { GitErrorCodes } from '../typings/git';
 import { RovodevCommandContext } from './api/componentApi';
-import { DetailedSiteInfo, ExtensionApi } from './api/extensionApi';
+import { DetailedSiteInfo, ExtensionApi, MinimalIssue } from './api/extensionApi';
 import { RovoDevApiClient, RovoDevApiError, RovoDevHealthcheckResponse } from './client';
 import { buildErrorDetails } from './errorDetailsBuilder';
 import { RovoDevChatContextProvider } from './rovoDevChatContextProvider';

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -1,6 +1,4 @@
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
-
-import { DetailedSiteInfo } from './api/extensionApi';
+import { DetailedSiteInfo, MinimalIssue } from './api/extensionApi';
 import {
     EntitlementCheckRovoDevHealthcheckResponse,
     RovoDevRetryPromptResponse,

--- a/src/rovo-dev/ui/landing-page/RovoDevLanding.tsx
+++ b/src/rovo-dev/ui/landing-page/RovoDevLanding.tsx
@@ -1,8 +1,7 @@
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import * as React from 'react';
 import { State } from 'src/rovo-dev/rovoDevTypes';
 
-import { DetailedSiteInfo } from '../../api/extensionApiTypes';
+import { DetailedSiteInfo, MinimalIssue } from '../../api/extensionApiTypes';
 import { McpConsentChoice } from '../rovoDevViewMessages';
 import { DisabledMessage } from './disabled-messages/DisabledMessage';
 import { RovoDevActions, RovoDevJiraWorkItems } from './RovoDevSuggestions';

--- a/src/rovo-dev/ui/landing-page/RovoDevSuggestions.tsx
+++ b/src/rovo-dev/ui/landing-page/RovoDevSuggestions.tsx
@@ -1,8 +1,7 @@
 import AiChatIcon from '@atlaskit/icon/core/ai-chat';
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import * as React from 'react';
 
-import { DetailedSiteInfo } from '../../api/extensionApiTypes';
+import { DetailedSiteInfo, MinimalIssue } from '../../api/extensionApiTypes';
 import { ActionItem } from './action-item/ActionItem';
 import { JiraWorkItem } from './jira-work-item/JiraWorkItem';
 

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -1,9 +1,8 @@
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import * as React from 'react';
 import { State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
-import { DetailedSiteInfo } from '../../api/extensionApiTypes';
+import { DetailedSiteInfo, MinimalIssue } from '../../api/extensionApiTypes';
 import { CheckFileExistsFunc, FollowUpActionFooter, OpenFileFunc, OpenJiraFunc } from '../common/common';
 import { DialogMessageItem } from '../common/DialogMessage';
 import { PullRequestForm } from '../create-pr/PullRequestForm';

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -3,7 +3,6 @@ import './RovoDevCodeHighlighting.css';
 
 import InformationCircleIcon from '@atlaskit/icon/core/information-circle';
 import { setGlobalTheme } from '@atlaskit/tokens';
-import { MinimalIssue } from '@atlassianlabs/jira-pi-common-models';
 import { highlightElement } from '@speed-highlight/core';
 import { detectLanguage } from '@speed-highlight/core/detect';
 import { useCallback, useState } from 'react';
@@ -12,7 +11,7 @@ import { RovoDevToolReturnResponse } from 'src/rovo-dev/client';
 import { RovoDevContextItem, State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { v4 } from 'uuid';
 
-import { DetailedSiteInfo } from '../api/extensionApiTypes';
+import { DetailedSiteInfo, MinimalIssue } from '../api/extensionApiTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from '../rovoDevWebviewProviderMessages';
 import { FeedbackType } from './feedback-form/FeedbackForm';
 import { ChatStream } from './messaging/ChatStream';


### PR DESCRIPTION
### What Is This Change?

Tiny chore: `MinimalIssue` is now also imported via `api/extensionApiTypes` - to make it easier to stub/copy later

This one got lost when I was moving dependencies earlier since `@atlassianlabs/jira-pi-common-models` is technically an external dependency, and didn't pop up on my tool-assisted radar :D

### How Has This Been Tested?

Basic checks + `npm run dev` & sanity clicks ;)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
