### PR TITLE
Revert "AXON-1294 - Rovo Dev webview state preservation when dragging to another panel or reloading"

### DIFF
--- a/src/react/atlascode/messagingApi.ts
+++ b/src/react/atlascode/messagingApi.ts
@@ -12,8 +12,8 @@ export type ReceiveMessageFunc<M extends ReducerAction<any, any>> = (message: M)
 
 interface VsCodeApi {
     postMessage<T = {}>(msg: T): void;
-    setState(state: Record<string, any>): void;
-    getState(): Record<string, any>;
+    setState(state: {}): void;
+    getState(): {};
 }
 declare function acquireVsCodeApi(): VsCodeApi;
 export function useMessagingApi<A, M extends ReducerAction<any, any>, R extends ReducerAction<any, any>>(
@@ -100,13 +100,6 @@ export function useMessagingApi<A, M extends ReducerAction<any, any>, R extends 
         [errorController, pmfController, onMessageHandler],
     );
 
-    const setState = useCallback(
-        (state: Record<string, any>): void => {
-            apiRef.setState(state);
-        },
-        [apiRef],
-    );
-
     useEffect(() => {
         window.addEventListener('message', internalMessageHandler);
         apiRef.postMessage({ type: 'refresh' });
@@ -116,5 +109,5 @@ export function useMessagingApi<A, M extends ReducerAction<any, any>, R extends 
         };
     }, [onMessageHandler, internalMessageHandler, apiRef]);
 
-    return { postMessage, postMessagePromise, setState };
+    return { postMessage, postMessagePromise };
 }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -46,7 +46,6 @@ import {
     RovoDevEntitlementCheckFailedDetail,
     RovoDevProviderMessage,
     RovoDevProviderMessageType,
-    RovoDevWebviewState,
 } from './rovoDevWebviewProviderMessages';
 import { ModifiedFile, RovoDevViewResponse, RovoDevViewResponseType } from './ui/rovoDevViewMessages';
 import { modifyFileTitleMap } from './ui/utils';
@@ -91,7 +90,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private _debugPanelEnabled = false;
     private _debugPanelContext: Record<string, string> = {};
     private _debugPanelMcpContext: Record<string, string> = {};
-    private _savedState: RovoDevWebviewState | undefined = undefined;
 
     private _userInfo: UserInfo | undefined;
 
@@ -242,7 +240,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
     public resolveWebviewView(
         webviewView: WebviewView,
-        context: WebviewViewResolveContext,
+        _context: WebviewViewResolveContext,
         _token: CancellationToken,
     ): Thenable<void> | void {
         this._webView = webviewView.webview;
@@ -252,10 +250,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
         this._chatProvider.setWebview(webview);
         this._chatContextprovider.setWebview(webview);
-
-        if (context.state) {
-            this._savedState = context.state as RovoDevWebviewState;
-        }
 
         webview.options = {
             enableCommandUris: true,
@@ -396,14 +390,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         this._webviewReady = true;
                         this.refreshDebugPanel(true);
                         this.refreshThinkingBlock();
-
-                        if (this._savedState) {
-                            await webview.postMessage({
-                                type: RovoDevProviderMessageType.RestoreState,
-                                state: this._savedState,
-                            });
-                            this._savedState = undefined;
-                        }
 
                         if (!this.isBoysenberry) {
                             // listen to change of process state by the process manager

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -11,7 +11,7 @@ import {
 } from './client';
 import { DisabledState, RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
 import { ModifiedFile } from './ui/rovoDevViewMessages';
-import { ChatMessage, DialogMessage } from './ui/utils';
+import { DialogMessage } from './ui/utils';
 
 export const enum RovoDevProviderMessageType {
     RovoDevDisabled = 'rovoDevDisabled',
@@ -38,7 +38,6 @@ export const enum RovoDevProviderMessageType {
     SetJiraWorkItems = 'setJiraWorkItems',
     CheckFileExistsComplete = 'checkFileExistsComplete',
     SetThinkingBlockEnabled = 'setThinkingBlockEnabled',
-    RestoreState = 'restoreState',
 }
 
 export type RovoDevDisabledReason = DisabledState['subState'];
@@ -50,14 +49,6 @@ export type RovoDevResponseMessageType =
     | RovoDevToolCallResponse
     | RovoDevToolReturnResponse
     | RovoDevRetryPromptResponse;
-
-export interface RovoDevWebviewState {
-    history: ChatMessage[];
-    isDeepPlanCreated: boolean;
-    isDeepPlanToggled: boolean;
-    isYoloModeToggled: boolean;
-    promptContextCollection: RovoDevContextItem[];
-}
 
 export type RovoDevProviderMessage =
     | ReducerAction<
@@ -104,5 +95,4 @@ export type RovoDevProviderMessage =
           RovoDevProviderMessageType.CheckFileExistsComplete,
           { requestId: string; filePath: string; exists: boolean }
       >
-    | ReducerAction<RovoDevProviderMessageType.SetThinkingBlockEnabled, { enabled: boolean }>
-    | ReducerAction<RovoDevProviderMessageType.RestoreState, { state: RovoDevWebviewState }>;
+    | ReducerAction<RovoDevProviderMessageType.SetThinkingBlockEnabled, { enabled: boolean }>;

--- a/src/rovo-dev/ui/create-pr/PullRequestForm.test.tsx
+++ b/src/rovo-dev/ui/create-pr/PullRequestForm.test.tsx
@@ -7,16 +7,9 @@ import { PullRequestChatItem, PullRequestForm } from './PullRequestForm';
 
 const mockPostMessage = jest.fn();
 const mockPostMessagePromise = jest.fn();
-const mockSetState = jest.fn();
 const mockOnCancel = jest.fn();
 const mockOnPullRequestCreated = jest.fn();
 const mockSetFormVisible = jest.fn();
-
-const mockMessagingApi = {
-    postMessage: mockPostMessage,
-    postMessagePromise: mockPostMessagePromise,
-    setState: mockSetState,
-};
 
 describe('PullRequestForm', () => {
     beforeEach(() => {
@@ -27,7 +20,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                messagingApi={mockMessagingApi}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={false}
                 setFormVisible={mockSetFormVisible}
@@ -41,7 +34,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                messagingApi={mockMessagingApi}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
                 setFormVisible={mockSetFormVisible}
@@ -60,7 +53,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                messagingApi={mockMessagingApi}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={false}
                 setFormVisible={mockSetFormVisible}
@@ -83,7 +76,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                messagingApi={mockMessagingApi}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
             />,
@@ -99,7 +92,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                messagingApi={mockMessagingApi}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
             />,
@@ -131,7 +124,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                messagingApi={mockMessagingApi}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
             />,
@@ -156,7 +149,7 @@ describe('PullRequestForm', () => {
         render(
             <PullRequestForm
                 onCancel={mockOnCancel}
-                messagingApi={mockMessagingApi}
+                messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                 onPullRequestCreated={mockOnPullRequestCreated}
                 isFormVisible={true}
             />,
@@ -185,7 +178,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -200,7 +193,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -214,7 +207,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -230,7 +223,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={false}
                     setFormVisible={mockSetFormVisible}
@@ -246,7 +239,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -272,7 +265,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -300,7 +293,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -325,7 +318,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={false}
                     setFormVisible={mockSetFormVisible}
@@ -349,7 +342,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={false}
                     setFormVisible={mockSetFormVisible}
@@ -371,7 +364,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -404,7 +397,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -437,7 +430,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                 />,
@@ -470,7 +463,7 @@ describe('PullRequestForm', () => {
             render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={false}
                 />,
@@ -485,7 +478,7 @@ describe('PullRequestForm', () => {
             const { rerender } = render(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={false}
                     setFormVisible={mockSetFormVisible}
@@ -498,7 +491,7 @@ describe('PullRequestForm', () => {
             rerender(
                 <PullRequestForm
                     onCancel={mockOnCancel}
-                    messagingApi={mockMessagingApi}
+                    messagingApi={{ postMessage: mockPostMessage, postMessagePromise: mockPostMessagePromise }}
                     onPullRequestCreated={mockOnPullRequestCreated}
                     isFormVisible={true}
                     setFormVisible={mockSetFormVisible}

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -428,24 +428,6 @@ const RovoDevView: React.FC = () => {
                     setThinkingBlockEnabled(() => event.enabled);
                     break;
 
-                case RovoDevProviderMessageType.RestoreState:
-                    if (event.state.history) {
-                        setHistory(event.state.history);
-                    }
-                    if (event.state.isDeepPlanCreated !== undefined) {
-                        setIsDeepPlanCreated(event.state.isDeepPlanCreated);
-                    }
-                    if (event.state.isDeepPlanToggled !== undefined) {
-                        setIsDeepPlanToggled(event.state.isDeepPlanToggled);
-                    }
-                    if (event.state.isYoloModeToggled !== undefined) {
-                        setIsYoloModeToggled(event.state.isYoloModeToggled);
-                    }
-                    if (event.state.promptContextCollection) {
-                        setPromptContextCollection(event.state.promptContextCollection);
-                    }
-                    break;
-
                 default:
                     // this is never supposed to happen since there aren't other type of messages
                     handleAppendResponse({
@@ -462,7 +444,7 @@ const RovoDevView: React.FC = () => {
         [handleAppendResponse, currentState.state, setSummaryMessageInHistory, clearChatHistory],
     );
 
-    const { postMessage, postMessagePromise, setState } = useMessagingApi<
+    const { postMessage, postMessagePromise } = useMessagingApi<
         RovoDevViewResponse,
         RovoDevProviderMessage,
         RovoDevProviderMessage
@@ -488,17 +470,6 @@ const RovoDevView: React.FC = () => {
             setPendingFilesForFiltering(null);
         }
     }, [pendingFilesForFiltering, postMessage]);
-
-    // Effect to save webview state when moved between panels
-    React.useEffect(() => {
-        setState({
-            history,
-            isDeepPlanCreated,
-            isDeepPlanToggled,
-            isYoloModeToggled,
-            promptContextCollection,
-        });
-    }, [history, isDeepPlanCreated, isDeepPlanToggled, isYoloModeToggled, promptContextCollection, setState]);
 
     const sendPrompt = useCallback(
         (text: string): boolean => {
@@ -911,7 +882,6 @@ const RovoDevView: React.FC = () => {
                     messagingApi={{
                         postMessage,
                         postMessagePromise,
-                        setState,
                     }}
                     pendingToolCall={pendingToolCallMessage}
                     deepPlanCreated={isDeepPlanCreated}


### PR DESCRIPTION
Reverts atlassian/atlascode#1314

Unfortunately we have to revert this change as it's saving the state of the webview in the context and it's persistent across VS Code instances.