### PR TITLE
AXON-1593 fix the metric failure in bby for DAU

### DIFF
--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -33,7 +33,7 @@
             "env": {
                 "ROVODEV_PORT": "8899",
                 "ROVODEV_ENABLED": "true",
-                "ROVODEV_BBY": "true",
+                "BBY_USERID": "test_user",
                 "ROVODEV_SANDBOX_ID": "bby_sandbox"
             },
             "preLaunchTask": "Start RovoDev Server"

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -253,7 +253,7 @@ export class SiteManager extends Disposable {
     }
 
     public getFirstAAID(productKey?: string): string | undefined {
-        if (process.env.ROVODEV_BBY && process.env.BBY_USERID) {
+        if (process.env.BBY_USERID) {
             return process.env.BBY_USERID;
         }
         if (productKey) {


### PR DESCRIPTION
### What Is This Change?
- BBY was failing to track usage because they stopped sending this env var: ROVODEV_BBY see this: https://app.amplitude.com/analytics/atlassian/chart/tp1gocz5?linkingDashboardId=rvcldgga&sharingId=cNrP8tJc
- fix: we can continue to rely on BBY_USERID, so changed the logic to do this


### Testing 
- Test locally emulatiing the BBY environment variable that I see most recently in BBY


