### PR TITLE
fix issue with boysenberry IDE not correctly using the "env.isTelemetryEnabled" var

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -456,9 +456,9 @@ export class Container {
         }
 
         const telemetryEnabled = env.isTelemetryEnabled || this.isBoysenberryMode;
-        Logger.debug(`[Analytics] VS Code telemetry enabled: ${telementryEnabled}`);
+        Logger.debug(`[Analytics] VS Code telemetry enabled: ${telemetryEnabled}`);
 
-        return telementryEnabled;
+        return telemetryEnabled;
     }
 
     static initializeBitbucket(bbCtx: BitbucketContext) {


### PR DESCRIPTION
### What Is This Change?
- BBY doesn't properly set the env var that VS Code typically uses 
- Options to fix: solve at the VS Code fork level or solve at the extension level. 
- Chose to solve at the extension level for speed of delivery 