### PR TITLE
[NOISSUE] Fix builds

### DIFF
--- a/src/rovo-dev/ui/messagingApi.tsx
+++ b/src/rovo-dev/ui/messagingApi.tsx
@@ -82,13 +82,6 @@ export function useMessagingApi<A, M extends ReducerAction<any, any>, R extends 
         [onMessageHandler],
     );
 
-    const setState = useCallback(
-        (state: Record<string, any>): void => {
-            apiRef.setState(state);
-        },
-        [apiRef],
-    );
-
     useEffect(() => {
         window.addEventListener('message', internalMessageHandler);
         apiRef.postMessage({ type: 'refresh' });
@@ -98,5 +91,5 @@ export function useMessagingApi<A, M extends ReducerAction<any, any>, R extends 
         };
     }, [onMessageHandler, internalMessageHandler, apiRef]);
 
-    return { postMessage, postMessagePromise, setState };
+    return { postMessage, postMessagePromise };
 }


### PR DESCRIPTION
### What Is This Change?

Quick follow-up after merging a stale PR that introduced CI issues in `main`

Merged #1326, but because of #1329 there was a conflict that flew under the radar :)

This PR remedies the `tsc` errors from `messagingApi` not having `setState` anymore

### How Has This Been Tested?

Basic sanity checks

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
