### PR TITLE
AXON-1527 Added the Create Bitbucket Pull Request button to the scm

### DIFF
--- a/package.json
+++ b/package.json
@@ -680,7 +680,7 @@
             "scm/title": [
                 {
                     "command": "atlascode.bb.createPullRequest",
-                    "when": "config.atlascode.bitbucket.enabled",
+                    "when": "atlascode:isBitbucketCloudRepo && config.atlascode.bitbucket.enabled",
                     "group": "navigation"
                 }
 			],

--- a/src/bitbucket/bbContext.ts
+++ b/src/bitbucket/bbContext.ts
@@ -1,6 +1,7 @@
 import { Disposable, Event, EventEmitter, Uri } from 'vscode';
 
 import { DetailedSiteInfo, ProductBitbucket } from '../atlclients/authInfo';
+import { CommandContext, setCommandContext } from '../commandContext';
 import { bbAPIConnectivityError } from '../constants';
 import { Container } from '../container';
 import { Logger } from '../logger';
@@ -119,6 +120,9 @@ export class BitbucketContext extends Disposable {
             }
         }
 
+        const isBitbucketCloudRepo = this.getBitbucketCloudRepositories().length > 0;
+        this.setIsBitbucketCloudRepo(isBitbucketCloudRepo);
+
         this._onDidChangeBitbucketContext.fire();
     }
 
@@ -176,6 +180,10 @@ export class BitbucketContext extends Disposable {
     override dispose() {
         this.disposeForNow();
         this._disposable.dispose();
+    }
+
+    private setIsBitbucketCloudRepo(isBitbucketCloudRepo: boolean) {
+        setCommandContext(CommandContext.IsBitbucketCloudRepo, isBitbucketCloudRepo);
     }
 
     disposeForNow() {

--- a/src/commandContext.ts
+++ b/src/commandContext.ts
@@ -16,6 +16,7 @@ export enum CommandContext {
     UseNewAuthFlow = 'atlascode:useNewAuthFlow',
     IsEditorFocused = 'atlascode:isEditorFocused',
     ShowCreateWorkItemWebview = 'atlascode:showCreateWorkItemWebview',
+    IsBitbucketCloudRepo = 'atlascode:isBitbucketCloudRepo',
 }
 
 export function setCommandContext(key: CommandContext | string, value: any) {


### PR DESCRIPTION
### What Is This Change?
The Source Control Management (SCM) extension has a "Create Pull Request" button that is only useful if the underlying rpo is github.  With this PR, we added a new button "Create Bitbucket Pull Request" that when clicked opens up the UI for creating a pull request for bitbucket repos.
<img width="684" height="302" alt="Screenshot 2025-11-30 at 2 01 15 PM" src="https://github.com/user-attachments/assets/2c505945-0312-4653-a3d4-3d31e3c1f0dd" />


### How Has This Been Tested?

Basic checks:

- [*] `npm run lint`
- [*] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change

demo
https://www.loom.com/share/f12631bd9ec54c56936b66890218f6d6