### PR TITLE
fix handling of required checkbox fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added support for Rovo Dev /usage command
 
+### Bug Fixes
+
+- Fixed validation for required checkbox fields on issue creation
+
 ## What's new in 4.0.10
 
 ### Features

--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -1583,6 +1583,7 @@ export abstract class AbstractIssueEditorPage<
                     this.handleInlineEdit(field, newSelectedValues);
                 };
 
+                const isRequired = currentSelectedValues.length === 0 && field.required;
                 checkField.allowedValues.forEach((value) => {
                     const isChecked = selectedIds.includes(value.id);
 
@@ -1592,7 +1593,7 @@ export abstract class AbstractIssueEditorPage<
                             name={`${field.key}-${value.id}`}
                             id={`${field.key}-${value.id}`}
                             value={value.id}
-                            isRequired={field.required}
+                            isRequired={isRequired}
                         >
                             {(fieldArgs: any) => (
                                 <Checkbox


### PR DESCRIPTION
### What Is This Change?

Validation for checkbox fields now works as expected on issue creation:

| Before | After |
|----|----|
| <img width="475" height="193" alt="image" src="https://github.com/user-attachments/assets/b876c083-4d66-4958-94c0-92aca03bcb9b" /> |  <img width="354" height="189" alt="image" src="https://github.com/user-attachments/assets/53ad55f6-6e3c-434c-a445-93802bffc79f" />

This behaviour is in line with Jira Cloud's own create issue UI

### How Has This Been Tested?

Please see loom on Slack :)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Recommendations:
- [x] Update the CHANGELOG if making a user facing change