### PR TITLE
AXON-1618: Fix pdfjs-dist vuln

### DIFF
--- a/.audit-ci.json
+++ b/.audit-ci.json
@@ -2,9 +2,7 @@
   "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
   "package-manager": "npm",
   "low": true,
-  "allowlist": [
-    "pdfjs-dist"
-  ],
+  "allowlist": [],
   "show-not-found": true,
   "output-format": "text",
   "report-type": "summary"

--- a/package-lock.json
+++ b/package-lock.json
@@ -903,22 +903,39 @@
             }
         },
         "node_modules/@atlaskit/code": {
-            "version": "17.2.7",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/code/-/code-17.2.7.tgz",
-            "integrity": "sha512-lfN54YPhmkZAMsbFf9v4lYAWE6aga3lwTAwoAOa0Z/pxDuZkFw7ASH1+2Aag1CHy3ggvVtwbrfoYcn+2Np3t2g==",
+            "version": "17.3.1",
+            "resolved": "https://registry.npmjs.org/@atlaskit/code/-/code-17.3.1.tgz",
+            "integrity": "sha512-BDNJV/CoFaNUSS9ek72aqgRt2Z5ZfFP5cTq0qYpY9zjVHpBeDRx0lIXCurpkRlzBgI/8KFa6Y38n3DD/oehdOQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/codemod-utils": "^4.2.0",
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/tokens": "^6.4.0",
-                "@atlaskit/tooltip": "^20.5.0",
+                "@atlaskit/tokens": "^8.0.0",
+                "@atlaskit/tooltip": "^20.8.0",
                 "@atlaskit/visually-hidden": "^3.0.0",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3",
+                "@compiled/react": "^0.18.6",
                 "bind-event-listener": "^3.0.0",
                 "memoize-one": "^6.0.0",
                 "raf-schd": "^4.0.3",
                 "refractor": "^3.6.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/code/node_modules/@atlaskit/tokens": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-8.4.0.tgz",
+            "integrity": "sha512-VIhKcAidRUhhb8huvGBYj7EgMHHO4e5rzo6QTfmcewFzd7J4XXI53YPnPn9w0kWdbk7Z+xrk2UONDWK5h7hkyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
             },
             "peerDependencies": {
                 "react": "^18.2.0"
@@ -1345,9 +1362,9 @@
             }
         },
         "node_modules/@atlaskit/ds-lib": {
-            "version": "5.1.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-5.1.1.tgz",
-            "integrity": "sha512-vwRSTKH5+C4Gi/Vtrmla4vfQwyRQZxcgzAYC4NJoMjcpf8heAgmyfCAIfcdpMgkKdQlF4LLi5tjOfDf0gLnv4Q==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/ds-lib/-/ds-lib-5.3.0.tgz",
+            "integrity": "sha512-j3DLHqBACSJsG3XqSgCIwZqvJhYkpSC8i+24n/JYCRjIxYEJMsuSXOtdeu0qBajREwgzmAFP6AVfVZh1zAWG/A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/platform-feature-flags": "^1.1.0",
@@ -15911,12 +15928,12 @@
             }
         },
         "node_modules/@atlaskit/icon-lab": {
-            "version": "5.10.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon-lab/-/icon-lab-5.10.0.tgz",
-            "integrity": "sha512-spewh5qQ55GmKEzFMsipxDV7vFzzPBErb7NPCoD0ChGJINReK0QF2/YiF+iEzyH1y29ML/IhOJAq9yMX1RCLJg==",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@atlaskit/icon-lab/-/icon-lab-5.12.1.tgz",
+            "integrity": "sha512-mgnt4An16fkxWSS7jfoIGw+Tzt7zXsG6DOyKCnS7znmp8om5uAL3lQeKdh0XQuAqZ3I2xEsZzSv/YxQb+lq/1A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/icon": "^28.5.0",
+                "@atlaskit/icon": "^29.0.0",
                 "@babel/runtime": "^7.0.0"
             },
             "peerDependencies": {
@@ -15924,17 +15941,49 @@
             }
         },
         "node_modules/@atlaskit/icon-lab/node_modules/@atlaskit/icon": {
-            "version": "28.5.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-28.5.0.tgz",
-            "integrity": "sha512-TYaOzVHVIDUwqWsOo45NCTZ1OUTxzj1gFW2MNihUImQZgUt/IOqFM9fgM29GzWKVL3FkG7jQqWHiR7VyhFjfTg==",
+            "version": "29.0.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/icon/-/icon-29.0.0.tgz",
+            "integrity": "sha512-Mi+nxksnoaqPnbbaCSF8P1eXMK9WhCJrzXjwsAORi37knvxg/eN/HqKjHhM2FwT/2NMX5VKMxzQ/5GWaBRVFZA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/tile": "^0.1.0",
-                "@atlaskit/tokens": "^6.4.0",
+                "@atlaskit/tile": "^1.0.0",
+                "@atlaskit/tokens": "^8.0.0",
                 "@babel/register": "^7.25.9",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3"
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/icon-lab/node_modules/@atlaskit/tile": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tile/-/tile-1.0.2.tgz",
+            "integrity": "sha512-7g+o/FGHcBl4KNIziMUHshCl9ECpwRYqsIfVT6LYWIfu8iVv72uvG9VIkEkFRVslqufL5jHO0XnxMc2h5MB7Tg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/skeleton": "^2.1.0",
+                "@atlaskit/tokens": "^8.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/icon-lab/node_modules/@atlaskit/tokens": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-8.4.0.tgz",
+            "integrity": "sha512-VIhKcAidRUhhb8huvGBYj7EgMHHO4e5rzo6QTfmcewFzd7J4XXI53YPnPn9w0kWdbk7Z+xrk2UONDWK5h7hkyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
             },
             "peerDependencies": {
                 "react": "^18.2.0"
@@ -17587,9 +17636,9 @@
             }
         },
         "node_modules/@atlaskit/media-client": {
-            "version": "35.5.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/media-client/-/media-client-35.5.0.tgz",
-            "integrity": "sha512-Czvv5g1jwA4rfcofRN98LpuhkGKHyZX4ITi064DeBiBE+fiyZKukAQuC3qwKbKtH96T6G/hnS2MnSpUck3vz4A==",
+            "version": "35.6.1",
+            "resolved": "https://registry.npmjs.org/@atlaskit/media-client/-/media-client-35.6.1.tgz",
+            "integrity": "sha512-hGpWz9SzYbDbslkK7f11vADDQEd1gmYj6HmWRrEyY/UyZyJgdOhyUrRDioBs3RN4guZzYryQ8fDc4ykC8OyVmQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/atlassian-context": "^0.6.0",
@@ -17690,51 +17739,109 @@
             }
         },
         "node_modules/@atlaskit/media-document-viewer": {
-            "version": "0.4.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/media-document-viewer/-/media-document-viewer-0.4.0.tgz",
-            "integrity": "sha512-TFTvQ4y1n8Ovgwnym2u3cnxke/Wb1y+a7N8RozWpU3wX1yDm7BHi5kWr3WihcO/f1d1Qtrpq2rSUYnU8AtgeDg==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@atlaskit/media-document-viewer/-/media-document-viewer-0.6.1.tgz",
+            "integrity": "sha512-bARHM0ZzGI+saotuIW+b0QFygmTKss6dg0bNVUfyUqspnPve/kh+cV63otjC7PXadbG6R8dSuGGf+RuQ5+MdNA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/browser-apis": "^0.0.1",
-                "@atlaskit/css": "^0.14.0",
-                "@atlaskit/icon": "^28.3.0",
+                "@atlaskit/css": "^0.17.0",
+                "@atlaskit/icon": "^29.0.0",
                 "@atlaskit/media-common": "^12.3.0",
-                "@atlaskit/primitives": "^14.15.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/primitives": "^16.3.0",
                 "@atlaskit/spinner": "^19.0.0",
-                "@atlaskit/tokens": "^6.4.0",
+                "@atlaskit/tokens": "^8.3.0",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3"
+                "@compiled/react": "^0.18.6"
             },
             "peerDependencies": {
                 "react": "^18.2.0"
             }
         },
         "node_modules/@atlaskit/media-document-viewer/node_modules/@atlaskit/css": {
-            "version": "0.14.4",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.14.4.tgz",
-            "integrity": "sha512-0RViwbSzefiKhVgSrnUKY7Gd/Qyi11wUpL0cam0y2zuu4XM2uZnUC4rDppTIwOkU+WaugczQ3YWLKP8gIjx4gQ==",
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/css/-/css-0.17.0.tgz",
+            "integrity": "sha512-xTjCKEeBPQWkpkvAt1feaO14pkSl/AV5Sp5CAvJSIiTTw3UtxBgfYryFrxnQMgAyVY2Y6+sW8wXU+/5Wff1MKQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/tokens": "^6.4.0",
+                "@atlaskit/tokens": "^8.3.0",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3"
+                "@compiled/react": "^0.18.6"
             },
             "peerDependencies": {
                 "react": "^18.2.0"
             }
         },
         "node_modules/@atlaskit/media-document-viewer/node_modules/@atlaskit/icon": {
-            "version": "28.5.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-28.5.0.tgz",
-            "integrity": "sha512-TYaOzVHVIDUwqWsOo45NCTZ1OUTxzj1gFW2MNihUImQZgUt/IOqFM9fgM29GzWKVL3FkG7jQqWHiR7VyhFjfTg==",
+            "version": "29.0.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/icon/-/icon-29.0.0.tgz",
+            "integrity": "sha512-Mi+nxksnoaqPnbbaCSF8P1eXMK9WhCJrzXjwsAORi37knvxg/eN/HqKjHhM2FwT/2NMX5VKMxzQ/5GWaBRVFZA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/tile": "^0.1.0",
-                "@atlaskit/tokens": "^6.4.0",
+                "@atlaskit/tile": "^1.0.0",
+                "@atlaskit/tokens": "^8.0.0",
                 "@babel/register": "^7.25.9",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3"
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/media-document-viewer/node_modules/@atlaskit/primitives": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-16.4.0.tgz",
+            "integrity": "sha512-LDPZjNrJnJGlaJgRkZlVu9+Xk093n0y6b39Rb5Z+K9fDBd1q4/pSRb2phse0SgIwzg6+mISxE5swcPYh6YtNIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.1.0",
+                "@atlaskit/app-provider": "^3.2.0",
+                "@atlaskit/css": "^0.17.0",
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/interaction-context": "^3.1.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^8.3.0",
+                "@atlaskit/visually-hidden": "^3.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/media-document-viewer/node_modules/@atlaskit/tile": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tile/-/tile-1.0.2.tgz",
+            "integrity": "sha512-7g+o/FGHcBl4KNIziMUHshCl9ECpwRYqsIfVT6LYWIfu8iVv72uvG9VIkEkFRVslqufL5jHO0XnxMc2h5MB7Tg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/skeleton": "^2.1.0",
+                "@atlaskit/tokens": "^8.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/media-document-viewer/node_modules/@atlaskit/tokens": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-8.4.0.tgz",
+            "integrity": "sha512-VIhKcAidRUhhb8huvGBYj7EgMHHO4e5rzo6QTfmcewFzd7J4XXI53YPnPn9w0kWdbk7Z+xrk2UONDWK5h7hkyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
             },
             "peerDependencies": {
                 "react": "^18.2.0"
@@ -18013,48 +18120,47 @@
             }
         },
         "node_modules/@atlaskit/media-viewer": {
-            "version": "52.4.25",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/media-viewer/-/media-viewer-52.4.25.tgz",
-            "integrity": "sha512-h/ESxwRdaFyxWwXB5RjEILYtKxPSk3lbsnEQUS9PPfi2Sa6gjAScFhSc9TLahbIv42zo4/jtSTB8U6ZTCL6APA==",
+            "version": "52.5.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/media-viewer/-/media-viewer-52.5.0.tgz",
+            "integrity": "sha512-ptIlWljtJ145+eMSKoeaOh3rwqZz67W5oX/HMaOF4DN+93ECTmQvWbnN+izaaySqeJqpsdVe8zyfKyc1cxqdHg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/analytics-next": "^11.1.0",
-                "@atlaskit/button": "^23.5.0",
-                "@atlaskit/code": "^17.2.0",
-                "@atlaskit/css": "^0.14.0",
-                "@atlaskit/form": "^14.2.0",
+                "@atlaskit/button": "^23.6.0",
+                "@atlaskit/code": "^17.3.0",
+                "@atlaskit/css": "^0.17.0",
+                "@atlaskit/form": "^14.3.0",
                 "@atlaskit/heading": "^5.2.0",
-                "@atlaskit/icon": "^28.3.0",
+                "@atlaskit/icon": "^29.0.0",
                 "@atlaskit/icon-file-type": "^7.0.0",
-                "@atlaskit/icon-lab": "^5.8.0",
-                "@atlaskit/media-client": "^35.4.0",
+                "@atlaskit/icon-lab": "^5.12.0",
+                "@atlaskit/media-client": "^35.6.0",
                 "@atlaskit/media-client-react": "^4.1.0",
                 "@atlaskit/media-common": "^12.3.0",
-                "@atlaskit/media-document-viewer": "^0.4.0",
+                "@atlaskit/media-document-viewer": "^0.6.0",
                 "@atlaskit/media-svg": "^2.1.0",
                 "@atlaskit/media-ui": "^28.7.0",
                 "@atlaskit/platform-feature-flags": "^1.1.0",
                 "@atlaskit/portal": "^5.1.0",
-                "@atlaskit/primitives": "^14.15.0",
+                "@atlaskit/primitives": "^16.4.0",
                 "@atlaskit/side-navigation": "^11.0.0",
                 "@atlaskit/spinner": "^19.0.0",
-                "@atlaskit/textfield": "^8.0.0",
+                "@atlaskit/textfield": "^8.1.0",
                 "@atlaskit/theme": "^21.0.0",
-                "@atlaskit/tokens": "^6.4.0",
-                "@atlaskit/tooltip": "^20.5.0",
+                "@atlaskit/tokens": "^8.4.0",
+                "@atlaskit/tooltip": "^20.10.0",
                 "@atlaskit/ufo": "^0.4.0",
                 "@babel/runtime": "^7.0.0",
                 "@codemirror/language": "6.10.8",
                 "@codemirror/language-data": "6.5.1",
                 "@codemirror/state": "6.5.1",
                 "@codemirror/view": "6.36.2",
-                "@compiled/react": "^0.18.3",
+                "@compiled/react": "^0.18.6",
                 "@kenjiuno/msgreader": "^1.2.6",
                 "@lezer/highlight": "1.2.1",
                 "deep-equal": "^1.0.1",
                 "fflate": "^0.8.1",
                 "mime": "^2.4.6",
-                "pdfjs-dist": "2.16.105",
                 "perf-marks": "^1.5.0",
                 "react-error-boundary": "^3.1.3",
                 "react-focus-lock": "^2.9.5",
@@ -18069,33 +18175,60 @@
                 "react-intl-next": "npm:react-intl@^5.18.1"
             }
         },
-        "node_modules/@atlaskit/media-viewer/node_modules/@atlaskit/css": {
-            "version": "0.14.4",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.14.4.tgz",
-            "integrity": "sha512-0RViwbSzefiKhVgSrnUKY7Gd/Qyi11wUpL0cam0y2zuu4XM2uZnUC4rDppTIwOkU+WaugczQ3YWLKP8gIjx4gQ==",
+        "node_modules/@atlaskit/media-viewer/node_modules/@atlaskit/button": {
+            "version": "23.6.3",
+            "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-23.6.3.tgz",
+            "integrity": "sha512-ufg3aIt8A5iQgVPNFrw9/dE0F2yGVLi39wwiyX+MC0zgjq/5KSPLAzyjO3gO/OhhGI3ZBu9OfnPB2fVVoRKH9Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/tokens": "^6.4.0",
+                "@atlaskit/analytics-next": "^11.1.0",
+                "@atlaskit/css": "^0.17.0",
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/focus-ring": "^3.0.0",
+                "@atlaskit/icon": "^29.0.0",
+                "@atlaskit/interaction-context": "^3.1.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/primitives": "^16.3.0",
+                "@atlaskit/spinner": "^19.0.0",
+                "@atlaskit/theme": "^21.0.0",
+                "@atlaskit/tokens": "^8.3.0",
+                "@atlaskit/tooltip": "^20.10.0",
+                "@atlaskit/visually-hidden": "^3.0.0",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3"
+                "@compiled/react": "^0.18.6",
+                "@emotion/react": "^11.7.1"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/media-viewer/node_modules/@atlaskit/css": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/css/-/css-0.17.0.tgz",
+            "integrity": "sha512-xTjCKEeBPQWkpkvAt1feaO14pkSl/AV5Sp5CAvJSIiTTw3UtxBgfYryFrxnQMgAyVY2Y6+sW8wXU+/5Wff1MKQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^8.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6"
             },
             "peerDependencies": {
                 "react": "^18.2.0"
             }
         },
         "node_modules/@atlaskit/media-viewer/node_modules/@atlaskit/form": {
-            "version": "14.2.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/form/-/form-14.2.0.tgz",
-            "integrity": "sha512-a124D4css0TqyVvuvkfHI/3TARTU4c7BzJqtK2L37EB456j2trv37mMwWROamk+x2voRlX++GV/kNKk9BvRvqg==",
+            "version": "14.3.1",
+            "resolved": "https://registry.npmjs.org/@atlaskit/form/-/form-14.3.1.tgz",
+            "integrity": "sha512-dWcRurtDTm2ozr3A6XD1NkCE/JHmVMBjMPShHkbejiaQV6+zqwoxkCeD2RjpqfS8lJreXpXvmN1D+B5PESV/fw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@atlaskit/css": "^0.14.0",
-                "@atlaskit/ds-lib": "^5.1.0",
+                "@atlaskit/css": "^0.17.0",
+                "@atlaskit/ds-lib": "^5.3.0",
                 "@atlaskit/heading": "^5.2.0",
-                "@atlaskit/icon": "^28.3.0",
+                "@atlaskit/icon": "^29.0.0",
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/primitives": "^14.15.0",
-                "@atlaskit/tokens": "^6.3.0",
+                "@atlaskit/primitives": "^16.3.0",
+                "@atlaskit/tokens": "^8.3.0",
                 "@babel/runtime": "^7.0.0",
                 "final-form": "^4.20.3",
                 "final-form-focus": "^1.1.2",
@@ -18106,17 +18239,74 @@
             }
         },
         "node_modules/@atlaskit/media-viewer/node_modules/@atlaskit/icon": {
-            "version": "28.5.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/icon/-/icon-28.5.0.tgz",
-            "integrity": "sha512-TYaOzVHVIDUwqWsOo45NCTZ1OUTxzj1gFW2MNihUImQZgUt/IOqFM9fgM29GzWKVL3FkG7jQqWHiR7VyhFjfTg==",
+            "version": "29.0.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/icon/-/icon-29.0.0.tgz",
+            "integrity": "sha512-Mi+nxksnoaqPnbbaCSF8P1eXMK9WhCJrzXjwsAORi37knvxg/eN/HqKjHhM2FwT/2NMX5VKMxzQ/5GWaBRVFZA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/platform-feature-flags": "^1.1.0",
-                "@atlaskit/tile": "^0.1.0",
-                "@atlaskit/tokens": "^6.4.0",
+                "@atlaskit/tile": "^1.0.0",
+                "@atlaskit/tokens": "^8.0.0",
                 "@babel/register": "^7.25.9",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3"
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/media-viewer/node_modules/@atlaskit/primitives": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-16.4.0.tgz",
+            "integrity": "sha512-LDPZjNrJnJGlaJgRkZlVu9+Xk093n0y6b39Rb5Z+K9fDBd1q4/pSRb2phse0SgIwzg6+mISxE5swcPYh6YtNIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.1.0",
+                "@atlaskit/app-provider": "^3.2.0",
+                "@atlaskit/css": "^0.17.0",
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/interaction-context": "^3.1.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^8.3.0",
+                "@atlaskit/visually-hidden": "^3.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/media-viewer/node_modules/@atlaskit/tile": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tile/-/tile-1.0.2.tgz",
+            "integrity": "sha512-7g+o/FGHcBl4KNIziMUHshCl9ECpwRYqsIfVT6LYWIfu8iVv72uvG9VIkEkFRVslqufL5jHO0XnxMc2h5MB7Tg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/skeleton": "^2.1.0",
+                "@atlaskit/tokens": "^8.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/media-viewer/node_modules/@atlaskit/tokens": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-8.4.0.tgz",
+            "integrity": "sha512-VIhKcAidRUhhb8huvGBYj7EgMHHO4e5rzo6QTfmcewFzd7J4XXI53YPnPn9w0kWdbk7Z+xrk2UONDWK5h7hkyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
             },
             "peerDependencies": {
                 "react": "^18.2.0"
@@ -20486,17 +20676,34 @@
             }
         },
         "node_modules/@atlaskit/textfield": {
-            "version": "8.0.13",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/textfield/-/textfield-8.0.13.tgz",
-            "integrity": "sha512-hnaTvZy9o1Cl29TytxlX3eSqSsK05fFh+r08zU4kGTZSg2pxo0Nn+zC4rQwr2KLd+EMsuPi7r7HS2P/KBQDeGQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/textfield/-/textfield-8.1.0.tgz",
+            "integrity": "sha512-UXUiocK4J6vjWR606sOM0AEVKZ0TNdpYKuP1NQseXSNkPrWoPZNpSrFzOYwF/56qTdmVWmftc8ubqfksUOj8mQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/analytics-next": "^11.1.0",
                 "@atlaskit/platform-feature-flags": "^1.1.0",
                 "@atlaskit/theme": "^21.0.0",
-                "@atlaskit/tokens": "^6.4.0",
+                "@atlaskit/tokens": "^8.0.0",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3"
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/textfield/node_modules/@atlaskit/tokens": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-8.4.0.tgz",
+            "integrity": "sha512-VIhKcAidRUhhb8huvGBYj7EgMHHO4e5rzo6QTfmcewFzd7J4XXI53YPnPn9w0kWdbk7Z+xrk2UONDWK5h7hkyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
             },
             "peerDependencies": {
                 "react": "^18.2.0"
@@ -20618,27 +20825,118 @@
             }
         },
         "node_modules/@atlaskit/tooltip": {
-            "version": "20.5.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tooltip/-/tooltip-20.5.1.tgz",
-            "integrity": "sha512-RlQU9pDXWbjCaY0RKEUsm6pAPd7ZR5goGN6pc1N81adySlgN8PClNLvX2NuPuyxXEwdTinpi34m8s66AgBDC6Q==",
+            "version": "20.10.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tooltip/-/tooltip-20.10.0.tgz",
+            "integrity": "sha512-qYOIN4YEQRZ5ys3syA+PVNEJImhh+DW522Gm/jRV/0Ux3uELwpmigWOOktqha5yxbgGEJR6nir9gyEYw5ZDhhg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@atlaskit/analytics-next": "^11.1.0",
-                "@atlaskit/ds-lib": "^5.1.0",
-                "@atlaskit/layering": "^3.0.0",
+                "@atlaskit/ds-lib": "^5.2.0",
+                "@atlaskit/layering": "^3.4.0",
                 "@atlaskit/motion": "^5.3.0",
                 "@atlaskit/platform-feature-flags": "^1.1.0",
                 "@atlaskit/popper": "^7.1.0",
                 "@atlaskit/portal": "^5.1.0",
                 "@atlaskit/theme": "^21.0.0",
-                "@atlaskit/tokens": "^6.4.0",
+                "@atlaskit/tokens": "^8.0.0",
                 "@babel/runtime": "^7.0.0",
-                "@compiled/react": "^0.18.3",
+                "@compiled/react": "^0.18.6",
                 "bind-event-listener": "^3.0.0"
             },
             "peerDependencies": {
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/tooltip/node_modules/@atlaskit/css": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/css/-/css-0.17.0.tgz",
+            "integrity": "sha512-xTjCKEeBPQWkpkvAt1feaO14pkSl/AV5Sp5CAvJSIiTTw3UtxBgfYryFrxnQMgAyVY2Y6+sW8wXU+/5Wff1MKQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/tokens": "^8.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/tooltip/node_modules/@atlaskit/layering": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/layering/-/layering-3.4.0.tgz",
+            "integrity": "sha512-6JkUGbkALkC/AedsbxY2m/465lRraLLvFMQ/mPN1oLMfzflMOiaHs4DLVW79R7iuR4ren8XOHAARVD36KPSflA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.2.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/platform-feature-flags-react": "^0.4.0",
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/tooltip/node_modules/@atlaskit/platform-feature-flags-react": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@atlaskit/platform-feature-flags-react/-/platform-feature-flags-react-0.4.3.tgz",
+            "integrity": "sha512-vc++ZXMxuSiwM5462Uiq5VHqnMxpZ35WxKwKVaA6pHK/QcY4om2KZKbzTY1wiNC62zPdBE33ZNxyLf8zh35rrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/css": "^0.17.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/primitives": "^16.3.0",
+                "@atlaskit/tokens": "^8.3.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6",
+                "react-magnetic-di": "^3.1.4"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/tooltip/node_modules/@atlaskit/primitives": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/primitives/-/primitives-16.4.0.tgz",
+            "integrity": "sha512-LDPZjNrJnJGlaJgRkZlVu9+Xk093n0y6b39Rb5Z+K9fDBd1q4/pSRb2phse0SgIwzg6+mISxE5swcPYh6YtNIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/analytics-next": "^11.1.0",
+                "@atlaskit/app-provider": "^3.2.0",
+                "@atlaskit/css": "^0.17.0",
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/interaction-context": "^3.1.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@atlaskit/tokens": "^8.3.0",
+                "@atlaskit/visually-hidden": "^3.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6",
+                "@emotion/react": "^11.7.1",
+                "@emotion/serialize": "^1.1.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
+            }
+        },
+        "node_modules/@atlaskit/tooltip/node_modules/@atlaskit/tokens": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-8.4.0.tgz",
+            "integrity": "sha512-VIhKcAidRUhhb8huvGBYj7EgMHHO4e5rzo6QTfmcewFzd7J4XXI53YPnPn9w0kWdbk7Z+xrk2UONDWK5h7hkyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^5.3.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0"
             }
         },
         "node_modules/@atlaskit/ufo": {
@@ -32856,13 +33154,6 @@
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
         },
-        "node_modules/dommatrix": {
-            "version": "1.0.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/dommatrix/-/dommatrix-1.0.3.tgz",
-            "integrity": "sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==",
-            "deprecated": "dommatrix is no longer maintained. Please use @thednp/dommatrix.",
-            "license": "MIT"
-        },
         "node_modules/domutils": {
             "version": "3.2.2",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/domutils/-/domutils-3.2.2.tgz",
@@ -40659,24 +40950,6 @@
                 "through": "~2.3"
             }
         },
-        "node_modules/pdfjs-dist": {
-            "version": "2.16.105",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/pdfjs-dist/-/pdfjs-dist-2.16.105.tgz",
-            "integrity": "sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "dommatrix": "^1.0.3",
-                "web-streams-polyfill": "^3.2.1"
-            },
-            "peerDependencies": {
-                "worker-loader": "^3.0.8"
-            },
-            "peerDependenciesMeta": {
-                "worker-loader": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/pend/-/pend-1.2.0.tgz",
@@ -46928,15 +47201,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.3.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/webidl-conversions": {


### PR DESCRIPTION
### What Is This Change?

Fix pdfjs-dist package vuln (media-viewer)

Before: 
<img width="374" height="44" alt="Screenshot 2025-12-02 at 15 20 48" src="https://github.com/user-attachments/assets/c5f9b391-b237-43fd-a8d1-324b980adcef" />

After:

<img width="264" height="48" alt="Screenshot 2025-12-02 at 15 20 39" src="https://github.com/user-attachments/assets/91c395b6-19d8-44c6-9c5b-8be5c4a43197" />

### How Has This Been Tested?

Basic checks:

- [ ] `npm audit`
