### PR TITLE
AXON-1499: save and show pre selected issue type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Added support for Rovo Dev /usage command
+- Add saving of last chosen issue type
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1329,9 +1329,9 @@
                     "description": "Shows active Jira issue key in the status bar",
                     "scope": "window"
                 },
-                "atlascode.jira.lastCreateSiteAndProject": {
+                "atlascode.jira.lastCreatePreSelectedValues": {
                     "type": "object",
-                    "description": "the last used site id and project key for create issue",
+                    "description": "the last used site id, project key, and issue type id for create issue",
                     "scope": "window",
                     "properties": {
                         "siteId": {
@@ -1339,6 +1339,10 @@
                             "default": ""
                         },
                         "projectKey": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "issueTypeId": {
                             "type": "string",
                             "default": ""
                         }

--- a/src/config/configuration.test.ts
+++ b/src/config/configuration.test.ts
@@ -1,8 +1,8 @@
 import { ConfigurationChangeEvent, ExtensionContext, workspace } from 'vscode';
 
-import { ConfigNamespace, JiraCreateSiteAndProjectKey } from '../constants';
+import { ConfigNamespace, JiraPreSelectedCreateKey } from '../constants';
 import { Configuration, configuration } from './configuration';
-import { SiteIdAndProjectKey } from './model';
+import { LastCreatePreSelectedValues } from './model';
 
 // Mock vscode module
 jest.mock('vscode', () => ({
@@ -156,22 +156,21 @@ describe('Configuration', () => {
         });
 
         it('should call updateEffective with correct parameters', async () => {
-            const siteAndProject: SiteIdAndProjectKey = { siteId: 'site1', projectKey: 'PROJ' };
+            const siteAndProject: LastCreatePreSelectedValues = {
+                siteId: 'site1',
+                projectKey: 'PROJ',
+                issueTypeId: '',
+            };
 
             await config.setLastCreateSiteAndProject(siteAndProject);
 
-            expect(config.updateEffective).toHaveBeenCalledWith(
-                JiraCreateSiteAndProjectKey,
-                siteAndProject,
-                null,
-                true,
-            );
+            expect(config.updateEffective).toHaveBeenCalledWith(JiraPreSelectedCreateKey, siteAndProject, null, true);
         });
 
         it('should handle undefined siteAndProject', async () => {
             await config.setLastCreateSiteAndProject(undefined);
 
-            expect(config.updateEffective).toHaveBeenCalledWith(JiraCreateSiteAndProjectKey, undefined, null, true);
+            expect(config.updateEffective).toHaveBeenCalledWith(JiraPreSelectedCreateKey, undefined, null, true);
         });
     });
 });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -11,8 +11,8 @@ import {
     workspace,
 } from 'vscode';
 
-import { ConfigNamespace, JiraCreateSiteAndProjectKey } from '../constants';
-import { SiteIdAndProjectKey } from './model';
+import { ConfigNamespace, JiraPreSelectedCreateKey } from '../constants';
+import { LastCreatePreSelectedValues } from './model';
 
 /*
 Configuration is a helper to manage configuration changes in various parts of the system.
@@ -108,8 +108,8 @@ export class Configuration extends Disposable {
             .update(section, value, target);
     }
 
-    async setLastCreateSiteAndProject(siteAndProject?: SiteIdAndProjectKey) {
-        await this.updateEffective(JiraCreateSiteAndProjectKey, siteAndProject, null, true);
+    async setLastCreateSiteAndProject(siteAndProject?: LastCreatePreSelectedValues) {
+        await this.updateEffective(JiraPreSelectedCreateKey, siteAndProject, null, true);
     }
 
     // this tries to figure out where the current value is set and update it there

--- a/src/config/model.ts
+++ b/src/config/model.ts
@@ -52,7 +52,7 @@ export interface RovoDevConfig {
 
 export interface JiraConfig {
     enabled: boolean;
-    lastCreateSiteAndProject: SiteIdAndProjectKey;
+    lastCreatePreSelectedValues: LastCreatePreSelectedValues;
     explorer: JiraExplorer;
     issueMonitor: JiraIssueMonitor;
     statusbar: JiraStatusBar;
@@ -63,9 +63,10 @@ export interface JiraConfig {
     showCreateIssueProblems: boolean;
 }
 
-export type SiteIdAndProjectKey = {
+export type LastCreatePreSelectedValues = {
     siteId: string;
     projectKey: string;
+    issueTypeId: string;
 };
 
 export interface JiraStatusBar {
@@ -207,7 +208,7 @@ const emptyStartWorkBranchTemplate: StartWorkBranchTemplate = {
 
 const emptyJiraConfig: JiraConfig = {
     enabled: true,
-    lastCreateSiteAndProject: { siteId: '', projectKey: '' },
+    lastCreatePreSelectedValues: { siteId: '', projectKey: '', issueTypeId: '' },
     explorer: emptyJiraExplorer,
     issueMonitor: emtpyIssueMonitor,
     statusbar: emptyJiraStatusBar,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 export const ExtensionId = 'atlassian.atlascode';
 export const ConfigNamespace = 'atlascode';
 export const extensionOutputChannelName = 'Atlassian';
-export const JiraCreateSiteAndProjectKey = 'jira.lastCreateSiteAndProject';
+export const JiraPreSelectedCreateKey = 'jira.lastCreatePreSelectedValues';
 export const JiraEnabledKey = 'jira.enabled';
 export const BitbucketEnabledKey = 'bitbucket.enabled';
 export const JiraHoverProviderConfigurationKey = 'jira.hover.enabled';

--- a/src/siteManager.test.ts
+++ b/src/siteManager.test.ts
@@ -77,8 +77,10 @@ describe('SiteManager', () => {
             },
             config: {
                 jira: {
-                    lastCreateSiteAndProject: {
+                    lastCreatePreSelectedValues: {
                         siteId: 'site1',
+                        projectKey: '',
+                        issueTypeId: '',
                     },
                 },
             },

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -351,7 +351,7 @@ export class SiteManager extends Disposable {
                     });
                 }
 
-                if (deletedSite.id === Container.config.jira.lastCreateSiteAndProject.siteId) {
+                if (deletedSite.id === Container.config.jira.lastCreatePreSelectedValues.siteId) {
                     configuration.setLastCreateSiteAndProject(undefined);
                 }
 

--- a/src/webviews/createIssueWebview.test.ts
+++ b/src/webviews/createIssueWebview.test.ts
@@ -35,9 +35,10 @@ jest.mock('../container', () => ({
         },
         config: {
             jira: {
-                lastCreateSiteAndProject: {
+                lastCreatePreSelectedValues: {
                     siteId: '',
                     projectKey: '',
+                    issueTypeId: '',
                 },
                 showCreateIssueProblems: false,
             },
@@ -1095,11 +1096,12 @@ describe('CreateIssueWebview', () => {
         });
     });
 
-    describe('Should correctly set site and project (updateSiteAndProject)', () => {
+    describe('Should correctly set site, project and issueTypeId (updateSiteAndProject)', () => {
         beforeEach(() => {
-            Container.config.jira.lastCreateSiteAndProject = {
+            Container.config.jira.lastCreatePreSelectedValues = {
                 siteId: '',
                 projectKey: '',
+                issueTypeId: '',
             };
             jest.spyOn(SearchJiraHelper, 'getAssignedIssuesPerSite').mockReturnValue([]);
         });
@@ -1108,9 +1110,10 @@ describe('CreateIssueWebview', () => {
             const lastUsedSiteId = 'last-used-site';
             const lastUsedProjectKey = 'last-used-project';
 
-            Container.config.jira.lastCreateSiteAndProject = {
+            Container.config.jira.lastCreatePreSelectedValues = {
                 siteId: lastUsedSiteId,
                 projectKey: lastUsedProjectKey,
+                issueTypeId: '',
             };
 
             Container.siteManager.getSiteForId = jest.fn().mockReturnValue({
@@ -1126,6 +1129,7 @@ describe('CreateIssueWebview', () => {
             expect(configuration.setLastCreateSiteAndProject).toHaveBeenCalledWith({
                 siteId: lastUsedSiteId,
                 projectKey: lastUsedProjectKey,
+                issueTypeId: '',
             });
         });
 
@@ -1158,6 +1162,7 @@ describe('CreateIssueWebview', () => {
             expect(configuration.setLastCreateSiteAndProject).toHaveBeenCalledWith({
                 siteId: maxIssuesSite.id,
                 projectKey: maxIssuesProject.key,
+                issueTypeId: '',
             });
         });
 
@@ -1174,6 +1179,7 @@ describe('CreateIssueWebview', () => {
             expect(configuration.setLastCreateSiteAndProject).toHaveBeenCalledWith({
                 siteId: 'first-site',
                 projectKey: 'first-project',
+                issueTypeId: '',
             });
         });
 
@@ -1195,6 +1201,7 @@ describe('CreateIssueWebview', () => {
             expect(configuration.setLastCreateSiteAndProject).toHaveBeenLastCalledWith({
                 projectKey: inputProject.key,
                 siteId: 'site-1',
+                issueTypeId: 'issueType-1',
             });
         });
 
@@ -1216,6 +1223,7 @@ describe('CreateIssueWebview', () => {
             expect(configuration.setLastCreateSiteAndProject).toHaveBeenLastCalledWith({
                 siteId: inputSite.id,
                 projectKey: 'TEST',
+                issueTypeId: 'issueType-1',
             });
         });
     });

--- a/src/work-items/create-work-item/createWorkItemWebviewProvider.ts
+++ b/src/work-items/create-work-item/createWorkItemWebviewProvider.ts
@@ -203,7 +203,7 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
 
             this._availableSites = this.toFieldMap(allSites);
 
-            const selectedSiteAndProject = Container.config.jira.lastCreateSiteAndProject;
+            const selectedSiteAndProject = Container.config.jira.lastCreatePreSelectedValues;
 
             const selectedSite =
                 this._availableSites[selectedSiteAndProject.siteId] ||
@@ -454,6 +454,7 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
                     await configuration.setLastCreateSiteAndProject({
                         siteId: this._selectedSite!.id,
                         projectKey: this._selectedProject!.key,
+                        issueTypeId: this._selectedIssueType?.id || '',
                     });
                     const payload = {
                         summary: message.payload.summary,
@@ -511,7 +512,7 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
             'create',
         );
 
-        const lastCreateSiteAndProject = Container.config.jira.lastCreateSiteAndProject;
+        const lastCreateSiteAndProject = Container.config.jira.lastCreatePreSelectedValues;
         const selectedProject =
             projects.projects.find((p) => p.key === lastCreateSiteAndProject.projectKey) || projects.projects[0];
 


### PR DESCRIPTION
### What Is This Change?
- added saving of last chosen issue type and showing it as pre-selected option in next iteration 
- renamed some types and methods as previously naming was project and site related and now we save also issue type id


https://github.com/user-attachments/assets/91b078e4-bf2e-4de9-b3eb-f6ed9192cf87



<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change