### PR TITLE
NO-ISSUE: Focus on prompt box when Rovo Dev is shown

### DIFF
--- a/src/rovo-dev/ui/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/rovo-dev/ui/prompt-box/prompt-input/PromptInput.tsx
@@ -175,6 +175,28 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
         });
     }, [currentState, editor, disabled]);
 
+    // Focus the editor when it becomes visible in the viewport - helps with opening Rovo Dev panel already focused
+    React.useEffect(() => {
+        const io = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if (
+                    entry.isIntersecting &&
+                    !!editor &&
+                    entry.target === document.getElementById('prompt-editor-container')
+                ) {
+                    const lineNumber = editor.getModel()!.getLineCount();
+                    const column = editor.getModel()!.getLineLength(lineNumber) + 1;
+                    editor.focus();
+                    editor.setPosition({ lineNumber, column }); // move cursor to end
+                }
+            });
+        });
+
+        io.observe(document.getElementById('prompt-editor-container')!);
+
+        return () => io.disconnect();
+    }, [editor]);
+
     const isWaitingForPrompt = React.useMemo(
         () =>
             currentState.state === 'WaitingForPrompt' ||


### PR DESCRIPTION
### What Is This Change?

Now if the Rovo Dev panel is shown, the user will be automatically focused on the prompt box.

### How Has This Been Tested?

Manually

Demo: https://www.loom.com/share/ad8aadad2c8e4a7f9934e924fc1197d0

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`