### PR TITLE
fix: show session token in debug panel context

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -1062,6 +1062,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         this._rovoDevApiClient = new RovoDevApiClient(hostname, rovoDevPort, sessionToken);
 
         this._debugPanelContext['RovoDevAddress'] = `http://${hostname}:${rovoDevPort}`;
+        this._debugPanelContext['SessionToken'] = sessionToken;
         this.refreshDebugPanel();
 
         // enable the 'show terminal' button only when in debugging
@@ -1094,6 +1095,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         // if the client becomes undefined, it means the process terminated while we were polling the healtcheck
         if (!rovoDevClient) {
             delete this._debugPanelContext['RovoDevAddress'];
+            delete this._debugPanelContext['SessionToken'];
             delete this._debugPanelContext['RovoDevHealthcheck'];
             this.refreshDebugPanel();
             return;


### PR DESCRIPTION
### What Is This Change?
- as a developer, I need to know what the session token is for the Rovo Dev CLI
- So, show it in the debug panel 


https://www.loom.com/share/003c5ba9770e4be2a4bb75ffae205369