### PR TITLE
chore: run audit-ci earlier in the build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run vulnerability audit
+        # "There is no Vulnerability in Media Viewer after 48.5.4. since it was fixed by patching, but npm audit still reports it.",
+        # So that switched to audit-ci with allowlist
+        run: npm run audit-ci
+
       - name: Compress node_modules
         run: tar -czf node_modules.tar.gz node_modules
 
@@ -64,11 +69,6 @@ jobs:
 
       - name: Extract node_modules
         run: tar -xzf node_modules.tar.gz
-
-      - name: Run vulnerability audit
-        # "There is no Vulnerability in Media Viewer after 48.5.4. since it was fixed by patching, but npm audit still reports it.",
-        # So that switched to audit-ci with allowlist
-        run: npm run audit-ci
 
       - name: Run linter
         run: npm run lint


### PR DESCRIPTION
### What Is This Change?

Small change to run `audit-ci` in the very first build step, immediately after the packages are installed.

### How Has This Been Tested?

N/A