### PR TITLE
[AXON-1661] chore: skip non-images in image error handler

### DIFF
--- a/src/react/imageErrorHandler.tsx
+++ b/src/react/imageErrorHandler.tsx
@@ -2,7 +2,13 @@ export const attachImageErrorHandler = () => {
     window.addEventListener(
         'error',
         (ee: ErrorEvent) => {
-            const targetEL = ee.target as HTMLElement;
+            const targetEL = ee.target;
+
+            if (!(targetEL instanceof HTMLElement)) {
+                // The target can be something other than an HTMLElement (e.g., Window)
+                // We only care about HTMLElements here
+                return;
+            }
 
             // Prevent re-processing the same image and avoid loops if the fallback fails
             if (targetEL.getAttribute('src') === 'images/no-image.svg') {


### PR DESCRIPTION
### What Is This Change?

Small side-fix while working on the rendering failure - let's not try to handle generic errors as if they are image loading errors

### How Has This Been Tested?

Tested it on the induced rendering error from AXON-1661, the `i.getAttribute is not a function` error goes away (no effect on the actual rendering problem ofc)

<img width="1588" height="416" alt="image" src="https://github.com/user-attachments/assets/8afd875c-e010-451c-971f-6fd058a0ccd3" />

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`