### PR TITLE
[AXON-1661] Add workaround for rovodev to not crash on bad content types

### DIFF
--- a/src/rovo-dev/ui/common/common.tsx
+++ b/src/rovo-dev/ui/common/common.tsx
@@ -77,9 +77,6 @@ export const MarkedDown: React.FC<{ value: string; onLinkClick: (href: string) =
     if (typeof value !== 'string') {
         // Silently recover from invalid types
         value = '';
-        console.log('BRUUUUUH received', value, 'replacing!!!!');
-    } else {
-        console.log('BRUUUUUH received', value, 'not replacing');
     }
 
     const spanRef = React.useRef<HTMLSpanElement>(null);


### PR DESCRIPTION
### What Is This Change?

Small workaround to not ungracefully whenever the content sent to `MarkedDown` is of the wrong type
Related to AXON-1661 but doesn't go into the root cause

### How Has This Been Tested?

Manually, against an artificially induced failure in tool call rendering, specifically

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
