### PR TITLE
Fix Rovo Dev response parser for pruned tool-calls

### DIFF
--- a/src/rovo-dev/client/responseParser.ts
+++ b/src/rovo-dev/client/responseParser.ts
@@ -444,7 +444,11 @@ export class RovoDevResponseParser {
                     yield tmpChunkToFlush;
                 }
 
-                yield this.parseGenericReponse(chunk);
+                this.previousChunk = this.parseGenericReponse(chunk);
+                tmpChunkToFlush = this.flushPreviousChunk();
+                if (tmpChunkToFlush) {
+                    yield tmpChunkToFlush;
+                }
             }
         }
     }


### PR DESCRIPTION
### What Is This Change?

When the `replay` is replaying pruned tool-calls, the response parser isn't adding them to the tool calls map, which results in the tool-response not having it embedded in the response.

This caused the `parseToolReturnMessage` function in utils.tsx to crash, and consequently the webview to crash.

This change fixes the parser logic.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`