### PR TITLE
[AXON-1673] add rovodev static config

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -35,6 +35,7 @@ import OnboardingProvider from './onboarding/onboardingProvider';
 import { registerQuickAuthCommand } from './onboarding/quickFlow';
 import { Pipeline } from './pipelines/model';
 import { RovodevCommandContext } from './rovo-dev/api/componentApi';
+import { RovodevStaticConfig } from './rovo-dev/api/rovodevStaticConfig';
 import { RovoDevCodeActionProvider } from './rovo-dev/rovoDevCodeActionProvider';
 import { RovoDevProcessManager } from './rovo-dev/rovoDevProcessManager';
 import { RovoDevWebviewProvider } from './rovo-dev/rovoDevWebviewProvider';
@@ -218,7 +219,7 @@ export class Container {
         );
 
         // in Boysenberry we don't need to listen to Jira auth updates
-        if (!process.env.ROVODEV_BBY) {
+        if (!RovodevStaticConfig.isBBY) {
             // Check Rovo Dev entitlement on startup
             await this._rovoDevEntitlementChecker.triggerEntitlementNotification();
             // refresh Rovo Dev when auth sites change
@@ -498,7 +499,7 @@ export class Container {
     }
 
     public static get isBoysenberryMode() {
-        return !!process.env.ROVODEV_BBY;
+        return !!RovodevStaticConfig.isBBY;
     }
 
     public static get configTarget(): ConfigTarget {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,13 +26,12 @@ import {
     BB_PIPELINES_FILENAME,
 } from './pipelines/yaml/pipelinesYamlHelper';
 import { registerResources } from './resources';
+import { RovodevStaticConfig } from './rovo-dev/api/rovodevStaticConfig';
 import { RovoDevProcessManager } from './rovo-dev/rovoDevProcessManager';
 import { GitExtension } from './typings/git';
 import { Features } from './util/featureFlags';
 import Performance from './util/perf';
 import { NotificationManagerImpl } from './views/notifications/notificationManager';
-
-const IsBoysenberry = process.env.ROVODEV_BBY === 'true';
 
 const AnalyticDelay = 5000;
 const PerfStartMarker = 'extension.start';
@@ -52,7 +51,7 @@ export async function activate(context: ExtensionContext) {
     Logger.configure(context);
 
     // this disables the main Atlassian activity bar when we are in Boysenberry,
-    setCommandContext(CommandContext.BbyEnvironmentActive, IsBoysenberry);
+    setCommandContext(CommandContext.BbyEnvironmentActive, RovodevStaticConfig.isBBY);
 
     // Mark ourselves as the PID in charge of refreshing credentials and start listening for pings.
     context.globalState.update('rulingPid', pid);
@@ -63,7 +62,7 @@ export async function activate(context: ExtensionContext) {
         activateErrorReporting();
         registerRovoDevCommands(context);
 
-        if (!IsBoysenberry) {
+        if (!RovodevStaticConfig.isBBY) {
             registerCommands(context);
             activateCodebucket(context);
 
@@ -86,7 +85,7 @@ export async function activate(context: ExtensionContext) {
         Container.clientManager.requestSite(site);
     });
 
-    if (!IsBoysenberry) {
+    if (!RovodevStaticConfig.isBBY) {
         if (previousVersion === undefined) {
             commands.executeCommand(Commands.ShowOnboardingFlow);
         } else {
@@ -99,7 +98,7 @@ export async function activate(context: ExtensionContext) {
         sendAnalytics(atlascodeVersion, context.globalState);
     }, delay);
 
-    if (!IsBoysenberry) {
+    if (!RovodevStaticConfig.isBBY) {
         context.subscriptions.push(languages.registerCodeLensProvider({ scheme: 'file' }, { provideCodeLenses }));
 
         // Following are async functions called without await so that they are run
@@ -212,7 +211,7 @@ async function sendAnalytics(version: string, globalState: Memento) {
 
 // this method is called when your extension is deactivated
 export function deactivate() {
-    if (!IsBoysenberry) {
+    if (!RovodevStaticConfig.isBBY) {
         RovoDevProcessManager.deactivateRovoDevProcessManager();
         NotificationManagerImpl.getInstance().stopListening();
     }

--- a/src/rovo-dev/api/rovodevStaticConfig.ts
+++ b/src/rovo-dev/api/rovodevStaticConfig.ts
@@ -1,0 +1,11 @@
+/**
+ * Rovodev static configuration values.
+ * These values are set at build time via environment variables.
+ */
+export const RovodevStaticConfig = {
+    /** Is this a special BBY environment? Defaults to false */
+    isBBY: process.env.ROVODEV_BBY === 'true',
+
+    /** User ID override for BBY environment */
+    bbyUserIdOverride: process.env.BBY_USERID || undefined,
+};

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { RovodevStaticConfig } from 'src/rovo-dev/api/rovodevStaticConfig';
 import { State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
@@ -15,8 +16,6 @@ import { ToolCallItem } from '../tools/ToolCallItem';
 import { ConnectionTimeout, DialogMessage, PullRequestMessage, Response, scrollToEnd } from '../utils';
 import { ChatStreamMessageRenderer } from './ChatStreamMessageRenderer';
 import { DropdownButton } from './dropdown-button/DropdownButton';
-
-const IsBoysenberry = process.env.ROVODEV_BBY === 'true';
 
 interface ChatStreamProps {
     chatHistory: Response[];
@@ -195,7 +194,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
     ]);
 
     // Other state management effect
-    if (IsBoysenberry) {
+    if (RovodevStaticConfig.isBBY) {
         React.useEffect(() => {
             if (currentState.state === 'WaitingForPrompt') {
                 const canCreatePR = chatHistory.length > 0;
@@ -236,7 +235,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
 
     return (
         <div ref={chatEndRef} className="chat-message-container">
-            {!IsBoysenberry && (
+            {!RovodevStaticConfig.isBBY && (
                 <RovoDevLanding
                     currentState={currentState}
                     isHistoryEmpty={chatHistory.length === 0}

--- a/src/rovo-dev/ui/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/rovo-dev/ui/prompt-box/prompt-input/PromptInput.tsx
@@ -9,6 +9,7 @@ import { token } from '@atlaskit/tokens';
 import Tooltip from '@atlaskit/tooltip';
 import * as monaco from 'monaco-editor';
 import React from 'react';
+import { RovodevStaticConfig } from 'src/rovo-dev/api/rovodevStaticConfig';
 import { DisabledState, State } from 'src/rovo-dev/rovoDevTypes';
 
 import { rovoDevTextareaStyles } from '../../rovoDevViewStyles';
@@ -23,8 +24,6 @@ import {
     setupPromptKeyBindings,
     SLASH_COMMANDS,
 } from './utils';
-
-const IsBoysenberry = process.env.ROVODEV_BBY === 'true';
 
 type NonDisabledState = Exclude<State, DisabledState>;
 
@@ -86,7 +85,7 @@ function createEditor(setIsEmpty: (isEmpty: boolean) => void) {
         return undefined;
     }
 
-    initMonaco(IsBoysenberry);
+    initMonaco(RovodevStaticConfig.isBBY);
 
     const editor = createMonacoPromptEditor(container);
 

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -12,6 +12,7 @@ import { RovoDevContextItem, State, ToolPermissionDialogChoice } from 'src/rovo-
 import { v4 } from 'uuid';
 
 import { DetailedSiteInfo, MinimalIssue } from '../api/extensionApiTypes';
+import { RovodevStaticConfig } from '../api/rovodevStaticConfig';
 import { RovoDevProviderMessage, RovoDevProviderMessageType } from '../rovoDevWebviewProviderMessages';
 import { FeedbackType } from './feedback-form/FeedbackForm';
 import { ChatStream } from './messaging/ChatStream';
@@ -44,8 +45,6 @@ import {
 
 const DEFAULT_LOADING_MESSAGE: string = 'Rovo dev is working';
 
-const IsBoysenberry = process.env.ROVODEV_BBY === 'true';
-
 const RovoDevView: React.FC = () => {
     const [currentState, setCurrentState] = useState<State>({ state: 'WaitingForPrompt' });
     const [pendingToolCallMessage, setPendingToolCallMessage] = useState('');
@@ -53,7 +52,7 @@ const RovoDevView: React.FC = () => {
     const [totalModifiedFiles, setTotalModifiedFiles] = useState<ToolReturnParseResult[]>([]);
     const [isDeepPlanCreated, setIsDeepPlanCreated] = useState(false);
     const [isDeepPlanToggled, setIsDeepPlanToggled] = useState(false);
-    const [isYoloModeToggled, setIsYoloModeToggled] = useState(IsBoysenberry);
+    const [isYoloModeToggled, setIsYoloModeToggled] = useState(RovodevStaticConfig.isBBY); // Yolo mode is default in Boysenberry
     const [isFullContextModeToggled, setIsFullContextModeToggled] = useState(false);
     const [workspacePath, setWorkspacePath] = useState<string>('');
     const [homeDir, setHomeDir] = useState<string>('');
@@ -308,7 +307,7 @@ const RovoDevView: React.FC = () => {
                 case RovoDevProviderMessageType.ProviderReady:
                     setWorkspacePath(event.workspacePath || '');
                     setHomeDir(event.homeDir || '');
-                    if (!IsBoysenberry && event.yoloMode !== undefined) {
+                    if (!RovodevStaticConfig.isBBY && event.yoloMode !== undefined) {
                         setIsYoloModeToggled(event.yoloMode);
                     }
                     setIsAtlassianUser(event.isAtlassianUser);
@@ -990,7 +989,9 @@ const RovoDevView: React.FC = () => {
                                     isYoloModeEnabled={isYoloModeToggled}
                                     isFullContextEnabled={isFullContextModeToggled}
                                     onDeepPlanToggled={() => setIsDeepPlanToggled((prev) => !prev)}
-                                    onYoloModeToggled={IsBoysenberry ? undefined : () => onYoloModeToggled()}
+                                    onYoloModeToggled={
+                                        RovodevStaticConfig.isBBY ? undefined : () => onYoloModeToggled()
+                                    }
                                     onFullContextToggled={
                                         isAtlassianUser ? () => onFullContextModeToggled() : undefined
                                     }

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -16,6 +16,7 @@ import { CredentialManager } from './atlclients/authStore';
 import { configuration } from './config/configuration';
 import { Container } from './container';
 import { Logger } from './logger';
+import { RovodevStaticConfig } from './rovo-dev/api/rovodevStaticConfig';
 
 export type SitesAvailableUpdateEvent = {
     sites: DetailedSiteInfo[];
@@ -253,8 +254,8 @@ export class SiteManager extends Disposable {
     }
 
     public getFirstAAID(productKey?: string): string | undefined {
-        if (process.env.ROVODEV_BBY && process.env.BBY_USERID) {
-            return process.env.BBY_USERID;
+        if (RovodevStaticConfig.isBBY && RovodevStaticConfig.bbyUserIdOverride) {
+            return RovodevStaticConfig.bbyUserIdOverride;
         }
         if (productKey) {
             return this.getFirstAAIDForProduct(productKey);

--- a/src/views/notifications/authNotifier.ts
+++ b/src/views/notifications/authNotifier.ts
@@ -1,3 +1,4 @@
+import { RovodevStaticConfig } from 'src/rovo-dev/api/rovodevStaticConfig';
 import { ConfigurationChangeEvent, Disposable, Uri } from 'vscode';
 
 import { Product, ProductJira } from '../../atlclients/authInfo';
@@ -40,7 +41,7 @@ export class AuthNotifier extends Disposable implements NotificationNotifier {
     }
 
     public fetchNotifications(): void {
-        if (process.env.ROVODEV_BBY) {
+        if (RovodevStaticConfig.isBBY) {
             return;
         }
         this.checkJiraAuth();


### PR DESCRIPTION
### What Is This Change?

Small reorg of how we use environment variables to configure rovodev. More changes like this coming, keeping the PRs small for easier reviews

 * Add and document global static configuration for Rovodev
 * Streamline the BBY check (`process.env.ROVODEV_BBY === 'true'` is the only check now, it was inconsistent before)

### How Has This Been Tested?

[Demo](https://www.loom.com/edit/9f8f755243c645daa233fa6051d946dc)

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`