### PR TITLE
[AXON-1673] chore: add reusable DefinePlugin config

### DIFF
--- a/webpack.env.config.js
+++ b/webpack.env.config.js
@@ -1,0 +1,39 @@
+const webpack = require('webpack');
+const dotenv = require('dotenv');
+
+// Load environment variables from .env file
+dotenv.config();
+
+const ENV_VARS = [
+    // FX3 configuration
+    'ATLASCODE_FX3_API_KEY',
+    'ATLASCODE_FX3_ENVIRONMENT',
+    'ATLASCODE_FX3_TARGET_APP',
+    'ATLASCODE_FX3_TIMEOUT',
+
+    // Developer feature flag overrides
+    'ATLASCODE_FF_OVERRIDES',
+    'ATLASCODE_EXP_OVERRIDES_BOOL',
+    'ATLASCODE_EXP_OVERRIDES_STRING',
+
+    // Is this BBY? (set to "true" if this is a special internal build)
+    'ROVODEV_BBY',
+];
+
+function createEnvPlugin({ nodeEnv, isBrowser = false }) {
+    const definitions = {
+        ...Object.fromEntries(
+            ENV_VARS.map((varName) => [`process.env.${varName}`, JSON.stringify(process.env[varName])]),
+        ),
+        'process.env.NODE_ENV': JSON.stringify(nodeEnv),
+    };
+
+    // Add process.browser for browser builds
+    if (isBrowser) {
+        definitions['process.browser'] = JSON.stringify(true);
+    }
+
+    return new webpack.DefinePlugin(definitions);
+}
+
+module.exports = { createEnvPlugin };

--- a/webpack.extension.dev.js
+++ b/webpack.extension.dev.js
@@ -1,14 +1,12 @@
 const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
-const dotenv = require('dotenv');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const { createEnvPlugin } = require('./webpack.env.config');
 
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 const nodeExternals = require('webpack-node-externals');
-
-dotenv.config();
 
 module.exports = [
     {
@@ -71,18 +69,7 @@ module.exports = [
             new webpack.WatchIgnorePlugin({
                 paths: [/\.js$/, /\.d\.ts$/],
             }),
-            new webpack.DefinePlugin({
-                'process.env.ATLASCODE_FX3_API_KEY': JSON.stringify(process.env.ATLASCODE_FX3_API_KEY),
-                'process.env.ATLASCODE_FX3_ENVIRONMENT': JSON.stringify(process.env.ATLASCODE_FX3_ENVIRONMENT),
-                'process.env.ATLASCODE_FX3_TARGET_APP': JSON.stringify(process.env.ATLASCODE_FX3_TARGET_APP),
-                'process.env.ATLASCODE_FX3_TIMEOUT': JSON.stringify(process.env.ATLASCODE_FX3_TIMEOUT),
-                'process.env.ATLASCODE_FF_OVERRIDES': JSON.stringify(process.env.ATLASCODE_FF_OVERRIDES),
-                'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
-                'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(
-                    process.env.ATLASCODE_EXP_OVERRIDES_STRING,
-                ),
-                'process.env.ROVODEV_BBY': JSON.stringify(process.env.ROVODEV_BBY),
-            }),
+            createEnvPlugin({ nodeEnv: 'development' }),
         ],
     },
     {

--- a/webpack.extension.prod.js
+++ b/webpack.extension.prod.js
@@ -1,15 +1,13 @@
 const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
-const dotenv = require('dotenv');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const nodeExternals = require('webpack-node-externals');
+const { createEnvPlugin } = require('./webpack.env.config');
 
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
-
-dotenv.config();
 
 module.exports = [
     {
@@ -97,18 +95,7 @@ module.exports = [
             new webpack.WatchIgnorePlugin({
                 paths: [/\.js$/, /\.d\.ts$/],
             }),
-            new webpack.DefinePlugin({
-                'process.env.ATLASCODE_FX3_API_KEY': JSON.stringify(process.env.ATLASCODE_FX3_API_KEY),
-                'process.env.ATLASCODE_FX3_ENVIRONMENT': JSON.stringify(process.env.ATLASCODE_FX3_ENVIRONMENT),
-                'process.env.ATLASCODE_FX3_TARGET_APP': JSON.stringify(process.env.ATLASCODE_FX3_TARGET_APP),
-                'process.env.ATLASCODE_FX3_TIMEOUT': JSON.stringify(process.env.ATLASCODE_FX3_TIMEOUT),
-                'process.env.ATLASCODE_FF_OVERRIDES': JSON.stringify(process.env.ATLASCODE_FF_OVERRIDES),
-                'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
-                'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(
-                    process.env.ATLASCODE_EXP_OVERRIDES_STRING,
-                ),
-                'process.env.ROVODEV_BBY': JSON.stringify(process.env.ROVODEV_BBY),
-            }),
+            createEnvPlugin({ nodeEnv: 'production' }),
         ],
         externals: ['vscode'],
     },

--- a/webpack.react.dev.js
+++ b/webpack.react.dev.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
-const dotenv = require('dotenv');
 const ForkTsCheckerNotifierWebpackPlugin = require('fork-ts-checker-notifier-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
@@ -9,11 +8,10 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const autoprefixer = require('autoprefixer');
 const { CompiledExtractPlugin } = require('@compiled/webpack-loader');
+const { createEnvPlugin } = require('./webpack.env.config');
 
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
-
-dotenv.config();
 
 module.exports = {
     mode: 'development',
@@ -101,16 +99,7 @@ module.exports = {
                 configFile: resolveApp('tsconfig.json'),
             },
         }),
-        new webpack.DefinePlugin({
-            'process.env.ATLASCODE_FX3_API_KEY': JSON.stringify(process.env.ATLASCODE_FX3_API_KEY),
-            'process.env.ATLASCODE_FX3_ENVIRONMENT': JSON.stringify(process.env.ATLASCODE_FX3_ENVIRONMENT),
-            'process.env.ATLASCODE_FX3_TARGET_APP': JSON.stringify(process.env.ATLASCODE_FX3_TARGET_APP),
-            'process.env.ATLASCODE_FX3_TIMEOUT': JSON.stringify(process.env.ATLASCODE_FX3_TIMEOUT),
-            'process.env.ATLASCODE_FF_OVERRIDES': JSON.stringify(process.env.ATLASCODE_FF_OVERRIDES),
-            'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
-            'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_STRING),
-            'process.env.ROVODEV_BBY': JSON.stringify(process.env.ROVODEV_BBY)
-        }),
+        createEnvPlugin({ nodeEnv: 'development', isBrowser: true }),
         new webpack.ProvidePlugin({
             process: 'process/browser',
         }),

--- a/webpack.react.prod.js
+++ b/webpack.react.prod.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
-const dotenv = require('dotenv');
 const ForkTsCheckerNotifierWebpackPlugin = require('fork-ts-checker-notifier-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
@@ -11,11 +10,10 @@ const CSSMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const { CompiledExtractPlugin } = require('@compiled/webpack-loader');
+const { createEnvPlugin } = require('./webpack.env.config');
 
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
-
-dotenv.config();
 
 module.exports = {
     bail: true,
@@ -131,18 +129,7 @@ module.exports = {
             resourceRegExp: /^\.\/locale$/,
             contextRegExp: /moment$/,
         }),
-        new webpack.DefinePlugin({
-            'process.env.ATLASCODE_FX3_API_KEY': JSON.stringify(process.env.ATLASCODE_FX3_API_KEY),
-            'process.env.ATLASCODE_FX3_ENVIRONMENT': JSON.stringify(process.env.ATLASCODE_FX3_ENVIRONMENT),
-            'process.env.ATLASCODE_FX3_TARGET_APP': JSON.stringify(process.env.ATLASCODE_FX3_TARGET_APP),
-            'process.env.ATLASCODE_FX3_TIMEOUT': JSON.stringify(process.env.ATLASCODE_FX3_TIMEOUT),
-            'process.env.ATLASCODE_FF_OVERRIDES': JSON.stringify(process.env.ATLASCODE_FF_OVERRIDES),
-            'process.env.ATLASCODE_EXP_OVERRIDES_BOOL': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_BOOL),
-            'process.env.ATLASCODE_EXP_OVERRIDES_STRING': JSON.stringify(process.env.ATLASCODE_EXP_OVERRIDES_STRING),
-            'process.env.ROVODEV_BBY': JSON.stringify(process.env.ROVODEV_BBY),
-            'process.env.NODE_ENV': JSON.stringify('production'),
-            'process.browser': JSON.stringify(true),
-        }),
+        createEnvPlugin({ nodeEnv: 'production', isBrowser: true }),
         new webpack.ProvidePlugin({
             process: 'process/browser',
         }),


### PR DESCRIPTION
### What Is This Change?

Move the duplicate environment setup logic from webpack configurations into a separate file.
There should be no changes to the logic or the builds

### How Has This Been Tested?

`npm run devcompile`
`npm run extension:install`

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`