### PR TITLE
AXON-1598-fix-deep-plan-bug

### DIFF
--- a/src/rovo-dev/ui/utils.tsx
+++ b/src/rovo-dev/ui/utils.tsx
@@ -206,12 +206,13 @@ export function parseToolReturnMessage(msg: RovoDevToolReturnResponse): ToolRetu
             break;
 
         case 'create_technical_plan':
-            if (msg.parsedContent) {
-                resp.push({
-                    content: '',
-                    technicalPlan: msg.parsedContent as TechnicalPlan,
-                });
-            }
+            // Use parsedContent if available (it's the parsed object), otherwise parse msg.content (string)
+            const planData: TechnicalPlan = msg.parsedContent ?? (msg.content ? JSON.parse(msg.content) : null);
+
+            resp.push({
+                content: '',
+                technicalPlan: planData,
+            });
             break;
 
         case 'mcp__atlassian__invoke_tool':


### PR DESCRIPTION
### What Is This Change?

During deep plan mode, the technical plan tool's response was not displayed in rovo dev chat.  This was a bug.  With this pr, we display the technical plan by retrieving it from the response which might come as just a string.  Earlier we were expecting a json object. 

Before change ( after prompt, no technical plan output)
<img width="522" height="287" alt="Screenshot 2025-12-15 at 1 42 57 PM" src="https://github.com/user-attachments/assets/a23623e2-2957-4674-b5ea-1bffab1e3041" />

After change (after prompt, technical plan output is shown)

<img width="310" height="682" alt="Screenshot 2025-12-15 at 1 42 40 PM" src="https://github.com/user-attachments/assets/99c65978-842e-4713-81e1-fdb4b8d1729c" />

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change

Demo
https://www.loom.com/share/2a0b19c5631d456b96d7f5cc6f28d15e