### PR TITLE
AXON-1681: fix string.replace bug workaround

### DIFF
--- a/src/rovo-dev/ui/common/common.tsx
+++ b/src/rovo-dev/ui/common/common.tsx
@@ -61,9 +61,9 @@ const strictEncodeUrl = (url: string) => {
 // Keep validateLink to allow only http/https.
 export const normalizeLinks = (messageText: string) => {
     if (typeof messageText !== 'string') {
-        console.warn('normalizeLinks called with non-string messageText', messageText);
+        console.warn('normalizeLinks called with non-string messageText', messageText, 'typeof:', typeof messageText);
         // Silently recover from invalid types
-        messageText = '';
+        return '';
     }
 
     let processed = messageText.replace(


### PR DESCRIPTION
### What Is This Change?

In original workaround, we do the type checking outside the `useMemo` block which only does the check on first render. So any subsequent renders will break the webview.

Now, we put the check inside `normalizeLinks` so it checks type on every render in `MarkedDown`

### How Has This Been Tested?

manually
Basic checks:

- [x] `npm run lint`
- [x] `npm run test`