### PR TITLE
AXON-1675 Make RovoDev responsive by adjusting width properties and aligning settings action

### DIFF
--- a/src/rovo-dev/ui/RovoDev.css
+++ b/src/rovo-dev/ui/RovoDev.css
@@ -54,7 +54,7 @@ body {
     font-family: var(--vscode-font-family);
     height: 100vh;
     margin: auto;
-    max-width: 800px;
+    width: 100%;
 
 
     /* atlaskit overrides */
@@ -298,7 +298,7 @@ body {
     justify-content: center;
     border: 1px solid var(--vscode-editorWidget-border);
     border-radius: 6px;
-    max-width: 400px;
+    width: fit-content;
     background-color: inherit;
     padding: 6px 12px;
 }
@@ -863,6 +863,7 @@ body {
 
 .prompt-settings-action {
     --ds-icon-inverse: var(--vscode-sideBar-background);
+    margin-left: auto;
 }
 
 .prompt-settings-logo {


### PR DESCRIPTION
### What Is This Change?

- Align setting buttons 
- Makes the chat fully responsive 

Out of scope: but worth considering:
- Min width? 

**Screenshot at different widths** 
<img width="3440" height="1440" alt="Screenshot 2025-12-17 at 6 09 23 PM" src="https://github.com/user-attachments/assets/a8ca49b0-a38b-4edf-b12f-9e45be57b3a6" />
<img width="3436" height="1426" alt="Screenshot 2025-12-17 at 6 09 07 PM" src="https://github.com/user-attachments/assets/72ee580d-696c-4a60-83e5-7a6cc7ff20e2" />
<img width="3440" height="1440" alt="Screenshot 2025-12-17 at 6 08 59 PM" src="https://github.com/user-attachments/assets/857b344e-d176-44d2-88f8-8d666351a5f4" />
<img width="3440" height="1440" alt="Screenshot 2025-12-17 at 6 08 52 PM" src="https://github.com/user-attachments/assets/151af7c6-c7f3-43ec-8387-ae270961fa49" />


### How Has This Been Tested?
Visually & Manually
