### PR TITLE
no-ticket: fix security vuln (GHSA-6rw7-vpxm-498p)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43254,9 +43254,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.14.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"


### PR DESCRIPTION
### What Is This Change?

# npm audit report

qs  <6.14.1
Severity: high
qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion - https://github.com/advisories/GHSA-6rw7-vpxm-498p
