### PR TITLE
AXON-1712 - fixed blank Jira issue page on first load

### DIFF
--- a/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
+++ b/src/webviews/components/issue/view-issue-screen/JiraIssuePage.tsx
@@ -1027,6 +1027,7 @@ export default class JiraIssuePage extends AbstractIssueEditorPage<Emit, Accept,
     }
 
     override componentDidMount() {
+        this.postMessage({ action: 'webviewReady' });
         this.postMessage({ action: 'getFeatureFlags' });
         this.postMessage({ action: 'checkRovoDevEntitlement' });
         this.postMessage({ action: 'fetchMediaToken' });

--- a/src/webviews/jiraIssueWebview.test.ts
+++ b/src/webviews/jiraIssueWebview.test.ts
@@ -270,15 +270,28 @@ describe('JiraIssueWebview', () => {
     });
 
     describe('invalidate', () => {
-        test('should update issue and update status bar', async () => {
+        test('should update issue and update status bar when webview is ready', async () => {
             const forceUpdateSpy = jest.spyOn(jiraIssueWebview as any, 'forceUpdateIssue').mockResolvedValue(undefined);
             jiraIssueWebview['_issue'] = mockIssue;
+            jiraIssueWebview['_webviewReady'] = true;
 
             await jiraIssueWebview.invalidate();
 
             expect(forceUpdateSpy).toHaveBeenCalled();
             expect(Container.jiraActiveIssueStatusBar.handleActiveIssueChange).toHaveBeenCalledWith(mockIssue.key);
             expect(Container.pmfStats.touchActivity).toHaveBeenCalled();
+        });
+
+        test('should defer invalidate when webview is not ready', async () => {
+            const forceUpdateSpy = jest.spyOn(jiraIssueWebview as any, 'forceUpdateIssue').mockResolvedValue(undefined);
+            jiraIssueWebview['_issue'] = mockIssue;
+            jiraIssueWebview['_webviewReady'] = false;
+            jiraIssueWebview['_needsRefresh'] = false;
+
+            await jiraIssueWebview.invalidate();
+
+            expect(forceUpdateSpy).not.toHaveBeenCalled();
+            expect(jiraIssueWebview['_needsRefresh']).toBe(true);
         });
     });
 


### PR DESCRIPTION
### What Is This Change?
**Issue**:
Previously, opening a Jira issue for the first time would sometimes show a blank page, requiring multiple attempts.

**Solution**:
- Add `_webviewReady` and `_needsRefresh` flags
- Defer `invalidate()` until webview ready
- Send `webviewReady` from JiraIssuePage `componentDidMount`

**Recordings**:
Before:
https://www.loom.com/share/d48a4e7f9b5341e2a25d5a48bacb64a6

After:
https://www.loom.com/share/e74b3967ae9a4bb88f07c19d5c7ca35a

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change