### PR TITLE
Fix failing unit test in AU timezone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -210,6 +210,7 @@
                 "process": "^0.11.10",
                 "source-map-loader": "^5.0.0",
                 "terser-webpack-plugin": "^5.3.0",
+                "timezone-mock": "^1.3.6",
                 "ts-jest": "^29.4.0",
                 "ts-loader": "^9.5.2",
                 "ts-node": "^10.9.2",
@@ -30646,7 +30647,6 @@
             "version": "1.0.2",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/base64-arraybuffer-es6": {
@@ -46224,6 +46224,12 @@
             "integrity": "sha512-2IAW0wqXAEVD8Vh+gpSqnsglLjnb06dDT9ypOsfKEqUrRMelsXW5hexfKIKg2woGSbBxp7zqbPYrMWZNdYYgDQ==",
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/timezone-mock": {
+            "version": "1.3.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/timezone-mock/-/timezone-mock-1.3.6.tgz",
+            "integrity": "sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==",
+            "dev": true
         },
         "node_modules/tiny-invariant": {
             "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -1808,6 +1808,7 @@
         "process": "^0.11.10",
         "source-map-loader": "^5.0.0",
         "terser-webpack-plugin": "^5.3.0",
+        "timezone-mock": "^1.3.6",
         "ts-jest": "^29.4.0",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/IssueHistory.test.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/IssueHistory.test.tsx
@@ -4,12 +4,14 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { IssueHistoryItem } from 'src/ipc/issueMessaging';
 import { disableConsole } from 'testsutil/console';
+import timezoneMock from 'timezone-mock';
 
 import { IssueHistory } from './IssueHistory';
 
 describe('IssueHistory', () => {
     beforeAll(() => {
         disableConsole('warn', 'error');
+        timezoneMock.register('US/Pacific');
     });
 
     it('renders loading state', () => {
@@ -228,7 +230,7 @@ describe('IssueHistory', () => {
         const history: IssueHistoryItem[] = [
             {
                 id: '123-status',
-                timestamp: '2025-11-05T00:00:00.000Z',
+                timestamp: '2025-11-05T15:58:00.000Z',
                 author: {
                     displayName: 'John Doe',
                     accountId: 'user-1',


### PR DESCRIPTION
### What Is This Change?

There is a unit test checking the formatted date that is failing because it's not designed to run in different time zones.
This change sticks the unit tests in a specific time zone (US/Pacific) preventing it from failing when ran in different time zones.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`