### PR TITLE
[AXON-1740] Disable Full context toggle in BBY

### DIFF
--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -1053,7 +1053,9 @@ const RovoDevView: React.FC = () => {
                                             RovodevStaticConfig.isBBY ? undefined : () => onYoloModeToggled()
                                         }
                                         onFullContextToggled={
-                                            isAtlassianUser ? () => onFullContextModeToggled() : undefined
+                                            isAtlassianUser && !RovodevStaticConfig.isBBY
+                                                ? () => onFullContextModeToggled()
+                                                : undefined
                                         }
                                         onSend={sendPrompt}
                                         onCancel={cancelResponse}


### PR DESCRIPTION
### What Is This Change?

Full Context mode is not available in BBY yet, and it will not be available for a while.
Disabling the toggle to avoid further confusion.

### How Has This Been Tested?

- [X] `npm run lint`
- [X] `npm run test`
- [X] `manual tests`