### PR TITLE
AXON-1755: Fix: Issue creation fails with "description: Operation value must be a string" error

### DIFF
--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.test.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.test.tsx
@@ -371,4 +371,128 @@ describe('CreateIssuePage', () => {
             expect(postMessageSpy).toHaveBeenCalledWith({ action: 'openJiraAuth' });
         });
     });
+
+    describe('handleSubmit description conversion', () => {
+        const mockDcSiteDetails: DetailedSiteInfo = {
+            ...mockSiteDetails,
+            isCloud: false,
+            name: 'DC Site',
+            host: 'jira.example.com',
+        };
+
+        it('should convert description to ADF for Cloud site with legacy editor', async () => {
+            const component = new CreateIssuePage({});
+            const postMessageSpy = jest.spyOn(component, 'postMessage');
+
+            component.state = {
+                ...component.state,
+                siteDetails: mockSiteDetails, // isCloud: true
+                showAtlaskitEditor: false, // legacy editor
+                fieldValues: {
+                    issuetype: { id: '1', name: 'Task' },
+                    project: { key: 'TEST', name: 'Test Project' },
+                    summary: 'Test Summary',
+                    description: 'Simple description text',
+                },
+                fields: {
+                    summary: {
+                        key: 'summary',
+                        name: 'Summary',
+                        required: true,
+                        uiType: UIType.Input,
+                        displayOrder: 1,
+                        valueType: ValueType.String,
+                        advanced: false,
+                        isArray: false,
+                        schema: 'summary',
+                    },
+                    description: {
+                        key: 'description',
+                        name: 'Description',
+                        required: false,
+                        uiType: UIType.Input,
+                        displayOrder: 2,
+                        valueType: ValueType.String,
+                        advanced: false,
+                        isArray: false,
+                        schema: 'description',
+                    },
+                },
+                selectFieldOptions: {
+                    site: [mockSiteDetails],
+                },
+            };
+
+            await component.handleSubmit({} as any);
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'createIssue',
+                    issueData: expect.objectContaining({
+                        // Description should be converted to ADF object for Cloud
+                        description: expect.objectContaining({
+                            type: 'doc',
+                            version: 1,
+                        }),
+                    }),
+                }),
+            );
+        });
+
+        it('should NOT convert description to ADF for Data Center site with legacy editor', async () => {
+            const component = new CreateIssuePage({});
+            const postMessageSpy = jest.spyOn(component, 'postMessage');
+
+            component.state = {
+                ...component.state,
+                siteDetails: mockDcSiteDetails, // isCloud: false
+                showAtlaskitEditor: false, // legacy editor
+                fieldValues: {
+                    issuetype: { id: '1', name: 'Task' },
+                    project: { key: 'TEST', name: 'Test Project' },
+                    summary: 'Test Summary',
+                    description: 'Simple description text',
+                },
+                fields: {
+                    summary: {
+                        key: 'summary',
+                        name: 'Summary',
+                        required: true,
+                        uiType: UIType.Input,
+                        displayOrder: 1,
+                        valueType: ValueType.String,
+                        advanced: false,
+                        isArray: false,
+                        schema: 'summary',
+                    },
+                    description: {
+                        key: 'description',
+                        name: 'Description',
+                        required: false,
+                        uiType: UIType.Input,
+                        displayOrder: 2,
+                        valueType: ValueType.String,
+                        advanced: false,
+                        isArray: false,
+                        schema: 'description',
+                    },
+                },
+                selectFieldOptions: {
+                    site: [mockDcSiteDetails],
+                },
+            };
+
+            await component.handleSubmit({} as any);
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'createIssue',
+                    issueData: expect.objectContaining({
+                        // Description should remain as string for DC
+                        description: 'Simple description text',
+                    }),
+                }),
+            );
+        });
+    });
 });

--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
@@ -310,9 +310,11 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
             return errs;
         }
 
-        // Convert WikiMarkup fields to ADF if using legacy editor
+        // Convert WikiMarkup fields to ADF if using legacy editor AND site is Cloud
+        // Jira Data Center requires WikiMarkup string, not ADF object
         const issueData = { ...this.state.fieldValues };
-        if (!this.state.showAtlaskitEditor) {
+
+        if (!this.state.showAtlaskitEditor && this.state.siteDetails.isCloud) {
             // Convert description if it's a string (WikiMarkup)
             if (issueData.description && typeof issueData.description === 'string') {
                 issueData.description = convertWikimarkupToAdf(issueData.description);


### PR DESCRIPTION
### What Is This Change?

**Source**:  https://github.com/atlassian/atlascode/issues/1462

**Problem**
Users on Jira Data Center were unable to create issues from the extension. The API returned the `error: description: Operation value must be a string`.

**Root Cause**
The extension was converting the description field to ADF for all Jira instances. However, ADF is only supported by Jira Cloud API v3. Jira Data Center expects description as a plain WikiMarkup string.

**Solution**
Added a check to only convert description to ADF format when the connected site is Jira Cloud. For Data Center instances, the description is now sent as a WikiMarkup string, which is the expected format.

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change