### PR TITLE
AXON-1762 add more data to the log and slowdown the retry attempts

### DIFF
--- a/src/atlclients/authStore.ts
+++ b/src/atlclients/authStore.ts
@@ -54,6 +54,7 @@ export class CredentialManager implements Disposable {
     private _refresher = new OAuthRefesher();
     private negotiator: Negotiator;
     private _refreshInFlight = new Map<string, Promise<void>>();
+    private _failedRefreshCache = new Map<string, { attemptsCount: number; lastAttemptAt: Date }>();
 
     constructor(
         context: ExtensionContext,
@@ -368,7 +369,10 @@ export class CredentialManager implements Disposable {
 
         if (credentials.expirationDate) {
             const diff = credentials.expirationDate - Date.now();
-            Logger.debug(`${Math.floor(diff / 1000)} seconds remaining for auth token.`);
+            Logger.debug(
+                `${Math.floor(diff / 1000)} seconds remaining for ${site.name} refresh token. ${diff > GRACE_PERIOD ? 'No refresh needed yet.' : 'refreshing...'}`,
+            );
+
             if (diff > GRACE_PERIOD) {
                 return credentials; // no need to refresh, we have enough time left
             }
@@ -527,6 +531,17 @@ export class CredentialManager implements Disposable {
         if (!isOAuthInfo(credentials)) {
             return undefined;
         }
+
+        const failedRefresh = this._failedRefreshCache.get(site.credentialId);
+        if (failedRefresh) {
+            const RETRY_DELAY = 5 * Time.MINUTES;
+            // if we already had multiple failed attempts recently, don't try again yet until enough time has passed
+            if (failedRefresh.attemptsCount > 5 && Date.now() - failedRefresh.lastAttemptAt.getTime() < RETRY_DELAY) {
+                Logger.debug(`Skipping token refresh for credentialID: ${site.credentialId} due to previous failures.`);
+                return undefined;
+            }
+        }
+
         Logger.debug(`refreshingAccessToken for ${site.baseApiUrl} credentialID: ${site.credentialId}`);
 
         const provider: OAuthProvider | undefined = oauthProviderForSite(site);
@@ -544,9 +559,16 @@ export class CredentialManager implements Disposable {
                 }
 
                 await this.saveAuthInfo(site, credentials);
+                if (this._failedRefreshCache.has(site.credentialId)) {
+                    this._failedRefreshCache.delete(site.credentialId);
+                }
                 Logger.debug(`Successfully saved refreshed tokens for credentialId: ${site.credentialId}`);
             } else if (tokenResponse.shouldInvalidate) {
                 credentials.state = AuthInfoState.Invalid;
+                this._failedRefreshCache.set(site.credentialId, {
+                    attemptsCount: (this._failedRefreshCache.get(site.credentialId)?.attemptsCount ?? 0) + 1,
+                    lastAttemptAt: new Date(),
+                });
                 await this.saveAuthInfo(site, credentials);
             }
         }

--- a/src/atlclients/basicInterceptor.ts
+++ b/src/atlclients/basicInterceptor.ts
@@ -8,7 +8,7 @@ import { AuthInterceptor } from './authInterceptor';
 import { CredentialManager } from './authStore';
 
 /**
- * BasicInterceptor detects any 401 or 403 responses from the REST service and blocks any further requests unitl the
+ * BasicInterceptor detects any 401 or 403 responses from the REST service and blocks any further requests until the
  * user has updated their password.
  */
 export class BasicInterceptor implements AuthInterceptor {

--- a/src/atlclients/oauthRefresher.ts
+++ b/src/atlclients/oauthRefresher.ts
@@ -74,7 +74,9 @@ export class OAuthRefesher implements Disposable {
             }
         } catch (err) {
             const responseStatusDescription = err.response?.status ? ` ${err.response.status}` : '';
-            Logger.error(err, 'Error while refreshing tokens' + responseStatusDescription);
+            const axiosErrorData = ` (Axios message: ${err?.response?.data?.error}. Axios description: ${err?.response?.data?.error_description})`;
+
+            Logger.error(err, 'Error while refreshing tokens' + responseStatusDescription + axiosErrorData);
             if (err.response?.status === 401 || err.response?.status === 403) {
                 Logger.debug(`Invalidating credentials due to ${err.response.status} while refreshing tokens`);
                 response.shouldInvalidate = true;


### PR DESCRIPTION
### What Is This Change?
This PR attempts to decrease amount of "Error while refreshing tokens'' errors by adding 5min pause period between refresh token attempts in case previous 5 attempts failed.
Additionally it extens captured error information by axios error data. 
<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [X] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [X] Update the CHANGELOG if making a user facing change