### PR TITLE
chore: bump rovodev version to 0.13.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     ],
     "main": "./build/extension/extension",
     "rovoDev": {
-        "version": "0.13.27"
+        "version": "0.13.28"
     },
     "scripts": {
         "vscode:uninstall": "node ./build/extension/uninstall.js",


### PR DESCRIPTION
### What Is This Change?

Quick bump of the rovodev version to `0.13.28` since that should in theory address a cross-platform compatibility issue (GLIBC)

Note: this will probably conflict with #1486, so happy to merge this after 1486 with the appropriate changelog edit ;D

### How Has This Been Tested?

Built the extension locally, did some sanity checks around rovodev

<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

