### PR TITLE
AXON-1777: fix dismiss button handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added missing labels for PR merge strategies(AXON-1733)
 - Fixed authentication error
 - Fixed user mentions not working in Jira issue comments when using editor
+- Fixed dismiss button handling for 'Credentials refused...' popup
 
 ## What's new in 4.0.14
 

--- a/src/atlclients/basicInterceptor.ts
+++ b/src/atlclients/basicInterceptor.ts
@@ -63,8 +63,10 @@ export class BasicInterceptor implements AuthInterceptor {
     showError() {
         window
             .showErrorMessage(`Credentials refused for ${this.site.baseApiUrl}`, { modal: false }, `Update Credentials`)
-            .then((response) => {
-                commands.executeCommand(Commands.ShowJiraAuth);
+            .then((userChoice) => {
+                if (userChoice === 'Update Credentials') {
+                    commands.executeCommand(Commands.ShowJiraAuth);
+                }
             });
     }
 }


### PR DESCRIPTION
### What Is This Change?
<img width="554" height="138" alt="Screenshot 2026-01-13 at 13 43 16" src="https://github.com/user-attachments/assets/df01c188-26be-467c-b02b-feb8d9d65fe3" />


**Current behaviour:** 
- When user clicks the dismiss button - `Atlassian Settings` page is opened ( the same behaviour as for `Update Credentials` button )

**Expected behaviour:** 
- When user clicks the dismiss button - popup is closed

Source: #1495 

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change