### PR TITLE
stop forgetting email in the auth dialogue

### DIFF
--- a/src/react/atlascode/config/auth/dialog/JiraApiTokenAuthForm.tsx
+++ b/src/react/atlascode/config/auth/dialog/JiraApiTokenAuthForm.tsx
@@ -26,10 +26,11 @@ export const JiraBasicAuthForm = ({
     preventClickDefault,
     onPasswordKeyDown,
 }: JiraBasicAuthFormProps) => {
-    const defaultSiteUsername = useMemo(
-        () => (defaultSiteWithAuth.auth as BasicAuthInfo).username || defaultSiteWithAuth.auth.user.email,
-        [defaultSiteWithAuth],
-    );
+    const defaultSiteUsername = useMemo(() => {
+        const basicAuth = defaultSiteWithAuth.auth as BasicAuthInfo;
+        // Use username if it's a non-empty string, otherwise fallback to user.email
+        return (basicAuth.username && basicAuth.username.trim()) || defaultSiteWithAuth.auth.user.email || '';
+    }, [defaultSiteWithAuth]);
 
     return (
         <React.Fragment>


### PR DESCRIPTION
### What Is This Change?
- When you edit the api token in the auth setting, it used to "forget" your email. This changes that. 



<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

