### PR TITLE
AXON-1783 - Added analytics tracking for rate limit errors on Create Jira issue page

### DIFF
--- a/src/jira/projectManager.ts
+++ b/src/jira/projectManager.ts
@@ -203,9 +203,29 @@ export class JiraProjectManager extends Disposable {
             const projectsSlice = projectsList.slice(cursor, cursor + size);
             await Promise.all(
                 projectsSlice.map(async (project) => {
-                    const hasCreateIssuePermission = await this.checkProjectPermission(site, project.key, permission);
-                    if (hasCreateIssuePermission) {
-                        projectsWithPermission.push(project);
+                    try {
+                        const hasCreateIssuePermission = await this.checkProjectPermission(
+                            site,
+                            project.key,
+                            permission,
+                        );
+                        if (hasCreateIssuePermission) {
+                            projectsWithPermission.push(project);
+                        }
+                    } catch (e: any) {
+                        if (e?.response?.status === 429) {
+                            const batchNumber = cursor / size + 1;
+                            Logger.error(
+                                e,
+                                'Rate limit hit while checking project permissions',
+                                `endpoint=/rest/api/2/mypermissions`,
+                                `context=filterProjectsByPermission`,
+                                `isCloud=${site.isCloud}`,
+                                `batchSize=${size}`,
+                                `batchNumber=${batchNumber}`,
+                            );
+                        }
+                        throw e;
                     }
                 }),
             );


### PR DESCRIPTION
### What Is This Change?

This PR is for a better understanding of the possible causes of `429` error (Too Many Requests) on Create Jira issue page.

Adds analytics event to monitor rate limit occurrences (429 error) when checking project permissions.
Tracks endpoint, context, isCloud flag, batch size and batch number to help identify patterns and frequency of rate limiting
<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change