### PR TITLE
[AXON-1804] add tab completion to rovodev login form

### DIFF
--- a/src/rovo-dev/ui/landing-page/disabled-messages/RovoDevLoginForm.test.tsx
+++ b/src/rovo-dev/ui/landing-page/disabled-messages/RovoDevLoginForm.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { RovoDevLoginForm } from './RovoDevLoginForm';
+
+// A minimal mock for Atlaskit CreatableSelect to allow us to test Tab selection behavior.
+jest.mock('@atlaskit/select', () => ({
+    __esModule: true,
+    CreatableSelect: React.forwardRef(
+        ({ inputId, inputValue, onInputChange, onChange, onKeyDown, isDisabled, tabSelectsValue }: any, ref: any) => {
+            const handleKeyDown = (e: any) => {
+                // Simulate tabSelectsValue: when Tab is pressed with input, trigger onChange
+                if (e.key === 'Tab' && tabSelectsValue && inputValue?.trim()) {
+                    onChange?.({ label: inputValue.trim(), value: inputValue.trim() });
+                }
+                // Also call the component's onKeyDown for focus management
+                onKeyDown?.(e);
+            };
+
+            return (
+                <input
+                    ref={ref}
+                    data-testid={inputId}
+                    id={inputId}
+                    value={inputValue ?? ''}
+                    disabled={isDisabled}
+                    onChange={(e) => onInputChange?.(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                />
+            );
+        },
+    ),
+}));
+
+jest.mock('@atlaskit/button/new', () => ({
+    __esModule: true,
+    default: ({ children, isDisabled, ...props }: any) => (
+        <button disabled={isDisabled} {...props}>
+            {children}
+        </button>
+    ),
+}));
+
+jest.mock('@atlaskit/textfield', () => ({
+    __esModule: true,
+    default: React.forwardRef(({ isDisabled, ...props }: any, ref: any) => (
+        <input ref={ref} disabled={isDisabled} {...props} />
+    )),
+}));
+
+describe('RovoDevLoginForm', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('commits typed host value when tabbing out (AXON-1804)', () => {
+        const onSubmit = jest.fn();
+        render(<RovoDevLoginForm onSubmit={onSubmit} />);
+
+        const hostInput = screen.getByTestId('host') as HTMLInputElement;
+        const emailInput = screen.getByTestId('email') as HTMLInputElement;
+        const apiTokenInput = document.getElementById('apiToken') as HTMLInputElement;
+
+        fireEvent.change(hostInput, { target: { value: 'my-site.atlassian.net' } });
+
+        // Pressing Tab should commit the typed value and move focus to email.
+        fireEvent.keyDown(hostInput, { key: 'Tab' });
+        act(() => {
+            jest.runOnlyPendingTimers();
+        });
+
+        expect(document.activeElement).toBe(emailInput);
+
+        // The sign-in button should still be disabled until email/token are set, but the host should now be committed.
+        // We verify indirectly by setting email/token and submitting.
+        fireEvent.change(emailInput, { target: { value: 'a@b.com' } });
+        fireEvent.keyDown(emailInput, { key: 'Tab' });
+        act(() => {
+            jest.runOnlyPendingTimers();
+        });
+
+        expect(document.activeElement).toBe(apiTokenInput);
+
+        fireEvent.change(apiTokenInput, { target: { value: 'token' } });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+
+        expect(onSubmit).toHaveBeenCalledWith('my-site.atlassian.net', 'a@b.com', 'token');
+    });
+});

--- a/src/rovo-dev/ui/landing-page/disabled-messages/RovoDevLoginForm.tsx
+++ b/src/rovo-dev/ui/landing-page/disabled-messages/RovoDevLoginForm.tsx
@@ -64,13 +64,18 @@ export const RovoDevLoginForm: React.FC<{
     credentialHints?: CredentialHint[];
 }> = ({ onSubmit, credentialHints = [] }) => {
     const [host, setHost] = React.useState('');
+    const [hostInputValue, setHostInputValue] = React.useState('');
+
     const [email, setEmail] = React.useState('');
+    const [emailInputValue, setEmailInputValue] = React.useState('');
+
     const [apiToken, setApiToken] = React.useState('');
     const [authValidationState, setAuthValidationState] = React.useState<{
         isValidating: boolean;
         error?: string;
     }>({ isValidating: false });
 
+    const hostSelectRef = React.useRef<any>(null);
     const emailSelectRef = React.useRef<any>(null);
     const apiTokenInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -136,14 +141,34 @@ export const RovoDevLoginForm: React.FC<{
                     Jira Cloud Site
                 </label>
                 <CreatableSelect
+                    ref={hostSelectRef}
                     inputId="host"
                     options={hostOptions}
                     placeholder="yoursite.atlassian.net"
                     isClearable
                     isDisabled={authValidationState.isValidating}
                     value={host ? { label: host, value: host } : null}
+                    inputValue={hostInputValue}
+                    tabSelectsValue={true}
+                    onInputChange={(newValue: string) => {
+                        setHostInputValue(newValue);
+                    }}
+                    onKeyDown={(e: React.KeyboardEvent) => {
+                        // Move focus to next field on Tab
+                        if (e.key === 'Tab' && !e.shiftKey) {
+                            setTimeout(() => emailSelectRef.current?.focus(), 0);
+                        }
+                    }}
+                    onBlur={() => {
+                        // If the user clicks away, keep what they typed.
+                        if (hostInputValue.trim().length > 0) {
+                            setHost(hostInputValue.trim());
+                            setHostInputValue('');
+                        }
+                    }}
                     onChange={(option: any) => {
                         setHost(option?.value || '');
+                        setHostInputValue('');
                         if (option?.value) {
                             setTimeout(() => emailSelectRef.current?.focus(), 0);
                         }
@@ -166,8 +191,26 @@ export const RovoDevLoginForm: React.FC<{
                     isClearable
                     isDisabled={authValidationState.isValidating}
                     value={email ? { label: email, value: email } : null}
+                    inputValue={emailInputValue}
+                    tabSelectsValue={true}
+                    onInputChange={(newValue: string) => {
+                        setEmailInputValue(newValue);
+                    }}
+                    onKeyDown={(e: React.KeyboardEvent) => {
+                        // Move focus to next field on Tab
+                        if (e.key === 'Tab' && !e.shiftKey) {
+                            setTimeout(() => apiTokenInputRef.current?.focus(), 0);
+                        }
+                    }}
+                    onBlur={() => {
+                        if (emailInputValue.trim().length > 0) {
+                            setEmail(emailInputValue.trim());
+                            setEmailInputValue('');
+                        }
+                    }}
                     onChange={(option: any) => {
                         setEmail(option?.value || '');
+                        setEmailInputValue('');
                         if (option?.value) {
                             setTimeout(() => apiTokenInputRef.current?.focus(), 0);
                         }


### PR DESCRIPTION
### What Is This Change?

(from the bugbash)
Small fix to add tab completion and click-off logic to persist values in the rovodev login form, and tests (autogenerated)

### How Has This Been Tested?

https://www.loom.com/share/9f71c2a7a504444caeeec43a99c27856