### PR TITLE
AXON-1794: Assignee of existing linked issues resets to unassigned when adding a new linked issue

### DIFF
--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -944,6 +944,9 @@ export class JiraIssueWebview
 
                             this._editUIData.fieldValues['issuelinks'] = resp;
 
+                            // Enhance the linked issues with transitions and assignee data
+                            await this.enhanceChildAndLinkedIssuesWithTransitions();
+
                             this.postMessage({
                                 type: 'fieldValueUpdate',
                                 fieldValues: {


### PR DESCRIPTION
### What Is This Change?

**Bug description**: If Jira already has linked issues, then when adding another one, all assignee fields become “Unassigned”

| Before | After |
|:--|:--|
| https://www.loom.com/share/ad35a76ff242440da02ced70586f2322 | https://www.loom.com/share/42a7aa7970e44029bd82b831f36bce92 |

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change