### PR TITLE
Add an explorer menu item to copy the source link if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -488,6 +488,11 @@
                 "category": "Bitbucket"
             },
             {
+                "command": "atlascode.bb.copySourceLink",
+                "title": "Copy Source Link",
+                "category": "Bitbucket"
+            },
+            {
                 "command": "atlascode.bb.editThisFile",
                 "title": "Edit this File",
                 "category": "Bitbucket",
@@ -707,6 +712,13 @@
                     "command": "atlascode.bb.editThisFile",
                     "group": "atlascode",
                     "when": "resourceScheme == atlascode.bbpr && config.atlascode.bitbucket.enabled"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "atlascode.bb.copySourceLink",
+                    "group": "atlascode",
+                    "when": "!explorerResourceIsFolder && config.atlascode.bitbucket.enabled && atlascode:isBitbucketCloudRepo"
                 }
             ],
             "scm/title": [

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -386,6 +386,10 @@ export async function prUrlCopiedEvent(): Promise<TrackEvent> {
     return trackEvent('copied', 'pullRequestUrl');
 }
 
+export async function sourceLinkCopiedEvent(): Promise<TrackEvent> {
+    return trackEvent('copied', 'sourceUrl');
+}
+
 // Misc Track Events
 
 export async function customJQLCreatedEvent(site: DetailedSiteInfo): Promise<TrackEvent> {

--- a/src/codebucket/backend/backend.ts
+++ b/src/codebucket/backend/backend.ts
@@ -95,4 +95,27 @@ export class Backend {
 
         throw new Error('Unable to determine the pull request');
     }
+
+    /**
+     * Get the repository's main branch name.
+     * Falls back to 'master' if the main branch cannot be determined.
+     */
+    public async findMainBranch(): Promise<string> {
+        const wsRepo = this.findRepository();
+        const site = wsRepo.mainSiteRemote.site;
+        if (!site) {
+            return 'master';
+        }
+        try {
+            const bbApi = await clientForSite(site);
+            const repo = await bbApi.repositories.get(site);
+            if (repo.mainbranch) {
+                return repo.mainbranch;
+            }
+        } catch (e) {
+            // Fall back to default if unable to fetch
+            console.warn('Failed to fetch main branch from API:', e instanceof Error ? e.message : String(e));
+        }
+        return 'master';
+    }
 }

--- a/src/codebucket/command/command-copy-source-link.ts
+++ b/src/codebucket/command/command-copy-source-link.ts
@@ -1,0 +1,41 @@
+import * as path from 'path';
+import slash from 'slash';
+import * as vscode from 'vscode';
+
+import { sourceLinkCopiedEvent } from '../../analytics';
+import { Container } from '../../container';
+import { CommandBase } from './command-base';
+
+export class CopySourceLinkCommand extends CommandBase {
+    private contextUri?: vscode.Uri;
+
+    public setContextUri(uri?: vscode.Uri): void {
+        this.contextUri = uri;
+    }
+
+    protected async execute(): Promise<void> {
+        const backend = await this.getBackend();
+        const remote = await backend.findBitbucketSite();
+
+        // Try to get file path from context URI if available (from explorer), otherwise from editor
+        let filePath: string;
+        if (this.contextUri) {
+            // Invoked from explorer context menu
+            filePath = slash(path.relative(backend.root, this.contextUri.fsPath));
+        } else {
+            // Invoked from editor or command palette
+            filePath = this.getFilePath(backend.root);
+        }
+
+        // Detect the repository's main branch (master or main)
+        const branch = await backend.findMainBranch();
+        const url = remote.getSourceUrl(branch, filePath, []);
+
+        await vscode.env.clipboard.writeText(url);
+        vscode.window.showInformationMessage(`Source link copied to clipboard`);
+
+        sourceLinkCopiedEvent().then((e) => {
+            Container.analyticsClient.sendTrackEvent(e);
+        });
+    }
+}

--- a/src/codebucket/command/registerCommands.ts
+++ b/src/codebucket/command/registerCommands.ts
@@ -1,6 +1,9 @@
-import { commands, ExtensionContext } from 'vscode';
+import { commands, ExtensionContext, Uri } from 'vscode';
 
+import { Container } from '../../container';
+import { Features } from '../../util/featureFlags';
 import { CopyBitbucketPullRequestCommand } from './command-copy-pullreqest';
+import { CopySourceLinkCommand } from './command-copy-source-link';
 import { OpenInBitbucketCommand } from './command-open';
 import { OpenBitbucketChangesetCommand } from './command-open-changeset';
 import { OpenBitbucketPullRequestCommand } from './command-open-pullrequest';
@@ -10,6 +13,7 @@ enum CodebucketCommands {
     OpenChangeset = 'atlascode.bb.openChangeset',
     ViewPullRequest = 'atlascode.bb.viewPullRequest',
     CopyPullRequest = 'atlascode.bb.copyPullRequest',
+    CopySourceLink = 'atlascode.bb.copySourceLink',
 }
 
 export function activate(context: ExtensionContext) {
@@ -34,4 +38,14 @@ export function activate(context: ExtensionContext) {
         copyPullRequest.run(),
     );
     context.subscriptions.push(copyPullRequestCmd);
+
+    const copySourceLinkEnabled = Container.featureFlagClient.checkGate(Features.CopySourceLinkCommand);
+    if (copySourceLinkEnabled) {
+        const copySourceLink = new CopySourceLinkCommand();
+        const copySourceLinkCmd = commands.registerCommand(CodebucketCommands.CopySourceLink, (uri?: Uri) => {
+            copySourceLink.setContextUri(uri);
+            return copySourceLink.run();
+        });
+        context.subscriptions.push(copySourceLinkCmd);
+    }
 }

--- a/src/util/features.ts
+++ b/src/util/features.ts
@@ -11,6 +11,7 @@ export enum Features {
     SentryLogging = 'atlascode-sentry-logging',
     DedicatedRovoDevAuth = 'atlascode-use-dedicated-rovodev-auth',
     RequireDedicatedRovoDevAuth = 'atlascode-require-dedicated-rovodev-auth',
+    CopySourceLinkCommand = 'atlascode-copy-source-link',
 }
 
 /**
@@ -20,6 +21,7 @@ export enum Features {
 export const defaultFeatureGateValues: Partial<FeatureGateValues> = {
     [Features.DedicatedRovoDevAuth]: true,
     [Features.RequireDedicatedRovoDevAuth]: false,
+    [Features.CopySourceLinkCommand]: false,
 };
 
 export const enum Experiments {

--- a/src/vscAnalyticsApi.ts
+++ b/src/vscAnalyticsApi.ts
@@ -49,6 +49,7 @@ import {
     quickFlowEvent,
     saveManualCodeEvent,
     sentryCapturedExceptionFailedEvent,
+    sourceLinkCopiedEvent,
     startIssueCreationEvent,
     uiErrorEvent,
     upgradedEvent,
@@ -225,6 +226,12 @@ export class VSCAnalyticsApi implements AnalyticsApi {
 
     public async firePrUrlCopiedEvent(): Promise<void> {
         return prUrlCopiedEvent().then((e) => {
+            this._analyticsClient.sendTrackEvent(e);
+        });
+    }
+
+    public async fireSourceLinkCopiedEvent(): Promise<void> {
+        return sourceLinkCopiedEvent().then((e) => {
             this._analyticsClient.sendTrackEvent(e);
         });
     }


### PR DESCRIPTION
### What Is This Change?
#### Problem

I often want to copy links to files, and share them with my team as we work across a lot of different repos. To do this, I copy the relative path and make my own URL in the browser to get to the correct file location in Bitbucket. This could be improved.

#### Solution

Create a new menu item in VsCode that builds the URL, allowing me to just copy the link to the file and directly share it with team members. 

#### Why Atlascode?

I have made an assumption that users downloading an extension for Bitbucket in VsCode would also like this functionality. I have talked with some team members and I think this is the easiest way to share a time saver with the wider Atlassian team.

<img width="838" height="725" alt="image" src="https://github.com/user-attachments/assets/4cf6b047-4cfd-4f39-9364-18df3227e25e" />


### How Has This Been Tested?
Local testing: ✅ 
Feature Gate ✅ 

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change