### PR TITLE
AXON-1820 - fixed worklog date format error for UTC timezone users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed Rovo Dev forgetting previous Yolo mode setting
+- Fixed worklog creation error for users in UTC timezone
 
 ## What's new in 4.0.17
 

--- a/src/webviews/components/issue/WorklogForm.test.tsx
+++ b/src/webviews/components/issue/WorklogForm.test.tsx
@@ -15,7 +15,7 @@ jest.mock('./WorklogForm', () => {
             onSave({
                 comment,
                 timeSpent,
-                started: '2023-01-01T10:00:00.000Z',
+                started: '2023-01-01T10:00:00.000+0000',
                 adjustEstimate: autoAdjust ? 'auto' : 'new',
                 newEstimate: autoAdjust ? undefined : newEstimate,
                 ...(worklogId && { worklogId }),
@@ -67,8 +67,8 @@ import WorklogForm from './WorklogForm';
 
 jest.mock('date-fns', () => ({
     format: jest.fn((date, formatString) => {
-        if (formatString === "yyyy-MM-dd'T'HH:mm:ss.SSSXX") {
-            return '2023-01-01T10:00:00.000Z';
+        if (formatString === "yyyy-MM-dd'T'HH:mm:ss.SSSxx") {
+            return '2023-01-01T10:00:00.000+0000';
         }
         return '2023-01-01';
     }),
@@ -142,7 +142,7 @@ describe('WorklogForm Component', () => {
 
             expect(defaultProps.onSave).toHaveBeenCalledWith({
                 comment: 'Test work',
-                started: '2023-01-01T10:00:00.000Z',
+                started: '2023-01-01T10:00:00.000+0000',
                 timeSpent: '1h',
                 adjustEstimate: 'auto',
                 newEstimate: undefined,
@@ -205,7 +205,7 @@ describe('WorklogForm Component', () => {
 
             expect(defaultProps.onSave).toHaveBeenCalledWith({
                 comment: '',
-                started: '2023-01-01T10:00:00.000Z',
+                started: '2023-01-01T10:00:00.000+0000',
                 timeSpent: '1h',
                 adjustEstimate: 'new',
                 newEstimate: '3h',
@@ -240,7 +240,7 @@ describe('WorklogForm Component', () => {
 
             expect(editingProps.onSave).toHaveBeenCalledWith({
                 comment: 'Existing work log',
-                started: '2023-01-01T10:00:00.000Z',
+                started: '2023-01-01T10:00:00.000+0000',
                 timeSpent: '2h',
                 adjustEstimate: 'auto',
                 newEstimate: undefined,

--- a/src/webviews/components/issue/WorklogForm.tsx
+++ b/src/webviews/components/issue/WorklogForm.tsx
@@ -33,7 +33,7 @@ const emptyForm = {
     autoAdjust: true,
 };
 
-const formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSXX";
+const formatString = "yyyy-MM-dd'T'HH:mm:ss.SSSxx";
 
 export default class WorklogForm extends React.Component<MyProps, MyState> {
     constructor(props: any) {


### PR DESCRIPTION
### What Is This Change?
https://github.com/atlassian/atlascode/issues/898

Changed `date-fns` format from 'XX' to 'xx' to ensure timezone is always output as numeric offset (+0000) instead of 'Z' for UTC+0, which Jira API cannot parse:

Jira API:

<img width="400" height="425" alt="Screenshot 2026-01-26 at 17 59 47" src="https://github.com/user-attachments/assets/863b71e2-dda4-42ab-8aab-9a71aa99a7dc" />


date-fns format():

<img width="500" height="223" alt="Screenshot 2026-01-26 at 17 40 16" src="https://github.com/user-attachments/assets/6a0b71ca-d9d2-4ea8-a57e-23a874807c19" />


<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>You don't have access to Rovo Dev Standard</strong>
Request access to Rovo Dev Standard.
[Check possible errors](https://support.atlassian.com/rovo/docs/troubleshoot-rovo-dev-code-reviews/)
<!-- /Rovo Dev code review status -->

