### PR TITLE
AXON-1721-fixing-sessionId-bug

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -152,8 +152,6 @@ export class Logger {
 
         if (SentryService.getInstance().isInitialized()) {
             try {
-                // Check if the subclass (e.g., RovoDevLogger) has a sessionId if not explicitly passed
-
                 SentryService.getInstance().captureException(ex, {
                     tags: {
                         productArea: productArea || 'unknown',


### PR DESCRIPTION
### What Is This Change?
just fixing a bug where for the RovoDev use case, to set the sessionId correctly,  In the existing code, we have a param sessionId but we overwrite it with a sessionId we try to retrieve from any sub class of Logger but that is not necessary.  


### How Has This Been Tested?

<img width="1263" height="339" alt="Screenshot 2026-01-27 at 5 29 07 PM" src="https://github.com/user-attachments/assets/630f9539-feda-487c-a261-04a511a1509b" />

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change