### PR TITLE
AXON-1851: fixed Right-click in the toolbar issues

### DIFF
--- a/src/views/jira/treeViews/customJqlViewProvider.test.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.test.ts
@@ -187,34 +187,41 @@ describe('CustomJqlViewProvider', () => {
 
                     expect(issues[0].label).toBe(mockedIssue2.key);
                     expect(issues[0].description).toBe(`${mockedIssue2.summary} | ${mockedIssue2.status.name}`);
+                    expect(issues[0].contextValue).toBe('jiraIssue');
 
                     expect(await provider.getChildren(issues[0])).toHaveLength(0);
 
                     expect(issues[1].label).toBe(parentKey);
+                    expect(issues[1].contextValue).toBe('jiraIssue');
 
                     const childrenIssues = await provider.getChildren(issues[1]);
                     expect(childrenIssues).toHaveLength(2);
 
                     expect(childrenIssues[0].label).toBe(mockedIssue1.key);
                     expect(childrenIssues[0].description).toBe(`${mockedIssue1.summary} | ${mockedIssue1.status.name}`);
+                    expect(childrenIssues[0].contextValue).toBe('jiraIssue');
 
                     expect(childrenIssues[1].label).toBe(mockedIssue3.key);
                     expect(childrenIssues[1].description).toBe(`${mockedIssue3.summary} | ${mockedIssue3.status.name}`);
+                    expect(childrenIssues[1].contextValue).toBe('jiraIssue');
                 } else {
                     expect(issues).toHaveLength(3);
 
                     expect(issues[0].label).toBe(mockedIssue1.key);
                     expect(issues[0].description).toBe(`${mockedIssue1.summary} | ${mockedIssue1.status.name}`);
+                    expect(issues[0].contextValue).toBe('jiraIssue');
 
                     expect(await provider.getChildren(issues[0])).toHaveLength(0);
 
                     expect(issues[1].label).toBe(mockedIssue2.key);
                     expect(issues[1].description).toBe(`${mockedIssue2.summary} | ${mockedIssue2.status.name}`);
+                    expect(issues[1].contextValue).toBe('jiraIssue');
 
                     expect(await provider.getChildren(issues[1])).toHaveLength(0);
 
                     expect(issues[2].label).toBe(mockedIssue3.key);
                     expect(issues[2].description).toBe(`${mockedIssue3.summary} | ${mockedIssue3.status.name}`);
+                    expect(issues[2].contextValue).toBe('jiraIssue');
 
                     expect(await provider.getChildren(issues[2])).toHaveLength(0);
                 }

--- a/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
+++ b/src/views/jira/treeViews/jiraAssignedWorkItemsViewProvider.test.ts
@@ -293,12 +293,15 @@ describe('AssignedWorkItemsViewProvider', () => {
 
             expect(children[0].label).toBe(mockedIssue1.key);
             expect(children[0].description).toBe(`${mockedIssue1.summary} | ${mockedIssue1.status.name}`);
+            expect(children[0].contextValue).toBe('assignedJiraIssue');
 
             expect(children[1].label).toBe(mockedIssue2.key);
             expect(children[1].description).toBe(`${mockedIssue2.summary} | ${mockedIssue2.status.name}`);
+            expect(children[1].contextValue).toBe('assignedJiraIssue');
 
             expect(children[2].label).toBe(mockedIssue3.key);
             expect(children[2].description).toBe(`${mockedIssue3.summary} | ${mockedIssue3.status.name}`);
+            expect(children[2].contextValue).toBe('assignedJiraIssue');
         });
     });
 

--- a/src/views/jira/treeViews/utils.test.ts
+++ b/src/views/jira/treeViews/utils.test.ts
@@ -160,6 +160,13 @@ describe('utils', () => {
             expect(jiraIssueNode).toBeDefined();
         });
 
+        it('should set contextValue to nodeType', () => {
+            const jiraIssueNode1 = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue1);
+            const jiraIssueNode2 = new JiraIssueNode(JiraIssueNode.NodeType.JiraAssignedIssuesNode, mockedIssue1);
+            expect(jiraIssueNode1.contextValue).toBe('jiraIssue');
+            expect(jiraIssueNode2.contextValue).toBe('assignedJiraIssue');
+        });
+
         it('getChildren should return children', async () => {
             const jiraIssueNode = new JiraIssueNode(JiraIssueNode.NodeType.CustomJqlQueriesNode, mockedIssue2);
             const children = await jiraIssueNode.getChildren();

--- a/src/views/jira/treeViews/utils.ts
+++ b/src/views/jira/treeViews/utils.ts
@@ -85,6 +85,7 @@ export class JiraIssueNode extends TreeItem implements AbstractBaseNode {
         this.description = `${summary} | ${issue.status.name}`;
         this.command = { command: Commands.ShowIssue, title: 'Show Issue', arguments: [issue] };
         this.iconPath = Uri.parse(issue.issuetype.iconUrl);
+        this.contextValue = nodeType;
         this.tooltip = `${issue.key} - ${issue.summary}\n\n${issue.priority.name}    |    ${issue.status.name}`;
         this.resourceUri = getJiraIssueUri(issue);
         this.children = issue.children.map((x) => new JiraIssueNode(nodeType, x));


### PR DESCRIPTION
### What Is This Change?

Fixed Right-click in the toolbar issues

Basic checks:

- [x] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>You don't have access to Rovo Dev Standard</strong>
Ask your organization admin to add you to Rovo Dev Standard.
[More about code review errors](https://support.atlassian.com/rovo/docs/troubleshoot-rovo-dev-code-reviews/)
<!-- /Rovo Dev code review status -->

