### PR TITLE
AXON-1856-Limiting-Error-Logging-Volume-To-Sentry

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -74,6 +74,7 @@ export class SentryService {
                 environment: config.environment || 'development',
                 sampleRate: config.sampleRate ?? 1.0,
                 tracesSampleRate: 0, // Disable transaction tracing
+                beforeSend: this.shouldSendEvent.bind(this),
             });
             this.sentryClient = Sentry;
             Logger.debug('Sentry initialized for Node.js environment.');
@@ -158,6 +159,31 @@ export class SentryService {
      */
     public getConfig(): SentryConfig | null {
         return this.config;
+    }
+
+    /**
+     * Filter function to determine if an event should be sent to Sentry.
+     * Returns null to block the event, or the event to allow it.
+     *
+     * Blocked events:
+     * - Unhandled rejections captured by Node.js process handler
+     * - Uncaught exceptions captured by Node.js process handler
+     * - Events explicitly marked as unhandled
+     */
+    private shouldSendEvent(event: Sentry.Event, hint: Sentry.EventHint): Sentry.Event | null {
+        const tags = event.tags;
+
+        // Define filters that should block events from being sent
+        const blockedFilters = [
+            { key: 'capturedBy', value: 'process.unhandledRejectionHandler' },
+            { key: 'capturedBy', value: 'uncaughtExceptionHandler' },
+            { key: 'handled', value: 'no' },
+        ];
+
+        // Check if any filter matches
+        const shouldBlock = blockedFilters.some((filter) => tags?.[filter.key] === filter.value);
+
+        return shouldBlock ? null : event;
     }
 }
 


### PR DESCRIPTION
### What Is This Change?

The volume of errors logged to Sentry is huge.  To reduce that, in the is PR, we filter out certain exceptions not be sent to Sentry.  These exceptions are thrown by the underlying VS Code instead of our own Atlascode.

The specific filters are taken by analyzing the data in [an hour interval of reported errors](https://atlassian-2y.sentry.io/explore/discover/homepage/?dataset=errors&end=2026-02-03T19%3A12%3A36.000&environment=production&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&query=handled%3Ayes%20%21capturedBy%3Aprocess.unhandledRejectionHandler%20%21capturedBy%3AClientManager.jiraClient%20%21capturedBy%3AOAuthRefesher.getNewTokens%20capturedBy%3AuncaughtExceptionHandler%20%21capturedBy%3AretryWithBackoff%20%21capturedBy%3ARovoDevEntitlementChecker.checkEntitlement%20%21message%3A%EF%80%8DContains%EF%80%8D%22Unable%20to%20connect%20to%20Bitbucket.%22%20%21capturedBy%3AgraphqlRequest&queryDataset=error-events&sort=-timestamp&start=2026-02-03T18%3A12%3A36.000&utc=true&yAxis=count%28%29)

### How Has This Been Tested?
<img width="1348" height="441" alt="Screenshot 2026-02-03 at 9 35 46 PM" src="https://github.com/user-attachments/assets/b2579574-d3f8-4e4e-bc3d-93e621a8ab88" />


Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>You don't have access to Rovo Dev Standard</strong>
Ask your organization admin to add you to Rovo Dev Standard.
[More about code review errors](https://support.atlassian.com/rovo/docs/troubleshoot-rovo-dev-code-reviews/)
<!-- /Rovo Dev code review status -->

