### PR TITLE
AXON-1861: Disable merge button if PR is draft

### DIFF
--- a/src/react/atlascode/pullrequest/PullRequestHeader.tsx
+++ b/src/react/atlascode/pullrequest/PullRequestHeader.tsx
@@ -1,8 +1,8 @@
 import { AppBar, Box, Link, Toolbar, Typography } from '@mui/material';
 import React from 'react';
 
+import { PullRequestHeaderActions } from './header-actions/PullRequestHeaderActions';
 import { PullRequestDetailsControllerApi, PullRequestDetailsState } from './pullRequestDetailsController';
-import { PullRequestHeaderActions } from './PullRequestHeaderActions';
 
 interface PullRequestHeaderProps {
     state: PullRequestDetailsState;

--- a/src/react/atlascode/pullrequest/header-actions/ApproveButton.tsx
+++ b/src/react/atlascode/pullrequest/header-actions/ApproveButton.tsx
@@ -2,7 +2,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { Box, Button, Typography } from '@mui/material';
 import React, { useCallback } from 'react';
 
-import { ApprovalStatus } from '../../../bitbucket/model';
+import { ApprovalStatus } from '../../../../bitbucket/model';
 
 type ApproveButtonProps = {
     hidden?: boolean;

--- a/src/react/atlascode/pullrequest/header-actions/MergeButton.tsx
+++ b/src/react/atlascode/pullrequest/header-actions/MergeButton.tsx
@@ -1,0 +1,40 @@
+import { Button, Tooltip, Typography } from '@mui/material';
+import React from 'react';
+
+type MergeButtonProps = {
+    prState: string;
+    isMerging: boolean;
+    isDraft: boolean;
+    onClick: () => void;
+};
+
+export const MergeButton: React.FC<MergeButtonProps> = ({ prState, isMerging, isDraft, onClick }) => {
+    const isDisabled = prState !== 'OPEN' || isMerging || isDraft;
+    const buttonText = prState === 'OPEN' ? 'Merge' : 'Merged';
+
+    let tooltipText = ''; // do not show tooltip when enabled
+    if (isDraft) {
+        tooltipText = 'This is a draft pull request. Mark as "ready for review" to enable merging.';
+    } else if (prState !== 'OPEN') {
+        tooltipText = `Pull request has "${prState.toLowerCase()}" state and cannot be merged.`;
+    } else if (isMerging) {
+        tooltipText = 'Merging in progress';
+    }
+
+    return (
+        <Tooltip title={tooltipText}>
+            {/*
+            By default disabled elements like <button> do not trigger user interactions so a Tooltip will not activate on normal events like hover.
+            To accommodate disabled elements, add a simple wrapper element, such as a span.
+            https://mui.com/material-ui/react-tooltip/#disabled-elements
+            */}
+            <div>
+                <Button color="primary" variant="contained" onClick={onClick} disabled={isDisabled} title={tooltipText}>
+                    <Typography variant="button" noWrap>
+                        {buttonText}
+                    </Typography>
+                </Button>
+            </div>
+        </Tooltip>
+    );
+};

--- a/src/react/atlascode/pullrequest/header-actions/MergeDialog.tsx
+++ b/src/react/atlascode/pullrequest/header-actions/MergeDialog.tsx
@@ -21,10 +21,11 @@ import {
 import { makeStyles } from '@mui/styles';
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { DetailedSiteInfo } from '../../../atlclients/authInfo';
-import { Commit, MergeStrategy, PullRequestData } from '../../../bitbucket/model';
-import { JiraTransitionMenu } from './JiraTransitionMenu';
-import { MergeChecks } from './MergeChecks';
+import { DetailedSiteInfo } from '../../../../atlclients/authInfo';
+import { Commit, MergeStrategy, PullRequestData } from '../../../../bitbucket/model';
+import { JiraTransitionMenu } from '../JiraTransitionMenu';
+import { MergeChecks } from '../MergeChecks';
+import { MergeButton } from './MergeButton';
 
 const useStyles = makeStyles((theme: Theme) => ({
     table: {
@@ -210,16 +211,12 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({
     return (
         <Box>
             <Box hidden={loadState.basicData}>
-                <Button
-                    color={'primary'}
-                    variant={'contained'}
+                <MergeButton
+                    prState={prData.state}
+                    isMerging={isMerging}
+                    isDraft={prData.draft}
                     onClick={handleOpen}
-                    disabled={prData.state !== 'OPEN' || isMerging}
-                >
-                    <Typography variant={'button'} noWrap>
-                        {prData.state === 'OPEN' ? 'Merge' : 'Merged'}
-                    </Typography>
-                </Button>
+                ></MergeButton>
             </Box>
             <Box hidden={!loadState.basicData}>
                 <CircularProgress />

--- a/src/react/atlascode/pullrequest/header-actions/PullRequestHeaderActions.tsx
+++ b/src/react/atlascode/pullrequest/header-actions/PullRequestHeaderActions.tsx
@@ -2,12 +2,12 @@ import { RefreshButton } from '@atlassianlabs/guipi-core-components';
 import { Box } from '@mui/material';
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { ApprovalStatus } from '../../../bitbucket/model';
-import { CopyLinkButton } from '../common/CopyLinkButton';
+import { ApprovalStatus } from '../../../../bitbucket/model';
+import { CopyLinkButton } from '../../common/CopyLinkButton';
+import { PullRequestDetailsControllerApi } from '../pullRequestDetailsController';
+import { PullRequestDetailsState } from '../pullRequestDetailsController';
 import { ApproveButton } from './ApproveButton';
 import { MergeDialog } from './MergeDialog';
-import { PullRequestDetailsControllerApi } from './pullRequestDetailsController';
-import { PullRequestDetailsState } from './pullRequestDetailsController';
 import { RequestChangesButton } from './RequestChangesButton';
 
 export interface PullRequestHeaderActionsProps {

--- a/src/react/atlascode/pullrequest/header-actions/RequestChangesButton.tsx
+++ b/src/react/atlascode/pullrequest/header-actions/RequestChangesButton.tsx
@@ -1,8 +1,8 @@
 import { Box, Button, Typography } from '@mui/material';
 import React, { useCallback } from 'react';
 
-import { ApprovalStatus } from '../../../bitbucket/model';
-import StoppedIcon from '../icons/StoppedIcon';
+import { ApprovalStatus } from '../../../../bitbucket/model';
+import StoppedIcon from '../../icons/StoppedIcon';
 type RequestChangesButtonProps = {
     hidden?: boolean;
     status: ApprovalStatus;


### PR DESCRIPTION
### What Is This Change?
This PR disables merge button in case PR is in draft status
<img width="1162" height="910" alt="Screenshot 2026-02-04 at 18 23 15" src="https://github.com/user-attachments/assets/31dacdc5-12ff-4e3a-ad10-7d6931e6a3cb" />

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>You don't have access to Rovo Dev Standard</strong>
Ask your organization admin to add you to Rovo Dev Standard.
[More about code review errors](https://support.atlassian.com/rovo/docs/troubleshoot-rovo-dev-code-reviews/)
<!-- /Rovo Dev code review status -->

