### PR TITLE
AXON-1856-Relaxing-the-filtering-restriction-for-exceptions-sent-to-sentry

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -175,13 +175,16 @@ export class SentryService {
 
         // Define filters that should block events from being sent
         const blockedFilters = [
-            { key: 'capturedBy', value: 'process.unhandledRejectionHandler' },
+            { key: 'capturedBy', value: 'unhandledRejection' },
             { key: 'capturedBy', value: 'uncaughtExceptionHandler' },
             { key: 'handled', value: 'no' },
         ];
 
         // Check if any filter matches
-        const shouldBlock = blockedFilters.some((filter) => tags?.[filter.key] === filter.value);
+        const shouldBlock = blockedFilters.some((filter) => {
+            const tagValue = tags?.[filter.key] as string;
+            return tagValue?.includes(filter.value);
+        });
 
         return shouldBlock ? null : event;
     }


### PR DESCRIPTION
### What Is This Change?

This PR is a small modification of [another PR ](https://github.com/atlassian/atlascode/pull/1566) that tries to reduce the volume of errors logged to Sentry by filtering out certain exceptions.  In this PR, we relax one of the filters to even filter out more exceptions.

### How Has This Been Tested?
<img width="956" height="172" alt="Screenshot 2026-02-05 at 6 45 15 AM" src="https://github.com/user-attachments/assets/0e36556e-0db8-40f0-b4ff-f68df5504dcc" />

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

