### PR TITLE
Feedback based on sam's question in slack about the scope of the rovo dev process restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
             },
             {
                 "command": "atlascode.rovodev.restartProcess",
-                "title": "Restart Rovo Dev Process",
+                "title": "Restart this Rovo Dev Process",
                 "category": "Rovo Dev",
                 "enablement": "atlascode:rovoDevEnabled"
             },


### PR DESCRIPTION
### What Is This Change?
Small wording change to clarify that the restart of the rovo dev process is only for "this" one, versus all instances of Rovo Dev on the machine 

Evidence: https://atlassian.slack.com/archives/C0AAPUH8HRS/p1770615068448489?thread_ts=1770268733.672799&cid=C0AAPUH8HRS
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

