### PR TITLE
disable ctrl f in prompt input

### DIFF
--- a/src/rovo-dev/ui/prompt-box/prompt-input/utils.tsx
+++ b/src/rovo-dev/ui/prompt-box/prompt-input/utils.tsx
@@ -340,6 +340,10 @@ export function setupPromptKeyBindings(editor: monaco.editor.IStandaloneCodeEdit
         editor.trigger('keyboard', 'type', { text: '\n' });
     });
 
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {
+        // disable default find action and trigger our own if needed
+    });
+
     // Tab key moves focus to the next focusable element (for keyboard accessibility)
     editor.addCommand(
         monaco.KeyCode.Tab,


### PR DESCRIPTION
disable the ctrl f operation in the prompt input editor box
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

