### PR TITLE
Revert "AXON-1456: Skip tests in pipeline if the PR only changes .md files"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-    paths-ignore:
-      - '**.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Reverts atlassian/atlascode#1529

Why? 

This change causes some of the required checks to be skipped. But they are still required. 

There is a fancy workaround for this. But, going to simplicity right now to move forward fast. 
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

