### PR TITLE
Fix npm package vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
                 "base64-arraybuffer-es6": "^3.1.0",
                 "clsx": "^2.1.1",
                 "date-fns": "^4.1.0",
-                "diff": "^8.0.2",
+                "diff": "^8.0.3",
                 "eventemitter3": "^5.0.1",
                 "express": "^5.1.0",
                 "fast-deep-equal": "^3.1.1",
@@ -107,7 +107,7 @@
                 "lodash.orderby": "^4.6.0",
                 "lodash.truncate": "^4.4.2",
                 "macaddress": "^0.5.3",
-                "markdown-it": "^14.1.0",
+                "markdown-it": "^14.1.1",
                 "merge-anything": "^6.0.6",
                 "monaco-editor": "^0.51.0",
                 "mustache": "^4.0.1",
@@ -1948,18 +1948,6 @@
                 "url": "https://opencollective.com/date-fns"
             }
         },
-        "node_modules/@atlaskit/editor-common/node_modules/entities": {
-            "version": "3.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/entities/-/entities-3.0.1.tgz",
-            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
         "node_modules/@atlaskit/editor-common/node_modules/linkify-it": {
             "version": "3.0.3",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/linkify-it/-/linkify-it-3.0.3.tgz",
@@ -1968,37 +1956,6 @@
             "dependencies": {
                 "uc.micro": "^1.0.1"
             }
-        },
-        "node_modules/@atlaskit/editor-common/node_modules/markdown-it": {
-            "version": "13.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/markdown-it/-/markdown-it-13.0.2.tgz",
-            "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "~3.0.1",
-                "linkify-it": "^4.0.1",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.js"
-            }
-        },
-        "node_modules/@atlaskit/editor-common/node_modules/markdown-it/node_modules/linkify-it": {
-            "version": "4.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/linkify-it/-/linkify-it-4.0.1.tgz",
-            "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^1.0.1"
-            }
-        },
-        "node_modules/@atlaskit/editor-common/node_modules/mdurl": {
-            "version": "1.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-            "license": "MIT"
         },
         "node_modules/@atlaskit/editor-common/node_modules/prosemirror-commands": {
             "version": "1.6.2",
@@ -2042,56 +1999,6 @@
                 "markdown-it": "^14.0.0",
                 "prosemirror-model": "^1.20.0"
             }
-        },
-        "node_modules/@atlaskit/editor-common/node_modules/prosemirror-markdown/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/@atlaskit/editor-common/node_modules/prosemirror-markdown/node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^2.0.0"
-            }
-        },
-        "node_modules/@atlaskit/editor-common/node_modules/prosemirror-markdown/node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
-                "mdurl": "^2.0.0",
-                "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.mjs"
-            }
-        },
-        "node_modules/@atlaskit/editor-common/node_modules/prosemirror-markdown/node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "license": "MIT"
-        },
-        "node_modules/@atlaskit/editor-common/node_modules/prosemirror-markdown/node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "license": "MIT"
         },
         "node_modules/@atlaskit/editor-common/node_modules/prosemirror-model": {
             "version": "1.24.1",
@@ -2556,49 +2463,6 @@
                 "@babel/runtime": "^7.0.0"
             }
         },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/entities": {
-            "version": "3.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/entities/-/entities-3.0.1.tgz",
-            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/linkify-it": {
-            "version": "4.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/linkify-it/-/linkify-it-4.0.1.tgz",
-            "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^1.0.1"
-            }
-        },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/markdown-it": {
-            "version": "13.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/markdown-it/-/markdown-it-13.0.2.tgz",
-            "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "~3.0.1",
-                "linkify-it": "^4.0.1",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.js"
-            }
-        },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/mdurl": {
-            "version": "1.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-            "license": "MIT"
-        },
         "node_modules/@atlaskit/editor-markdown-transformer/node_modules/prosemirror-commands": {
             "version": "1.6.2",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/prosemirror-commands/-/prosemirror-commands-1.6.2.tgz",
@@ -2641,56 +2505,6 @@
                 "markdown-it": "^14.0.0",
                 "prosemirror-model": "^1.20.0"
             }
-        },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/prosemirror-markdown/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/prosemirror-markdown/node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^2.0.0"
-            }
-        },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/prosemirror-markdown/node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
-                "mdurl": "^2.0.0",
-                "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.mjs"
-            }
-        },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/prosemirror-markdown/node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "license": "MIT"
-        },
-        "node_modules/@atlaskit/editor-markdown-transformer/node_modules/prosemirror-markdown/node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "license": "MIT"
         },
         "node_modules/@atlaskit/editor-markdown-transformer/node_modules/prosemirror-model": {
             "version": "1.24.1",
@@ -33873,9 +33687,9 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "2.2.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/body-parser/-/body-parser-2.2.1.tgz",
-            "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+            "version": "2.2.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
             "dependencies": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
@@ -33883,7 +33697,7 @@
                 "http-errors": "^2.0.0",
                 "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.0",
+                "qs": "^6.14.1",
                 "raw-body": "^3.0.1",
                 "type-is": "^2.0.1"
             },
@@ -36430,10 +36244,9 @@
             "license": "MIT"
         },
         "node_modules/diff": {
-            "version": "8.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/diff/-/diff-8.0.2.tgz",
-            "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
-            "license": "BSD-3-Clause",
+            "version": "8.0.3",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/diff/-/diff-8.0.3.tgz",
+            "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -42589,10 +42402,9 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-            "license": "MIT",
+            "version": "14.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -46542,10 +46354,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-            "license": "BSD-3-Clause",
+            "version": "6.14.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/qs/-/qs-6.14.2.tgz",
+            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
             "dependencies": {
                 "side-channel": "^1.1.0"
             },

--- a/package.json
+++ b/package.json
@@ -1741,7 +1741,7 @@
         "base64-arraybuffer-es6": "^3.1.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
-        "diff": "^8.0.2",
+        "diff": "^8.0.3",
         "eventemitter3": "^5.0.1",
         "express": "^5.1.0",
         "fast-deep-equal": "^3.1.1",
@@ -1759,7 +1759,7 @@
         "lodash.orderby": "^4.6.0",
         "lodash.truncate": "^4.4.2",
         "macaddress": "^0.5.3",
-        "markdown-it": "^14.1.0",
+        "markdown-it": "^14.1.1",
         "merge-anything": "^6.0.6",
         "monaco-editor": "^0.51.0",
         "mustache": "^4.0.1",
@@ -1896,7 +1896,8 @@
             "@sentry/browser": "^7.119.2"
         },
         "@atlaskit/editor-common": {
-            "@sentry/browser": "^7.119.2"
+            "@sentry/browser": "^7.119.2",
+            "markdown-it": "^14.1.1"
         },
         "fetch-mock": {
             "path-to-regexp": "^3.2.0"
@@ -1929,6 +1930,12 @@
         },
         "express": {
             "body-parser": "^2.2.1"
+        },
+        "prosemirror-markdown": {
+            "markdown-it": "^14.1.1"
+        },
+        "@atlaskit/editor-markdown-transformer": {
+            "markdown-it": "^14.1.1"
         },
         "jws": "^4.0.1"
     }


### PR DESCRIPTION
diff  6.0.0 - 8.0.2
jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch - https://github.com/advisories/GHSA-73rr-hh4g-fpgx

markdown-it  13.0.0 - 14.1.0
Severity: moderate
markdown-it is has a Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-38c4-r59v-3vqw

qs  6.7.0 - 6.14.1
qs's arrayLimit bypass in comma parsing allows denial of service - https://github.com/advisories/GHSA-w7fw-mjwx-w883
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

