### PR TITLE
[AXON-1902] Enable error telemetry in Boysenberry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,7 +138,11 @@ export async function activate(context: ExtensionContext) {
 }
 
 function activateErrorReporting(): void {
-    if (Container.isDebugging || Container.featureFlagClient.checkGate(Features.EnableErrorTelemetry)) {
+    if (
+        Container.isDebugging ||
+        RovodevStaticConfig.isBBY ||
+        Container.featureFlagClient.checkGate(Features.EnableErrorTelemetry)
+    ) {
         registerAnalyticsClient(Container.analyticsClient);
     } else {
         unregisterErrorReporting();


### PR DESCRIPTION
### What Is This Change?

In Boysenberry we don't have the StatSig client set up, so the feature flag for enabling error telemetry always resolved to `false` and error telemetry was never sent.

With this change we enable Boysenberry at 100% for error telemetry.

Follow up change: we should enable the stat sig client in Boysenberry, too.
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

