### PR TITLE
AXON-1912: Restore fix for errror that appears on "stop watching"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
                 "@atlassianlabs/guipi-jira-components": "^3.2.0",
                 "@atlassianlabs/jira-metaui-client": "^2.0.0",
                 "@atlassianlabs/jira-metaui-transformer": "^2.0.0",
-                "@atlassianlabs/jira-pi-client": "2.0.1",
+                "@atlassianlabs/jira-pi-client": "^2.0.2",
                 "@atlassianlabs/jira-pi-common-models": "^2.0.0",
                 "@atlassianlabs/jira-pi-meta-models": "^2.0.0",
                 "@atlassianlabs/pi-client-common": "^2.0.0",
@@ -24152,13 +24152,14 @@
             }
         },
         "node_modules/@atlassianlabs/jira-pi-client": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlassianlabs/jira-pi-client/-/jira-pi-client-2.0.1.tgz",
-            "integrity": "sha512-wwq04WqnejB0FhryZU6OlI1dh5Q9DtEvtwBfHDVI9i6ID4QAM3PhBF3dK9/HlqsFcFYb856tzjOxyFbqTn2pfg==",
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlassianlabs/jira-pi-client/-/jira-pi-client-2.0.2.tgz",
+            "integrity": "sha512-MzCexrMAETlxf334B+OevT566BCk9fZWg+iU0t/BrJix2/tqkLlbdH6S2Ow58MswAnVWIIs8J2DOwSlxfvbkmw==",
+            "license": "MIT",
             "dependencies": {
-                "@atlassianlabs/jira-pi-common-models": "^2.0.1",
-                "@atlassianlabs/jira-pi-meta-models": "^2.0.1",
-                "@atlassianlabs/pi-client-common": "^2.0.1",
+                "@atlassianlabs/jira-pi-common-models": "^2.0.2",
+                "@atlassianlabs/jira-pi-meta-models": "^2.0.2",
+                "@atlassianlabs/pi-client-common": "^2.0.2",
                 "@babel/runtime": ">=7.10.0"
             },
             "peerDependencies": {
@@ -24167,19 +24168,21 @@
             }
         },
         "node_modules/@atlassianlabs/jira-pi-common-models": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlassianlabs/jira-pi-common-models/-/jira-pi-common-models-2.0.1.tgz",
-            "integrity": "sha512-lxaOJljZ8DUPj0rUWP20O6+hazxUjnKoyQIHzJXf7IeExnL5/AyyjVGOez3but/08MYe1fku87TA0XRvbRqEmw==",
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlassianlabs/jira-pi-common-models/-/jira-pi-common-models-2.0.2.tgz",
+            "integrity": "sha512-eOK2o2KdXwBPKpjHRM18Bt6ThE/FX8Azx4JNDXmmZmskM40mf8FynbqiC4AeeI9llIPGy10gc9uTlHdov0BKHg==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": ">=7.10.0"
             }
         },
         "node_modules/@atlassianlabs/jira-pi-meta-models": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlassianlabs/jira-pi-meta-models/-/jira-pi-meta-models-2.0.1.tgz",
-            "integrity": "sha512-O0g3VBdChQnK2Zim3j5ocDWfO20h+pIqROW9dLxk5CTU77C6S8EZjqgMfVlsvEZBbnNBrVqk05fypJ2pcf6nnw==",
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlassianlabs/jira-pi-meta-models/-/jira-pi-meta-models-2.0.2.tgz",
+            "integrity": "sha512-d5MaMmsITP/dT45EPs54PprE6lNvI/j7OW6rc7wfHbZAxL09W8no4Zc5pI7MAvDAQv1P3bax+koYGGY+tu7bnw==",
+            "license": "MIT",
             "dependencies": {
-                "@atlassianlabs/jira-pi-common-models": "^2.0.1",
+                "@atlassianlabs/jira-pi-common-models": "^2.0.2",
                 "@babel/runtime": ">=7.10.0"
             }
         },
@@ -24190,9 +24193,10 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@atlassianlabs/pi-client-common": {
-            "version": "2.0.1",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlassianlabs/pi-client-common/-/pi-client-common-2.0.1.tgz",
-            "integrity": "sha512-w3x0T6WaZDD/kvWod/S9pTHQMd6LzG8oiZ7FbSySeXKcPqkcilOvof9chKScE2TRh8TRTVmui2MgUNjiwfKFxQ==",
+            "version": "2.0.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@atlassianlabs/pi-client-common/-/pi-client-common-2.0.2.tgz",
+            "integrity": "sha512-LJG3AzPBEaRmZjaYmdE7vc2TePeoDwKCO5gKyCUIMRvVGwDEU7CE7XxR+MSJu4hPfI1KLvDcCWwInMuzkiyuHQ==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": ">=7.10.0"
             }

--- a/package.json
+++ b/package.json
@@ -725,7 +725,7 @@
                     "when": "atlascode:isBitbucketCloudRepo && config.atlascode.bitbucket.enabled",
                     "group": "navigation"
                 }
-			],
+            ],
             "view/title": [
                 {
                     "command": "atlascode.rovodev.sessionHistory",
@@ -1719,7 +1719,7 @@
         "@atlassianlabs/guipi-jira-components": "^3.2.0",
         "@atlassianlabs/jira-metaui-client": "^2.0.0",
         "@atlassianlabs/jira-metaui-transformer": "^2.0.0",
-        "@atlassianlabs/jira-pi-client": "2.0.1",
+        "@atlassianlabs/jira-pi-client": "^2.0.2",
         "@atlassianlabs/jira-pi-common-models": "^2.0.0",
         "@atlassianlabs/jira-pi-meta-models": "^2.0.0",
         "@atlassianlabs/pi-client-common": "^2.0.0",
@@ -1901,7 +1901,7 @@
         },
         "@atlaskit/teams-client": {
             "@sentry/browser": "^7.119.2"
-        },        
+        },
         "@atlaskit/editor-common": {
             "@sentry/browser": "^7.119.2",
             "markdown-it": "^14.1.1"

--- a/src/webviews/components/issue/WatchesForm.tsx
+++ b/src/webviews/components/issue/WatchesForm.tsx
@@ -98,10 +98,10 @@ export default class WatchesForm extends React.Component<MyProps, MyState> {
             return this.getEmptyWatchers();
         }
 
-        const watcherList = this.props.watches.watchers.map((watcher) => {
+        const watcherList = this.props.watches.watchers.map((watcher, index) => {
             const avatar = watcher.avatarUrls && watcher.avatarUrls['48x48'] ? watcher.avatarUrls['48x48'] : '';
             return (
-                <div className="ac-inline-watcher ac-inline-watcher-hover">
+                <div key={index} className="ac-inline-watcher ac-inline-watcher-hover">
                     <Avatar size="small" src={avatar} />
                     <div className="ac-inline-watcher-name">{watcher.displayName}</div>
                     <div className="ac-inline-watcher-delete" onClick={() => this.props.onRemoveWatcher(watcher)}></div>

--- a/src/webviews/jiraIssueWebview.test.ts
+++ b/src/webviews/jiraIssueWebview.test.ts
@@ -1052,353 +1052,509 @@ describe('JiraIssueWebview', () => {
             expect(postMessageSpy).toHaveBeenCalled();
         });
 
-        test('should handle createWorklog action', async () => {
-            const worklogData = {
-                timeSpent: '1h',
-                comment: 'Work done',
-                adjustEstimate: 'new',
-                newEstimate: '2h',
-            };
+        describe('worklog actions', () => {
+            test('should handle createWorklog action', async () => {
+                const worklogData = {
+                    timeSpent: '1h',
+                    comment: 'Work done',
+                    adjustEstimate: 'new',
+                    newEstimate: '2h',
+                };
 
-            const msg = {
-                action: 'createWorklog',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                worklogData,
-                nonce: 'nonce-123',
-            };
-
-            const createdWorklog = {
-                id: 'worklog-1',
-                timeSpent: '1h',
-                comment: 'Work done',
-            };
-
-            mockJiraClient.addWorklog.mockResolvedValue(createdWorklog);
-            jiraIssueWebview['_editUIData'].fieldValues['worklog'] = { worklogs: [] };
-
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
-
-            await jiraIssueWebview['onMessageReceived'](msg);
-
-            expect(mockJiraClient.addWorklog).toHaveBeenCalledWith(
-                mockIssue.key,
-                { timeSpent: '1h', comment: 'Work done' },
-                { adjustEstimate: 'new', newEstimate: '2h' },
-            );
-            expect(jiraIssueWebview['_editUIData'].fieldValues['worklog'].worklogs).toContain(createdWorklog);
-            expect(postMessageSpy).toHaveBeenCalledWith({
-                type: 'fieldValueUpdate',
-                fieldValues: { worklog: { worklogs: [createdWorklog] }, nonce: 'nonce-123' },
-            });
-        });
-
-        test('should handle updateWorklog action', async () => {
-            const worklogData = {
-                timeSpent: '2h',
-                comment: 'Updated work done',
-                adjustEstimate: 'auto',
-            };
-
-            const msg = {
-                action: 'updateWorklog',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                worklogId: 'worklog-1',
-                worklogData,
-                nonce: 'nonce-123',
-            };
-
-            const updatedWorklog = {
-                id: 'worklog-1',
-                timeSpent: '2h',
-                comment: 'Updated work done',
-            };
-
-            (mockJiraClient as any).putToJira = jest.fn().mockResolvedValue(updatedWorklog);
-            jiraIssueWebview['_editUIData'].fieldValues['worklog'] = {
-                worklogs: [{ id: 'worklog-1', timeSpent: '1h', comment: 'Old work' }],
-            };
-
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
-
-            await jiraIssueWebview['onMessageReceived'](msg);
-
-            expect((mockJiraClient as any).putToJira).toHaveBeenCalledWith(
-                'issue/TEST-123/worklog/worklog-1',
-                { timeSpent: '2h', comment: 'Updated work done' },
-                { adjustEstimate: 'auto' },
-            );
-            expect(jiraIssueWebview['_editUIData'].fieldValues['worklog'].worklogs[0]).toEqual(updatedWorklog);
-            expect(postMessageSpy).toHaveBeenCalledWith({
-                type: 'fieldValueUpdate',
-                fieldValues: { worklog: { worklogs: [updatedWorklog] }, nonce: 'nonce-123' },
-            });
-        });
-
-        test('should handle deleteWorklog action', async () => {
-            const msg = {
-                action: 'deleteWorklog',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                worklogId: 'worklog-1',
-                adjustEstimate: 'auto',
-                nonce: 'nonce-123',
-            };
-
-            (mockJiraClient as any).deleteToJira = jest.fn().mockResolvedValue({});
-            jiraIssueWebview['_editUIData'].fieldValues['worklog'] = {
-                worklogs: [
-                    { id: 'worklog-1', timeSpent: '1h', comment: 'Work to delete' },
-                    { id: 'worklog-2', timeSpent: '2h', comment: 'Work to keep' },
-                ],
-            };
-
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
-
-            await jiraIssueWebview['onMessageReceived'](msg);
-
-            expect((mockJiraClient as any).deleteToJira).toHaveBeenCalledWith('issue/TEST-123/worklog/worklog-1', {
-                adjustEstimate: 'auto',
-            });
-            expect(jiraIssueWebview['_editUIData'].fieldValues['worklog'].worklogs).toHaveLength(1);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['worklog'].worklogs[0].id).toBe('worklog-2');
-            expect(postMessageSpy).toHaveBeenCalledWith({
-                type: 'fieldValueUpdate',
-                fieldValues: {
-                    worklog: { worklogs: [{ id: 'worklog-2', timeSpent: '2h', comment: 'Work to keep' }] },
+                const msg = {
+                    action: 'createWorklog',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    worklogData,
                     nonce: 'nonce-123',
-                },
+                };
+
+                const createdWorklog = {
+                    id: 'worklog-1',
+                    timeSpent: '1h',
+                    comment: 'Work done',
+                };
+
+                mockJiraClient.addWorklog.mockResolvedValue(createdWorklog);
+                jiraIssueWebview['_editUIData'].fieldValues['worklog'] = { worklogs: [] };
+
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect(mockJiraClient.addWorklog).toHaveBeenCalledWith(
+                    mockIssue.key,
+                    { timeSpent: '1h', comment: 'Work done' },
+                    { adjustEstimate: 'new', newEstimate: '2h' },
+                );
+                expect(jiraIssueWebview['_editUIData'].fieldValues['worklog'].worklogs).toContain(createdWorklog);
+                expect(postMessageSpy).toHaveBeenCalledWith({
+                    type: 'fieldValueUpdate',
+                    fieldValues: { worklog: { worklogs: [createdWorklog] }, nonce: 'nonce-123' },
+                });
+            });
+
+            test('should handle updateWorklog action', async () => {
+                const worklogData = {
+                    timeSpent: '2h',
+                    comment: 'Updated work done',
+                    adjustEstimate: 'auto',
+                };
+
+                const msg = {
+                    action: 'updateWorklog',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    worklogId: 'worklog-1',
+                    worklogData,
+                    nonce: 'nonce-123',
+                };
+
+                const updatedWorklog = {
+                    id: 'worklog-1',
+                    timeSpent: '2h',
+                    comment: 'Updated work done',
+                };
+
+                (mockJiraClient as any).putToJira = jest.fn().mockResolvedValue(updatedWorklog);
+                jiraIssueWebview['_editUIData'].fieldValues['worklog'] = {
+                    worklogs: [{ id: 'worklog-1', timeSpent: '1h', comment: 'Old work' }],
+                };
+
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect((mockJiraClient as any).putToJira).toHaveBeenCalledWith(
+                    'issue/TEST-123/worklog/worklog-1',
+                    { timeSpent: '2h', comment: 'Updated work done' },
+                    { adjustEstimate: 'auto' },
+                );
+                expect(jiraIssueWebview['_editUIData'].fieldValues['worklog'].worklogs[0]).toEqual(updatedWorklog);
+                expect(postMessageSpy).toHaveBeenCalledWith({
+                    type: 'fieldValueUpdate',
+                    fieldValues: { worklog: { worklogs: [updatedWorklog] }, nonce: 'nonce-123' },
+                });
+            });
+
+            test('should handle deleteWorklog action', async () => {
+                const msg = {
+                    action: 'deleteWorklog',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    worklogId: 'worklog-1',
+                    adjustEstimate: 'auto',
+                    nonce: 'nonce-123',
+                };
+
+                (mockJiraClient as any).deleteToJira = jest.fn().mockResolvedValue({});
+                jiraIssueWebview['_editUIData'].fieldValues['worklog'] = {
+                    worklogs: [
+                        { id: 'worklog-1', timeSpent: '1h', comment: 'Work to delete' },
+                        { id: 'worklog-2', timeSpent: '2h', comment: 'Work to keep' },
+                    ],
+                };
+
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect((mockJiraClient as any).deleteToJira).toHaveBeenCalledWith('issue/TEST-123/worklog/worklog-1', {
+                    adjustEstimate: 'auto',
+                });
+                expect(jiraIssueWebview['_editUIData'].fieldValues['worklog'].worklogs).toHaveLength(1);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['worklog'].worklogs[0].id).toBe('worklog-2');
+                expect(postMessageSpy).toHaveBeenCalledWith({
+                    type: 'fieldValueUpdate',
+                    fieldValues: {
+                        worklog: { worklogs: [{ id: 'worklog-2', timeSpent: '2h', comment: 'Work to keep' }] },
+                        nonce: 'nonce-123',
+                    },
+                });
+            });
+
+            test('should handle updateWorklog action with new estimate', async () => {
+                const worklogData = {
+                    timeSpent: '2h',
+                    comment: 'Updated work done',
+                    adjustEstimate: 'new',
+                    newEstimate: '3h',
+                };
+
+                const msg = {
+                    action: 'updateWorklog',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    worklogId: 'worklog-1',
+                    worklogData,
+                    nonce: 'nonce-123',
+                };
+
+                const updatedWorklog = {
+                    id: 'worklog-1',
+                    timeSpent: '2h',
+                    comment: 'Updated work done',
+                };
+
+                (mockJiraClient as any).putToJira = jest.fn().mockResolvedValue(updatedWorklog);
+                jiraIssueWebview['_editUIData'].fieldValues['worklog'] = {
+                    worklogs: [{ id: 'worklog-1', timeSpent: '1h', comment: 'Old work' }],
+                };
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect((mockJiraClient as any).putToJira).toHaveBeenCalledWith(
+                    'issue/TEST-123/worklog/worklog-1',
+                    { timeSpent: '2h', comment: 'Updated work done' },
+                    { adjustEstimate: 'new', newEstimate: '3h' },
+                );
+            });
+
+            test('should handle deleteWorklog action with new estimate', async () => {
+                const msg = {
+                    action: 'deleteWorklog',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    worklogId: 'worklog-1',
+                    adjustEstimate: 'new',
+                    newEstimate: '4h',
+                    nonce: 'nonce-123',
+                };
+
+                (mockJiraClient as any).deleteToJira = jest.fn().mockResolvedValue({});
+                jiraIssueWebview['_editUIData'].fieldValues['worklog'] = {
+                    worklogs: [{ id: 'worklog-1', timeSpent: '1h', comment: 'Work to delete' }],
+                };
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect((mockJiraClient as any).deleteToJira).toHaveBeenCalledWith('issue/TEST-123/worklog/worklog-1', {
+                    adjustEstimate: 'new',
+                    newEstimate: '4h',
+                });
+            });
+
+            test('should handle updateWorklog error', async () => {
+                const worklogData = {
+                    timeSpent: '2h',
+                    comment: 'Updated work done',
+                    adjustEstimate: 'auto',
+                };
+
+                const msg = {
+                    action: 'updateWorklog',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    worklogId: 'worklog-1',
+                    worklogData,
+                    nonce: 'nonce-123',
+                };
+
+                const error = new Error('Update failed');
+                (mockJiraClient as any).putToJira = jest.fn().mockRejectedValue(error);
+
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect(postMessageSpy).toHaveBeenCalledWith({
+                    type: 'error',
+                    reason: expect.objectContaining({
+                        title: 'Error updating worklog',
+                    }),
+                    nonce: 'nonce-123',
+                });
+            });
+
+            test('should handle deleteWorklog error', async () => {
+                const msg = {
+                    action: 'deleteWorklog',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    worklogId: 'worklog-1',
+                    adjustEstimate: 'auto',
+                    nonce: 'nonce-123',
+                };
+
+                const error = new Error('Delete failed');
+                (mockJiraClient as any).deleteToJira = jest.fn().mockRejectedValue(error);
+
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect(postMessageSpy).toHaveBeenCalledWith({
+                    type: 'error',
+                    reason: expect.objectContaining({
+                        title: 'Error deleting worklog',
+                    }),
+                    nonce: 'nonce-123',
+                });
             });
         });
 
-        test('should handle updateWorklog action with new estimate', async () => {
-            const worklogData = {
-                timeSpent: '2h',
-                comment: 'Updated work done',
-                adjustEstimate: 'new',
-                newEstimate: '3h',
-            };
+        describe('watchers actions', () => {
+            test('should handle addWatcher action', async () => {
+                const watcher = { accountId: 'user-1', displayName: 'Test User' };
+                const msg = {
+                    action: 'addWatcher',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    watcher,
+                    nonce: 'nonce-123',
+                };
 
-            const msg = {
-                action: 'updateWorklog',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                worklogId: 'worklog-1',
-                worklogData,
-                nonce: 'nonce-123',
-            };
+                jiraIssueWebview['_editUIData'].fieldValues['watches'] = {
+                    watchCount: 0,
+                    watchers: [],
+                    isWatching: false,
+                };
+                jiraIssueWebview['_currentUser'] = { accountId: 'user-1' } as any;
 
-            const updatedWorklog = {
-                id: 'worklog-1',
-                timeSpent: '2h',
-                comment: 'Updated work done',
-            };
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
 
-            (mockJiraClient as any).putToJira = jest.fn().mockResolvedValue(updatedWorklog);
-            jiraIssueWebview['_editUIData'].fieldValues['worklog'] = {
-                worklogs: [{ id: 'worklog-1', timeSpent: '1h', comment: 'Old work' }],
-            };
+                await jiraIssueWebview['onMessageReceived'](msg);
 
-            await jiraIssueWebview['onMessageReceived'](msg);
+                expect(mockJiraClient.addWatcher).toHaveBeenCalledWith(mockIssue.key, watcher.accountId);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchers).toContain(watcher);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchCount).toBe(1);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].isWatching).toBe(true);
+                expect(postMessageSpy).toHaveBeenCalled();
+            });
 
-            expect((mockJiraClient as any).putToJira).toHaveBeenCalledWith(
-                'issue/TEST-123/worklog/worklog-1',
-                { timeSpent: '2h', comment: 'Updated work done' },
-                { adjustEstimate: 'new', newEstimate: '3h' },
-            );
-        });
+            test('should handle removeWatcher action', async () => {
+                const watcher = { accountId: 'user-1', displayName: 'Test User' };
+                const msg = {
+                    action: 'removeWatcher',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    watcher,
+                    nonce: 'nonce-123',
+                };
 
-        test('should handle deleteWorklog action with new estimate', async () => {
-            const msg = {
-                action: 'deleteWorklog',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                worklogId: 'worklog-1',
-                adjustEstimate: 'new',
-                newEstimate: '4h',
-                nonce: 'nonce-123',
-            };
+                jiraIssueWebview['_editUIData'].fieldValues['watches'] = {
+                    watchCount: 1,
+                    watchers: [watcher],
+                    isWatching: true,
+                };
+                jiraIssueWebview['_currentUser'] = { accountId: 'user-1' } as any;
 
-            (mockJiraClient as any).deleteToJira = jest.fn().mockResolvedValue({});
-            jiraIssueWebview['_editUIData'].fieldValues['worklog'] = {
-                worklogs: [{ id: 'worklog-1', timeSpent: '1h', comment: 'Work to delete' }],
-            };
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
 
-            await jiraIssueWebview['onMessageReceived'](msg);
+                await jiraIssueWebview['onMessageReceived'](msg);
 
-            expect((mockJiraClient as any).deleteToJira).toHaveBeenCalledWith('issue/TEST-123/worklog/worklog-1', {
-                adjustEstimate: 'new',
-                newEstimate: '4h',
+                expect(mockJiraClient.removeWatcher).toHaveBeenCalledWith(mockIssue.key, {
+                    accountId: watcher.accountId,
+                });
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchers).not.toContain(watcher);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchCount).toBe(0);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].isWatching).toBe(false);
+                expect(postMessageSpy).toHaveBeenCalled();
+            });
+
+            test('should handle removeWatcher action(Jira DC)', async () => {
+                const watcher = {
+                    key: 'testUserKey',
+                    accountId: 'user-1',
+                    displayName: 'Test User',
+                };
+                const siteDetailsDC = { ...mockSiteDetails, isCloud: false };
+                const msg = {
+                    action: 'removeWatcher',
+                    site: siteDetailsDC,
+                    issueKey: mockIssue.key,
+                    watcher,
+                    nonce: 'nonce-123',
+                };
+
+                jiraIssueWebview['_editUIData'].fieldValues['watches'] = {
+                    watchCount: 1,
+                    watchers: [watcher],
+                    isWatching: true,
+                };
+                jiraIssueWebview['_currentUser'] = { key: 'testUserKey' } as any;
+
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect(mockJiraClient.removeWatcher).toHaveBeenCalledWith(mockIssue.key, { username: watcher.key });
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchers).not.toContain(watcher);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchCount).toBe(0);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].isWatching).toBe(false);
+                expect(postMessageSpy).toHaveBeenCalled();
+            });
+
+            test('should handle removeWatcher action when watchers is undefined', async () => {
+                const watcher = { accountId: 'user-1', displayName: 'Test User' };
+                const msg = {
+                    action: 'removeWatcher',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    watcher,
+                    nonce: 'nonce-456',
+                };
+
+                jiraIssueWebview['_editUIData'].fieldValues['watches'] = {
+                    watchCount: 1,
+                    isWatching: true,
+                    // watchers is undefined
+                };
+                jiraIssueWebview['_currentUser'] = { accountId: 'user-1' } as any;
+
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect(mockJiraClient.removeWatcher).toHaveBeenCalledWith(mockIssue.key, {
+                    accountId: watcher.accountId,
+                });
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchers).toEqual([]);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchCount).toBe(0);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].isWatching).toBe(false);
+                expect(postMessageSpy).toHaveBeenCalled();
+            });
+
+            test('should handle removeWatcher action when watcher not found', async () => {
+                const watcher = { accountId: 'user-2', displayName: 'Other User' };
+                const msg = {
+                    action: 'removeWatcher',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    watcher,
+                    nonce: 'nonce-789',
+                };
+
+                jiraIssueWebview['_editUIData'].fieldValues['watches'] = {
+                    watchCount: 1,
+                    // watchers does not contain the watcher
+                    watchers: [{ accountId: 'user-1', displayName: 'Test User' }],
+                    isWatching: true,
+                };
+                jiraIssueWebview['_currentUser'] = { accountId: 'user-2' } as any;
+
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+                await jiraIssueWebview['onMessageReceived'](msg);
+
+                expect(mockJiraClient.removeWatcher).toHaveBeenCalledWith(mockIssue.key, {
+                    accountId: watcher.accountId,
+                });
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchers).toHaveLength(1);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchCount).toBe(1);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].isWatching).toBe(false);
+                expect(postMessageSpy).toHaveBeenCalled();
             });
         });
 
-        test('should handle updateWorklog error', async () => {
-            const worklogData = {
-                timeSpent: '2h',
-                comment: 'Updated work done',
-                adjustEstimate: 'auto',
-            };
+        describe('votes actions', () => {
+            test('should handle addVote action', async () => {
+                const voter = { accountId: 'user-1', displayName: 'Test User' };
+                const msg = {
+                    action: 'addVote',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    voter,
+                    nonce: 'nonce-123',
+                };
 
-            const msg = {
-                action: 'updateWorklog',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                worklogId: 'worklog-1',
-                worklogData,
-                nonce: 'nonce-123',
-            };
+                jiraIssueWebview['_editUIData'].fieldValues['votes'] = {
+                    votes: 0,
+                    voters: [],
+                    hasVoted: false,
+                };
 
-            const error = new Error('Update failed');
-            (mockJiraClient as any).putToJira = jest.fn().mockRejectedValue(error);
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
 
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+                await jiraIssueWebview['onMessageReceived'](msg);
 
-            await jiraIssueWebview['onMessageReceived'](msg);
-
-            expect(postMessageSpy).toHaveBeenCalledWith({
-                type: 'error',
-                reason: expect.objectContaining({
-                    title: 'Error updating worklog',
-                }),
-                nonce: 'nonce-123',
+                expect(mockJiraClient.addVote).toHaveBeenCalledWith(mockIssue.key);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].voters).toContain(voter);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].votes).toBe(1);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].hasVoted).toBe(true);
+                expect(postMessageSpy).toHaveBeenCalled();
             });
-        });
 
-        test('should handle deleteWorklog error', async () => {
-            const msg = {
-                action: 'deleteWorklog',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                worklogId: 'worklog-1',
-                adjustEstimate: 'auto',
-                nonce: 'nonce-123',
-            };
+            test('should handle removeVote action', async () => {
+                const voter = { accountId: 'user-1', displayName: 'Test User' };
+                const msg = {
+                    action: 'removeVote',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    voter,
+                    nonce: 'nonce-123',
+                };
 
-            const error = new Error('Delete failed');
-            (mockJiraClient as any).deleteToJira = jest.fn().mockRejectedValue(error);
+                jiraIssueWebview['_editUIData'].fieldValues['votes'] = {
+                    votes: 1,
+                    voters: [voter],
+                    hasVoted: true,
+                };
 
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
 
-            await jiraIssueWebview['onMessageReceived'](msg);
+                await jiraIssueWebview['onMessageReceived'](msg);
 
-            expect(postMessageSpy).toHaveBeenCalledWith({
-                type: 'error',
-                reason: expect.objectContaining({
-                    title: 'Error deleting worklog',
-                }),
-                nonce: 'nonce-123',
+                expect(mockJiraClient.removeVote).toHaveBeenCalledWith(mockIssue.key);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].voters).not.toContain(voter);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].votes).toBe(0);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].hasVoted).toBe(false);
+                expect(postMessageSpy).toHaveBeenCalled();
             });
-        });
 
-        test('should handle addWatcher action', async () => {
-            const watcher = { accountId: 'user-1', displayName: 'Test User' };
-            const msg = {
-                action: 'addWatcher',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                watcher,
-                nonce: 'nonce-123',
-            };
+            test('should handle removeVote action when voters is undefined', async () => {
+                const voter = { accountId: 'user-1', displayName: 'Test User' };
+                const msg = {
+                    action: 'removeVote',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    voter,
+                    nonce: 'nonce-456',
+                };
 
-            jiraIssueWebview['_editUIData'].fieldValues['watches'] = {
-                watchCount: 0,
-                watchers: [],
-                isWatching: false,
-            };
-            jiraIssueWebview['_currentUser'] = { accountId: 'user-1' } as any;
+                jiraIssueWebview['_editUIData'].fieldValues['votes'] = {
+                    votes: 1,
+                    hasVoted: true,
+                };
 
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
 
-            await jiraIssueWebview['onMessageReceived'](msg);
+                await jiraIssueWebview['onMessageReceived'](msg);
 
-            expect(mockJiraClient.addWatcher).toHaveBeenCalledWith(mockIssue.key, watcher.accountId);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchers).toContain(watcher);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchCount).toBe(1);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].isWatching).toBe(true);
-            expect(postMessageSpy).toHaveBeenCalled();
-        });
+                expect(mockJiraClient.removeVote).toHaveBeenCalledWith(mockIssue.key);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].voters).toEqual([]);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].votes).toBe(0);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].hasVoted).toBe(false);
+                expect(postMessageSpy).toHaveBeenCalled();
+            });
 
-        test('should handle removeWatcher action', async () => {
-            const watcher = { accountId: 'user-1', displayName: 'Test User' };
-            const msg = {
-                action: 'removeWatcher',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                watcher,
-                nonce: 'nonce-123',
-            };
+            test('should handle removeVote action when voter not found', async () => {
+                const voter = { accountId: 'user-2', displayName: 'Other User' };
+                const msg = {
+                    action: 'removeVote',
+                    site: mockSiteDetails,
+                    issueKey: mockIssue.key,
+                    voter,
+                    nonce: 'nonce-789',
+                };
 
-            jiraIssueWebview['_editUIData'].fieldValues['watches'] = {
-                watchCount: 1,
-                watchers: [watcher],
-                isWatching: true,
-            };
-            jiraIssueWebview['_currentUser'] = { accountId: 'user-1' } as any;
+                jiraIssueWebview['_editUIData'].fieldValues['votes'] = {
+                    votes: 1,
+                    voters: [{ accountId: 'user-1', displayName: 'Test User' }],
+                    hasVoted: true,
+                };
+                jiraIssueWebview['_currentUser'] = { accountId: 'user-2' } as any;
 
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+                const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
 
-            await jiraIssueWebview['onMessageReceived'](msg);
+                await jiraIssueWebview['onMessageReceived'](msg);
 
-            expect(mockJiraClient.removeWatcher).toHaveBeenCalledWith(mockIssue.key, watcher.accountId);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchers).not.toContain(watcher);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].watchCount).toBe(0);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['watches'].isWatching).toBe(false);
-            expect(postMessageSpy).toHaveBeenCalled();
-        });
-
-        test('should handle addVote action', async () => {
-            const voter = { accountId: 'user-1', displayName: 'Test User' };
-            const msg = {
-                action: 'addVote',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                voter,
-                nonce: 'nonce-123',
-            };
-
-            jiraIssueWebview['_editUIData'].fieldValues['votes'] = {
-                votes: 0,
-                voters: [],
-                hasVoted: false,
-            };
-
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
-
-            await jiraIssueWebview['onMessageReceived'](msg);
-
-            expect(mockJiraClient.addVote).toHaveBeenCalledWith(mockIssue.key);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].voters).toContain(voter);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].votes).toBe(1);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].hasVoted).toBe(true);
-            expect(postMessageSpy).toHaveBeenCalled();
-        });
-
-        test('should handle removeVote action', async () => {
-            const voter = { accountId: 'user-1', displayName: 'Test User' };
-            const msg = {
-                action: 'removeVote',
-                site: mockSiteDetails,
-                issueKey: mockIssue.key,
-                voter,
-                nonce: 'nonce-123',
-            };
-
-            jiraIssueWebview['_editUIData'].fieldValues['votes'] = {
-                votes: 1,
-                voters: [voter],
-                hasVoted: true,
-            };
-
-            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
-
-            await jiraIssueWebview['onMessageReceived'](msg);
-
-            expect(mockJiraClient.removeVote).toHaveBeenCalledWith(mockIssue.key);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].voters).not.toContain(voter);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].votes).toBe(0);
-            expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].hasVoted).toBe(false);
-            expect(postMessageSpy).toHaveBeenCalled();
+                expect(mockJiraClient.removeVote).toHaveBeenCalledWith(mockIssue.key);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].voters).toHaveLength(1);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].votes).toBe(1);
+                expect(jiraIssueWebview['_editUIData'].fieldValues['votes'].hasVoted).toBe(false);
+                expect(postMessageSpy).toHaveBeenCalled();
+            });
         });
 
         test('should handle addAttachments action', async () => {

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -1248,7 +1248,13 @@ export class JiraIssueWebview
                         handled = true;
                         try {
                             const client = await Container.clientManager.jiraClient(msg.site);
-                            await client.removeWatcher(msg.issueKey, msg.watcher.accountId);
+                            const isCloud = msg.site.isCloud;
+                            const msgWatcherAccountId = msg.watcher.accountId; // undefined for Server/Data Center
+                            const msgWatcherKey = msg.watcher.key; // undefined for Cloud
+                            const query = isCloud ? { accountId: msgWatcherAccountId } : { username: msgWatcherKey };
+
+                            await client.removeWatcher(msg.issueKey, query);
+
                             if (
                                 !this._editUIData.fieldValues['watches'] ||
                                 !this._editUIData.fieldValues['watches'].watchers ||
@@ -1257,13 +1263,19 @@ export class JiraIssueWebview
                                 this._editUIData.fieldValues['watches'].watchers = [];
                             }
                             const foundIndex: number = this._editUIData.fieldValues['watches'].watchers.findIndex(
-                                (user: User) => user.accountId === msg.watcher.accountId,
+                                (user: User) => {
+                                    const isAccountIdEqual = user.accountId === msgWatcherAccountId;
+                                    const isUsernameEqual = user.key && msgWatcherKey && user.key === msgWatcherKey;
+                                    return isCloud ? isAccountIdEqual : isUsernameEqual;
+                                },
                             );
                             if (foundIndex > -1) {
                                 this._editUIData.fieldValues['watches'].watchers.splice(foundIndex, 1);
                             }
-
-                            if (msg.watcher.accountId === this._currentUser.accountId) {
+                            const isCurrentUserWatcher = isCloud
+                                ? msgWatcherAccountId === this._currentUser.accountId
+                                : msgWatcherKey === this._currentUser.key;
+                            if (isCurrentUserWatcher) {
                                 this._editUIData.fieldValues['watches'].isWatching = false;
                             }
 


### PR DESCRIPTION
* AXON-690 fix stop watching error for DC

* AXON-690 removes log message and fixes spelling issue

* AXON-690 update version of jira-pi-client

* AXON-690 update unit tests

* AXON-690 slightly increases test coverage and groups the tests.

### What Is This Change?
This PR restores fix for errror that appears on "stop watching", that was previously removed in https://github.com/atlassian/atlascode/pull/1598
<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [x] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

