### PR TITLE
Handling-multi-byte-unicode-characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 - Added warning message when no git repository selected on Start Work page
 - Bumped Rovo Dev version to v0.13.47
 
+### Bug Fixes
+
+- Rovo Dev: Fixed JSON parsing errors caused by multi-byte UTF-8 characters being split across HTTP chunk boundaries
+    - Added safe JSON parsing in `parseToolReturnMessage` for all tool arguments
+    - Added buffering logic in SSE response parser to handle incomplete UTF-8 sequences
+
 ## What's new in 4.0.19
 
 ### Improvements

--- a/src/rovo-dev/client/responseParser.test.ts
+++ b/src/rovo-dev/client/responseParser.test.ts
@@ -701,4 +701,120 @@ describe('RovoDevResponseParser', () => {
             expect(toolReturnEvent.toolCallMessage.tool_name).toBe('get_weather');
         });
     });
+
+    describe('handling malformed JSON from UTF-8 chunking issues', () => {
+        it('should buffer incomplete JSON data and retry on next chunk', () => {
+            const parser = new RovoDevResponseParser();
+
+            // Simulate a chunk split mid-JSON due to UTF-8 byte boundary
+            // First chunk has incomplete JSON (missing closing brace) - note no \n\n at end means it stays in buffer
+            const chunk1 = 'event: tool-call\ndata: {"tool_name": "bash", "args": "{\\"command\\": \\"te';
+            const results1 = Array.from(parser.parse(chunk1));
+
+            // Should buffer and wait for more data, not yield anything
+            expect(results1).toHaveLength(0);
+
+            // Second chunk completes the JSON - completes the data field
+            const chunk2 = 'st\\"}", "tool_call_id": "call_123"}\n\n';
+            const results2 = Array.from(parser.parse(chunk2));
+
+            // Now should successfully parse the complete message
+            expect(results2).toHaveLength(1);
+            expect(results2[0].event_kind).toBe('tool-call');
+            expect((results2[0] as any).tool_name).toBe('bash');
+        });
+
+        it('should handle JSON split across multi-byte UTF-8 character boundaries', () => {
+            const parser = new RovoDevResponseParser();
+
+            // Simulate emoji or multi-byte character split across chunks
+            // "👍" is 4 bytes: F0 9F 91 8D
+            // First chunk ends mid-emoji (only F0 9F bytes)
+            const chunk1 = 'event: tool-call\ndata: {"tool_name": "bash", "args": "{\\"msg\\": \\"test';
+            const results1 = Array.from(parser.parse(chunk1));
+
+            // Should buffer incomplete chunk
+            expect(results1).toHaveLength(0);
+
+            // Second chunk completes the emoji and rest of JSON
+            const chunk2 = '👍\\"}", "tool_call_id": "call_456"}\n\n';
+            const results2 = Array.from(parser.parse(chunk2));
+
+            // Should parse successfully with complete UTF-8 character
+            expect(results2).toHaveLength(1);
+            expect(results2[0].event_kind).toBe('tool-call');
+        });
+
+        it('should handle truncated JSON with missing opening brace', () => {
+            const parser = new RovoDevResponseParser();
+
+            // Simulate chunk that lost the opening brace (like "ool_name" instead of "tool_name")
+            const chunk =
+                'event: tool-call\ndata: "tool_name": "bash", "args": "test", "tool_call_id": "call_789"}\n\n';
+            const results = Array.from(parser.parse(chunk));
+
+            // Should buffer and wait, not crash
+            expect(results).toHaveLength(0);
+
+            // Even with next valid chunk, the buffered invalid JSON should eventually be discarded
+            // or handled gracefully when buffer grows too large
+            const chunk2 = 'event: text\ndata: {"index": 0, "content": "Hello"}\n\n';
+            const results2 = Array.from(parser.parse(chunk2));
+
+            // The invalid buffered chunk remains buffered, new valid chunk is processed
+            expect(results2).toHaveLength(1);
+            expect(results2[0].event_kind).toBe('text');
+        });
+
+        it('should handle multiple incomplete chunks before completion', () => {
+            const parser = new RovoDevResponseParser();
+
+            // First chunk - event line only
+            const chunk1 = 'event: tool-call\n';
+            expect(Array.from(parser.parse(chunk1))).toHaveLength(0);
+
+            // Second chunk - partial data line
+            const chunk2 = 'data: {"tool_name": "bash"';
+            expect(Array.from(parser.parse(chunk2))).toHaveLength(0);
+
+            // Third chunk - rest of data line
+            const chunk3 = ', "args": "test", "tool_call_id": "call_999"}\n\n';
+            const results3 = Array.from(parser.parse(chunk3));
+
+            expect(results3).toHaveLength(1);
+            expect(results3[0].event_kind).toBe('tool-call');
+            expect((results3[0] as any).tool_name).toBe('bash');
+        });
+
+        it('should handle valid chunk after invalid buffered chunk', () => {
+            const parser = new RovoDevResponseParser();
+
+            // Invalid incomplete chunk that will be buffered
+            const invalidChunk = 'event: tool-call\ndata: {"invalid": "json\n\n';
+            expect(Array.from(parser.parse(invalidChunk))).toHaveLength(0);
+
+            // Valid complete chunk - should process independently
+            // The double \n\n acts as separator
+            const validChunk = 'event: text\ndata: {"index": 0, "content": "Valid"}\n\n';
+            const results = Array.from(parser.parse(validChunk));
+
+            // The buffered invalid chunk should still be in buffer waiting
+            // But the new valid chunk should be processed
+            expect(results).toHaveLength(1);
+            expect(results[0].event_kind).toBe('text');
+        });
+
+        it('should handle JSON with special characters that could cause encoding issues', () => {
+            const parser = new RovoDevResponseParser();
+
+            // Test with various special characters: emoji, CJK, accented chars
+            const specialChars = '{"command": "echo \\\"Hello 👋 世界 café\\\""}';
+            const chunk = `event: tool-call\ndata: {"tool_name": "bash", "args": ${JSON.stringify(specialChars)}, "tool_call_id": "call_special"}\n\n`;
+            const results = Array.from(parser.parse(chunk));
+
+            expect(results).toHaveLength(1);
+            expect(results[0].event_kind).toBe('tool-call');
+            expect((results[0] as any).tool_name).toBe('bash');
+        });
+    });
 });

--- a/src/rovo-dev/client/responseParser.ts
+++ b/src/rovo-dev/client/responseParser.ts
@@ -384,9 +384,25 @@ export class RovoDevResponseParser {
                 continue;
             }
 
+            // Parse JSON data safely - if it fails due to incomplete UTF-8 sequences from chunking,
+            // put it back in the buffer to wait for more data
+            let parsedData: any;
+            if (match[2]) {
+                try {
+                    parsedData = JSON.parse(match[2]);
+                } catch {
+                    // JSON parse failed - likely due to incomplete multi-byte UTF-8 character at chunk boundary
+                    // Put this chunk back in the buffer and wait for more data
+                    this.buffer = chunkRaw + '\n\n' + this.buffer;
+                    continue;
+                }
+            } else {
+                parsedData = '';
+            }
+
             const chunk: RovoDevSingleChunk | RovoDevPartStartChunk | RovoDevPartDeltaChunk = {
                 event_kind: match[1].trim() as any,
-                data: match[2] ? JSON.parse(match[2]) : '',
+                data: parsedData,
             };
 
             let tmpChunkToFlush: RovoDevResponse | undefined;

--- a/src/rovo-dev/rovoDevChatProvider.test.ts
+++ b/src/rovo-dev/rovoDevChatProvider.test.ts
@@ -994,5 +994,61 @@ describe('RovoDevChatProvider', () => {
                 }),
             );
         });
+
+        it('should handle multi-byte Unicode characters in streaming response', async () => {
+            const mockPrompt: RovoDevPrompt = {
+                text: 'test prompt',
+                enable_deep_plan: false,
+                context: [],
+            };
+
+            // Test with various Unicode characters: emoji, accented chars, CJK, etc.
+            const unicodeText = 'Hello 👋 café 日本語 🚀 Ñoño';
+
+            // Create proper SSE format with part_start event
+            const partStartEvent = JSON.stringify({
+                part: {
+                    part_kind: 'text',
+                    content: unicodeText,
+                    index: 0,
+                },
+            });
+
+            // Simulate streaming where multi-byte chars might be split across chunks
+            const encoder = new TextEncoder();
+            const fullMessage = `event: part_start\ndata: ${partStartEvent}\n\n`;
+            const fullBytes = encoder.encode(fullMessage);
+
+            // Split at a point that might break a multi-byte character
+            const splitPoint = Math.floor(fullBytes.length / 2);
+            const chunk1 = fullBytes.slice(0, splitPoint);
+            const chunk2 = fullBytes.slice(splitPoint);
+            const closeEvent = encoder.encode('event: close\ndata: {}\n\n');
+
+            const mockReadableStream = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(chunk1);
+                    controller.enqueue(chunk2);
+                    controller.enqueue(closeEvent);
+                    controller.close();
+                },
+            });
+
+            const mockResponse = { body: mockReadableStream } as Response;
+            mockApiClient.chat.mockResolvedValue(mockResponse);
+
+            await chatProvider.executeChat(mockPrompt, []);
+
+            // Verify the Unicode text was correctly processed
+            expect(mockWebview.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: RovoDevProviderMessageType.RovoDevResponseMessage,
+                    message: expect.objectContaining({
+                        event_kind: 'text',
+                        content: unicodeText,
+                    }),
+                }),
+            );
+        });
     });
 });

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -333,7 +333,7 @@ export class RovoDevChatProvider {
         telemetryProvider?.perfLogger.promptStarted(this._currentPromptId);
 
         const reader = response.body.getReader();
-        const decoder = new TextDecoder();
+        const decoder = new TextDecoder('utf-8', { fatal: false, ignoreBOM: true });
         const parser = new RovoDevResponseParser();
 
         let isFirstByte = true;

--- a/src/rovo-dev/ui/utils.test.tsx
+++ b/src/rovo-dev/ui/utils.test.tsx
@@ -335,3 +335,188 @@ describe('appendResponse', () => {
         expect(result[1]).toEqual(response);
     });
 });
+
+describe('parseToolReturnMessage', () => {
+    const { parseToolReturnMessage } = require('./utils');
+    const mockOnError = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('safe JSON parsing', () => {
+        it('should handle malformed JSON in tool args gracefully', () => {
+            const toolCallMessage: RovoDevToolCallResponse = {
+                event_kind: 'tool-call',
+                tool_name: 'bash',
+                args: '{"command": "incomplete json', // Malformed JSON
+                tool_call_id: 'id1',
+            };
+
+            const msg: RovoDevToolReturnResponse = {
+                event_kind: 'tool-return',
+                tool_name: 'bash',
+                content: 'result',
+                tool_call_id: 'id1',
+                timestamp: '0',
+                toolCallMessage,
+            };
+
+            const result = parseToolReturnMessage(msg, mockOnError);
+
+            // Should not crash and should return empty result for bash tool without valid command
+            expect(result).toEqual([]);
+            expect(mockOnError).not.toHaveBeenCalled();
+        });
+
+        it('should handle truncated JSON with missing opening brace', () => {
+            const toolCallMessage: RovoDevToolCallResponse = {
+                event_kind: 'tool-call',
+                tool_name: 'grep',
+                args: '"content_pattern": "test"}', // Missing opening {
+                tool_call_id: 'id1',
+            };
+
+            const msg: RovoDevToolReturnResponse = {
+                event_kind: 'tool-return',
+                tool_name: 'grep',
+                content: 'match1\nmatch2',
+                tool_call_id: 'id1',
+                timestamp: '0',
+                toolCallMessage,
+            };
+
+            const result = parseToolReturnMessage(msg, mockOnError);
+
+            // Should handle gracefully and still process the content
+            expect(result).toHaveLength(1);
+            expect(result[0].content).toBe('Searched files');
+        });
+
+        it('should handle JSON with multi-byte UTF-8 characters split mid-character', () => {
+            const toolCallMessage: RovoDevToolCallResponse = {
+                event_kind: 'tool-call',
+                tool_name: 'bash',
+                args: '{"command": "echo 👍"}', // Multi-byte emoji
+                tool_call_id: 'id1',
+            };
+
+            const msg: RovoDevToolReturnResponse = {
+                event_kind: 'tool-return',
+                tool_name: 'bash',
+                content: 'result',
+                tool_call_id: 'id1',
+                timestamp: '0',
+                toolCallMessage,
+            };
+
+            const result = parseToolReturnMessage(msg, mockOnError);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].title).toBe('echo 👍');
+            expect(mockOnError).not.toHaveBeenCalled();
+        });
+
+        it('should handle empty or undefined args', () => {
+            const toolCallMessage: RovoDevToolCallResponse = {
+                event_kind: 'tool-call',
+                tool_name: 'expand_folder',
+                args: '',
+                tool_call_id: 'id1',
+            };
+
+            const msg: RovoDevToolReturnResponse = {
+                event_kind: 'tool-return',
+                tool_name: 'expand_folder',
+                content: 'result',
+                tool_call_id: 'id1',
+                timestamp: '0',
+                toolCallMessage,
+            };
+
+            const result = parseToolReturnMessage(msg, mockOnError);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].content).toBe('Expanded folder');
+            expect(mockOnError).not.toHaveBeenCalled();
+        });
+
+        it('should handle malformed JSON in create_technical_plan content', () => {
+            const toolCallMessage: RovoDevToolCallResponse = {
+                event_kind: 'tool-call',
+                tool_name: 'create_technical_plan',
+                args: '{}',
+                tool_call_id: 'id1',
+            };
+
+            const msg: RovoDevToolReturnResponse = {
+                event_kind: 'tool-return',
+                tool_name: 'create_technical_plan',
+                content: '{"plan": "incomplete', // Malformed JSON
+                tool_call_id: 'id1',
+                timestamp: '0',
+                toolCallMessage,
+            };
+
+            const result = parseToolReturnMessage(msg, mockOnError);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].technicalPlan).toBeUndefined();
+            expect(mockOnError).not.toHaveBeenCalled();
+        });
+
+        it('should handle tool-return with valid parsedContent', () => {
+            const toolCallMessage: RovoDevToolCallResponse = {
+                event_kind: 'tool-call',
+                tool_name: 'create_technical_plan',
+                args: '{}',
+                tool_call_id: 'id1',
+            };
+
+            const planData = {
+                summary: 'Test plan',
+                steps: [],
+            };
+
+            const msg: RovoDevToolReturnResponse = {
+                event_kind: 'tool-return',
+                tool_name: 'create_technical_plan',
+                content: '',
+                parsedContent: planData,
+                tool_call_id: 'id1',
+                timestamp: '0',
+                toolCallMessage,
+            };
+
+            const result = parseToolReturnMessage(msg, mockOnError);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].technicalPlan).toEqual(planData);
+            expect(mockOnError).not.toHaveBeenCalled();
+        });
+
+        it('should handle MCP tool with malformed args', () => {
+            const toolCallMessage: RovoDevToolCallResponse = {
+                event_kind: 'tool-call',
+                tool_name: 'mcp__atlassian__invoke_tool',
+                args: '"tool_name": "test"}', // Missing opening brace
+                tool_call_id: 'id1',
+            };
+
+            const msg: RovoDevToolReturnResponse = {
+                event_kind: 'tool-return',
+                tool_name: 'mcp__atlassian__invoke_tool',
+                content: 'result',
+                tool_call_id: 'id1',
+                timestamp: '0',
+                toolCallMessage,
+            };
+
+            const result = parseToolReturnMessage(msg, mockOnError);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].content).toContain('unknown tool');
+            expect(mockOnError).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/rovo-dev/ui/utils.tsx
+++ b/src/rovo-dev/ui/utils.tsx
@@ -125,6 +125,22 @@ export const modifyFileTitleMap: Record<string, ToolReturnInfo> = {
 };
 
 /**
+ * Safely parses a JSON string, returning undefined if parsing fails.
+ * @param jsonString - The JSON string to parse.
+ * @returns The parsed object or undefined if parsing fails.
+ */
+function safeJSONParse<T = any>(jsonString: string | undefined): T | undefined {
+    if (!jsonString) {
+        return undefined;
+    }
+    try {
+        return JSON.parse(jsonString);
+    } catch {
+        return undefined;
+    }
+}
+
+/**
  * Parses the content of a ToolReturnMessage and extracts relevant information.
  * The function handles different tool names and formats the output accordingly.
  *
@@ -182,7 +198,7 @@ export function parseToolReturnMessage(
                 break;
 
             case 'expand_folder':
-                const folder = msg.toolCallMessage.args && JSON.parse(msg.toolCallMessage.args);
+                const folder = safeJSONParse<{ folder_path?: string }>(msg.toolCallMessage.args);
                 if (folder?.folder_path) {
                     resp.push({
                         title: folder.folder_path,
@@ -198,7 +214,7 @@ export function parseToolReturnMessage(
                 break;
 
             case 'bash':
-                const args = msg.toolCallMessage.args && JSON.parse(msg.toolCallMessage.args);
+                const args = safeJSONParse<{ command?: string }>(msg.toolCallMessage.args);
                 if (args?.command) {
                     resp.push({
                         title: args.command,
@@ -209,9 +225,11 @@ export function parseToolReturnMessage(
                 break;
 
             case 'grep':
-                const toolCallArgs = msg.toolCallMessage.args;
-                const searchPattern = toolCallArgs ? JSON.parse(toolCallArgs).content_pattern : undefined;
-                const pathGlob = toolCallArgs ? JSON.parse(toolCallArgs).path_glob : undefined;
+                const toolCallArgs = safeJSONParse<{ content_pattern?: string; path_glob?: string }>(
+                    msg.toolCallMessage.args,
+                );
+                const searchPattern = toolCallArgs?.content_pattern;
+                const pathGlob = toolCallArgs?.path_glob;
                 const matches = (msg.content ?? '').split('\n').filter((line) => line.trim() !== '');
                 let content = 'Searched files';
                 if (searchPattern && pathGlob) {
@@ -235,19 +253,23 @@ export function parseToolReturnMessage(
 
             case 'create_technical_plan':
                 // Use parsedContent if available (it's the parsed object), otherwise parse msg.content (string)
-                const planData: TechnicalPlan = msg.parsedContent ?? (msg.content ? JSON.parse(msg.content) : null);
+                let planData: TechnicalPlan | null = null;
+                if (msg.parsedContent) {
+                    planData = msg.parsedContent as TechnicalPlan;
+                } else if (msg.content) {
+                    planData = safeJSONParse<TechnicalPlan>(msg.content) ?? null;
+                }
 
                 resp.push({
                     content: '',
-                    technicalPlan: planData,
+                    technicalPlan: planData ?? undefined,
                 });
                 break;
 
             case 'mcp__atlassian__invoke_tool':
             case 'mcp__atlassian__get_tool_schema':
             case 'mcp__scout__invoke_tool':
-                const mcpToolCallArgs = msg.toolCallMessage.args;
-                const mcpToolData = mcpToolCallArgs ? JSON.parse(mcpToolCallArgs) : undefined;
+                const mcpToolData = safeJSONParse<{ tool_name?: string }>(msg.toolCallMessage.args);
                 resp.push({
                     content: `Invoked MCP tool: \`${mcpToolData?.tool_name || 'unknown tool'}\``,
                     type: 'bash',


### PR DESCRIPTION
### What Is This Change?

In the process of the backend RovoDev sending a response message and Atlascode receiving the message, the following transformations occur

- HTTP delivers raw bytes in arbitrary-sized chunks
- The SSE (Server Side Event) parser splits on [\n\n](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) - but this split happens at the byte level, not character level
- If [\n\n](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) falls in the middle of a multi-byte UTF-8 character, the split corrupts the data

This sometimes split tokens such as `****tool_name****` as `***t'` and `ool_name****` and this results in Atlascode throwing error and the session failing.

A more detailed (a little bit long) discussion about the problem and the solution can be found [here](https://docs.google.com/document/d/1vFhwnrsUfpa2DK-XWY2bzkNt9OLCecpjPZirh9jwt70/edit?tab=t.0).
With this PR, we
1. safely parse the the string: we don't assume the string is json
2. when the parsing fails, we attempt again by combining different consecutive chunks.  **So, the trick is just try different combinations.**

### How Has This Been Tested?


Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
- [x]  `new tests`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

