### PR TITLE
fix(jira): wiki markup formatting/html rendering #1560

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - Rovo Dev: Agent model selection both via /models command, and dedicated drop-down menu
 
+### Bug Fixes
+
+- Fixed Jira comments losing wiki markup formatting when posted or updated - comments now fetch and preserve server-rendered HTML content
+
 ## What's new in 4.0.21
 
 ### Bug Fixes

--- a/src/commands/jira/postComment.test.ts
+++ b/src/commands/jira/postComment.test.ts
@@ -1,0 +1,273 @@
+import { Comment, CommentVisibility, IssueKeyAndSite } from '@atlassianlabs/jira-pi-common-models';
+
+import { issueCommentEvent } from '../../analytics';
+import { DetailedSiteInfo } from '../../atlclients/authInfo';
+import { Container } from '../../container';
+import { Logger } from '../../logger';
+import { fetchCommentWithRenderedBody, postComment } from './postComment';
+
+jest.mock('../../container');
+jest.mock('../../analytics');
+jest.mock('../../logger');
+
+describe('postComment', () => {
+    const mockSiteDetails: DetailedSiteInfo = {
+        userId: 'user-123',
+        id: 'site-1',
+        name: 'Test Site',
+        avatarUrl: 'https://example.com/avatar.png',
+        baseLinkUrl: 'https://example.com',
+        baseApiUrl: 'https://example.com/rest/api',
+        isCloud: true,
+        credentialId: 'cred-1',
+        host: 'example.com',
+        product: {
+            name: 'JIRA',
+            key: 'jira',
+        },
+    };
+
+    const mockIssue: IssueKeyAndSite<DetailedSiteInfo> = {
+        key: 'TEST-123',
+        siteDetails: mockSiteDetails,
+    };
+
+    const mockComment: Comment = {
+        id: 'comment-1',
+        body: 'Test comment',
+        renderedBody: '<p>Test comment</p>',
+        author: {
+            accountId: 'user-123',
+            displayName: 'Test User',
+            avatarUrls: {
+                '16x16': 'https://example.com/16x16',
+                '24x24': 'https://example.com/24x24',
+                '32x32': 'https://example.com/32x32',
+                '48x48': 'https://example.com/48x48',
+            },
+            active: true,
+            emailAddress: 'test@example.com',
+            key: 'user-123',
+            self: 'https://example.com/user/123',
+            timeZone: 'UTC',
+        },
+        created: '2023-01-01T12:00:00Z',
+        updated: '2023-01-01T12:00:00Z',
+        self: 'https://example.com/comment/1',
+        visibility: undefined,
+        jsdPublic: false,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Setup Container mocks with proper structure using Object.defineProperty
+        const mockClientManager = {
+            jiraClient: jest.fn(),
+        };
+        const mockAnalyticsClient = {
+            sendTrackEvent: jest.fn(),
+        };
+
+        Object.defineProperty(Container, 'clientManager', {
+            value: mockClientManager,
+            writable: true,
+            configurable: true,
+        });
+
+        Object.defineProperty(Container, 'analyticsClient', {
+            value: mockAnalyticsClient,
+            writable: true,
+            configurable: true,
+        });
+    });
+
+    describe('postComment', () => {
+        it('should post a new comment to Cloud', async () => {
+            const mockClient = {
+                addComment: jest.fn().mockResolvedValue(mockComment),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+            (issueCommentEvent as jest.Mock).mockResolvedValue({ event: 'test' });
+            (Container.analyticsClient.sendTrackEvent as jest.Mock).mockReturnValue(undefined);
+
+            const commentBody = 'New comment';
+            const result = await postComment(mockIssue, commentBody);
+
+            expect(result).toEqual(mockComment);
+            expect(mockClient.addComment).toHaveBeenCalledWith('TEST-123', commentBody, undefined);
+        });
+
+        it('should post a new comment to DC with converted string body', async () => {
+            const dcSiteDetails: DetailedSiteInfo = { ...mockSiteDetails, isCloud: false };
+            const dcIssue: IssueKeyAndSite<DetailedSiteInfo> = {
+                ...mockIssue,
+                siteDetails: dcSiteDetails,
+            };
+
+            const mockClient = {
+                addComment: jest.fn().mockResolvedValue(mockComment),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+            (issueCommentEvent as jest.Mock).mockResolvedValue({ event: 'test' });
+            (Container.analyticsClient.sendTrackEvent as jest.Mock).mockReturnValue(undefined);
+
+            const commentBody = { type: 'doc', version: 1, content: [] };
+            const result = await postComment(dcIssue, commentBody);
+
+            expect(result).toEqual(mockComment);
+            expect(mockClient.addComment).toHaveBeenCalled();
+        });
+
+        it('should update an existing comment', async () => {
+            const mockClient = {
+                updateComment: jest.fn().mockResolvedValue(mockComment),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+            (issueCommentEvent as jest.Mock).mockResolvedValue({ event: 'test' });
+            (Container.analyticsClient.sendTrackEvent as jest.Mock).mockReturnValue(undefined);
+
+            const commentBody = 'Updated comment';
+            const result = await postComment(mockIssue, commentBody, 'comment-1');
+
+            expect(result).toEqual(mockComment);
+            expect(mockClient.updateComment).toHaveBeenCalledWith('TEST-123', 'comment-1', commentBody, undefined);
+        });
+
+        it('should post a comment with visibility restriction', async () => {
+            const mockClient = {
+                addComment: jest.fn().mockResolvedValue(mockComment),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+            (issueCommentEvent as jest.Mock).mockResolvedValue({ event: 'test' });
+            (Container.analyticsClient.sendTrackEvent as jest.Mock).mockReturnValue(undefined);
+
+            const commentBody = 'Restricted comment';
+            const visibility: CommentVisibility = { type: 'group', value: 'jira-developers' };
+            const result = await postComment(mockIssue, commentBody, undefined, visibility);
+
+            expect(result).toEqual(mockComment);
+            expect(mockClient.addComment).toHaveBeenCalledWith('TEST-123', commentBody, visibility);
+        });
+
+        it('should send an analytics event after posting a comment', async () => {
+            const mockAnalyticsEvent = { event: 'issue.comment.created' };
+            const mockClient = {
+                addComment: jest.fn().mockResolvedValue(mockComment),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+            (issueCommentEvent as jest.Mock).mockResolvedValue(mockAnalyticsEvent);
+
+            await postComment(mockIssue, 'New comment');
+
+            expect(issueCommentEvent).toHaveBeenCalledWith(mockSiteDetails);
+            expect(Container.analyticsClient.sendTrackEvent).toHaveBeenCalledWith(mockAnalyticsEvent);
+        });
+    });
+
+    describe('fetchCommentWithRenderedBody', () => {
+        it('should fetch a comment with renderedBody', async () => {
+            const mockClient = {
+                getComment: jest.fn().mockResolvedValue(mockComment),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+
+            const result = await fetchCommentWithRenderedBody(mockIssue, 'comment-1');
+
+            expect(result).toEqual(mockComment);
+            expect(mockClient.getComment).toHaveBeenCalledWith('TEST-123', 'comment-1', 'renderedBody');
+        });
+
+        it('should return comment with empty renderedBody if not provided', async () => {
+            const commentWithoutRenderedBody: Comment = {
+                ...mockComment,
+                renderedBody: undefined,
+            };
+
+            const mockClient = {
+                getComment: jest.fn().mockResolvedValue(commentWithoutRenderedBody),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+
+            const result = await fetchCommentWithRenderedBody(mockIssue, 'comment-1');
+
+            expect(result).toEqual(commentWithoutRenderedBody);
+            expect(mockClient.getComment).toHaveBeenCalledWith('TEST-123', 'comment-1', 'renderedBody');
+        });
+
+        it('should handle errors gracefully and log them', async () => {
+            const mockError = new Error('Failed to fetch comment');
+            const mockClient = {
+                getComment: jest.fn().mockRejectedValue(mockError),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+
+            await expect(fetchCommentWithRenderedBody(mockIssue, 'comment-1')).rejects.toThrow(mockError);
+
+            expect(Logger.error).toHaveBeenCalledWith(mockError, expect.stringContaining('Failed to fetch comment'));
+        });
+
+        it('should include issue key and comment ID in error message', async () => {
+            const mockError = new Error('Network error');
+            const mockClient = {
+                getComment: jest.fn().mockRejectedValue(mockError),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+
+            await expect(fetchCommentWithRenderedBody(mockIssue, 'comment-123')).rejects.toThrow('Network error');
+
+            expect(Logger.error).toHaveBeenCalledWith(mockError, expect.stringContaining('comment-123'));
+            expect(Logger.error).toHaveBeenCalledWith(mockError, expect.stringContaining('TEST-123'));
+        });
+
+        it('should work with different site types (Cloud)', async () => {
+            const mockClient = {
+                getComment: jest.fn().mockResolvedValue(mockComment),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+
+            const result = await fetchCommentWithRenderedBody(mockIssue, 'comment-1');
+
+            expect(result).toEqual(mockComment);
+        });
+
+        it('should work with different site types (DC)', async () => {
+            const dcSiteDetails: DetailedSiteInfo = { ...mockSiteDetails, isCloud: false };
+            const dcIssue: IssueKeyAndSite<DetailedSiteInfo> = {
+                ...mockIssue,
+                siteDetails: dcSiteDetails,
+            };
+
+            const mockClient = {
+                getComment: jest.fn().mockResolvedValue(mockComment),
+                authorizationProvider: jest.fn(),
+            };
+
+            (Container.clientManager.jiraClient as jest.Mock).mockResolvedValue(mockClient);
+
+            const result = await fetchCommentWithRenderedBody(dcIssue, 'comment-1');
+
+            expect(result).toEqual(mockComment);
+            expect(mockClient.getComment).toHaveBeenCalledWith('TEST-123', 'comment-1', 'renderedBody');
+        });
+    });
+});

--- a/src/commands/jira/postComment.ts
+++ b/src/commands/jira/postComment.ts
@@ -3,6 +3,7 @@ import { Comment, CommentVisibility, IssueKeyAndSite } from '@atlassianlabs/jira
 import { issueCommentEvent } from '../../analytics';
 import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { Container } from '../../container';
+import { Logger } from '../../logger';
 import { commentBodyToString } from '../../util/adfToCommentBody';
 
 /** DC expects comment body as string; Cloud accepts ADF. Normalize only for DC. */
@@ -26,4 +27,30 @@ export async function postComment(
     });
 
     return resp;
+}
+
+/**
+ * Fetches a comment with its renderedBody field populated.
+ * This ensures wiki markup formatting is preserved when displaying comments.
+ *
+ * @param issue - The issue containing the comment
+ * @param commentId - The ID of the comment to fetch
+ * @returns Promise<Comment> with renderedBody populated
+ */
+export async function fetchCommentWithRenderedBody(
+    issue: IssueKeyAndSite<DetailedSiteInfo>,
+    commentId: string,
+): Promise<Comment> {
+    try {
+        const client = await Container.clientManager.jiraClient(issue.siteDetails);
+
+        // Fetch comment with expand parameter to get renderedBody
+        // The expand parameter requests additional fields including HTML-rendered content
+        const comment = await (client as any).getComment(issue.key, commentId, 'renderedBody');
+
+        return comment;
+    } catch (error) {
+        Logger.error(error, `Failed to fetch comment ${commentId} with renderedBody for issue ${issue.key}`);
+        throw error;
+    }
 }

--- a/src/webviews/components/AdfAwareContent.test.tsx
+++ b/src/webviews/components/AdfAwareContent.test.tsx
@@ -1,0 +1,370 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { AdfAwareContent } from './AdfAwareContent';
+import { AtlascodeMentionProvider } from './issue/common/AtlaskitEditor/AtlascodeMentionsProvider';
+
+jest.mock('@atlaskit/renderer', () => ({
+    ReactRenderer: ({ document, 'data-test-id': testId }: any) => <div data-testid={testId}>Rendered ADF Content</div>,
+}));
+
+jest.mock('react-intl-next', () => ({
+    IntlProvider: ({ children }: any) => children,
+}));
+
+describe('AdfAwareContent', () => {
+    const mockMentionProvider: AtlascodeMentionProvider = {
+        search: jest.fn(),
+        shouldHighlightMention: jest.fn(),
+        recordMentionSelection: jest.fn(),
+    } as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('Valid ADF content', () => {
+        it('should render valid ADF string content', () => {
+            const validAdf = JSON.stringify({
+                type: 'doc',
+                version: 1,
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Hello world',
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            const { container } = render(<AdfAwareContent content={validAdf} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByTestId('adf-renderer')).toBeDefined();
+            expect(screen.getByText('Rendered ADF Content')).toBeDefined();
+            expect(container.firstChild).toMatchSnapshot();
+        });
+
+        it('should render valid ADF object content', () => {
+            const validAdfObject = {
+                type: 'doc',
+                version: 1,
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Test content',
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            render(<AdfAwareContent content={validAdfObject as any} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByTestId('adf-renderer')).toBeDefined();
+        });
+
+        it('should render ADF with complex content structure', () => {
+            const complexAdf = JSON.stringify({
+                type: 'doc',
+                version: 1,
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Bold text: ',
+                            },
+                            {
+                                type: 'text',
+                                text: 'important',
+                                marks: [
+                                    {
+                                        type: 'strong',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        type: 'bulletList',
+                        content: [
+                            {
+                                type: 'listItem',
+                                content: [
+                                    {
+                                        type: 'paragraph',
+                                        content: [
+                                            {
+                                                type: 'text',
+                                                text: 'Item 1',
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            render(<AdfAwareContent content={complexAdf} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByTestId('adf-renderer')).toBeDefined();
+        });
+
+        it('should render ADF with mentions', () => {
+            const adfWithMentions = JSON.stringify({
+                type: 'doc',
+                version: 1,
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Hey ',
+                            },
+                            {
+                                type: 'mention',
+                                attrs: {
+                                    id: 'user-123',
+                                    text: '@John',
+                                },
+                            },
+                            {
+                                type: 'text',
+                                text: ', check this out',
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            render(<AdfAwareContent content={adfWithMentions} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByTestId('adf-renderer')).toBeDefined();
+        });
+    });
+
+    describe('Invalid ADF content', () => {
+        it('should render empty when content is null', () => {
+            render(<AdfAwareContent content={null as any} mentionProvider={mockMentionProvider} />);
+
+            // When content is null, React renders <p /> (empty paragraph)
+            const paragraph = screen.getByRole('paragraph');
+            expect(paragraph.textContent).toBe('');
+        });
+
+        it('should render empty when content is undefined', () => {
+            render(<AdfAwareContent content={undefined as any} mentionProvider={mockMentionProvider} />);
+
+            // When content is undefined, React renders <p /> (empty paragraph)
+            const paragraph = screen.getByRole('paragraph');
+            expect(paragraph.textContent).toBe('');
+        });
+
+        it('should render empty when content is empty string', () => {
+            render(<AdfAwareContent content="" mentionProvider={mockMentionProvider} />);
+
+            // When content is empty string, React renders <p /> (empty paragraph)
+            const paragraph = screen.getByRole('paragraph');
+            expect(paragraph.textContent).toBe('');
+        });
+
+        it('should render plain text for invalid JSON', () => {
+            const invalidJson = '{invalid json}';
+
+            render(<AdfAwareContent content={invalidJson} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByText(invalidJson)).toBeDefined();
+        });
+
+        it('should render plain text for missing type field', () => {
+            const noType = JSON.stringify({
+                version: 1,
+                content: [],
+            });
+
+            render(<AdfAwareContent content={noType} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByText(noType)).toBeDefined();
+        });
+
+        it('should render plain text for missing version field', () => {
+            const noVersion = JSON.stringify({
+                type: 'doc',
+                content: [],
+            });
+
+            render(<AdfAwareContent content={noVersion} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByText(noVersion)).toBeDefined();
+        });
+    });
+
+    describe('Content parsing edge cases', () => {
+        it('should handle ADF with empty content array', () => {
+            const adfEmptyContent = JSON.stringify({
+                type: 'doc',
+                version: 1,
+                content: [],
+            });
+
+            render(<AdfAwareContent content={adfEmptyContent} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByTestId('adf-renderer')).toBeDefined();
+        });
+
+        it('should handle plain text that looks like JSON', () => {
+            const pseudoJson = '{"type": "unknown", "data": []}';
+
+            render(<AdfAwareContent content={pseudoJson} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByText(pseudoJson)).toBeDefined();
+        });
+
+        it('should handle special characters in plain text fallback', () => {
+            const textWithSpecialChars = '<script>alert("xss")</script>';
+
+            render(<AdfAwareContent content={textWithSpecialChars} mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByText(textWithSpecialChars)).toBeDefined();
+        });
+
+        it('should reparse content when content prop changes', () => {
+            const { rerender } = render(
+                <AdfAwareContent
+                    content={JSON.stringify({
+                        type: 'doc',
+                        version: 1,
+                        content: [
+                            {
+                                type: 'paragraph',
+                                content: [{ type: 'text', text: 'First' }],
+                            },
+                        ],
+                    })}
+                    mentionProvider={mockMentionProvider}
+                />,
+            );
+
+            expect(screen.getByTestId('adf-renderer')).toBeDefined();
+
+            rerender(<AdfAwareContent content="Plain text fallback" mentionProvider={mockMentionProvider} />);
+
+            expect(screen.getByText('Plain text fallback')).toBeDefined();
+            expect(screen.queryByTestId('adf-renderer')).toBeNull();
+        });
+    });
+
+    describe('Memoization', () => {
+        it('should memoize the component to prevent unnecessary re-renders', () => {
+            const { rerender } = render(
+                <AdfAwareContent
+                    content={JSON.stringify({
+                        type: 'doc',
+                        version: 1,
+                        content: [],
+                    })}
+                    mentionProvider={mockMentionProvider}
+                />,
+            );
+
+            const firstRender = screen.getByTestId('adf-renderer');
+
+            rerender(
+                <AdfAwareContent
+                    content={JSON.stringify({
+                        type: 'doc',
+                        version: 1,
+                        content: [],
+                    })}
+                    mentionProvider={mockMentionProvider}
+                />,
+            );
+
+            const secondRender = screen.getByTestId('adf-renderer');
+            expect(firstRender).toBeDefined();
+            expect(secondRender).toBeDefined();
+        });
+    });
+
+    describe('Snapshot Tests', () => {
+        it('should match snapshot for valid ADF content', () => {
+            const validAdf = JSON.stringify({
+                type: 'doc',
+                version: 1,
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [{ type: 'text', text: 'Hello world' }],
+                    },
+                ],
+            });
+
+            const { container } = render(<AdfAwareContent content={validAdf} mentionProvider={mockMentionProvider} />);
+
+            expect(container).toMatchSnapshot('valid-adf-content');
+        });
+
+        it('should match snapshot for invalid content fallback', () => {
+            const { container } = render(
+                <AdfAwareContent content={null as any} mentionProvider={mockMentionProvider} />,
+            );
+
+            expect(container).toMatchSnapshot('invalid-content-fallback');
+        });
+
+        it('should match snapshot for complex ADF with formatting', () => {
+            const complexAdf = JSON.stringify({
+                type: 'doc',
+                version: 1,
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            { type: 'text', text: 'Bold: ' },
+                            {
+                                type: 'text',
+                                text: 'important',
+                                marks: [{ type: 'strong' }],
+                            },
+                        ],
+                    },
+                    {
+                        type: 'bulletList',
+                        content: [
+                            {
+                                type: 'listItem',
+                                content: [
+                                    {
+                                        type: 'paragraph',
+                                        content: [{ type: 'text', text: 'Item 1' }],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            const { container } = render(
+                <AdfAwareContent content={complexAdf} mentionProvider={mockMentionProvider} />,
+            );
+
+            expect(container).toMatchSnapshot('complex-adf-with-formatting');
+        });
+    });
+});

--- a/src/webviews/components/AdfAwareContent.tsx
+++ b/src/webviews/components/AdfAwareContent.tsx
@@ -4,7 +4,7 @@ import { IntlProvider } from 'react-intl-next';
 
 import { AtlascodeMentionProvider } from './issue/common/AtlaskitEditor/AtlascodeMentionsProvider';
 interface AdfAwareContentProps {
-    content: string;
+    content: string | any;
     mentionProvider: AtlascodeMentionProvider;
 }
 
@@ -16,8 +16,16 @@ export const AdfAwareContent: React.FC<AdfAwareContentProps> = memo(({ content, 
     // Memoize the parsed document to avoid re-parsing on every render
     const document = useMemo(() => {
         try {
-            // Parse content as ADF JSON directly (no Wiki Markup transformation)
-            return typeof content === 'string' ? JSON.parse(content) : content;
+            // Parse content (handle both ADF object and string)
+            const parsed = typeof content === 'string' ? JSON.parse(content) : content;
+
+            // Validate proper ADF structure - must be a doc node with version 1
+            if (parsed && parsed.type === 'doc' && parsed.version === 1) {
+                return parsed;
+            }
+
+            console.warn('Invalid ADF structure, cannot render. Expected doc type with version 1.', parsed);
+            return null;
         } catch (error) {
             console.error('Failed to parse ADF content:', error);
             return null;

--- a/src/webviews/components/__snapshots__/AdfAwareContent.test.tsx.snap
+++ b/src/webviews/components/__snapshots__/AdfAwareContent.test.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`AdfAwareContent Snapshot Tests should match snapshot for complex ADF with formatting: complex-adf-with-formatting 1`] = `
+<div>
+  <div
+    data-testid="adf-renderer"
+  >
+    Rendered ADF Content
+  </div>
+</div>
+`;
+
+exports[`AdfAwareContent Snapshot Tests should match snapshot for invalid content fallback: invalid-content-fallback 1`] = `
+<div>
+  <p />
+</div>
+`;
+
+exports[`AdfAwareContent Snapshot Tests should match snapshot for valid ADF content: valid-adf-content 1`] = `
+<div>
+  <div
+    data-testid="adf-renderer"
+  >
+    Rendered ADF Content
+  </div>
+</div>
+`;
+
+exports[`AdfAwareContent Valid ADF content should render valid ADF string content 1`] = `
+<div
+  data-testid="adf-renderer"
+>
+  Rendered ADF Content
+</div>
+`;

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/IssueCommentComponent.test.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/IssueCommentComponent.test.tsx
@@ -1,4 +1,5 @@
 import { Comment as JiraComment, User } from '@atlassianlabs/jira-pi-common-models';
+type ADFDoc = { version: number; type: 'doc'; content: any[] };
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { DetailedSiteInfo, Product } from 'src/atlclients/authInfo';
@@ -23,6 +24,8 @@ const mockSiteDetails: DetailedSiteInfo = {
         key: 'jira',
     } as Product,
 };
+
+type JiraCommentWithAdf = Omit<JiraComment, 'body'> & { body: string | ADFDoc };
 
 const mockCurrentUser: User = {
     accountId: 'user-123',
@@ -278,5 +281,259 @@ describe('IssueCommentComponent', () => {
             }),
             undefined,
         );
+    });
+
+    describe('Comment body text rendering (bodyText logic)', () => {
+        it('should prefer renderedBody over body when available', () => {
+            const commentWithRenderedBody: JiraComment = {
+                id: 'comment-3',
+                body: 'h1. This is wiki markup',
+                renderedBody: '<h1>This is wiki markup</h1>',
+                author: mockComments[0].author,
+                created: '2023-01-03T12:00:00Z',
+                updated: '2023-01-03T12:00:00Z',
+                self: '',
+                visibility: undefined,
+                jsdPublic: false,
+            };
+
+            renderWithEditorProvider(
+                <IssueCommentComponent
+                    siteDetails={mockSiteDetails}
+                    currentUser={mockCurrentUser}
+                    comments={[commentWithRenderedBody]}
+                    isServiceDeskProject={false}
+                    onSave={mockOnSave}
+                    onCreate={mockOnCreate}
+                    fetchUsers={mockFetchUsers}
+                    fetchImage={mockFetchImage}
+                    onDelete={mockOnDelete}
+                    commentText=""
+                    onCommentTextChange={mockOnCommentTextChange}
+                    isEditingComment={false}
+                    onEditingCommentChange={mockOnEditingCommentChange}
+                    isAtlaskitEditorEnabled={false}
+                    mentionProvider={mockMentionProvider}
+                    handleEditorFocus={mockHandleEditorFocus}
+                />,
+            );
+
+            // The rendered body should be used to display the comment
+            expect(mockFetchImage).not.toHaveBeenCalled(); // Just checking component rendered
+        });
+
+        it('should convert ADF to WikiMarkup when renderedBody is not available', () => {
+            const adfComment: JiraCommentWithAdf = {
+                id: 'comment-4',
+                body: {
+                    version: 1,
+                    type: 'doc',
+                    content: [
+                        {
+                            type: 'paragraph',
+                            content: [
+                                {
+                                    type: 'text',
+                                    text: 'This is ADF content',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                author: mockComments[0].author,
+                created: '2023-01-04T12:00:00Z',
+                updated: '2023-01-04T12:00:00Z',
+                self: '',
+                visibility: undefined,
+                jsdPublic: false,
+            };
+
+            renderWithEditorProvider(
+                <IssueCommentComponent
+                    siteDetails={mockSiteDetails}
+                    currentUser={mockCurrentUser}
+                    comments={[adfComment]}
+                    isServiceDeskProject={false}
+                    onSave={mockOnSave}
+                    onCreate={mockOnCreate}
+                    fetchUsers={mockFetchUsers}
+                    fetchImage={mockFetchImage}
+                    onDelete={mockOnDelete}
+                    commentText=""
+                    onCommentTextChange={mockOnCommentTextChange}
+                    isEditingComment={false}
+                    onEditingCommentChange={mockOnEditingCommentChange}
+                    isAtlaskitEditorEnabled={false}
+                    mentionProvider={mockMentionProvider}
+                    handleEditorFocus={mockHandleEditorFocus}
+                />,
+            );
+
+            // Component should render without errors
+            expect(screen.getByTestId('issue.comments-section')).toBeTruthy();
+        });
+
+        it('should use plain text body as fallback when no renderedBody or ADF', () => {
+            const plainTextComment: JiraComment = {
+                id: 'comment-5',
+                body: 'Plain text comment',
+                author: mockComments[0].author,
+                created: '2023-01-05T12:00:00Z',
+                updated: '2023-01-05T12:00:00Z',
+                self: '',
+                visibility: undefined,
+                jsdPublic: false,
+            };
+
+            renderWithEditorProvider(
+                <IssueCommentComponent
+                    siteDetails={mockSiteDetails}
+                    currentUser={mockCurrentUser}
+                    comments={[plainTextComment]}
+                    isServiceDeskProject={false}
+                    onSave={mockOnSave}
+                    onCreate={mockOnCreate}
+                    fetchUsers={mockFetchUsers}
+                    fetchImage={mockFetchImage}
+                    onDelete={mockOnDelete}
+                    commentText=""
+                    onCommentTextChange={mockOnCommentTextChange}
+                    isEditingComment={false}
+                    onEditingCommentChange={mockOnEditingCommentChange}
+                    isAtlaskitEditorEnabled={false}
+                    mentionProvider={mockMentionProvider}
+                    handleEditorFocus={mockHandleEditorFocus}
+                />,
+            );
+
+            expect(screen.getByTestId('issue.comments-section')).toBeTruthy();
+        });
+
+        it('should handle comments with all text formatting possibilities', () => {
+            const complexComment: JiraComment = {
+                id: 'comment-6',
+                body: '*bold* _italic_ -strikethrough- +underline+ [link|http://example.com]',
+                renderedBody:
+                    '<p><strong>bold</strong> <em>italic</em> <s>strikethrough</s> <u>underline</u> <a href="http://example.com">link</a></p>',
+                author: mockComments[0].author,
+                created: '2023-01-06T12:00:00Z',
+                updated: '2023-01-06T12:00:00Z',
+                self: '',
+                visibility: undefined,
+                jsdPublic: false,
+            };
+
+            renderWithEditorProvider(
+                <IssueCommentComponent
+                    siteDetails={mockSiteDetails}
+                    currentUser={mockCurrentUser}
+                    comments={[complexComment]}
+                    isServiceDeskProject={false}
+                    onSave={mockOnSave}
+                    onCreate={mockOnCreate}
+                    fetchUsers={mockFetchUsers}
+                    fetchImage={mockFetchImage}
+                    onDelete={mockOnDelete}
+                    commentText=""
+                    onCommentTextChange={mockOnCommentTextChange}
+                    isEditingComment={false}
+                    onEditingCommentChange={mockOnEditingCommentChange}
+                    isAtlaskitEditorEnabled={false}
+                    mentionProvider={mockMentionProvider}
+                    handleEditorFocus={mockHandleEditorFocus}
+                />,
+            );
+
+            expect(screen.getByTestId('issue.comments-section')).toBeTruthy();
+        });
+    });
+
+    describe('Snapshot Tests', () => {
+        it('should match snapshot when rendering multiple comments', () => {
+            const { container } = renderWithEditorProvider(
+                <IssueCommentComponent
+                    siteDetails={mockSiteDetails}
+                    currentUser={mockCurrentUser}
+                    comments={mockComments}
+                    isServiceDeskProject={false}
+                    onSave={mockOnSave}
+                    onCreate={mockOnCreate}
+                    fetchUsers={mockFetchUsers}
+                    fetchImage={mockFetchImage}
+                    onDelete={mockOnDelete}
+                    commentText=""
+                    onCommentTextChange={mockOnCommentTextChange}
+                    isEditingComment={false}
+                    onEditingCommentChange={mockOnEditingCommentChange}
+                    isAtlaskitEditorEnabled={false}
+                    mentionProvider={mockMentionProvider}
+                    handleEditorFocus={mockHandleEditorFocus}
+                />,
+            );
+
+            expect(container).toMatchSnapshot('multiple-comments');
+        });
+
+        it('should match snapshot when rendering comment with renderedBody', () => {
+            const commentWithRenderedBody: JiraComment = {
+                id: 'comment-3',
+                body: 'h1. Heading\nSome content',
+                renderedBody: '<h1>Heading</h1><p>Some content</p>',
+                author: mockComments[0].author,
+                created: '2023-01-03T12:00:00Z',
+                updated: '2023-01-03T12:00:00Z',
+                self: '',
+                visibility: undefined,
+                jsdPublic: false,
+            };
+
+            const { container } = renderWithEditorProvider(
+                <IssueCommentComponent
+                    siteDetails={mockSiteDetails}
+                    currentUser={mockCurrentUser}
+                    comments={[commentWithRenderedBody]}
+                    isServiceDeskProject={false}
+                    onSave={mockOnSave}
+                    onCreate={mockOnCreate}
+                    fetchUsers={mockFetchUsers}
+                    fetchImage={mockFetchImage}
+                    onDelete={mockOnDelete}
+                    commentText=""
+                    onCommentTextChange={mockOnCommentTextChange}
+                    isEditingComment={false}
+                    onEditingCommentChange={mockOnEditingCommentChange}
+                    isAtlaskitEditorEnabled={false}
+                    mentionProvider={mockMentionProvider}
+                    handleEditorFocus={mockHandleEditorFocus}
+                />,
+            );
+
+            expect(container).toMatchSnapshot('comment-with-rendered-body');
+        });
+
+        it('should match snapshot for empty comment list', () => {
+            const { container } = renderWithEditorProvider(
+                <IssueCommentComponent
+                    siteDetails={mockSiteDetails}
+                    currentUser={mockCurrentUser}
+                    comments={[]}
+                    isServiceDeskProject={false}
+                    onSave={mockOnSave}
+                    onCreate={mockOnCreate}
+                    fetchUsers={mockFetchUsers}
+                    fetchImage={mockFetchImage}
+                    onDelete={mockOnDelete}
+                    commentText=""
+                    onCommentTextChange={mockOnCommentTextChange}
+                    isEditingComment={false}
+                    onEditingCommentChange={mockOnEditingCommentChange}
+                    isAtlaskitEditorEnabled={false}
+                    mentionProvider={mockMentionProvider}
+                    handleEditorFocus={mockHandleEditorFocus}
+                />,
+            );
+
+            expect(container).toMatchSnapshot('empty-comment-list');
+        });
     });
 });

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/IssueCommentComponent.tsx
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/IssueCommentComponent.tsx
@@ -21,10 +21,13 @@ import JiraIssueTextAreaEditor from '../../common/JiraIssueTextArea';
 import { useEditorState } from '../EditorStateContext';
 import { useEditorForceClose } from '../hooks/useEditorForceClose';
 
+type ADFDoc = { version: number; type: 'doc'; content: any[] };
+type JiraCommentWithAdf = Omit<JiraComment, 'body'> & { body: string | ADFDoc };
+
 export type IssueCommentComponentProps = {
     siteDetails: DetailedSiteInfo;
     currentUser: User;
-    comments: JiraComment[];
+    comments: JiraCommentWithAdf[];
     isServiceDeskProject: boolean;
     onSave: (commentBody: any, commentId?: string, restriction?: CommentVisibility) => void; // Can be string or ADF object
     onCreate: (commentBody: any, restriction?: CommentVisibility) => void; // Can be string or ADF object
@@ -41,7 +44,7 @@ export type IssueCommentComponentProps = {
 };
 const CommentComponent: React.FC<{
     siteDetails: DetailedSiteInfo;
-    comment: JiraComment;
+    comment: JiraCommentWithAdf;
     onSave: (t: any, commentId?: string, restriction?: CommentVisibility) => void; // Can be string or ADF object
     fetchImage: (url: string) => Promise<string>;
     onDelete: (commentId: string) => void;
@@ -78,7 +81,21 @@ const CommentComponent: React.FC<{
         [isAtlaskitEditorEnabled, closeEditor, editorId],
     );
     const [isSaving, setIsSaving] = React.useState(false);
-    const bodyText = comment.renderedBody ? comment.renderedBody : comment.body;
+    const bodyText = React.useMemo(() => {
+        // Prefer renderedBody (HTML from server) - this preserves wiki markup formatting
+        if (comment.renderedBody) {
+            return comment.renderedBody;
+        }
+
+        // Fallback: If no renderedBody and body is ADF, convert to WikiMarkup for display
+        const cb: any = comment.body;
+        if (typeof cb === 'object' && cb !== null && cb.version === 1 && cb.type === 'doc') {
+            return convertAdfToWikimarkup(cb);
+        }
+
+        // Last resort: display as-is (plain text or string)
+        return comment.body as any;
+    }, [comment.body, comment.renderedBody]);
 
     // Convert comment body to appropriate format for editor
     const getCommentTextForEditor = React.useCallback(
@@ -415,7 +432,7 @@ export const IssueCommentComponent: React.FC<IssueCommentComponentProps> = ({
             />
             {comments
                 .sort((a, b) => (a.created > b.created ? -1 : 1))
-                .map((comment: JiraComment) => (
+                .map((comment: JiraCommentWithAdf) => (
                     <CommentComponent
                         key={`${comment.id}::${comment.updated}`}
                         siteDetails={siteDetails}

--- a/src/webviews/components/issue/view-issue-screen/mainpanel/__snapshots__/IssueCommentComponent.test.tsx.snap
+++ b/src/webviews/components/issue/view-issue-screen/mainpanel/__snapshots__/IssueCommentComponent.test.tsx.snap
@@ -1,0 +1,459 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`IssueCommentComponent Snapshot Tests should match snapshot for empty comment list: empty-comment-list 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-0"
+    data-testid="issue.comments-section"
+    style="display: flex; flex-direction: column; padding-top: 8px; gap: 16px;"
+  >
+    <div
+      class="MuiBox-root css-0"
+      style="display: flex; flex-direction: column; width: 100%;"
+    >
+      <div
+        class="MuiBox-root css-0"
+        data-testid="issue.new-comment"
+        style="display: flex; flex-direction: row; align-items: center;"
+      >
+        <div
+          class="MuiBox-root css-0"
+          style="margin-right: 8px; margin-top: 0px;"
+        >
+          <div
+            class="_12ji1r31 _1qu2glyw _12y3idpf _1e0c1o8l _kqswh2mm"
+          >
+            <span
+              class="_vchh1ntv _bfhkcxp3 _16qs1nhn _19itglyw _12ji1r31 _1qu2glyw _12y31o36 _1reo15vq _18m915vq _v564ieh6 _1e0c1txw _kqswpfqs _4cvr1fhb _1bah1h6o _2lx21bp4 _80om1kw7 _6rthv77o _1pfhv77o _12l2v77o _ahbqv77o _85i5ze3t _1q51ze3t _y4tize3t _bozgze3t _t9ec1aqe _9v7aze3t _qc5o1p41 _z0ai1osq _18postnw _1hfk1j28 _aetrf705 _1peqidpf _11fnglyw _1ejjglyw _mizu194a _1ah3v77o _ra3xnqa1 _128mdkaa _4dave4h9 _2rko1qll _14mj1qll _1bsb1tcg _4t3i1tcg"
+              style="--avatar-bg-color: var(--vscode-editor-background)!important; --avatar-box-shadow: 0 0 0 2px var(--vscode-editor-background)!important;"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                class="_16jlkb7n _1o9zkb7n _i0dl1osq _1e0c1txw _1bsb1osq _4t3i1osq _2rko1rr0"
+                data-ssr-placeholder-ignored="true"
+                data-vc="avatar-image"
+                src="https://avatar.example.com/48x48"
+              />
+            </span>
+          </div>
+        </div>
+        <div
+          class="_16jlkb7n _1o9zkb7n _i0dl1osq _11c82smr _1reo15vq _18m915vq _v564r5cv _189ee4h9 _1e0c1txw _vchhusvi _4cvr1h6o _1bah1yb4 _lcxv1wug _s7n4jp4b _slp31hna _1tnqfajl _1h6drsbi _1dqonqa1 _syazi7uo _80om1kdv _bfhk1j9a _msj6gir2 _1q51e4h9 _85i5e4h9 _bozgidpf _y4tiidpf _1p9x1v1w _qao9r01l _q433vyy1 _4cvxrsbi _irr3l4ek ac-inputField"
+          data-ds--text-field--container="true"
+          role="presentation"
+          style="max-width: 100%;"
+        >
+          <input
+            class="_19itidpf _11c81ixg _12ji1r31 _1qu2glyw _12y31o36 _vchhusvi _1bsb1osq _1ul9idpf _bfhk1j28 _syaz1kw7 _80om1kw7 _14ji12x7 _olc612x7 _1kod12x7 _7ba012x7 _1goxglyw _13xeglyw _1n7e1l2s _1idr1rpy _1tn22smr _l9oiu2gc _549yu2gc _1h5w12x7 _124212x7"
+            css="[object Object]"
+            data-ds--text-field--input="true"
+            placeholder="Add a comment..."
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`IssueCommentComponent Snapshot Tests should match snapshot when rendering comment with renderedBody: comment-with-rendered-body 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-0"
+    data-testid="issue.comments-section"
+    style="display: flex; flex-direction: column; padding-top: 8px; gap: 16px;"
+  >
+    <div
+      class="MuiBox-root css-0"
+      style="display: flex; flex-direction: column; width: 100%;"
+    >
+      <div
+        class="MuiBox-root css-0"
+        data-testid="issue.new-comment"
+        style="display: flex; flex-direction: row; align-items: center;"
+      >
+        <div
+          class="MuiBox-root css-0"
+          style="margin-right: 8px; margin-top: 0px;"
+        >
+          <div
+            class="_12ji1r31 _1qu2glyw _12y3idpf _1e0c1o8l _kqswh2mm"
+          >
+            <span
+              class="_vchh1ntv _bfhkcxp3 _16qs1nhn _19itglyw _12ji1r31 _1qu2glyw _12y31o36 _1reo15vq _18m915vq _v564ieh6 _1e0c1txw _kqswpfqs _4cvr1fhb _1bah1h6o _2lx21bp4 _80om1kw7 _6rthv77o _1pfhv77o _12l2v77o _ahbqv77o _85i5ze3t _1q51ze3t _y4tize3t _bozgze3t _t9ec1aqe _9v7aze3t _qc5o1p41 _z0ai1osq _18postnw _1hfk1j28 _aetrf705 _1peqidpf _11fnglyw _1ejjglyw _mizu194a _1ah3v77o _ra3xnqa1 _128mdkaa _4dave4h9 _2rko1qll _14mj1qll _1bsb1tcg _4t3i1tcg"
+              style="--avatar-bg-color: var(--vscode-editor-background)!important; --avatar-box-shadow: 0 0 0 2px var(--vscode-editor-background)!important;"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                class="_16jlkb7n _1o9zkb7n _i0dl1osq _1e0c1txw _1bsb1osq _4t3i1osq _2rko1rr0"
+                data-ssr-placeholder-ignored="true"
+                data-vc="avatar-image"
+                src="https://avatar.example.com/48x48"
+              />
+            </span>
+          </div>
+        </div>
+        <div
+          class="_16jlkb7n _1o9zkb7n _i0dl1osq _11c82smr _1reo15vq _18m915vq _v564r5cv _189ee4h9 _1e0c1txw _vchhusvi _4cvr1h6o _1bah1yb4 _lcxv1wug _s7n4jp4b _slp31hna _1tnqfajl _1h6drsbi _1dqonqa1 _syazi7uo _80om1kdv _bfhk1j9a _msj6gir2 _1q51e4h9 _85i5e4h9 _bozgidpf _y4tiidpf _1p9x1v1w _qao9r01l _q433vyy1 _4cvxrsbi _irr3l4ek ac-inputField"
+          data-ds--text-field--container="true"
+          role="presentation"
+          style="max-width: 100%;"
+        >
+          <input
+            class="_19itidpf _11c81ixg _12ji1r31 _1qu2glyw _12y31o36 _vchhusvi _1bsb1osq _1ul9idpf _bfhk1j28 _syaz1kw7 _80om1kw7 _14ji12x7 _olc612x7 _1kod12x7 _7ba012x7 _1goxglyw _13xeglyw _1n7e1l2s _1idr1rpy _1tn22smr _l9oiu2gc _549yu2gc _1h5w12x7 _124212x7"
+            css="[object Object]"
+            data-ds--text-field--input="true"
+            placeholder="Add a comment..."
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="_1e0c11p5 _vchhusvi _gy1pu2gc _1p57u2gc _kqswh2mm _yv0e5bpd _1lmcvpz5"
+    >
+      <div
+        class="_19itglyw _vchhusvi _r06hglyw _nd5l1ofd"
+      >
+        <div
+          class="_12ji1r31 _1qu2glyw _12y3idpf _1e0c1o8l _kqswh2mm"
+        >
+          <span
+            class="_vchh1ntv _bfhkcxp3 _16qs1nhn _19itglyw _12ji1r31 _1qu2glyw _12y31o36 _1reo15vq _18m915vq _v564ieh6 _1e0c1txw _kqswpfqs _4cvr1fhb _1bah1h6o _2lx21bp4 _80om1kw7 _6rthv77o _1pfhv77o _12l2v77o _ahbqv77o _85i5ze3t _1q51ze3t _y4tize3t _bozgze3t _t9ec1aqe _9v7aze3t _qc5o1p41 _z0ai1osq _18postnw _1hfk1j28 _aetrf705 _1peqidpf _11fnglyw _1ejjglyw _mizu194a _1ah3v77o _ra3xnqa1 _128mdkaa _4dave4h9 _2rko1qll _14mj1qll _1bsb1tcg _4t3i1tcg"
+            style="--avatar-bg-color: var(--vscode-editor-background)!important; --avatar-box-shadow: 0 0 0 2px var(--vscode-editor-background)!important;"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              class="_16jlkb7n _1o9zkb7n _i0dl1osq _1e0c1txw _1bsb1osq _4t3i1osq _2rko1rr0"
+              data-ssr-placeholder-ignored="true"
+              data-vc="avatar-image"
+              src="https://avatar.example.com/48x48"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="_nd5l8niw _1ul9idpf _1q51v77o _slp31hna"
+      >
+        <div
+          class="_1e0c1txw _vchhusvi _gy1p12x7 _1p5712x7 _2lx21bp4 _1bah1fhb"
+        >
+          <div
+            class="_1e0c1txw _vchhusvi _gy1p1b66 _1p571b66 _2lx21bp4 _1bah1fhb"
+          >
+            <h3
+              class="_11c82smr"
+            >
+              <span
+                class="_1e0c1txw _vchhusvi _gy1pu2gc _1p57u2gc _4cvr1h6o _2lx2vrvc"
+              >
+                <span
+                  class="_syaz1gjq _k48p1wq8"
+                  role="presentation"
+                >
+                  <div
+                    class="jira-comment-author"
+                  >
+                    Another User
+                  </div>
+                </span>
+                <div
+                  class="inlinePanelSubheading"
+                >
+                  about 3 years ago
+                </div>
+              </span>
+            </h3>
+            <div
+              class="_19itglyw _vchhusvi _r06hglyw _syaz1fxt"
+            >
+              <p>
+                <h1>
+                  Heading
+                </h1>
+                <p>
+                  Some content
+                </p>
+              </p>
+            </div>
+          </div>
+          <div
+            class="css-1w890ve"
+          >
+            <span
+              role="presentation"
+            >
+              <button
+                class="css-1j0hxvg"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="css-1gd7hga"
+                >
+                  Edit
+                </span>
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`IssueCommentComponent Snapshot Tests should match snapshot when rendering multiple comments: multiple-comments 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-0"
+    data-testid="issue.comments-section"
+    style="display: flex; flex-direction: column; padding-top: 8px; gap: 16px;"
+  >
+    <div
+      class="MuiBox-root css-0"
+      style="display: flex; flex-direction: column; width: 100%;"
+    >
+      <div
+        class="MuiBox-root css-0"
+        data-testid="issue.new-comment"
+        style="display: flex; flex-direction: row; align-items: center;"
+      >
+        <div
+          class="MuiBox-root css-0"
+          style="margin-right: 8px; margin-top: 0px;"
+        >
+          <div
+            class="_12ji1r31 _1qu2glyw _12y3idpf _1e0c1o8l _kqswh2mm"
+          >
+            <span
+              class="_vchh1ntv _bfhkcxp3 _16qs1nhn _19itglyw _12ji1r31 _1qu2glyw _12y31o36 _1reo15vq _18m915vq _v564ieh6 _1e0c1txw _kqswpfqs _4cvr1fhb _1bah1h6o _2lx21bp4 _80om1kw7 _6rthv77o _1pfhv77o _12l2v77o _ahbqv77o _85i5ze3t _1q51ze3t _y4tize3t _bozgze3t _t9ec1aqe _9v7aze3t _qc5o1p41 _z0ai1osq _18postnw _1hfk1j28 _aetrf705 _1peqidpf _11fnglyw _1ejjglyw _mizu194a _1ah3v77o _ra3xnqa1 _128mdkaa _4dave4h9 _2rko1qll _14mj1qll _1bsb1tcg _4t3i1tcg"
+              style="--avatar-bg-color: var(--vscode-editor-background)!important; --avatar-box-shadow: 0 0 0 2px var(--vscode-editor-background)!important;"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                class="_16jlkb7n _1o9zkb7n _i0dl1osq _1e0c1txw _1bsb1osq _4t3i1osq _2rko1rr0"
+                data-ssr-placeholder-ignored="true"
+                data-vc="avatar-image"
+                src="https://avatar.example.com/48x48"
+              />
+            </span>
+          </div>
+        </div>
+        <div
+          class="_16jlkb7n _1o9zkb7n _i0dl1osq _11c82smr _1reo15vq _18m915vq _v564r5cv _189ee4h9 _1e0c1txw _vchhusvi _4cvr1h6o _1bah1yb4 _lcxv1wug _s7n4jp4b _slp31hna _1tnqfajl _1h6drsbi _1dqonqa1 _syazi7uo _80om1kdv _bfhk1j9a _msj6gir2 _1q51e4h9 _85i5e4h9 _bozgidpf _y4tiidpf _1p9x1v1w _qao9r01l _q433vyy1 _4cvxrsbi _irr3l4ek ac-inputField"
+          data-ds--text-field--container="true"
+          role="presentation"
+          style="max-width: 100%;"
+        >
+          <input
+            class="_19itidpf _11c81ixg _12ji1r31 _1qu2glyw _12y31o36 _vchhusvi _1bsb1osq _1ul9idpf _bfhk1j28 _syaz1kw7 _80om1kw7 _14ji12x7 _olc612x7 _1kod12x7 _7ba012x7 _1goxglyw _13xeglyw _1n7e1l2s _1idr1rpy _1tn22smr _l9oiu2gc _549yu2gc _1h5w12x7 _124212x7"
+            css="[object Object]"
+            data-ds--text-field--input="true"
+            placeholder="Add a comment..."
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="_1e0c11p5 _vchhusvi _gy1pu2gc _1p57u2gc _kqswh2mm _yv0e5bpd _1lmcvpz5"
+    >
+      <div
+        class="_19itglyw _vchhusvi _r06hglyw _nd5l1ofd"
+      >
+        <div
+          class="_12ji1r31 _1qu2glyw _12y3idpf _1e0c1o8l _kqswh2mm"
+        >
+          <span
+            class="_vchh1ntv _bfhkcxp3 _16qs1nhn _19itglyw _12ji1r31 _1qu2glyw _12y31o36 _1reo15vq _18m915vq _v564ieh6 _1e0c1txw _kqswpfqs _4cvr1fhb _1bah1h6o _2lx21bp4 _80om1kw7 _6rthv77o _1pfhv77o _12l2v77o _ahbqv77o _85i5ze3t _1q51ze3t _y4tize3t _bozgze3t _t9ec1aqe _9v7aze3t _qc5o1p41 _z0ai1osq _18postnw _1hfk1j28 _aetrf705 _1peqidpf _11fnglyw _1ejjglyw _mizu194a _1ah3v77o _ra3xnqa1 _128mdkaa _4dave4h9 _2rko1qll _14mj1qll _1bsb1tcg _4t3i1tcg"
+            style="--avatar-bg-color: var(--vscode-editor-background)!important; --avatar-box-shadow: 0 0 0 2px var(--vscode-editor-background)!important;"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              class="_16jlkb7n _1o9zkb7n _i0dl1osq _1e0c1txw _1bsb1osq _4t3i1osq _2rko1rr0"
+              data-ssr-placeholder-ignored="true"
+              data-vc="avatar-image"
+              src="https://avatar.example.com/48x48"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="_nd5l8niw _1ul9idpf _1q51v77o _slp31hna"
+      >
+        <div
+          class="_1e0c1txw _vchhusvi _gy1p12x7 _1p5712x7 _2lx21bp4 _1bah1fhb"
+        >
+          <div
+            class="_1e0c1txw _vchhusvi _gy1p1b66 _1p571b66 _2lx21bp4 _1bah1fhb"
+          >
+            <h3
+              class="_11c82smr"
+            >
+              <span
+                class="_1e0c1txw _vchhusvi _gy1pu2gc _1p57u2gc _4cvr1h6o _2lx2vrvc"
+              >
+                <span
+                  class="_syaz1gjq _k48p1wq8"
+                  role="presentation"
+                >
+                  <div
+                    class="jira-comment-author"
+                  >
+                    Another User
+                  </div>
+                </span>
+                <div
+                  class="inlinePanelSubheading"
+                >
+                  about 3 years ago
+                </div>
+              </span>
+            </h3>
+            <div
+              class="_19itglyw _vchhusvi _r06hglyw _syaz1fxt"
+            >
+              <p>
+                <p>
+                  Another test comment
+                </p>
+              </p>
+            </div>
+          </div>
+          <div
+            class="css-1w890ve"
+          >
+            <span
+              role="presentation"
+            >
+              <button
+                class="css-1j0hxvg"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="css-1gd7hga"
+                >
+                  Edit
+                </span>
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="_1e0c11p5 _vchhusvi _gy1pu2gc _1p57u2gc _kqswh2mm _yv0e5bpd _1lmcvpz5"
+    >
+      <div
+        class="_19itglyw _vchhusvi _r06hglyw _nd5l1ofd"
+      >
+        <div
+          class="_12ji1r31 _1qu2glyw _12y3idpf _1e0c1o8l _kqswh2mm"
+        >
+          <span
+            class="_vchh1ntv _bfhkcxp3 _16qs1nhn _19itglyw _12ji1r31 _1qu2glyw _12y31o36 _1reo15vq _18m915vq _v564ieh6 _1e0c1txw _kqswpfqs _4cvr1fhb _1bah1h6o _2lx21bp4 _80om1kw7 _6rthv77o _1pfhv77o _12l2v77o _ahbqv77o _85i5ze3t _1q51ze3t _y4tize3t _bozgze3t _t9ec1aqe _9v7aze3t _qc5o1p41 _z0ai1osq _18postnw _1hfk1j28 _aetrf705 _1peqidpf _11fnglyw _1ejjglyw _mizu194a _1ah3v77o _ra3xnqa1 _128mdkaa _4dave4h9 _2rko1qll _14mj1qll _1bsb1tcg _4t3i1tcg"
+            style="--avatar-bg-color: var(--vscode-editor-background)!important; --avatar-box-shadow: 0 0 0 2px var(--vscode-editor-background)!important;"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              class="_16jlkb7n _1o9zkb7n _i0dl1osq _1e0c1txw _1bsb1osq _4t3i1osq _2rko1rr0"
+              data-ssr-placeholder-ignored="true"
+              data-vc="avatar-image"
+              src="https://avatar.example.com/48x48"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="_nd5l8niw _1ul9idpf _1q51v77o _slp31hna"
+      >
+        <div
+          class="_1e0c1txw _vchhusvi _gy1p12x7 _1p5712x7 _2lx21bp4 _1bah1fhb"
+        >
+          <div
+            class="_1e0c1txw _vchhusvi _gy1p1b66 _1p571b66 _2lx21bp4 _1bah1fhb"
+          >
+            <h3
+              class="_11c82smr"
+            >
+              <span
+                class="_1e0c1txw _vchhusvi _gy1pu2gc _1p57u2gc _4cvr1h6o _2lx2vrvc"
+              >
+                <span
+                  class="_syaz1gjq _k48p1wq8"
+                  role="presentation"
+                >
+                  <div
+                    class="jira-comment-author"
+                  >
+                    Test User
+                  </div>
+                </span>
+                <div
+                  class="inlinePanelSubheading"
+                >
+                  about 3 years ago
+                </div>
+              </span>
+            </h3>
+            <div
+              class="_19itglyw _vchhusvi _r06hglyw _syaz1fxt"
+            >
+              <p>
+                <p>
+                  This is a test comment
+                </p>
+              </p>
+            </div>
+          </div>
+          <div
+            class="css-1w890ve"
+          >
+            <span
+              role="presentation"
+            >
+              <button
+                class="css-1j0hxvg"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="css-1gd7hga"
+                >
+                  Edit
+                </span>
+              </button>
+            </span>
+            <span
+              class="css-zlt279"
+            >
+              ·
+            </span>
+            <span
+              role="presentation"
+            >
+              <button
+                class="css-1j0hxvg"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="css-1gd7hga"
+                >
+                  Delete
+                </span>
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/webviews/jiraIssueWebview.test.ts
+++ b/src/webviews/jiraIssueWebview.test.ts
@@ -10,7 +10,7 @@ import { expansionCastTo } from 'testsutil/miscFunctions';
 import { commands, env, WebviewPanel } from 'vscode';
 
 import { DetailedSiteInfo, emptySiteInfo, ProductJira } from '../atlclients/authInfo';
-import { postComment } from '../commands/jira/postComment';
+import { fetchCommentWithRenderedBody, postComment } from '../commands/jira/postComment';
 import { startWorkOnIssue } from '../commands/jira/startWorkOnIssue';
 import { Container } from '../container';
 import * as fetchIssue from '../jira/fetchIssue';
@@ -773,6 +773,7 @@ describe('JiraIssueWebview', () => {
 
             const newComment = { id: 'comment-1', body: commentBody };
             (postComment as jest.Mock).mockResolvedValue(newComment);
+            (fetchCommentWithRenderedBody as jest.Mock).mockResolvedValue(newComment);
 
             jiraIssueWebview['_editUIData'].fieldValues['comment'] = { comments: [] };
             const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
@@ -798,19 +799,25 @@ describe('JiraIssueWebview', () => {
                 nonce: 'nonce-123',
             };
 
-            const existingComment = { id: commentId, body: 'Original comment' };
             const updatedComment = { id: commentId, body: commentBody };
 
             (postComment as jest.Mock).mockResolvedValue(updatedComment);
+            (fetchCommentWithRenderedBody as jest.Mock).mockResolvedValue(updatedComment);
 
             jiraIssueWebview['_editUIData'].fieldValues['comment'] = {
-                comments: [existingComment],
+                comments: [{ id: commentId, body: 'Original comment' }],
             };
+
+            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
 
             await jiraIssueWebview['onMessageReceived'](msg);
 
             expect(postComment).toHaveBeenCalledWith(mockIssue, commentBody, commentId, undefined);
             expect(jiraIssueWebview['_editUIData'].fieldValues['comment'].comments[0]).toEqual(updatedComment);
+            expect(postMessageSpy).toHaveBeenCalledWith({
+                type: 'fieldValueUpdate',
+                fieldValues: { comment: { comments: [updatedComment] }, nonce: 'nonce-123' },
+            });
         });
 
         test('should handle deleteComment action', async () => {
@@ -837,6 +844,140 @@ describe('JiraIssueWebview', () => {
                 type: 'fieldValueUpdate',
                 fieldValues: { comment: { comments: [] }, nonce: 'nonce-123' },
             });
+        });
+
+        test('should fetch comment with renderedBody when creating a new comment', async () => {
+            const commentBody = 'New comment with wiki markup';
+            const msg = {
+                action: 'comment',
+                commentBody,
+                issue: mockIssue,
+                nonce: 'nonce-123',
+            };
+
+            const newComment = { id: 'comment-1', body: commentBody };
+            const fullCommentWithRenderedBody = {
+                ...newComment,
+                renderedBody: '<p>New comment with wiki markup</p>',
+            };
+
+            (postComment as jest.Mock).mockResolvedValue(newComment);
+            (fetchCommentWithRenderedBody as jest.Mock).mockResolvedValue(fullCommentWithRenderedBody);
+
+            jiraIssueWebview['_editUIData'].fieldValues['comment'] = { comments: [] };
+            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+            await jiraIssueWebview['onMessageReceived'](msg);
+
+            expect(postComment).toHaveBeenCalledWith(mockIssue, commentBody, undefined, undefined);
+            expect(fetchCommentWithRenderedBody).toHaveBeenCalledWith(mockIssue, 'comment-1');
+            expect(jiraIssueWebview['_editUIData'].fieldValues['comment'].comments).toContain(
+                fullCommentWithRenderedBody,
+            );
+            expect(postMessageSpy).toHaveBeenCalledWith({
+                type: 'fieldValueUpdate',
+                fieldValues: { comment: { comments: [fullCommentWithRenderedBody] }, nonce: 'nonce-123' },
+            });
+        });
+
+        test('should fallback to postComment result if fetchCommentWithRenderedBody fails', async () => {
+            const commentBody = 'New comment';
+            const msg = {
+                action: 'comment',
+                commentBody,
+                issue: mockIssue,
+                nonce: 'nonce-123',
+            };
+
+            const newComment = { id: 'comment-1', body: commentBody };
+
+            (postComment as jest.Mock).mockResolvedValue(newComment);
+            (fetchCommentWithRenderedBody as jest.Mock).mockRejectedValue(new Error('Fetch failed'));
+
+            jiraIssueWebview['_editUIData'].fieldValues['comment'] = { comments: [] };
+
+            await jiraIssueWebview['onMessageReceived'](msg);
+
+            expect(fetchCommentWithRenderedBody).toHaveBeenCalledWith(mockIssue, 'comment-1');
+            // Should still add the comment from postComment response
+            expect(jiraIssueWebview['_editUIData'].fieldValues['comment'].comments).toContain(newComment);
+            expect(Logger.warn).toHaveBeenCalledWith(
+                expect.any(Error),
+                expect.stringContaining('Failed to fetch comment with renderedBody'),
+            );
+        });
+
+        test('should fetch comment with renderedBody when updating an existing comment', async () => {
+            const commentId = 'comment-1';
+            const commentBody = 'Updated comment with formatting';
+            const msg = {
+                action: 'comment',
+                commentBody,
+                commentId,
+                issue: mockIssue,
+                nonce: 'nonce-123',
+            };
+
+            const updatedComment = { id: commentId, body: commentBody };
+            const fullCommentWithRenderedBody = {
+                ...updatedComment,
+                renderedBody: '<p>Updated comment <strong>with formatting</strong></p>',
+            };
+
+            (postComment as jest.Mock).mockResolvedValue(updatedComment);
+            (fetchCommentWithRenderedBody as jest.Mock).mockResolvedValue(fullCommentWithRenderedBody);
+
+            const existingComment = { id: commentId, body: 'Original comment' };
+            jiraIssueWebview['_editUIData'].fieldValues['comment'] = {
+                comments: [existingComment],
+            };
+
+            const postMessageSpy = jest.spyOn(jiraIssueWebview as any, 'postMessage');
+
+            await jiraIssueWebview['onMessageReceived'](msg);
+
+            expect(postComment).toHaveBeenCalledWith(mockIssue, commentBody, commentId, undefined);
+            expect(fetchCommentWithRenderedBody).toHaveBeenCalledWith(mockIssue, commentId);
+            expect(jiraIssueWebview['_editUIData'].fieldValues['comment'].comments[0]).toEqual(
+                fullCommentWithRenderedBody,
+            );
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'fieldValueUpdate',
+                }),
+            );
+        });
+
+        test('should fallback to postComment result when updating if fetchCommentWithRenderedBody fails', async () => {
+            const commentId = 'comment-1';
+            const commentBody = 'Updated comment text';
+            const msg = {
+                action: 'comment',
+                commentBody,
+                commentId,
+                issue: mockIssue,
+                nonce: 'nonce-123',
+            };
+
+            const updatedComment = { id: commentId, body: commentBody };
+
+            (postComment as jest.Mock).mockResolvedValue(updatedComment);
+            (fetchCommentWithRenderedBody as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+            const existingComment = { id: commentId, body: 'Original comment' };
+            jiraIssueWebview['_editUIData'].fieldValues['comment'] = {
+                comments: [existingComment],
+            };
+
+            await jiraIssueWebview['onMessageReceived'](msg);
+
+            expect(fetchCommentWithRenderedBody).toHaveBeenCalledWith(mockIssue, commentId);
+            // Should use the basic comment response when fetch fails
+            expect(jiraIssueWebview['_editUIData'].fieldValues['comment'].comments[0]).toEqual(updatedComment);
+            expect(Logger.warn).toHaveBeenCalledWith(
+                expect.any(Error),
+                expect.stringContaining('Failed to fetch comment with renderedBody'),
+            );
         });
 
         test('should handle createIssue action', async () => {

--- a/src/webviews/jiraIssueWebview.ts
+++ b/src/webviews/jiraIssueWebview.ts
@@ -31,7 +31,7 @@ import { performanceEvent } from '../analytics';
 import { DetailedSiteInfo, emptySiteInfo, Product, ProductJira } from '../atlclients/authInfo';
 import { clientForSite } from '../bitbucket/bbUtils';
 import { PullRequestData } from '../bitbucket/model';
-import { postComment } from '../commands/jira/postComment';
+import { fetchCommentWithRenderedBody, postComment } from '../commands/jira/postComment';
 import { showIssue } from '../commands/jira/showIssue';
 import { startWorkOnIssue } from '../commands/jira/startWorkOnIssue';
 import { configuration } from '../config/configuration';
@@ -849,7 +849,17 @@ export class JiraIssueWebview
                                 if (Array.isArray(comments)) {
                                     const idx = comments.findIndex((value) => value.id === msg.commentId);
                                     if (idx >= 0) {
-                                        comments.splice(idx, 1, res);
+                                        // Fetch full comment with renderedBody to preserve formatting
+                                        try {
+                                            const fullComment = await fetchCommentWithRenderedBody(msg.issue, res.id);
+                                            comments.splice(idx, 1, fullComment);
+                                        } catch (fetchError) {
+                                            Logger.warn(
+                                                fetchError,
+                                                'Failed to fetch comment with renderedBody, using API response',
+                                            );
+                                            comments.splice(idx, 1, res);
+                                        }
                                     }
                                 } else {
                                     throw new Error(
@@ -858,7 +868,17 @@ export class JiraIssueWebview
                                 }
                             } else {
                                 const res = await postComment(msg.issue, msg.commentBody, undefined, msg.restriction);
-                                this._editUIData.fieldValues['comment'].comments.push(res);
+                                // Fetch full comment with renderedBody to preserve formatting
+                                try {
+                                    const fullComment = await fetchCommentWithRenderedBody(msg.issue, res.id);
+                                    this._editUIData.fieldValues['comment'].comments.push(fullComment);
+                                } catch (fetchError) {
+                                    Logger.warn(
+                                        fetchError,
+                                        'Failed to fetch comment with renderedBody, using API response',
+                                    );
+                                    this._editUIData.fieldValues['comment'].comments.push(res);
+                                }
                             }
 
                             this.postMessage({


### PR DESCRIPTION
fixes #1560

### What Is This Change?

## Problem

Comments posted/updated in the AtlasCode Jira extension lose wiki markup formatting and HTML rendering when displayed. The issue occurred because the extension was using the raw comment body returned from the API without fetching the server-rendered HTML version.

## Key Features

✅ **Preserves Formatting:** Wiki markup and HTML rendering retained  
✅ **Backward Compatible:** Graceful fallback for errors  
✅ **Cloud & DC Support:** Works with both Jira instances  
✅ **Error Handling:** Comprehensive logging for debugging  
✅ **Type Safe:** Full TypeScript support with ADF types  
✅ **Well Tested:** 40+ new test cases with edge cases  

## Breaking Changes

None. All changes are additive or internal improvements.

## Solution

Implemented `fetchCommentWithRenderedBody()` function to fetch comments with the `renderedBody` field populated. This preserves:
- Wiki markup formatting (e.g., `*bold*`, `_italic_`, `h1.` headers)
- HTML-rendered content from the server
- Consistent formatting across Cloud and Data Center (DC) Jira instances

### How Has This Been Tested?

### 1. **src/commands/jira/postComment.ts** (Modified)
- **Added:** `fetchCommentWithRenderedBody()` export
- **Functionality:** 
  - Fetches comment with `expand='renderedBody'` parameter
  - Preserves HTML-rendered content
  - Includes error handling with logging
- **Impact:** Core utility for retrieving full comment data

### 2. **src/commands/jira/postComment.test.ts** (New)
- **Test Count:** 11 test cases
- **Coverage:**
  - ✅ Post new comment to Cloud
  - ✅ Post new comment to DC with ADF conversion
  - ✅ Update existing comment
  - ✅ Comment with visibility restrictions
  - ✅ Analytics event tracking
  - ✅ Fetch comment with renderedBody
  - ✅ Handle missing renderedBody
  - ✅ Error handling and logging
  - ✅ Cloud vs DC site type handling

### 3. **src/webviews/components/AdfAwareContent.tsx** (Modified)
- **Changes:**
  - Enhanced type signature: `content: string | any` (was `string`)
  - Added ADF structure validation (`type: 'doc'`, `version: 1`)
  - Improved fallback logic for invalid content
  - Better error messages and warnings
- **Impact:** Component now properly validates and renders ADF content

### 4. **src/webviews/components/AdfAwareContent.test.tsx** (New)
- **Test Count:** 20+ test cases
- **Coverage:**
  - ✅ Valid ADF string rendering
  - ✅ Valid ADF object rendering
  - ✅ Complex ADF structures with formatting
  - ✅ ADF with mentions
  - ✅ Invalid content handling (null, undefined, empty string)
  - ✅ Invalid JSON strings
  - ✅ Missing required ADF fields
  - ✅ Edge cases and special characters
  - ✅ Content prop changes
  - ✅ Memoization behavior

### 5. **src/webviews/components/issue/view-issue-screen/mainpanel/IssueCommentComponent.tsx** (Modified)
- **Changes:**
  - Added type definitions: `ADFDoc` and `JiraCommentWithAdf`
  - Updated `comments` prop type to support ADF bodies
  - Enhanced `bodyText` calculation with memoization
  - Proper ADF to WikiMarkup conversion fallback
  - Preference order: `renderedBody` → ADF conversion → plain text
- **Impact:** Component correctly handles all comment body formats

### 6. **src/webviews/components/issue/view-issue-screen/mainpanel/IssueCommentComponent.test.tsx** (Modified)
- **New Tests:** 4 describe blocks with 4 test cases
- **Coverage:**
  - ✅ Prefers renderedBody over body
  - ✅ Converts ADF to WikiMarkup when renderedBody unavailable
  - ✅ Falls back to plain text
  - ✅ Handles complex formatting possibilities
- **Impact:** Validates comment body rendering logic

### 7. **src/webviews/jiraIssueWebview.ts** (Modified)
- **Changes:**
  - Updated import to include `fetchCommentWithRenderedBody`
  - Enhanced comment handler in `onMessageReceived()`
  - Calls `fetchCommentWithRenderedBody()` after post/update
  - Graceful fallback if fetch fails
  - Added error logging with `Logger.warn()`
- **Impact:** Comments now display with preserved formatting

### 8. **src/webviews/jiraIssueWebview.test.ts** (Modified)
- **New Tests:** 4 test cases
- **Coverage:**
  - ✅ Fetch comment with renderedBody on create
  - ✅ Fallback if fetchCommentWithRenderedBody fails
  - ✅ Fetch comment with renderedBody on update
  - ✅ Fallback on update fetch failure
- **Impact:** Integration tests verify end-to-end behavior

## Statistics

- **Files Modified:** 8
- **New Test Files:** 2
- **Total Test Cases Added:** 40+
- **Lines of Code Added:** ~800
- **Linting Status:** ✅ Passing

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

