### PR TITLE
Ignoring-cache-file-path-api-call-errors-as-they-are-already-silently-skipped

### DIFF
--- a/src/rovo-dev/client/rovoDevApiClient.ts
+++ b/src/rovo-dev/client/rovoDevApiClient.ts
@@ -107,8 +107,8 @@ export class RovoDevApiClient {
         } catch (err) {
             const reason = err.cause?.code || err.message || err;
             const error = new RovoDevApiError(`Failed to fetch '${restApi} API: ${reason}'`, 0, undefined);
-            // Skip logging for healthcheck calls since they're polled frequently during startup
-            if (restApi !== '/healthcheck') {
+            // Skip logging for healthcheck and cache-file-path calls since they're polled frequently or expected to fail
+            if (restApi !== '/healthcheck' && !restApi.includes('/cache-file-path')) {
                 RovoDevTelemetryProvider.logError(error, String(reason));
             }
             throw error;
@@ -119,8 +119,8 @@ export class RovoDevApiClient {
         } else {
             const message = `Failed to fetch '${restApi} API: HTTP ${response.status}'`;
             const error = new RovoDevApiError(message, response.status, response);
-            // Skip logging for healthcheck calls since they're polled frequently during startup
-            if (restApi !== '/healthcheck') {
+            // Skip logging for healthcheck and cache-file-path calls since they're polled frequently or expected to fail
+            if (restApi !== '/healthcheck' && !restApi.includes('/cache-file-path')) {
                 RovoDevTelemetryProvider.logError(error, message);
             }
             throw error;


### PR DESCRIPTION
### What Is This Change?

the api **/cache-file-path** call to RovoDev  is used to retrieve cached info about sessions.  However, if the api fails for whatever reason, we silently ignore the errors.  Consequently, there is no need to log errors for such use cases.  This PR does exactly that.

### How Has This Been Tested?

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

