### PR TITLE
Centered tool call statement AXON-1949

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - **RovoDev**: Refactored JSON parsing logic with `safeJsonParse` helper function to reduce code duplication and improve maintainability
+- **RovoDev**: Centered text within tool call statements in RovoDev chat.
 
 ### Bug Fixes
 

--- a/src/rovo-dev/ui/RovoDev.css
+++ b/src/rovo-dev/ui/RovoDev.css
@@ -260,6 +260,13 @@ body {
     word-break: break-all;
 }
 
+.tool-return-content p {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap;;
+}
+
 .tool-call-item span {
     color: var(--vscode-input-placeholderForeground)
 }


### PR DESCRIPTION
### What Is This Change?

Centered the text items in the tool return content.

Before
<img width="627" height="513" alt="Screenshot 2026-03-05 at 2 48 08 PM" src="https://github.com/user-attachments/assets/555ce969-a182-4a97-97b2-d2756b1ffeb6" />

After
<img width="734" height="309" alt="Screenshot 2026-03-05 at 2 56 50 PM" src="https://github.com/user-attachments/assets/1ea3f313-cd10-4ad7-bb9d-4ee9c8211ad6" />


### How Has This Been Tested?

Tested by calling some tool calls and mcp tool calls in the chat.

Basic checks:

- [X] `npm run lint`
- [X] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [X] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

