### PR TITLE
AXON-1972: fix error handling uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - **RovoDev**: Fixed chat message not appearing when clicking "Fix with Rovo Dev" before the chat view is fully initialized - now waits for the webview to be ready before executing the chat command
+- Fixed "Cannot read properties of undefined (reading 'initiateApiTokenAuth')" error
 
 ### Features
 

--- a/src/lib/webview/controller/config/configV3WebviewController.ts
+++ b/src/lib/webview/controller/config/configV3WebviewController.ts
@@ -119,7 +119,11 @@ export class ConfigV3WebviewController implements WebviewController<SectionV3Cha
         }
     }
 
-    public update(section: SectionV3ChangeMessage) {
+    public update(section?: SectionV3ChangeMessage) {
+        if (section === undefined) {
+            this.invalidate();
+            return;
+        }
         // Store the section data for potential invalidate calls
         this._initialSection = section;
 

--- a/src/lib/webview/controller/config/configWebviewController.ts
+++ b/src/lib/webview/controller/config/configWebviewController.ts
@@ -118,7 +118,11 @@ export class ConfigWebviewController implements WebviewController<SectionChangeM
         }
     }
 
-    public update(section: SectionChangeMessage) {
+    public update(section?: SectionChangeMessage) {
+        if (section === undefined) {
+            this.invalidate();
+            return;
+        }
         // Store the section data for potential invalidate calls
         this._initialSection = section;
 


### PR DESCRIPTION
### What Is This Change?
- Fixed error handling uri issue

**Current behaviour:**


https://github.com/user-attachments/assets/e0bad9a3-55c9-49d6-a91a-511d8ed9da07


**Fixed behaviour:**


https://github.com/user-attachments/assets/7534bfa6-6eb7-4f7e-936d-a3588b707c03


<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

