### PR TITLE
chore: add release stable skill prompt

### DIFF
--- a/.rovodev/prompts.yml
+++ b/.rovodev/prompts.yml
@@ -1,4 +1,7 @@
 prompts:
-  - name: bump-version
-    description: Bump version
-    content_file: bump-version.md
+    - name: bump-version
+      description: Bump version
+      content_file: bump-version.md
+    - name: release-stable
+      description: Find next stable version and run release script
+      content_file: release-stable.md

--- a/.rovodev/release-stable.md
+++ b/.rovodev/release-stable.md
@@ -1,0 +1,7 @@
+1. Ensure you are on `main` and up to date: run `git checkout main && git fetch origin && git pull origin main`
+2. Find the latest stable tag (exclude nightly tags): run `git fetch --tags && git tag --list 'v*' | grep -v 'nightly' | sort -V | tail -n 1`
+3. Derive the next valid stable version from that tag by incrementing patch (e.g. `v4.0.22` -> `4.0.23`)
+4. Validate the derived version is stable: run `./scripts/version/assert-stable.sh <next_version>`
+5. Ensure `CHANGELOG.md` contains `## What's new in <next_version>`
+6. Invoke the stable release script: run `npm run release:stable -- <next_version>`
+7. If release message is needed, invoke with custom message: `npm run release:stable -- <next_version> "Release v<next_version>"`


### PR DESCRIPTION
### What Is This Change?

this PR adds a skill that would find the next version number and releases a stable version of atlascode

### How Has This Been Tested?


Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

