### PR TITLE
[Axon-1383] Teamcamp rovo dev in Help and Feedback is disabled

### DIFF
--- a/src/views/helpDataProvider.ts
+++ b/src/views/helpDataProvider.ts
@@ -57,7 +57,7 @@ export class HelpDataProvider extends BaseTreeDataProvider {
                 ...(Container.isRovoDevEnabled && Container.siteManager.productHasAtLeastOneSite(ProductJira)
                     ? [
                           new InternalLinkNode('Rovo Dev', 'Chat with Atlassian coding agent', iconSet.ROVODEV, {
-                              command: 'workbench.view.extension.atlascode-rovo-dev',
+                              command: 'atlascode.views.rovoDev.webView.focus',
                               title: 'Open Rovo Dev Chat',
                           }),
                       ]
@@ -87,7 +87,7 @@ export class HelpDataProvider extends BaseTreeDataProvider {
                 ...(Container.isRovoDevEnabled && Container.siteManager.productHasAtLeastOneSite(ProductJira)
                     ? [
                           new InternalLinkNode('Rovo Dev', 'Chat with Atlassian coding agent', iconSet.ROVODEV, {
-                              command: 'workbench.view.extension.atlascode-rovo-dev',
+                              command: 'atlascode.views.rovoDev.webView.focus',
                               title: 'Open Rovo Dev Chat',
                           }),
                       ]


### PR DESCRIPTION
### What Is This Change?
Problem: In the Help and Feedback section, the Rovo Dev tab is disabled and doesn't allow users to click on it.
In the InternalLinkNode command, it was set as 'workbench.view.extension.atlascode-rovo-dev' 

Fix: Changed the InternalLinkNode command to 'atlascode.views.rovoDev.webView.focus' so it focuses on the RovoDev webview and makes it clickable

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `manual tests`

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

