### PR TITLE
AXON-1786: Merge consecutive warning message into thinking block

### DIFF
--- a/src/rovo-dev/ui/utils.tsx
+++ b/src/rovo-dev/ui/utils.tsx
@@ -437,6 +437,25 @@ export const appendResponse = (
 
             return [...prev, appendedMessage];
         }
+
+        // Group consecutive _RovoDevDialog messages when thinking blocks are enabled
+        if (
+            thinkingBlockEnabled &&
+            latest?.event_kind === '_RovoDevDialog' &&
+            response?.event_kind === '_RovoDevDialog'
+        ) {
+            const prevGroup = prev.pop();
+            // If previous message is also a thinking group, merge them
+            if (prevGroup !== undefined) {
+                if (Array.isArray(prevGroup)) {
+                    return [...prev, [...prevGroup, latest, response]];
+                } else {
+                    return [...prev, prevGroup, [latest, response]];
+                }
+            }
+            return [...prev, [latest, response]];
+        }
+
         // Group tool return with previous message if applicable
         if (response.event_kind === 'tool-return' || response.event_kind === 'retry-prompt') {
             if (response.event_kind === 'tool-return') {
@@ -469,6 +488,12 @@ export const appendResponse = (
             }
         }
     } else {
+        // Add consecutive _RovoDevDialog to existing thinking block if latest is already a thinking block array
+        if (thinkingBlockEnabled && response?.event_kind === '_RovoDevDialog') {
+            latest.push(response);
+            return [...prev, latest];
+        }
+
         if (response.event_kind === 'tool-return' || response.event_kind === 'retry-prompt') {
             if (response.event_kind === 'tool-return') {
                 handleAppendModifiedFileToolReturns(response);


### PR DESCRIPTION
### What Is This Change?

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

This pull request introduces enhancements to the message grouping logic in the `appendResponse` function within `src/rovo-dev/ui/utils.tsx`. The main focus is on improving how consecutive `_RovoDevDialog` messages are grouped when thinking blocks are enabled, making the UI more organized and easier to follow.

Message grouping improvements:

* Added logic to group consecutive `_RovoDevDialog` messages into thinking blocks when `thinkingBlockEnabled` is true, ensuring related dialog messages are visually grouped together.
* Enhanced handling for appending new `_RovoDevDialog` messages to existing thinking block arrays, allowing dynamic extension of thinking blocks as new messages arrive.
* * 

https://github.com/user-attachments/assets/700a7a87-e964-464b-86cd-1b5112406295



### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

