### PR TITLE
AXON-1979: Others section shouldn't render if there is no items in prompt setting popup

### DIFF
--- a/src/rovo-dev/ui/prompt-box/prompt-settings-popup/PromptSettingsPopup.tsx
+++ b/src/rovo-dev/ui/prompt-box/prompt-settings-popup/PromptSettingsPopup.tsx
@@ -7,7 +7,7 @@ import Popup, { PopupComponentProps } from '@atlaskit/popup';
 import { Box } from '@atlaskit/primitives';
 import { token } from '@atlaskit/tokens';
 import Tooltip from '@atlaskit/tooltip';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { AgentMode, RovoDevModeInfo } from 'src/rovo-dev/client';
 
 import AgentModeSection from './AgentModeSection';
@@ -20,6 +20,16 @@ const styles = cssMap({
         marginBottom: token('space.100', '8px'),
     },
 });
+
+interface OtherSectionItem {
+    key: string;
+    icon: React.ReactElement;
+    label: string;
+    description: string;
+    action: () => void;
+    toggled: boolean;
+    isInternalOnly?: boolean;
+}
 
 interface PromptSettingsPopupProps {
     onDeepPlanToggled?: () => void;
@@ -76,6 +86,34 @@ const PromptSettingsPopup: React.FC<PromptSettingsPopupProps> = ({
         [onAgentModeChange, onClose],
     );
 
+    const otherSectionItems = useMemo((): OtherSectionItem[] => {
+        const items: OtherSectionItem[] = [];
+        if (onFullContextToggled) {
+            items.push({
+                key: 'fullContext',
+                icon: <TelescopeIcon label="Full-Context mode" />,
+                label: 'Full-Context mode',
+                description:
+                    'Toggle Full-Context mode to enable the agent to research documents and historical data, helping it better understand the problem to solve.',
+                action: onFullContextToggled,
+                toggled: isFullContextEnabled,
+                isInternalOnly: true,
+            });
+        }
+        if (onYoloModeToggled) {
+            items.push({
+                key: 'yolo',
+                icon: <LockUnlockedIcon label="YOLO mode" />,
+                label: 'YOLO',
+                description:
+                    'Toggle yolo mode which runs all file CRUD operations and bash commands without confirmation. Use with caution!',
+                action: onYoloModeToggled,
+                toggled: isYoloModeEnabled,
+            });
+        }
+        return items;
+    }, [onFullContextToggled, onYoloModeToggled, isFullContextEnabled, isYoloModeEnabled]);
+
     if (!onDeepPlanToggled && !onYoloModeToggled && !onFullContextToggled) {
         return null;
     }
@@ -114,33 +152,29 @@ const PromptSettingsPopup: React.FC<PromptSettingsPopupProps> = ({
                         availableModes={availableAgentModes}
                         setAgentMode={handleAgentModeChange}
                     />
-                    <Box
-                        as="p"
-                        xcss={styles.sectionTitle}
-                        style={{
-                            fontSize: '12px',
-                        }}
-                    >
-                        Others
-                    </Box>
-                    {onFullContextToggled && (
-                        <PromptSettingsItem
-                            icon={<TelescopeIcon label="Full-Context mode" />}
-                            label="Full-Context mode"
-                            description="Toggle Full-Context mode to enable the agent to research documents and historical data, helping it better understand the problem to solve."
-                            action={onFullContextToggled}
-                            toggled={isFullContextEnabled}
-                            isInternalOnly={true}
-                        />
-                    )}
-                    {onYoloModeToggled && (
-                        <PromptSettingsItem
-                            icon={<LockUnlockedIcon label="YOLO mode" />}
-                            label="YOLO"
-                            description="Toggle yolo mode which runs all file CRUD operations and bash commands without confirmation. Use with caution!"
-                            action={onYoloModeToggled}
-                            toggled={isYoloModeEnabled}
-                        />
+                    {otherSectionItems.length > 0 && (
+                        <>
+                            <Box
+                                as="p"
+                                xcss={styles.sectionTitle}
+                                style={{
+                                    fontSize: '12px',
+                                }}
+                            >
+                                Others
+                            </Box>
+                            {otherSectionItems.map((item) => (
+                                <PromptSettingsItem
+                                    key={item.key}
+                                    icon={item.icon}
+                                    label={item.label}
+                                    description={item.description}
+                                    action={item.action}
+                                    toggled={item.toggled}
+                                    isInternalOnly={item.isInternalOnly}
+                                />
+                            ))}
+                        </>
                     )}
                 </div>
             )}


### PR DESCRIPTION
### What Is This Change?

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

Conditionally render others section

<img width="450" height="932" alt="Screenshot 2026-03-11 at 09 05 56" src="https://github.com/user-attachments/assets/fed0c045-3a89-462a-b2e6-2382d1a5aa50" />


### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

