### PR TITLE
OpenRovoDevLogFile clean up. 

### DIFF
--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -565,11 +565,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                     case RovoDevViewResponseType.OpenMcpConfiguration:
                         await commands.executeCommand(RovodevCommands.OpenRovoDevMcpJson);
                         break;
-
-                    case RovoDevViewResponseType.OpenRovoDevLogFile:
-                        await commands.executeCommand(RovodevCommands.OpenRovoDevLogFile);
-                        break;
-
                     case RovoDevViewResponseType.StartNewSession:
                         await this.executeNewSession();
                         break;

--- a/src/rovo-dev/ui/rovoDevViewMessages.tsx
+++ b/src/rovo-dev/ui/rovoDevViewMessages.tsx
@@ -45,7 +45,6 @@ export const enum RovoDevViewResponseType {
     GetCurrentAgentMode = 'getCurrentAgentMode',
     FilterModifiedFilesByContent = 'filterModifiedFilesByContent',
     OpenExternalLink = 'openExternalLink',
-    OpenRovoDevLogFile = 'openRovoDevLogFile',
     MessageRendered = 'messageRendered',
     ReportRenderError = 'reportRenderError',
     StartNewSession = 'startNewSession',
@@ -110,7 +109,6 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.GetCurrentAgentMode>
     | ReducerAction<RovoDevViewResponseType.FilterModifiedFilesByContent, { files: ModifiedFile[] }>
     | ReducerAction<RovoDevViewResponseType.OpenExternalLink, { href: string }>
-    | ReducerAction<RovoDevViewResponseType.OpenRovoDevLogFile>
     | ReducerAction<RovoDevViewResponseType.MessageRendered, { promptId: string }>
     | ReducerAction<
           RovoDevViewResponseType.ReportRenderError,


### PR DESCRIPTION

### What Is This Change?
OpenRovoDevLogFile clean up. Follow up to https://github.com/atlassian/atlascode/pull/1718

### How Has This Been Tested?
- Checked that the Rovo Dev Log file can still be opened from the command palette 
