### PR TITLE
Ensuring-Unhalndled-exceptions-from-other-extensions-are-not-sent-to-Amplitude

### DIFF
--- a/src/errorReporting.test.ts
+++ b/src/errorReporting.test.ts
@@ -166,6 +166,13 @@ describe('errorReporting', () => {
                 );
             });
 
+            it('capturedBy unhandledRejectionHandler should NOT send to analytics', () => {
+                const error = createError('Error1');
+                errorlistener!({ error, capturedBy: 'process.unhandledRejectionHandler' });
+
+                expect(analytics.errorEvent).not.toHaveBeenCalled();
+            });
+
             it('with productArea', () => {
                 const error = createError('Error1');
                 errorlistener!({ error, productArea: 'RovoDev' });

--- a/src/errorReporting.ts
+++ b/src/errorReporting.ts
@@ -17,6 +17,8 @@ let _logger_onError_eventRegistration: Disposable | undefined = undefined;
 let analyticsClient: AnalyticsClient | undefined;
 let eventQueue: Promise<TrackEvent>[] = [];
 
+const filteredExceptions = ['uncaughtexception', 'unhandledrejection'];
+
 function safeExecute(body: () => void, finallyBody?: () => void): void {
     try {
         body();
@@ -45,15 +47,18 @@ function unhandledRejectionHandler(error: Error | string): void {
     errorHandlerWithFilter(undefined, error, 'NodeJS.unhandledRejection');
 }
 
+function shouldSkipAnalyticsForNodeGlobalError(capturedBy?: string): boolean {
+    if (!capturedBy) {
+        return false;
+    }
+
+    const capturedByLower = capturedBy.toLowerCase();
+    return filteredExceptions.some((exception) => capturedByLower.includes(exception));
+}
+
 function errorHandlerWithFilter(productArea: ErrorProductArea, error: Error | string, capturedBy: string): void {
     safeExecute(() => {
-        // Don't send uncaughtException or unhandledRejection errors to Amplitude
-        // These are handled by extension.ts and logged via Logger.error
-        const filteredExceptions = ['uncaughtexception', 'unhandledrejection'];
-        const capturedByLower = capturedBy.toLowerCase();
-        const isNodeJsGlobalError = filteredExceptions.some((exception) => capturedByLower.includes(exception));
-
-        if (isNodeJsGlobalError) {
+        if (shouldSkipAnalyticsForNodeGlobalError(capturedBy)) {
             return;
         }
 
@@ -107,18 +112,20 @@ export function registerErrorReporting(): void {
         process.addListener('uncaughtExceptionMonitor', uncaughtExceptionMonitorHandler);
         process.addListener('unhandledRejection', unhandledRejectionHandler);
 
-        _logger_onError_eventRegistration = Logger.onError(
-            (data) =>
-                errorHandler(
-                    data.productArea,
-                    data.error,
-                    data.errorMessage,
-                    data.params,
-                    data.rovoDevParams,
-                    data.capturedBy,
-                ),
-            undefined,
-        );
+        _logger_onError_eventRegistration = Logger.onError((data) => {
+            if (shouldSkipAnalyticsForNodeGlobalError(data.capturedBy)) {
+                return;
+            }
+
+            errorHandler(
+                data.productArea,
+                data.error,
+                data.errorMessage,
+                data.params,
+                data.rovoDevParams,
+                data.capturedBy,
+            );
+        }, undefined);
     });
 }
 


### PR DESCRIPTION
### What Is This Change?

Other VS Code extensions can have their unhandled exceptions reported to Atlascode’s Amplitude because all extensions share the same runtime environment. Previously, we mitigated this by filtering these errors on one of the reporting paths. In this PR, we ensure both reporting paths apply the same filtering, so these external errors are no longer sent.

### How Has This Been Tested?


Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
- [x] `new tests`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

