### PR TITLE
Fix some more npm package vulnerabilities

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,9 +42,7 @@ jobs:
         # but we should be diligent and fix them when they are discovered
         # We also skip the audit for dev dependencies, since they don't
         # end up on the distributed package.
-
-        # TODO AXON-1932 - setting to critical for now to unblock the build
-        run: npm audit --audit-level=critical --omit=dev
+        run: npm audit --audit-level=moderate --omit=dev
 
       - name: Compress node_modules
         run: tar -czf node_modules.tar.gz node_modules

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
             npm-${{ runner.os }}-
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit
 
       - name: Run vulnerability audit
         # We allow low severity vulnerabilities to not block the build, 

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,7 +184,7 @@
                 "autoprefixer": "^10.4.20",
                 "concurrently": "^9.1.2",
                 "css-loader": "^7.1.2",
-                "css-minimizer-webpack-plugin": "^7.0.2",
+                "css-minimizer-webpack-plugin": "^8.0.0",
                 "dotenv": "^17.2.3",
                 "eslint": "^9.27.0",
                 "eslint-import-resolver-typescript": "^4.4.1",
@@ -33731,7 +33731,6 @@
             "version": "4.0.4",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
             }
@@ -33912,10 +33911,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.3",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-5.0.3.tgz",
-            "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-            "license": "MIT",
+            "version": "5.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
@@ -35108,9 +35106,9 @@
             }
         },
         "node_modules/css-minimizer-webpack-plugin": {
-            "version": "7.0.4",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-7.0.4.tgz",
-            "integrity": "sha512-2iACis+P8qdLj1tHcShtztkGhCNIRUajJj7iX0IM9a5FA0wXGwjV8Nf6+HsBjBfb4LO8TTAVoetBbM54V6f3+Q==",
+            "version": "8.0.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-8.0.0.tgz",
+            "integrity": "sha512-9bEpzHs8gEq6/cbEj418jXL/YWjBUD2YTLLk905Npt2JODqnRITin0+So5Vx4Dp5vyi2Lpt9pp2QHzQ7fdxNrw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
@@ -35118,10 +35116,10 @@
                 "jest-worker": "^30.0.5",
                 "postcss": "^8.4.40",
                 "schema-utils": "^4.2.0",
-                "serialize-javascript": "^6.0.2"
+                "serialize-javascript": "^7.0.3"
             },
             "engines": {
-                "node": ">= 18.12.0"
+                "node": ">= 20.9.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -43136,12 +43134,11 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-10.2.2.tgz",
-            "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-            "license": "BlueOak-1.0.0",
+            "version": "10.2.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -46955,16 +46952,6 @@
             "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
             "license": "MIT"
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/range-parser": {
             "version": "1.2.1",
             "resolved": "https://packages.atlassian.com/api/npm/npm-remote/range-parser/-/range-parser-1.2.1.tgz",
@@ -48438,13 +48425,12 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.5",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -1734,14 +1734,14 @@
         "@atlaskit/tokens": "^6.1.1",
         "@atlaskit/tooltip": "^20.4.3",
         "@atlaskit/width-detector": "^5.0.4",
-        "@atlassianlabs/guipi-core-components": "^3.2.0",
-        "@atlassianlabs/guipi-jira-components": "^3.2.0",
         "@atlassian-pi/jira-metaui-client": "^3.0.2",
         "@atlassian-pi/jira-metaui-transformer": "^3.0.0",
         "@atlassian-pi/jira-pi-client": "^3.0.2",
         "@atlassian-pi/jira-pi-common-models": "^3.0.0",
         "@atlassian-pi/jira-pi-meta-models": "^3.0.0",
         "@atlassian-pi/pi-client-common": "^3.0.0",
+        "@atlassianlabs/guipi-core-components": "^3.2.0",
+        "@atlassianlabs/guipi-jira-components": "^3.2.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^5.18.0",
@@ -1855,7 +1855,7 @@
         "autoprefixer": "^10.4.20",
         "concurrently": "^9.1.2",
         "css-loader": "^7.1.2",
-        "css-minimizer-webpack-plugin": "^7.0.2",
+        "css-minimizer-webpack-plugin": "^8.0.0",
         "dotenv": "^17.2.3",
         "eslint": "^9.27.0",
         "eslint-import-resolver-typescript": "^4.4.1",
@@ -1898,10 +1898,10 @@
     },
     "overrides": {
         "@sentry/node": {
-            "minimatch": "10.2.2"
+            "minimatch": "^10.2.5"
         },
         "vscode-languageclient": {
-            "minimatch": "10.2.2"
+            "minimatch": "^10.2.5"
         },
         "@atlaskit/analytics-next-stable-react-context": {
             "react": "^18.3.1"


### PR DESCRIPTION
### brace-expansion  4.0.0 - 5.0.4
Severity: moderate
brace-expansion: Zero-step sequence causes process hang and memory exhaustion - https://github.com/advisories/GHSA-f886-m6hf-6m8v

### minimatch  10.0.0 - 10.2.2
Severity: high
minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments - https://github.com/advisories/GHSA-7r86-cg39-jmmj
minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions - https://github.com/advisories/GHSA-23c5-xmqv-rm74

### serialize-javascript  <=7.0.4
Severity: high
Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString() - https://github.com/advisories/GHSA-5c6j-r48x-rmvq
Serialize JavaScript has CPU Exhaustion Denial of Service via crafted array-like objects - https://github.com/advisories/GHSA-qj8w-gfj5-8c6v






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

