### PR TITLE
feat(jira): add getActiveIssue command to expose active issue key to other extensions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
+  workflow_dispatch: 
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **RovoDev**: Upgraded Rovo Dev to v0.13.63
 - **RovoDev**: Generalized MCP tool parsing in chat UI to support any MCP toolset via regex matching (`mcp__<name>__invoke_tool` / `mcp__<name>__get_tool_schema`) instead of hardcoded tool names
+- **Jira**: Added `atlascode.jira.getActiveIssue` command so other VS Code extensions and tasks can retrieve the active Jira issue key shown in the status bar
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -386,6 +386,11 @@
                 "category": "Jira"
             },
             {
+                "command": "atlascode.jira.getActiveIssue",
+                "title": "Get Active Jira Issue Key",
+                "category": "Jira"
+            },
+            {
                 "command": "atlascode.jira.transitionIssue",
                 "title": "Transition Issue...",
                 "category": "Jira"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,7 @@ export const enum Commands {
     ShowIssueForKey = 'atlascode.jira.showIssueForKey',
     ShowIssueForSiteIdAndKey = 'atlascode.jira.showIssueForSiteIdAndKey',
     ShowIssueForURL = 'atlascode.jira.showIssueForURL',
+    JiraGetActiveIssue = 'atlascode.jira.getActiveIssue',
     ShowConfigPage = 'atlascode.showConfigPage',
     ShowConfigPageV3 = 'atlascode.showConfigPageV3',
     ShowConfigPageFromExtensionContext = 'atlascode.extensionContext.showConfigPage',

--- a/src/views/jira/activeIssueStatusBar.test.ts
+++ b/src/views/jira/activeIssueStatusBar.test.ts
@@ -14,6 +14,9 @@ import { JiraActiveIssueStatusBar } from './activeIssueStatusBar';
 jest.mock('../../constants', () => ({
     AssignedJiraItemsViewId: 'assignedJiraItemsView',
     JiraEnabledKey: 'jira.enabled',
+    Commands: {
+        JiraGetActiveIssue: 'atlascode.jira.getActiveIssue',
+    },
 }));
 
 // Mock Container
@@ -332,6 +335,20 @@ describe('JiraActiveIssueStatusBar', () => {
 
             // Verify analytics were sent
             expect(Container.analyticsClient.sendUIEvent).toHaveBeenCalledWith({ name: 'open-active-issue' });
+        });
+
+        it('should register and return active issue key from command', async () => {
+            activeIssueStatusBar = new JiraActiveIssueStatusBar(mockBitbucketContext);
+            await activeIssueStatusBar.handleActiveIssueChange();
+
+            const commandRegistration = (commands.registerCommand as jest.Mock).mock.calls.find(
+                (call) => call[0] === 'atlascode.jira.getActiveIssue',
+            );
+
+            expect(commandRegistration).toBeTruthy();
+
+            const commandHandler = commandRegistration[1];
+            await expect(commandHandler()).resolves.toBe('TEST-123');
         });
     });
 });

--- a/src/views/jira/activeIssueStatusBar.ts
+++ b/src/views/jira/activeIssueStatusBar.ts
@@ -15,7 +15,7 @@ import { DetailedSiteInfo } from '../../atlclients/authInfo';
 import { BitbucketContext } from '../../bitbucket/bbContext';
 import { showIssue } from '../../commands/jira/showIssue';
 import { configuration } from '../../config/configuration';
-import { AssignedJiraItemsViewId, JiraEnabledKey } from '../../constants';
+import { AssignedJiraItemsViewId, Commands, JiraEnabledKey } from '../../constants';
 import { Container } from '../../container';
 import { getCachedIssue } from '../../jira/fetchIssue';
 import { issueForKey } from '../../jira/issueForKey';
@@ -37,6 +37,7 @@ export class JiraActiveIssueStatusBar implements Disposable {
         Container.context.subscriptions.push(
             configuration.onDidChange((e) => this.handleConfigurationChange(e)),
             bbCtx.onDidChangeBitbucketContext(() => this.handleRepoChange()),
+            commands.registerCommand(Commands.JiraGetActiveIssue, () => this.activeIssue?.key),
         );
         void this.handleConfigurationChange(configuration.initializingChangeEvent);
     }


### PR DESCRIPTION
### What Is This Change?

Adds a new VS Code command `atlascode.jira.getActiveIssue` that returns the key of the currently active Jira issue displayed in the status bar.

This allows other VS Code extensions and tasks (e.g., git commit hooks, custom task runners, or companion extensions) to programmatically retrieve the active Jira issue key without scraping the UI. The command is registered in the `JiraActiveIssueStatusBar` and simply returns `this.activeIssue?.key`, so it's lightweight and has no side effects.

**Changes across 5 files:**

- **`package.json`** — Registers the new `atlascode.jira.getActiveIssue` command under the "Jira" category.
- **`src/constants.ts`** — Adds the `JiraGetActiveIssue` entry to the `Commands` enum.
- **`src/views/jira/activeIssueStatusBar.ts`** — Imports the new command constant and registers a handler via `commands.registerCommand` that returns the active issue's key (or `undefined` if none is set).
- **`src/views/jira/activeIssueStatusBar.test.ts`** — Adds a test verifying the command is registered and returns the expected issue key.
- **`CHANGELOG.md`** — Documents the new command in the Unreleased section.

### How Has This Been Tested?

- Added a unit test in `activeIssueStatusBar.test.ts` that confirms the command is registered and returns the correct issue key (`'TEST-123'`) when an active issue is present.
- The implementation is a single-line return from an already-maintained property (`this.activeIssue?.key`), so risk of regression is minimal.

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks:
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [[See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

