### PR TITLE
FLOW-2024: expose http endpoint for sending a prompt to rovodev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
+## What's new in 4.0.29
+
+### Features
+
+- **RovoDev (BBY)**: Exposed a local HTTP endpoint `POST http://127.0.0.1:9999/rovodev/chat` that allows external services (e.g. DevAI Sandbox) to send prompts to the Rovo Dev chat UI. Returns `200` on success or `409` if the agent is already busy.
+- **RovoDev (BBY)**: Added `GET http://127.0.0.1:9999/rovodev/health` healthcheck endpoint that returns server status and whether the agent is currently busy.
+
 ## What's new in 4.0.28
 
 ### Improvements
@@ -12,7 +19,6 @@
 ### Bug Fixes
 
 - **Webview**: Fixed `ChunkLoadError` for CSS chunks (e.g. `atlascodeRovoDev`, `compiled-css`) when running with a Firefox-based webview engine (e.g. code-server). Switched from `MiniCssExtractPlugin` to `style-loader` in the React webpack bundles so CSS is injected as `<style>` tags instead of being dynamically fetched as separate files, which Firefox cannot do for `vscode-resource` URLs.
-
 
 ## What's new in 4.0.27
 
@@ -50,7 +56,6 @@
 ### Features
 
 - **RovoDev**: Added copy code button within the Rovo Dev chat for code blocks in the chat.
-
 
 ## What's new in 4.0.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
-## What's new in 4.0.29
-
-### Features
-
-- **RovoDev (BBY)**: Exposed a local HTTP endpoint `POST http://127.0.0.1:9999/rovodev/chat` that allows external services (e.g. DevAI Sandbox) to send prompts to the Rovo Dev chat UI. Returns `200` on success or `409` if the agent is already busy.
-- **RovoDev (BBY)**: Added `GET http://127.0.0.1:9999/rovodev/health` healthcheck endpoint that returns server status and whether the agent is currently busy.
-
 ## What's new in 4.0.28
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - **Webview**: Fixed `ChunkLoadError` for CSS chunks (e.g. `atlascodeRovoDev`, `compiled-css`) when running with a Firefox-based webview engine (e.g. code-server). Switched from `MiniCssExtractPlugin` to `style-loader` in the React webpack bundles so CSS is injected as `<style>` tags instead of being dynamically fetched as separate files, which Firefox cannot do for `vscode-resource` URLs.
 
+
 ## What's new in 4.0.27
 
 ### Improvements
@@ -49,6 +50,7 @@
 ### Features
 
 - **RovoDev**: Added copy code button within the Rovo Dev chat for code blocks in the chat.
+
 
 ## What's new in 4.0.23
 

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -124,6 +124,10 @@ export class RovoDevChatProvider {
 
     private _abortController: AbortController | null = null;
 
+    public get isAgentRunning(): boolean {
+        return this._abortController !== null;
+    }
+
     constructor(
         private readonly _isBoysenberry: boolean,
         private _telemetryProvider: RovoDevTelemetryProvider,

--- a/src/rovo-dev/rovoDevLocalServer.ts
+++ b/src/rovo-dev/rovoDevLocalServer.ts
@@ -1,0 +1,78 @@
+import express, { Request, Response } from 'express';
+import * as http from 'http';
+import { Logger } from 'src/logger';
+import { Disposable } from 'vscode';
+
+export const ROVODEV_LOCAL_SERVER_PORT = 9999;
+
+/**
+ * A local HTTP server that allows external services (e.g. DevAI Sandbox) to send prompts
+ * to the Rovo Dev chat UI via AtlasCode.
+ */
+export class RovoDevLocalServer implements Disposable {
+    private _server: http.Server | undefined;
+
+    constructor(
+        private readonly _invokeRovoDevAsk: (prompt: string) => Promise<void>,
+        private readonly _isAgentRunning: () => boolean,
+    ) {}
+
+    public start(): void {
+        const app = express();
+        app.use(express.json());
+
+        app.get('/rovodev/health', (_req: Request, res: Response) => {
+            res.status(200).json({ status: 'ok', agentBusy: this._isAgentRunning() });
+        });
+
+        app.post('/rovodev/chat', async (req: Request, res: Response) => {
+            const message: string | undefined = req.body?.message;
+
+            if (!message || typeof message !== 'string' || message.trim() === '') {
+                res.status(400).json({ success: false, error: 'message is required' });
+                return;
+            }
+
+            Logger.debug(`RovoDevLocalServer: received prompt via /axon/chat`);
+
+            // Check if the agent is already running before attempting to send the prompt.
+            // This prevents a second request from corrupting the chat UI with a 409 error.
+            if (this._isAgentRunning()) {
+                res.status(409).json({ success: false, error: 'agent_busy' });
+                return;
+            }
+
+            try {
+                await this._invokeRovoDevAsk(message.trim());
+                res.status(200).json({ success: true });
+            } catch (err: any) {
+                Logger.debug(`RovoDevLocalServer: error invoking RovoDev ask: ${err}`);
+                res.status(500).json({ success: false, error: 'internal_error' });
+            }
+        });
+
+        this._server = http.createServer(app);
+        this._server.listen(ROVODEV_LOCAL_SERVER_PORT, '127.0.0.1', () => {
+            Logger.debug(`RovoDevLocalServer: listening on http://127.0.0.1:${ROVODEV_LOCAL_SERVER_PORT}`);
+        });
+
+        this._server.on('error', (err: NodeJS.ErrnoException) => {
+            if (err.code === 'EADDRINUSE') {
+                Logger.debug(
+                    `RovoDevLocalServer: port ${ROVODEV_LOCAL_SERVER_PORT} already in use, skipping server start.`,
+                );
+            } else {
+                Logger.debug(`RovoDevLocalServer: server error: ${err.message}`);
+            }
+        });
+    }
+
+    public dispose(): void {
+        if (this._server) {
+            this._server.close(() => {
+                Logger.debug('RovoDevLocalServer: server stopped.');
+            });
+            this._server = undefined;
+        }
+    }
+}

--- a/src/rovo-dev/rovoDevLocalServer.ts
+++ b/src/rovo-dev/rovoDevLocalServer.ts
@@ -3,7 +3,9 @@ import * as http from 'http';
 import { Logger } from 'src/logger';
 import { Disposable } from 'vscode';
 
-export const ROVODEV_LOCAL_SERVER_PORT = 9999;
+export const ROVODEV_LOCAL_SERVER_PORT = process.env.ROVODEV_LOCAL_SERVER_PORT
+    ? parseInt(process.env.ROVODEV_LOCAL_SERVER_PORT, 10)
+    : 9999;
 
 /**
  * A local HTTP server that allows external services (e.g. DevAI Sandbox) to send prompts

--- a/src/rovo-dev/rovoDevLocalServer.ts
+++ b/src/rovo-dev/rovoDevLocalServer.ts
@@ -33,7 +33,7 @@ export class RovoDevLocalServer implements Disposable {
                 return;
             }
 
-            Logger.debug(`RovoDevLocalServer: received prompt via /axon/chat`);
+            Logger.debug(`RovoDevLocalServer: received prompt via /rovodev/chat`);
 
             // Check if the agent is already running before attempting to send the prompt.
             // This prevents a second request from corrupting the chat UI with a 409 error.

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -42,6 +42,7 @@ import { RovoDevChatProvider } from './rovoDevChatProvider';
 import { RovoDevDwellTracker } from './rovoDevDwellTracker';
 import { RovoDevFeedbackManager } from './rovoDevFeedbackManager';
 import { RovoDevJiraItemsProvider } from './rovoDevJiraItemsProvider';
+import { RovoDevLocalServer } from './rovoDevLocalServer';
 import { RovoDevProcessManager, RovoDevProcessState } from './rovoDevProcessManager';
 import { RovoDevSessionManager } from './rovoDevSessionManager';
 import { RovoDevTelemetryProvider } from './rovoDevTelemetryProvider';
@@ -116,6 +117,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private _disposables: Disposable[] = [];
 
     private _dwellTracker?: RovoDevDwellTracker;
+    private _localServer?: RovoDevLocalServer;
 
     private _extensionPath: string;
     private _extensionUri: Uri;
@@ -189,6 +191,14 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
         if (this.isBoysenberry) {
             this.appInstanceId = process.env.ROVODEV_SANDBOX_ID as string;
+
+            // Start the local HTTP server so external services can
+            // send prompts to the Rovo Dev chat UI via POST /rovodev/chat.
+            this._localServer = new RovoDevLocalServer(
+                (prompt) => this.invokeRovoDevAskCommand(prompt),
+                () => this._chatProvider.isAgentRunning,
+            );
+            this._localServer.start();
         } else {
             this.appInstanceId = this.extensionApi.metadata.appInstanceId();
         }
@@ -1307,6 +1317,8 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
     private _dispose() {
         this._stopModifiedFilesPoll();
+        this._localServer?.dispose();
+        this._localServer = undefined;
         this._disposables.forEach((d) => d.dispose());
         this._disposables = [];
         if (this._webView) {


### PR DESCRIPTION


### What Is This Change?

- Start an http server with endpoint to send a prompt to Rovodev so that it is visible in the chat 
- Also surface endpoint for health status 

Jira: https://softwareteams.atlassian.net/browse/AXON-1621 

### How Has This Been Tested?

Tested by running locally 
- Rovodev is initialised properly
- User can still type prompts from the chatbox
- Hitting the new endpoint shows both user prompt and responses in the chat 
- Hitting the endpoint while an existing chat is in process returns 409 (no change to chat) 
- Reloading page shows the full chat history 
















<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

