### PR TITLE
fix: Bitbucket OAuth ERR_CONNECTION_REFUSED on localhost:31415 (#1663)

### DIFF
--- a/src/atlclients/oauthDancer.ts
+++ b/src/atlclients/oauthDancer.ts
@@ -5,7 +5,6 @@ import * as http from 'http';
 import Mustache from 'mustache';
 import PCancelable from 'p-cancelable';
 import pTimeout from 'p-timeout';
-import { promisify } from 'util';
 import { v4 } from 'uuid';
 import * as vscode from 'vscode';
 import { Disposable } from 'vscode';
@@ -309,12 +308,16 @@ export class OAuthDancer implements Disposable {
 
         if (!this._srv) {
             this._srv = http.createServer(this._app);
-            const listenPromise = promisify(this._srv.listen.bind(this._srv));
             try {
-                await listenPromise(31415, () => {});
+                await new Promise<void>((resolve, reject) => {
+                    this._srv!.once('listening', resolve);
+                    this._srv!.once('error', reject);
+                    this._srv!.listen(31415, '127.0.0.1');
+                });
                 Logger.debug('auth server started on port 31415');
             } catch (err) {
                 Logger.error(err, 'Unable to start auth listener on localhost:31415');
+                this._srv = undefined;
                 return Promise.reject(`Unable to start auth listener on localhost:31415: ${err}`);
             }
 


### PR DESCRIPTION
Fixes #1663 — Bitbucket OAuth fails with ERR_CONNECTION_REFUSED on 127.0.0.1:31415.

The local callback server was started using util.promisify(server.listen) which resolves before the TCP socket is actually bound, so the browser opened before the server was ready. Replaced with proper 'listening'/'error' event-based startup to guarantee the server is accepting connections before the browser is launched. Also fixes silent EADDRINUSE errors and consistent failures in WSL.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

