### PR TITLE
FLOW-1878 live preview messaging

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -105,6 +105,9 @@ export const enum Commands {
 
     // Extension management commands
     AddRecommendedExtension = 'atlascode.addRecommendedExtension',
+
+    // Boysenberry-only commands
+    BoysenberryShowPreviewPanel = 'workbench.action.showPreviewPanel',
 }
 
 // Jira projects field pagination

--- a/src/rovo-dev/analytics/events.ts
+++ b/src/rovo-dev/analytics/events.ts
@@ -123,6 +123,17 @@ export namespace Track {
         };
     };
 
+    export type CreateLivePreviewButtonClicked = {
+        action: 'rovoDevCreateLivePreviewButtonClicked';
+        subject: 'atlascode';
+        attributes: {
+            rovoDevEnv: RovoDevEnv;
+            appInstanceId: string;
+            sessionId: string;
+            promptId: string;
+        };
+    };
+
     export type RestoreSessionClicked = {
         action: 'clicked';
         subject: 'rovoDevRestoreSession';

--- a/src/rovo-dev/api/componentApi.ts
+++ b/src/rovo-dev/api/componentApi.ts
@@ -18,6 +18,7 @@ export const RovodevCommands = {
     RovodevOpenHelp: 'atlascode.rovodev.openHelp',
     RovodevEnable: 'atlascode.rovodev.enable',
     RovodevOpenChat: 'atlascode.rovodev.openChat',
+    ShowPreviewPanel: 'atlascode.rovodev.showPreviewPanel',
 } as const;
 
 /**

--- a/src/rovo-dev/api/componentApi.ts
+++ b/src/rovo-dev/api/componentApi.ts
@@ -18,7 +18,6 @@ export const RovodevCommands = {
     RovodevOpenHelp: 'atlascode.rovodev.openHelp',
     RovodevEnable: 'atlascode.rovodev.enable',
     RovodevOpenChat: 'atlascode.rovodev.openChat',
-    ShowPreviewPanel: 'atlascode.rovodev.showPreviewPanel',
 } as const;
 
 /**

--- a/src/rovo-dev/client/responseParser.ts
+++ b/src/rovo-dev/client/responseParser.ts
@@ -179,6 +179,10 @@ interface RovoDevThinkingChunk {
     event_kind: 'thinking';
 }
 
+interface RovoDevUiChangedDetectedChunk {
+    event_kind: 'ui_changes_detected';
+}
+
 type RovoDevSingleResponseRaw =
     | RovoDevUserPromptResponseRaw
     | RovoDevTextResponseRaw
@@ -211,7 +215,8 @@ type RovoDevSingleChunk =
     | RovoDevCloseChunk
     | RovoDevReplayEndChunk
     | RovoDevRequestUsageChunk
-    | RovoDevThinkingChunk;
+    | RovoDevThinkingChunk
+    | RovoDevUiChangedDetectedChunk;
 
 // https://ai.pydantic.dev/api/messages/#pydantic_ai.messages.PartStartEvent
 interface RovoDevPartStartResponseRaw {
@@ -582,6 +587,12 @@ export class RovoDevResponseParser {
                 return buffer
                     ? generateError(Error(`Rovo Dev parser error: ${chunk.event_kind} seem to be split`))
                     : chunk;
+
+            case 'ui_changes_detected': {
+                return buffer
+                    ? generateError(Error(`Rovo Dev parser error: ${chunk.event_kind} seem to be split`))
+                    : { event_kind: 'ui_changes_detected' };
+            }
 
             // events we ignore
             case 'request-usage':

--- a/src/rovo-dev/client/responseParserInterfaces.ts
+++ b/src/rovo-dev/client/responseParserInterfaces.ts
@@ -198,7 +198,7 @@ export type RovoDevToolName =
 
 export type RovoDevToolPemissionScenario = 'ASK' | 'ALLOWED' | 'DENIED';
 
-export type RovoDevDeferredToolCallName = 'ask_user_questions' | 'exit_plan_mode';
+export type RovoDevDeferredToolCallName = 'ask_user_questions' | 'exit_plan_mode' | 'ui_changes_complete';
 
 export interface RovoDevAskUserQuestionsToolArgs {
     questions: {

--- a/src/rovo-dev/client/responseParserInterfaces.ts
+++ b/src/rovo-dev/client/responseParserInterfaces.ts
@@ -176,6 +176,7 @@ export type RovoDevResponse =
     | RovoDevModelsResponse
     | RovoDevCloseResponse
     | RovoDevReplayEndResponse
+    | RovoDevUiChangedDetectedResponse
     | RovoDevIgnoredResponse;
 
 export type RovoDevToolName =
@@ -194,11 +195,16 @@ export type RovoDevToolName =
     | 'mcp__atlassian__get_tool_schema'
     | 'mcp__scout__invoke_tool'
     | 'update_todo'
+    | 'configure_live_preview'
     | RovoDevDeferredToolCallName;
 
 export type RovoDevToolPemissionScenario = 'ASK' | 'ALLOWED' | 'DENIED';
 
-export type RovoDevDeferredToolCallName = 'ask_user_questions' | 'exit_plan_mode' | 'ui_changes_complete';
+export type RovoDevDeferredToolCallName = 'ask_user_questions' | 'exit_plan_mode';
+
+export interface RovoDevUiChangedDetectedResponse {
+    event_kind: 'ui_changes_detected';
+}
 
 export interface RovoDevAskUserQuestionsToolArgs {
     questions: {

--- a/src/rovo-dev/client/rovoDevApiClient.ts
+++ b/src/rovo-dev/client/rovoDevApiClient.ts
@@ -401,4 +401,9 @@ export class RovoDevApiClient {
         const response = await this.fetchApi('/v3/invalidate-file-cache', 'POST', body);
         return await response.json();
     }
+
+    /** Invokes the POST `/v3/live-preview` API to start a live preview for the current project. */
+    public async createLivePreview(): Promise<void> {
+        await this.fetchApi('/v3/live-preview', 'POST', JSON.stringify({}));
+    }
 }

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -527,6 +527,17 @@ export class RovoDevChatProvider {
                         args: exitPlanModeArgs,
                     });
                     break;
+                case 'ui_changes_complete':
+                    await webview.postMessage({
+                        type: RovoDevProviderMessageType.ShowLivePreviewButton,
+                    });
+                    // Immediately acknowledge the deferred tool call so the agent is not blocked
+                    this._pendingDeferredRequest = undefined;
+                    await this.executeDeferredToolCall({
+                        tool_call_id: deferredTool.tool_call_id,
+                        result: 'UI changes acknowledged.',
+                    });
+                    break;
                 default:
                     throw new Error(`Unknown deferred tool call: ${deferredTool.tool_name}`);
             }

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -1,8 +1,10 @@
 import { Logger } from 'src/logger';
 import { RovoDevViewResponse } from 'src/rovo-dev/ui/rovoDevViewMessages';
 import { v4 } from 'uuid';
-import { Event, EventEmitter } from 'vscode';
+import { commands, Event, EventEmitter } from 'vscode';
 
+import { Container } from '../container';
+import { Features } from '../util/features';
 import { ExtensionApi } from './api/extensionApi';
 import {
     AgentMode,
@@ -527,17 +529,6 @@ export class RovoDevChatProvider {
                         args: exitPlanModeArgs,
                     });
                     break;
-                case 'ui_changes_complete':
-                    await webview.postMessage({
-                        type: RovoDevProviderMessageType.ShowLivePreviewButton,
-                    });
-                    // Immediately acknowledge the deferred tool call so the agent is not blocked
-                    this._pendingDeferredRequest = undefined;
-                    await this.executeDeferredToolCall({
-                        tool_call_id: deferredTool.tool_call_id,
-                        result: 'UI changes acknowledged.',
-                    });
-                    break;
                 default:
                     throw new Error(`Unknown deferred tool call: ${deferredTool.tool_name}`);
             }
@@ -558,11 +549,28 @@ export class RovoDevChatProvider {
 
         switch (response.event_kind) {
             case 'text':
+                await webview.postMessage({
+                    type: RovoDevProviderMessageType.RovoDevResponseMessage,
+                    message: response,
+                });
+                break;
+
             case 'tool-call':
                 await webview.postMessage({
                     type: RovoDevProviderMessageType.RovoDevResponseMessage,
                     message: response,
                 });
+
+                if (response.tool_name === 'configure_live_preview') {
+                    try {
+                        const args = JSON.parse(response.args);
+                        if (args.port) {
+                            await commands.executeCommand('workbench.action.launchLivePreview', args.port);
+                        }
+                    } catch (e) {
+                        Logger.debug('Failed to parse configure_live_preview args:', e);
+                    }
+                }
                 break;
 
             case 'tool-return':
@@ -788,6 +796,17 @@ export class RovoDevChatProvider {
                 } else {
                     this.processError(new Error('Invalid models response'));
                 }
+                break;
+
+            case 'ui_changes_detected':
+                // Only show live preview button in Boysenberry
+                if (!Container.isBoysenberryMode || !Container.featureFlagClient.checkGate(Features.BbyLivePreview)) {
+                    return;
+                }
+
+                await webview.postMessage({
+                    type: RovoDevProviderMessageType.ShowLivePreviewButton,
+                });
                 break;
 
             case 'close':

--- a/src/rovo-dev/rovoDevTelemetryProvider.ts
+++ b/src/rovo-dev/rovoDevTelemetryProvider.ts
@@ -27,6 +27,7 @@ export type TelemetryEvent =
     | PartialEvent<Track.GitPushAction>
     | PartialEvent<Track.DetailsExpanded>
     | PartialEvent<Track.CreatePrButtonClicked>
+    | PartialEvent<Track.CreateLivePreviewButtonClicked>
     | PartialEvent<Track.AiResultViewed>
     | PartialEvent<Track.RestartProcessAction>
     | PartialEvent<Track.RestoreSessionClicked>

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -25,6 +25,7 @@ import {
     workspace,
 } from 'vscode';
 
+import { Commands } from '../constants';
 import { GitErrorCodes } from '../typings/git';
 import { RovodevCommandContext, RovodevCommands } from './api/componentApi';
 import { DetailedSiteInfo, ExtensionApi, MinimalIssue } from './api/extensionApi';
@@ -45,7 +46,7 @@ import { RovoDevJiraItemsProvider } from './rovoDevJiraItemsProvider';
 import { RovoDevProcessManager, RovoDevProcessState } from './rovoDevProcessManager';
 import { RovoDevSessionManager } from './rovoDevSessionManager';
 import { RovoDevTelemetryProvider } from './rovoDevTelemetryProvider';
-import { RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
+import { RovoDevContextItem } from './rovoDevTypes';
 import { readLastNLogLines, removeCustomCliTags } from './rovoDevUtils';
 import {
     RovoDevAgentModel,
@@ -576,9 +577,6 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
 
                     case RovoDevViewResponseType.CreateLivePreview:
                         await this.executeCreateLivePreview();
-                        break;
-
-                    case RovoDevViewResponseType.ReportCreateLivePreviewButtonClicked:
                         this._telemetryProvider.fireTelemetryEvent({
                             action: 'rovoDevCreateLivePreviewButtonClicked',
                             subject: 'atlascode',
@@ -1243,13 +1241,11 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
     private async executeCreateLivePreview(): Promise<void> {
         try {
             // Immediately switch VSCode to preview mode with loading spinner
-            await commands.executeCommand(RovodevCommands.ShowPreviewPanel);
-            // Send a prompt to the agent to start a live preview
-            const prompt: RovoDevPrompt = {
-                text: 'Start a live preview for this project.',
-                context: [],
-            };
-            await this._chatProvider.executeChat(prompt, []);
+            await commands.executeCommand(Commands.BoysenberryShowPreviewPanel);
+            // Call the agent API directly to start a live preview
+            await this.executeApiWithErrorHandling(async (client) => {
+                await client.createLivePreview();
+            }, false);
         } catch (e) {
             await this.processError(e);
         }

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -45,7 +45,7 @@ import { RovoDevJiraItemsProvider } from './rovoDevJiraItemsProvider';
 import { RovoDevProcessManager, RovoDevProcessState } from './rovoDevProcessManager';
 import { RovoDevSessionManager } from './rovoDevSessionManager';
 import { RovoDevTelemetryProvider } from './rovoDevTelemetryProvider';
-import { RovoDevContextItem } from './rovoDevTypes';
+import { RovoDevContextItem, RovoDevPrompt } from './rovoDevTypes';
 import { readLastNLogLines, removeCustomCliTags } from './rovoDevUtils';
 import {
     RovoDevAgentModel,
@@ -571,6 +571,20 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         await webview.postMessage({
                             type: RovoDevProviderMessageType.UpdateSavedPrompts,
                             savedPrompts: prompts,
+                        });
+                        break;
+
+                    case RovoDevViewResponseType.CreateLivePreview:
+                        await this.executeCreateLivePreview();
+                        break;
+
+                    case RovoDevViewResponseType.ReportCreateLivePreviewButtonClicked:
+                        this._telemetryProvider.fireTelemetryEvent({
+                            action: 'rovoDevCreateLivePreviewButtonClicked',
+                            subject: 'atlascode',
+                            attributes: {
+                                promptId: this._chatProvider.currentPromptId,
+                            },
                         });
                         break;
 
@@ -1224,6 +1238,21 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         });
 
         await this.handleRovoDevLogout();
+    }
+
+    private async executeCreateLivePreview(): Promise<void> {
+        try {
+            // Immediately switch VSCode to preview mode with loading spinner
+            await commands.executeCommand(RovodevCommands.ShowPreviewPanel);
+            // Send a prompt to the agent to start a live preview
+            const prompt: RovoDevPrompt = {
+                text: 'Start a live preview for this project.',
+                context: [],
+            };
+            await this._chatProvider.executeChat(prompt, []);
+        } catch (e) {
+            await this.processError(e);
+        }
     }
 
     private async executeApiWithErrorHandling<T>(

--- a/src/rovo-dev/rovoDevWebviewProviderMessages.ts
+++ b/src/rovo-dev/rovoDevWebviewProviderMessages.ts
@@ -49,6 +49,7 @@ export const enum RovoDevProviderMessageType {
     UpdateAgentModels = 'updateAgentModels',
     AgentModelChanged = 'agentModelChanged',
     SetModifiedFiles = 'setModifiedFiles',
+    ShowLivePreviewButton = 'showLivePreviewButton',
 }
 
 export type RovoDevDisabledReason = DisabledState['subState'];
@@ -148,4 +149,5 @@ export type RovoDevProviderMessage =
       >
     | ReducerAction<RovoDevProviderMessageType.UpdateAgentModels, { models: RovoDevAgentModel[] }>
     | ReducerAction<RovoDevProviderMessageType.AgentModelChanged, RovoDevAgentModel>
-    | ReducerAction<RovoDevProviderMessageType.SetModifiedFiles, { files: ModifiedFile[] }>;
+    | ReducerAction<RovoDevProviderMessageType.SetModifiedFiles, { files: ModifiedFile[] }>
+    | ReducerAction<RovoDevProviderMessageType.ShowLivePreviewButton>;

--- a/src/rovo-dev/ui/RovoDev.css
+++ b/src/rovo-dev/ui/RovoDev.css
@@ -479,7 +479,7 @@ body {
 }
 
 /* Pull Request button styles */
-.pull-request-button {
+.chat-action-button {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -490,7 +490,7 @@ body {
     border: 0;
     border-radius: 6px;
 }
-.pull-request-button:hover {
+.chat-action-button:hover {
     background-color: var(--vscode-button-hoverBackground);
     cursor: pointer;
 }

--- a/src/rovo-dev/ui/common/DialogMessage.tsx
+++ b/src/rovo-dev/ui/common/DialogMessage.tsx
@@ -308,6 +308,7 @@ const friendlyToolName: Record<RovoDevToolName, string> = {
     update_todo: 'Update todo list',
     ask_user_questions: 'Ask user questions',
     exit_plan_mode: 'Exit plan mode',
+    configure_live_preview: 'Configure live preview',
 };
 
 const ToolCall: React.FC<{

--- a/src/rovo-dev/ui/common/common.tsx
+++ b/src/rovo-dev/ui/common/common.tsx
@@ -186,6 +186,22 @@ export interface OpenJiraFunc {
 
 export type CheckFileExistsFunc = (filePath: string) => boolean | null;
 
+export const FollowUpActionFooter: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'flex-start',
+                marginTop: '8px',
+                marginBottom: '8px',
+            }}
+        >
+            {children}
+        </div>
+    );
+};
+
 export const renderChatHistory = (
     msg: ChatMessage,
     openFile: OpenFileFunc,

--- a/src/rovo-dev/ui/live-preview/LivePreviewButton.tsx
+++ b/src/rovo-dev/ui/live-preview/LivePreviewButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { RovoDevProviderMessage } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
+import { RovoDevProviderMessage } from '../../rovoDevWebviewProviderMessages';
 import { useMessagingApi } from '../messagingApi';
 import { RovoDevViewResponse, RovoDevViewResponseType } from '../rovoDevViewMessages';
 
@@ -15,13 +15,17 @@ export const LivePreviewButton: React.FC<LivePreviewButtonProps> = ({ messagingA
 
     const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
-        postMessage({ type: RovoDevViewResponseType.ReportCreateLivePreviewButtonClicked });
         setIsLoading(true);
         postMessage({ type: RovoDevViewResponseType.CreateLivePreview });
     };
 
     return (
-        <button className="pull-request-button" onClick={handleClick} title="Create live preview" disabled={isLoading}>
+        <button
+            className="chat-action-button secondary"
+            onClick={handleClick}
+            title="Create live preview"
+            disabled={isLoading}
+        >
             {isLoading ? (
                 <i className="codicon codicon-loading codicon-modifier-spin" />
             ) : (

--- a/src/rovo-dev/ui/live-preview/LivePreviewButton.tsx
+++ b/src/rovo-dev/ui/live-preview/LivePreviewButton.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { RovoDevProviderMessage } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
+
+import { useMessagingApi } from '../messagingApi';
+import { RovoDevViewResponse, RovoDevViewResponseType } from '../rovoDevViewMessages';
+
+interface LivePreviewButtonProps {
+    messagingApi: ReturnType<
+        typeof useMessagingApi<RovoDevViewResponse, RovoDevProviderMessage, RovoDevProviderMessage>
+    >;
+}
+
+export const LivePreviewButton: React.FC<LivePreviewButtonProps> = ({ messagingApi: { postMessage } }) => {
+    const [isLoading, setIsLoading] = React.useState(false);
+
+    const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        postMessage({ type: RovoDevViewResponseType.ReportCreateLivePreviewButtonClicked });
+        setIsLoading(true);
+        postMessage({ type: RovoDevViewResponseType.CreateLivePreview });
+    };
+
+    return (
+        <button className="pull-request-button" onClick={handleClick} title="Create live preview" disabled={isLoading}>
+            {isLoading ? (
+                <i className="codicon codicon-loading codicon-modifier-spin" />
+            ) : (
+                <i className="codicon codicon-play" />
+            )}
+            Create live preview
+        </button>
+    );
+};

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -6,6 +6,7 @@ import { RovoDevProviderMessage } from 'src/rovo-dev/rovoDevWebviewProviderMessa
 import { DetailedSiteInfo, MinimalIssue } from '../../api/extensionApiTypes';
 import { CheckFileExistsFunc, OpenFileFunc, OpenJiraFunc } from '../common/common';
 import { DialogMessageItem } from '../common/DialogMessage';
+import { LivePreviewButton } from '../live-preview/LivePreviewButton';
 import { CredentialHint } from '../landing-page/disabled-messages/RovoDevLoginForm';
 import { RovoDevLanding } from '../landing-page/RovoDevLanding';
 import { useMessagingApi } from '../messagingApi';
@@ -47,6 +48,7 @@ interface ChatStreamProps {
     onLinkClick: (href: string) => void;
     credentialHints?: CredentialHint[];
     onGeneratePlanClick?: (planId: string, proceed: boolean) => void;
+    showLivePreviewButton?: boolean;
 }
 
 export const ChatStream: React.FC<ChatStreamProps> = ({
@@ -71,6 +73,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
     onLinkClick,
     credentialHints,
     onGeneratePlanClick,
+    showLivePreviewButton,
 }) => {
     const chatEndRef = React.useRef<HTMLDivElement>(null);
     const sentinelRef = React.useRef<HTMLDivElement>(null);
@@ -271,6 +274,13 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                 </div>
             )}
 
+            {!isChatHistoryDisabled && currentState.state === 'WaitingForPrompt' && (
+                <FollowUpActionFooter>
+                    {showLivePreviewButton && (
+                        <LivePreviewButton messagingApi={messagingApi} />
+                    )}
+                </FollowUpActionFooter>
+            )}
             <div id="sentinel" ref={sentinelRef} style={{ height: '10px', width: '100%', pointerEvents: 'none' }} />
         </div>
     );

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -4,11 +4,12 @@ import { State, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 import { RovoDevProviderMessage } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
 import { DetailedSiteInfo, MinimalIssue } from '../../api/extensionApiTypes';
-import { CheckFileExistsFunc, OpenFileFunc, OpenJiraFunc } from '../common/common';
+import { CheckFileExistsFunc, FollowUpActionFooter, OpenFileFunc, OpenJiraFunc } from '../common/common';
 import { DialogMessageItem } from '../common/DialogMessage';
 import { LivePreviewButton } from '../live-preview/LivePreviewButton';
 import { CredentialHint } from '../landing-page/disabled-messages/RovoDevLoginForm';
 import { RovoDevLanding } from '../landing-page/RovoDevLanding';
+import { LivePreviewButton } from '../live-preview/LivePreviewButton';
 import { useMessagingApi } from '../messagingApi';
 import { McpConsentChoice, RovoDevViewResponse } from '../rovoDevViewMessages';
 import { SubagentInfo, ToolCallItem } from '../tools/ToolCallItem';
@@ -198,6 +199,9 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
         currentState.state !== 'WaitingForPrompt' &&
         (currentState.state !== 'Initializing' || currentState.isPromptPending);
 
+    const showActionFooter =
+        !isChatHistoryDisabled && currentState.state === 'WaitingForPrompt' && showLivePreviewButton;
+
     return (
         <div ref={chatEndRef} className="chat-message-container">
             {(!RovodevStaticConfig.isBBY ||
@@ -274,11 +278,9 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                 </div>
             )}
 
-            {!isChatHistoryDisabled && currentState.state === 'WaitingForPrompt' && (
+            {showActionFooter && (
                 <FollowUpActionFooter>
-                    {showLivePreviewButton && (
-                        <LivePreviewButton messagingApi={messagingApi} />
-                    )}
+                    <LivePreviewButton messagingApi={messagingApi} />
                 </FollowUpActionFooter>
             )}
             <div id="sentinel" ref={sentinelRef} style={{ height: '10px', width: '100%', pointerEvents: 'none' }} />

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -6,7 +6,6 @@ import { RovoDevProviderMessage } from 'src/rovo-dev/rovoDevWebviewProviderMessa
 import { DetailedSiteInfo, MinimalIssue } from '../../api/extensionApiTypes';
 import { CheckFileExistsFunc, FollowUpActionFooter, OpenFileFunc, OpenJiraFunc } from '../common/common';
 import { DialogMessageItem } from '../common/DialogMessage';
-import { LivePreviewButton } from '../live-preview/LivePreviewButton';
 import { CredentialHint } from '../landing-page/disabled-messages/RovoDevLoginForm';
 import { RovoDevLanding } from '../landing-page/RovoDevLanding';
 import { LivePreviewButton } from '../live-preview/LivePreviewButton';

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -86,6 +86,7 @@ const RovoDevView: React.FC = () => {
     const [currentAgentModel, setCurrentAgentModel] = useState<RovoDevAgentModel | undefined>(undefined);
     const hasPendingDeferredActionRef = useRef(false);
     const [availableAgentModels, setAvailableAgentModels] = useState<RovoDevAgentModel[]>([]);
+    const [showLivePreviewButton, setShowLivePreviewButton] = useState(false);
 
     // Initialize atlaskit theme for proper token support
     React.useEffect(() => {
@@ -169,6 +170,7 @@ const RovoDevView: React.FC = () => {
         setIsFeedbackFormVisible(false);
         setPendingToolCallMessage('');
         setPendingSubagentTasks([]);
+        setShowLivePreviewButton(false);
     }, [keepFiles, totalModifiedFiles]);
 
     const onError = useCallback(
@@ -509,6 +511,10 @@ const RovoDevView: React.FC = () => {
 
                 case RovoDevProviderMessageType.UpdateAgentModels:
                     setAvailableAgentModels(event.models);
+                    break;
+
+                case RovoDevProviderMessageType.ShowLivePreviewButton:
+                    setShowLivePreviewButton(true);
                     break;
 
                 default:
@@ -1098,6 +1104,7 @@ const RovoDevView: React.FC = () => {
                         onLinkClick={onLinkClick}
                         credentialHints={credentialHints}
                         onGeneratePlanClick={(e: string, proceed: boolean) => handleExitPlanMode(proceed, e)}
+                        showLivePreviewButton={showLivePreviewButton}
                     />
                     {!hidePromptBox && (
                         <div className="input-section-container">

--- a/src/rovo-dev/ui/rovoDevViewMessages.tsx
+++ b/src/rovo-dev/ui/rovoDevViewMessages.tsx
@@ -48,6 +48,8 @@ export const enum RovoDevViewResponseType {
     AskUserQuestionsSubmit = 'askUserQuestionsSubmit',
     ExitPlanModeSubmit = 'exitPlanModeSubmit',
     RefreshModifiedFiles = 'refreshModifiedFiles',
+    CreateLivePreview = 'createLivePreview',
+    ReportCreateLivePreviewButtonClicked = 'reportCreateLivePreviewButtonClicked',
 }
 
 export type FileOperationType = 'modify' | 'create' | 'delete';
@@ -114,4 +116,6 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.FetchSavedPrompts>
     | ReducerAction<RovoDevViewResponseType.AskUserQuestionsSubmit, AskUserQuestionsResultMessage>
     | ReducerAction<RovoDevViewResponseType.ExitPlanModeSubmit, ExitPlanModeResultMessage>
-    | ReducerAction<RovoDevViewResponseType.RefreshModifiedFiles>;
+    | ReducerAction<RovoDevViewResponseType.RefreshModifiedFiles>
+    | ReducerAction<RovoDevViewResponseType.CreateLivePreview>
+    | ReducerAction<RovoDevViewResponseType.ReportCreateLivePreviewButtonClicked>;

--- a/src/rovo-dev/ui/rovoDevViewMessages.tsx
+++ b/src/rovo-dev/ui/rovoDevViewMessages.tsx
@@ -49,7 +49,6 @@ export const enum RovoDevViewResponseType {
     ExitPlanModeSubmit = 'exitPlanModeSubmit',
     RefreshModifiedFiles = 'refreshModifiedFiles',
     CreateLivePreview = 'createLivePreview',
-    ReportCreateLivePreviewButtonClicked = 'reportCreateLivePreviewButtonClicked',
 }
 
 export type FileOperationType = 'modify' | 'create' | 'delete';
@@ -114,8 +113,7 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.RestartProcess>
     | ReducerAction<RovoDevViewResponseType.ShowSessionHistory>
     | ReducerAction<RovoDevViewResponseType.FetchSavedPrompts>
+    | ReducerAction<RovoDevViewResponseType.CreateLivePreview>
     | ReducerAction<RovoDevViewResponseType.AskUserQuestionsSubmit, AskUserQuestionsResultMessage>
     | ReducerAction<RovoDevViewResponseType.ExitPlanModeSubmit, ExitPlanModeResultMessage>
-    | ReducerAction<RovoDevViewResponseType.RefreshModifiedFiles>
-    | ReducerAction<RovoDevViewResponseType.CreateLivePreview>
-    | ReducerAction<RovoDevViewResponseType.ReportCreateLivePreviewButtonClicked>;
+    | ReducerAction<RovoDevViewResponseType.RefreshModifiedFiles>;

--- a/src/rovo-dev/ui/tools/ToolCallItem.tsx
+++ b/src/rovo-dev/ui/tools/ToolCallItem.tsx
@@ -84,6 +84,8 @@ export function parseToolCallMessage(msgToolName: RovoDevToolName): string {
             return 'Exiting plan mode';
         case 'update_todo':
             return 'Updating todo';
+        case 'configure_live_preview':
+            return 'Configuring live preview';
         default:
             // @ts-expect-error ts(2339) - msgToolName here should be 'never'
             return msgToolName.toString();

--- a/src/util/features.ts
+++ b/src/util/features.ts
@@ -10,6 +10,7 @@ export enum Features {
     RovoDevLspEnabled = 'atlascode-enable-rovodev-lsp',
     SentryLogging = 'atlascode-sentry-logging',
     RequireDedicatedRovoDevAuth = 'atlascode-require-dedicated-rovodev-auth',
+    BbyLivePreview = 'rovodev_live_preview_chat_integration',
 }
 
 /**


### PR DESCRIPTION
Live Preview in boysemberry from chat:
* Receive and process messaging from cli that PR has ui changes
* Show Live Preview button when in BBY
* When clicked, call the cli api to start live preview
* When live preview sends the configure preview tool start event back, switch to preview panel (preview panel managed in vscode fork)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

