### PR TITLE
fix: load assignee options on initial dropdown open

### DIFF
--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -1478,7 +1478,10 @@ export abstract class AbstractIssueEditorPage<
                                                     },
                                                 )}
                                                 loadOptions={async (input: any) =>
-                                                    await this.loadSelectOptionsForField(field as SelectFieldUI, input || " ")
+                                                    await this.loadSelectOptionsForField(
+                                                        field as SelectFieldUI,
+                                                        input || ' ',
+                                                    )
                                                 }
                                                 onMenuClose={() => {
                                                     if (this.state.loadingField === field.key) {

--- a/src/webviews/components/issue/AbstractIssueEditorPage.tsx
+++ b/src/webviews/components/issue/AbstractIssueEditorPage.tsx
@@ -1469,7 +1469,7 @@ export abstract class AbstractIssueEditorPage<
                                                     this.state.loadingField !== field.key
                                                 }
                                                 isClearable={this.isClearableSelect(selectField)}
-                                                defaultOptions={this.state.selectFieldOptions[field.key]}
+                                                defaultOptions
                                                 isLoading={this.state.loadingField === field.key}
                                                 onChange={FieldValidators.chain(
                                                     fieldArgs.fieldProps.onChange,
@@ -1478,7 +1478,7 @@ export abstract class AbstractIssueEditorPage<
                                                     },
                                                 )}
                                                 loadOptions={async (input: any) =>
-                                                    await this.loadSelectOptionsForField(field as SelectFieldUI, input)
+                                                    await this.loadSelectOptionsForField(field as SelectFieldUI, input || " ")
                                                 }
                                                 onMenuClose={() => {
                                                     if (this.state.loadingField === field.key) {


### PR DESCRIPTION
fixes: #1800


### What Is This Change?

Fixes the assignee dropdown in the create issue webview not loading options on initial open. Previously, users had to type a search query before any assignees appeared, this didn't match Jira's own webapp behavior where options load immediately.


The fix passes a space character as the initial input to `loadOptions`, triggering the fetch on first open without requiring user input.

### How Has This Been Tested?

Manually tested in the VS Code extension:
- Opened create issue webview
- Clicked assignee dropdown — options load immediately without typing
- Typed a search query — filtering still works correctly
- Tested empty results case — falls back to `[]`

Basic checks:
- [x] `npm run lint`
- [x] `npm run test`






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

