### PR TITLE
Flow noissue fix minor external chat issues

### DIFF
--- a/src/rovo-dev/rovoDevLocalServer.ts
+++ b/src/rovo-dev/rovoDevLocalServer.ts
@@ -27,7 +27,7 @@ export class RovoDevLocalServer implements Disposable {
             res.status(200).json({ status: 'ok', agentBusy: this._isAgentRunning() });
         });
 
-        app.post('/rovodev/chat', (req: Request, res: Response) => {
+        app.post('/rovodev/chat', async (req: Request, res: Response) => {
             const message: string | undefined = req.body?.message;
 
             if (!message || typeof message !== 'string' || message.trim() === '') {
@@ -44,13 +44,13 @@ export class RovoDevLocalServer implements Disposable {
                 return;
             }
 
-            // Respond immediately — callers are async and don't need to wait for the full agent response
-            res.status(202).json({ success: true });
-
-            // Fire-and-forget — errors are handled internally by the chat provider
-            this._invokeRovoDevAsk(message.trim()).catch((err) => {
+            try {
+                await this._invokeRovoDevAsk(message.trim());
+                res.status(202).json({ success: true });
+            } catch (err: any) {
                 Logger.debug(`RovoDevLocalServer: error invoking RovoDev ask: ${err}`);
-            });
+                res.status(500).json({ success: false, error: 'internal_error' });
+            }
         });
 
         this._server = http.createServer(app);

--- a/src/rovo-dev/rovoDevLocalServer.ts
+++ b/src/rovo-dev/rovoDevLocalServer.ts
@@ -15,7 +15,7 @@ export class RovoDevLocalServer implements Disposable {
     private _server: http.Server | undefined;
 
     constructor(
-        private readonly _invokeRovoDevAsk: (prompt: string) => Promise<void>,
+        private readonly _invokeRovoDevAsk: (prompt: string) => Promise<boolean>,
         private readonly _isAgentRunning: () => boolean,
     ) {}
 
@@ -45,8 +45,14 @@ export class RovoDevLocalServer implements Disposable {
             }
 
             try {
-                await this._invokeRovoDevAsk(message.trim());
-                res.status(202).json({ success: true });
+                // Await until the chat has been triggered (webview ready, auth checked, prompt dispatched),
+                // but not until the full agent response completes — streaming is fire-and-forget.
+                const triggered = await this._invokeRovoDevAsk(message.trim());
+                if (triggered) {
+                    res.status(202).json({ success: true });
+                } else {
+                    res.status(503).json({ success: false, error: 'provider_not_ready' });
+                }
             } catch (err: any) {
                 Logger.debug(`RovoDevLocalServer: error invoking RovoDev ask: ${err}`);
                 res.status(500).json({ success: false, error: 'internal_error' });

--- a/src/rovo-dev/rovoDevLocalServer.ts
+++ b/src/rovo-dev/rovoDevLocalServer.ts
@@ -27,7 +27,7 @@ export class RovoDevLocalServer implements Disposable {
             res.status(200).json({ status: 'ok', agentBusy: this._isAgentRunning() });
         });
 
-        app.post('/rovodev/chat', async (req: Request, res: Response) => {
+        app.post('/rovodev/chat', (req: Request, res: Response) => {
             const message: string | undefined = req.body?.message;
 
             if (!message || typeof message !== 'string' || message.trim() === '') {
@@ -44,13 +44,13 @@ export class RovoDevLocalServer implements Disposable {
                 return;
             }
 
-            try {
-                await this._invokeRovoDevAsk(message.trim());
-                res.status(200).json({ success: true });
-            } catch (err: any) {
+            // Respond immediately — callers are async and don't need to wait for the full agent response
+            res.status(202).json({ success: true });
+
+            // Fire-and-forget — errors are handled internally by the chat provider
+            this._invokeRovoDevAsk(message.trim()).catch((err) => {
                 Logger.debug(`RovoDevLocalServer: error invoking RovoDev ask: ${err}`);
-                res.status(500).json({ success: false, error: 'internal_error' });
-            }
+            });
         });
 
         this._server = http.createServer(app);

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -196,7 +196,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
             // Start the local HTTP server so external services can
             // send prompts to the Rovo Dev chat UI via POST /rovodev/chat.
             this._localServer = new RovoDevLocalServer(
-                (prompt) => this.invokeRovoDevAskCommand(prompt),
+                (prompt) => this.invokeRovoDevAskCommand(prompt, undefined, true),
                 () => this._chatProvider.isAgentRunning,
             );
             this._localServer.start();
@@ -1276,7 +1276,18 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         }
     }
 
-    public async invokeRovoDevAskCommand(prompt: string, context?: RovoDevContextItem[]): Promise<void> {
+    /**
+     * Invokes a RovoDev chat prompt.
+     *
+     * When `fireAndForget` is true, the chat promise is returned directly without being awaited,
+     * allowing the caller to decide whether to await it or not.
+     * When false (default), the chat is awaited before returning.
+     */
+    public async invokeRovoDevAskCommand(
+        prompt: string,
+        context?: RovoDevContextItem[],
+        fireAndForget?: boolean,
+    ): Promise<void> {
         // Always focus on the specific vscode view, even if disabled (so user can see the login prompt)
         await this.extensionApi.commands.focusRovodevView();
 
@@ -1301,7 +1312,13 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         // Actually invoke the rovodev service, feed responses to the webview as normal
         const revertedChanges = this._revertedChanges;
         this._revertedChanges = [];
-        await this._chatProvider.executeChat({ text: prompt, context: context || [] }, revertedChanges);
+        const chatPromise = this._chatProvider.executeChat({ text: prompt, context: context || [] }, revertedChanges);
+
+        if (fireAndForget) {
+            return chatPromise;
+        }
+
+        await chatPromise;
     }
 
     /**

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -1287,7 +1287,7 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         prompt: string,
         context?: RovoDevContextItem[],
         fireAndForget?: boolean,
-    ): Promise<void> {
+    ): Promise<boolean> {
         // Always focus on the specific vscode view, even if disabled (so user can see the login prompt)
         await this.extensionApi.commands.focusRovodevView();
 
@@ -1300,13 +1300,13 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         });
 
         if (!initialized) {
-            return;
+            return false;
         }
 
         // If disabled, we still want to show the webview but don't execute the chat
         // The webview will show the appropriate login prompt
         if (this.isDisabled) {
-            return;
+            return false;
         }
 
         // Actually invoke the rovodev service, feed responses to the webview as normal
@@ -1315,10 +1315,14 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
         const chatPromise = this._chatProvider.executeChat({ text: prompt, context: context || [] }, revertedChanges);
 
         if (fireAndForget) {
-            return chatPromise;
+            chatPromise.catch((err) => {
+                Logger.debug(`RovoDevWebviewProvider: error executing chat: ${err}`);
+            });
+            return true;
         }
 
         await chatPromise;
+        return true;
     }
 
     /**

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -88,8 +88,6 @@ const RovoDevView: React.FC = () => {
     const [availableAgentModels, setAvailableAgentModels] = useState<RovoDevAgentModel[]>([]);
     const [showLivePreviewButton, setShowLivePreviewButton] = useState(false);
 
-    console.log('RovoDevView currentState======', currentState);
-
     // Initialize atlaskit theme for proper token support
     React.useEffect(() => {
         const initializeTheme = () => {

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -88,6 +88,8 @@ const RovoDevView: React.FC = () => {
     const [availableAgentModels, setAvailableAgentModels] = useState<RovoDevAgentModel[]>([]);
     const [showLivePreviewButton, setShowLivePreviewButton] = useState(false);
 
+    console.log('RovoDevView currentState======', currentState);
+
     // Initialize atlaskit theme for proper token support
     React.useEffect(() => {
         const initializeTheme = () => {
@@ -248,6 +250,7 @@ const RovoDevView: React.FC = () => {
         (event: RovoDevProviderMessage): void => {
             switch (event.type) {
                 case RovoDevProviderMessageType.SignalPromptSent:
+                    setCurrentState({ state: 'GeneratingResponse' });
                     setPendingToolCallMessage(DEFAULT_LOADING_MESSAGE);
                     if (event.echoMessage) {
                         handleAppendResponse({


### PR DESCRIPTION
### What Is This Change?

- Currently the local server `/rovodev/chat` endpoint waits until the full rovodev response is returned. We want to instead make sure rovodev chat has been called but then return immediately so that async processes calling this endpoint are not blocked longer than they need to 
- Set state immediately to `GeneratingResponse` when we receive a prompt (e.g. from endpoint), so that there is no gap between seeing the prompt appear and seeing `Rovo Dev is working` message. 

### How Has This Been Tested?

Tested locally in app






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

