### PR TITLE
fix: Border color fixed in Light Mode

### DIFF
--- a/src/webviews/components/App.css
+++ b/src/webviews/components/App.css
@@ -1213,7 +1213,7 @@ div[role='dialog'],
 .ac-form-select__control {
     background: var(--vscode-input-background) !important;
     color: var(--vscode-dropdown-foreground) !important;
-    border: 1px solid var(--vscode-editor-background) !important;
+    border: 1px solid var(--vscode-settings-textInputBorder) !important;
 }
 
 .ac-form-select__control--is-focused,

--- a/src/webviews/components/issue/common/JiraIssueTextArea.tsx
+++ b/src/webviews/components/issue/common/JiraIssueTextArea.tsx
@@ -70,7 +70,7 @@ const JiraIssueTextAreaEditor: React.FC<Props> = ({
                     style={{
                         background: 'var(--vscode-input-background)',
                         color: isDisabled ? 'var(--vscode-disabledForeground)' : 'var(--vscode-input-foreground)',
-                        border: '1px solid var(--vscode-input-border)',
+                        border: '1px solid var(--vscode-settings-textInputBorder)',
                         caretColor: 'var(--vscode-editorCursor-background)',
                         minHeight: isDescription ? '175px' : '100px',
                         borderRadius: '2px',


### PR DESCRIPTION
fixes: #1807

### What Is This Change?

Border colors in the `Create Work Item` page were not visible in light mode due to dark favoured css. Fixed the border color to be visible across both light and dark themes.

### How Has This Been Tested?

Manually verified in both light and dark mode in the VS Code extension webview.

Basic checks:
- [x] `npm run lint`
- [x] `npm run test`

Before:
<img width="878" height="668" alt="Screenshot 2026-04-28 at 18 33 13" src="https://github.com/user-attachments/assets/0c93a614-10e9-4129-bb40-0a310a8309fb" />

After:

<img width="878" height="668" alt="Screenshot 2026-04-28 at 18 50 50" src="https://github.com/user-attachments/assets/41a2f427-b3da-45a3-84ff-5d837db57458" />













<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

