### PR TITLE
AXON-2035: fix: safely stringify tool args in ToolCallBody to prevent React erro…

### DIFF
--- a/src/rovo-dev/ui/common/DialogMessage.tsx
+++ b/src/rovo-dev/ui/common/DialogMessage.tsx
@@ -30,6 +30,16 @@ function safeJsonParse<T = any>(value: string | T | null | undefined): T {
     return typeof value === 'string' ? JSON.parse(value) : value;
 }
 
+function toDisplayString(value: unknown): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    return JSON.stringify(value);
+}
+
 export const DialogMessageItem: React.FC<{
     msg: DialogMessage;
     isRetryAfterErrorButtonEnabled?: (uid: string) => boolean;
@@ -343,7 +353,7 @@ const ToolCallBody: React.FC<{
     if (toolName === 'bash') {
         return (
             <pre style={{ margin: '0' }}>
-                <code style={{ maxWidth: '100%' }}>{jsonArgs.command}</code>
+                <code style={{ maxWidth: '100%' }}>{toDisplayString(jsonArgs.command)}</code>
             </pre>
         );
     } else if (toolName === 'grep') {
@@ -391,6 +401,6 @@ const ToolCallBody: React.FC<{
             </ul>
         );
     } else {
-        return <div>{toolArgs}</div>;
+        return <div>{toDisplayString(toolArgs)}</div>;
     }
 };


### PR DESCRIPTION
### What Is This Change?

The customer has been getting this error 
<img width="424" height="707" alt="image" src="https://github.com/user-attachments/assets/36187c29-6c70-4e60-a5b8-5682b554693d" />
likely because React is trying to render and object rather than a string. I've put some guards to JSON.stringify it in that situation so we can see the real error.

### How Has This Been Tested?

Tested before with some mock data:
<img width="534" height="574" alt="SCR-20260430-lcyh" src="https://github.com/user-attachments/assets/83838a60-0f6b-419a-aea2-d09ea110fd3c" />

Tested after:
<img width="466" height="465" alt="SCR-20260430-lelc" src="https://github.com/user-attachments/assets/c8cc0ebb-8bec-452a-b7ca-e53f36cd87ff" />

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`
- [x] `manual check`






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

