### PR TITLE
Fix npm package vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33524,11 +33524,11 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/axios/-/axios-1.15.0.tgz",
-            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+            "version": "1.16.0",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }
@@ -37245,9 +37245,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -37258,8 +37258,7 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fastify"
                 }
-            ],
-            "license": "BSD-3-Clause"
+            ]
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -44065,9 +44064,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.14",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -44083,7 +44082,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -50096,14 +50094,13 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "11.1.1",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
-            "license": "MIT",
             "bin": {
                 "uuid": "dist/esm/bin/uuid"
             }

--- a/src/rovo-dev/util/downloadFile.ts
+++ b/src/rovo-dev/util/downloadFile.ts
@@ -23,7 +23,8 @@ export async function downloadAndUnzip(
         responseType: 'stream',
     });
 
-    const totalLength = parseInt(response.headers['content-length'] || '0', 10);
+    const contentLengthHeaderValue = (response.headers['content-length'] as string) || '0';
+    const totalLength = parseInt(contentLengthHeaderValue, 10);
     let downloaded = 0;
 
     if (!fs.existsSync(downloadPath)) {


### PR DESCRIPTION
**axios  1.0.0 - 1.15.1**
Severity: high
Axios: Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy - https://github.com/advisories/GHSA-w9j2-pvgh-6h63
Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0 - https://github.com/advisories/GHSA-pmwg-cvhr-8vh7
Axios: Invisible JSON Response Tampering via Prototype Pollution Gadget in `parseReviver` - https://github.com/advisories/GHSA-3w6x-2g7m-8v23
Axios: Null Byte Injection via Reverse-Encoding in AxiosURLSearchParams - https://github.com/advisories/GHSA-xhjh-pmcv-23jw
Axios: CRLF Injection in multipart/form-data body via unsanitized blob.type in formDataToStream - https://github.com/advisories/GHSA-445q-vr5w-6q77
Axios: no_proxy bypass via IP alias allows SSRF - https://github.com/advisories/GHSA-m7pr-hjqh-92cm
Axios: unbounded recursion in toFormData causes DoS via deeply nested request data - https://github.com/advisories/GHSA-62hf-57xw-28j9
Axios' HTTP adapter-streamed uploads bypass maxBodyLength when maxRedirects: 0 - https://github.com/advisories/GHSA-5c9x-8gcm-mpgx
Axios: HTTP adapter streamed responses bypass maxContentLength - https://github.com/advisories/GHSA-vf2m-468p-8v99
Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking - https://github.com/advisories/GHSA-pf86-5x62-jrwf
Axios: Header Injection via Prototype Pollution - https://github.com/advisories/GHSA-6chq-wfr3-2hj9
Axios: XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` Boolean Coercion - https://github.com/advisories/GHSA-xx6v-rp6x-q39c
Axios has prototype pollution read-side gadgets in HTTP adapter that allow credential injection and request hijacking - https://github.com/advisories/GHSA-q8qp-cvcw-x6jj

**fast-uri  <=3.1.1**
Severity: high
fast-uri vulnerable to path traversal via percent-encoded dot segments - https://github.com/advisories/GHSA-q3j6-qgpj-74h6
fast-uri vulnerable to host confusion via percent-encoded authority delimiters - https://github.com/advisories/GHSA-v39h-62p7-jpjc

**postcss  <8.5.10**
Severity: moderate
PostCSS has XSS via Unescaped </style> in its CSS Stringify Output - https://github.com/advisories/GHSA-qx2v-qp2m-jg93

**uuid  11.0.0 - 11.1.0**
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

