### PR TITLE
[VULN-1869774] Fix remote code execution via HTML

### DIFF
--- a/src/react/atlascode/common/editor/MarkdownEditor.tsx
+++ b/src/react/atlascode/common/editor/MarkdownEditor.tsx
@@ -107,9 +107,17 @@ const mdParser = new MarkdownParser(schema, defaultMarkdownParser.tokenizer, {
  * IMPORTANT: outer div's "suggestion-item-list" class is mandatory. The plugin uses this class for querying.
  * IMPORTANT: inner div's "suggestion-item" class is mandatory too for the same reasons
  */
+const escapeHtml = (str: string): string =>
+    str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+
 const getMentionSuggestionsHTML = (items: any[]) =>
     '<div class="suggestion-item-list">' +
-    items.map((i) => '<div class="suggestion-item">' + i.name + '</div>').join('') +
+    items.map((i) => '<div class="suggestion-item">' + escapeHtml(i.name) + '</div>').join('') +
     '</div>';
 
 const reactPropsKey = new PluginKey('reactProps');

--- a/src/webview/singleViewFactory.test.ts
+++ b/src/webview/singleViewFactory.test.ts
@@ -172,7 +172,6 @@ describe('SingleWebview', () => {
             expect(window.createWebviewPanel).toHaveBeenCalledWith('react', '', column, {
                 retainContextWhenHidden: true,
                 enableFindWidget: true,
-                enableCommandUris: true,
                 enableScripts: true,
                 localResourceRoots: [
                     { scheme: 'file', path: '/test' },

--- a/src/webview/singleViewFactory.ts
+++ b/src/webview/singleViewFactory.ts
@@ -74,7 +74,6 @@ export class SingleWebview<FD, R> implements ReactWebview<FD> {
             this._panel = window.createWebviewPanel(viewType, '', column ? column : ViewColumn.Active, {
                 retainContextWhenHidden: true,
                 enableFindWidget: true,
-                enableCommandUris: true,
                 enableScripts: true,
                 localResourceRoots: [
                     Uri.file(path.join(this._extensionPath, 'build')),

--- a/src/webviews/abstractWebview.ts
+++ b/src/webviews/abstractWebview.ts
@@ -108,7 +108,6 @@ export abstract class AbstractReactWebview implements ReactWebview {
                 {
                     retainContextWhenHidden: true,
                     enableFindWidget: true,
-                    enableCommandUris: true,
                     enableScripts: true,
                     localResourceRoots: [
                         Uri.file(path.join(this._extensionPath, 'build')),


### PR DESCRIPTION
## Security fix: HTML injection / RCE in mention autocomplete (VULN-1869774)

### Problem

A stored HTML injection vulnerability in the PR comment mention autocomplete allowed an attacker to achieve Remote Code Execution on any victim who typed @ in the rich text editor. The attack chain:

1. Attacker sets their Atlassian display name to an HTML payload (e.g. <a href="command:workbench.action.terminal.sendSequence?...">Intern</a>)
2. When a victim types @ in a PR comment, the display name is concatenated directly into an HTML string in getMentionSuggestionsHTML without any escaping
3. That string is assigned to el.innerHTML by the prosemirror-mentions library, rendering the attacker’s HTML as live DOM
4. Because webviews had enableCommandUris: true, the injected command: link executes arbitrary VS Code commands — including sending text to the integrated terminal

### Fix

- MarkdownEditor.tsx: Added escapeHtml() and applied it to user display names before HTML concatenation in getMentionSuggestionsHTML
- singleViewFactory.ts / abstractWebview.ts: Removed enableCommandUris: true — these React webviews use postMessage for all communication and never need command: URI execution. (Note: rovoDevWebviewProvider.ts and createWorkItemWebviewProvider.ts retain enableCommandUris: true as they legitimately require it)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

