### PR TITLE
docs: fix README typo in authentication troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Compatible with VS Code, Cursor, Windsurf and other forks.
 
 
 # Troubleshooting 
-If the table below doesn't help you, [raise an issue here.](https://github.com/atlassian/atlascode/issues?q=is%3Aissue%20state%3Aopen%20sort%3Aupdated-desc)
+If the table below does not help you, [raise an issue here.](https://github.com/atlassian/atlascode/issues?q=is%3Aissue%20state%3Aopen%20sort%3Aupdated-desc)
 
 | Issue | Troubleshooting Steps |
 |-------|----------------------|

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If the table below doesn't help you, [raise an issue here.](https://github.com/a
 | **Jira Work Items not displaying** | 1. Confirm you are on the latest stable release<br>2. Try restarting the IDE<br>3. Try re-authenticating |
 | **Bitbucket PRs not displaying** | 1. Confirm you are in a repo that uses Bitbucket as a remote<br>2. Confirm you are on the latest stable release<br>3. Try restarting the IDE<br>4. Try re-authenticating |
 | **Bitbucket Pipelines not displaying** | 1. Confirm you are in a repo that uses Bitbucket as a remote<br>2. Confirm you are on the latest stable release<br>3. Try restarting the IDE<br>4. Try re-authenticating |
-| **Authentication: Bitbucket/Jira Server failing to Authneticate** | 1. Confirm your server version is supported by the [Atlassian End of Support Policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html)<br>2. Confirm you are on the latest stable release<br>3. Try restarting the IDE<br>4. Try re-authenticating |
+| **Authentication: Bitbucket/Jira Server failing to Authenticate** | 1. Confirm your server version is supported by the [Atlassian End of Support Policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html)<br>2. Confirm you are on the latest stable release<br>3. Try restarting the IDE<br>4. Try re-authenticating |
 
 # Compatibility
 


### PR DESCRIPTION
This is a minimal documentation-only change used to verify external PR automation behavior on the current repository configuration.\n\nChange:\n- Fix README typo: Authneticate -> Authenticate\n