### PR TITLE
FLOW-2254: catch terminated error to handle more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- **RovoDev**: Fixed `TypeError: terminated` from Node.js undici being incorrectly surfaced as an error dialog when aborting an in-flight chat request. The error is now silently handled as a normal abort, preventing spurious error messages and noisy telemetry — particularly in Boysenberry mode where long-running YOLO streams make mid-stream aborts more common.
+
 - Fixed shell command injection vulnerability (VULN-1825192) in git operations. The `Shell` utility class now uses `shell: false` when spawning processes, and all git commands pass arguments as separate array elements rather than interpolating user-controlled values (e.g. branch names, file paths, commit hashes) directly into shell command strings. This prevents Remote Code Execution via maliciously crafted git branch names.
 
 ## What's new in 4.0.29

--- a/src/rovo-dev/rovoDevChatProvider.test.ts
+++ b/src/rovo-dev/rovoDevChatProvider.test.ts
@@ -464,6 +464,19 @@ describe('RovoDevChatProvider', () => {
 
             expect(chatProvider['_lastMessageSentTime']).toBeUndefined();
         });
+
+        it('should clear pending deferred request on cancellation so next prompt is sent as plain message', async () => {
+            await chatProvider.setReady(mockApiClient);
+
+            // Simulate a pending deferred tool call (e.g. ask_user_questions)
+            chatProvider['_pendingDeferredRequest'] = 'deferred-tool-call-123';
+
+            mockApiClient.cancel.mockResolvedValue({ cancelled: true, message: 'Cancelled' });
+
+            await chatProvider.executeCancel(false);
+
+            expect(chatProvider['_pendingDeferredRequest']).toBeUndefined();
+        });
     });
 
     describe('signalToolRequestChoiceSubmit', () => {
@@ -1041,6 +1054,54 @@ describe('RovoDevChatProvider', () => {
                     message: expect.objectContaining({
                         text: 'The command /unknowncommand is not supported.',
                     }),
+                }),
+            );
+        });
+
+        it('should handle undici TypeError: terminated as an abort (no error dialog)', async () => {
+            // Simulates the Node.js undici error thrown when AbortController.abort() is called
+            // on an in-flight fetch. undici throws a plain TypeError with message "terminated"
+            // rather than an AbortError, so it must be caught explicitly.
+            const terminatedError = new TypeError('terminated');
+            mockApiClient.chat.mockRejectedValue(terminatedError);
+
+            const mockPrompt: RovoDevPrompt = {
+                text: 'test prompt',
+                context: [],
+            };
+
+            await chatProvider.executeChat(mockPrompt, []);
+
+            // Should NOT show an error dialog — terminated is a normal abort side-effect
+            expect(mockWebview.postMessage).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: RovoDevProviderMessageType.ShowDialog,
+                }),
+            );
+
+            // Should send CompleteMessage so the UI returns to an interactive state
+            expect(mockWebview.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: RovoDevProviderMessageType.CompleteMessage,
+                }),
+            );
+        });
+
+        it('should still show error dialog for other TypeErrors (not terminated)', async () => {
+            // Ensures the fix is narrowly scoped and doesn't swallow real TypeErrors
+            const otherTypeError = new TypeError('Failed to fetch');
+            mockApiClient.chat.mockRejectedValue(otherTypeError);
+
+            const mockPrompt: RovoDevPrompt = {
+                text: 'test prompt',
+                context: [],
+            };
+
+            await chatProvider.executeChat(mockPrompt, []);
+
+            expect(mockWebview.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: RovoDevProviderMessageType.ShowDialog,
                 }),
             );
         });

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -326,6 +326,12 @@ export class RovoDevChatProvider {
     public async executeCancel(fromNewSession: boolean): Promise<boolean> {
         const webview = this._webView!;
 
+        // Clear any pending deferred tool call so the next user prompt is sent
+        // as a plain message instead of a tool-call response.  Without this the
+        // backend would reject the prompt with "Cannot provide a new user prompt
+        // when the message history contains unprocessed tool calls".
+        this._pendingDeferredRequest = undefined;
+
         let success: boolean;
         if (this._rovoDevApiClient) {
             if (this._pendingCancellation) {
@@ -967,7 +973,7 @@ export class RovoDevChatProvider {
             try {
                 await func(this._rovoDevApiClient);
             } catch (error) {
-                if (error.name === 'AbortError') {
+                if (error.name === 'AbortError' || (error instanceof TypeError && error.message === 'terminated')) {
                     await webview.postMessage({
                         type: RovoDevProviderMessageType.CompleteMessage,
                         promptId: this._currentPromptId,


### PR DESCRIPTION
### What Is This Change?

We are getting a lot of instances of an error in Boysenberry 
`TypeError: terminated
	at Fetch.onAborted (node:internal/deps/undici/undici:11322:53)
	at Fetch.emit (node:events:519:28)`

Error source: Node.js undici (the fetch implementation in Node 18+)
Trigger: AbortController.abort() called on an active fetch stream
Why not caught: The guard checks for error.name === 'AbortError', but undici throws TypeError with message "terminated" instead
Why more common in BBY: Boysenberry’s YOLO mode runs longer uninterrupted streams, making mid-stream aborts more likely
User impact: An unexpected error dialog appears in the chat UI when the request is aborted

Fix: Implement the fix in executeStreamingApiWithErrorHandling to also catch the TypeError: terminated


<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?
Manually and by adding a new test.
<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [ ] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

