### PR TITLE
Flow 2152 send atlascode analytics to jira

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## What's new in 4.0.30
 
+### Improvements
+
+- **RovoDev (BBY)**: Analytics events from the Boysenberry environment are now piped through the webview messaging layer (via `ReportAnalyticsEvent`) rather than being called directly on the extension API, consistent with how live-preview and modified files data are handled.
+
 ### Bug Fixes
 
 - **RovoDev**: Fixed `TypeError: terminated` from Node.js undici being incorrectly surfaced as an error dialog when aborting an in-flight chat request. The error is now silently handled as a normal abort, preventing spurious error messages and noisy telemetry — particularly in Boysenberry mode where long-running YOLO streams make mid-stream aborts more common.

--- a/src/rovo-dev/api/extensionApi.ts
+++ b/src/rovo-dev/api/extensionApi.ts
@@ -16,6 +16,8 @@ import { AuthInfo, DetailedSiteInfo, ProductJira } from './extensionApiTypes';
 // Re-export types for convenience
 export * from './extensionApiTypes';
 export * from '../analytics/events';
+export { RovoDevViewResponseType } from '../ui/rovoDevViewMessages';
+export type { TelemetryEvent } from '../rovoDevTelemetryProvider';
 
 // TODO: getAxiosInstance is being re-exported for now, to not break compatability with curl logging
 //       in the future, we'd need to re-implement it, or just use the library directly

--- a/src/rovo-dev/rovoDevWebviewProvider.test.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.test.ts
@@ -136,13 +136,16 @@ jest.mock('src/commandContext', () => ({
     },
 }));
 
-jest.mock('path', () => ({
-    isAbsolute: (path: string) => path.startsWith('/') || path.startsWith('C:'),
-    join: (...paths: string[]) => paths.join('/'),
-    relative: (from: string, to: string) => to.replace(from, ''),
-    basename: (path: string) => path.split('/').pop(),
-    sep: '/',
-}));
+jest.mock('path', () => {
+    const pathImpl = {
+        isAbsolute: (p: string) => p.startsWith('/') || p.startsWith('C:'),
+        join: (...paths: string[]) => paths.filter(Boolean).join('/'),
+        relative: (from: string, to: string) => to.replace(from, ''),
+        basename: (p: string) => p.split('/').pop(),
+        sep: '/',
+    };
+    return { ...pathImpl, default: pathImpl };
+});
 
 jest.mock('./util/fsPromises', () => ({
     getFsPromise: jest.fn(),

--- a/src/rovo-dev/rovoDevWebviewProvider.test.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.test.ts
@@ -31,6 +31,7 @@ jest.mock('./api/extensionApi', () => ({
             showDiff: jest.fn(),
             setCommandContext: jest.fn(),
         },
+        getHtmlForView: jest.fn(() => '<html></html>'),
     })),
 }));
 
@@ -136,10 +137,10 @@ jest.mock('src/commandContext', () => ({
 }));
 
 jest.mock('path', () => ({
-    isAbsolute: jest.fn((path) => path.startsWith('/') || path.startsWith('C:')),
-    join: jest.fn((...paths) => paths.join('/')),
-    relative: jest.fn((from, to) => to.replace(from, '')),
-    basename: jest.fn((path) => path.split('/').pop()),
+    isAbsolute: (path: string) => path.startsWith('/') || path.startsWith('C:'),
+    join: (...paths: string[]) => paths.join('/'),
+    relative: (from: string, to: string) => to.replace(from, ''),
+    basename: (path: string) => path.split('/').pop(),
     sep: '/',
 }));
 
@@ -759,6 +760,67 @@ describe('RovoDevWebviewProvider - Business Logic', () => {
             expect(handleToolPermissionChoice('allowAll')).toBe('Allow all tools');
             expect(handleToolPermissionChoice('deny')).toBe('Handle tool permission: deny');
             expect(handleToolPermissionChoice('allow')).toBe('Handle tool permission: allow');
+        });
+    });
+
+    describe('ReportAnalyticsEvent message handling', () => {
+        let messageHandler: (msg: any) => Promise<void>;
+        let mockFireTelemetryEvent: jest.Mock;
+
+        beforeEach(() => {
+            let capturedHandler: (msg: any) => Promise<void>;
+            const localProvider = new RovoDevWebviewProvider(
+                { workspaceState: { get: jest.fn(), update: jest.fn() } } as any,
+                '/test/extension',
+            );
+
+            const mockWebview = {
+                options: {},
+                html: '',
+                asWebviewUri: jest.fn((uri) => uri),
+                cspSource: 'mock-csp',
+                postMessage: jest.fn().mockResolvedValue(true),
+                onDidReceiveMessage: jest.fn((handler) => {
+                    capturedHandler = handler;
+                    return { dispose: jest.fn() };
+                }),
+            };
+
+            const mockWebviewView = {
+                webview: mockWebview,
+                visible: true,
+                onDidChangeVisibility: jest.fn(() => ({ dispose: jest.fn() })),
+            };
+
+            localProvider.resolveWebviewView(mockWebviewView as any, {} as any, {} as any);
+            messageHandler = capturedHandler!;
+            mockFireTelemetryEvent = (localProvider as any)._telemetryProvider.fireTelemetryEvent;
+        });
+
+        it('should forward analytics events to the telemetry provider', async () => {
+            const event = {
+                action: 'rovoDevSomeAction',
+                subject: 'atlascode',
+                attributes: { promptId: 'test-prompt-id', someAttribute: 'value' },
+            };
+
+            await messageHandler({ type: 'reportAnalyticsEvent', event });
+
+            expect(mockFireTelemetryEvent).toHaveBeenCalledWith(event);
+        });
+
+        it('should forward analytics events with no attributes', async () => {
+            const event = { action: 'rovoDevMinimalEvent', subject: 'atlascode' };
+
+            await messageHandler({ type: 'reportAnalyticsEvent', event });
+
+            expect(mockFireTelemetryEvent).toHaveBeenCalledWith(event);
+        });
+
+        it('should not call fireTelemetryEvent for other message types', async () => {
+            await messageHandler({ type: 'refresh' });
+
+            expect(mockFireTelemetryEvent).not.toHaveBeenCalled();
         });
     });
 

--- a/src/rovo-dev/rovoDevWebviewProvider.ts
+++ b/src/rovo-dev/rovoDevWebviewProvider.ts
@@ -602,6 +602,10 @@ export class RovoDevWebviewProvider extends Disposable implements WebviewViewPro
                         break;
                     }
 
+                    case RovoDevViewResponseType.ReportAnalyticsEvent:
+                        await this._telemetryProvider.fireTelemetryEvent(e.event);
+                        break;
+
                     case RovoDevViewResponseType.AskUserQuestionsSubmit:
                     case RovoDevViewResponseType.ExitPlanModeSubmit:
                         const deferredToolResponse: RovoDevDeferredToolCallResponse = {

--- a/src/rovo-dev/ui/rovoDevViewMessages.tsx
+++ b/src/rovo-dev/ui/rovoDevViewMessages.tsx
@@ -1,3 +1,4 @@
+import { TelemetryEvent } from 'src/rovo-dev/rovoDevTelemetryProvider';
 import { RovoDevContextItem, RovoDevPrompt, ToolPermissionDialogChoice } from 'src/rovo-dev/rovoDevTypes';
 
 import { AgentMode } from '../client';
@@ -49,6 +50,7 @@ export const enum RovoDevViewResponseType {
     ExitPlanModeSubmit = 'exitPlanModeSubmit',
     RefreshModifiedFiles = 'refreshModifiedFiles',
     CreateLivePreview = 'createLivePreview',
+    ReportAnalyticsEvent = 'reportAnalyticsEvent',
 }
 
 export type FileOperationType = 'modify' | 'create' | 'delete';
@@ -116,4 +118,5 @@ export type RovoDevViewResponse =
     | ReducerAction<RovoDevViewResponseType.CreateLivePreview>
     | ReducerAction<RovoDevViewResponseType.AskUserQuestionsSubmit, AskUserQuestionsResultMessage>
     | ReducerAction<RovoDevViewResponseType.ExitPlanModeSubmit, ExitPlanModeResultMessage>
-    | ReducerAction<RovoDevViewResponseType.RefreshModifiedFiles>;
+    | ReducerAction<RovoDevViewResponseType.RefreshModifiedFiles>
+    | ReducerAction<RovoDevViewResponseType.ReportAnalyticsEvent, { event: TelemetryEvent }>;


### PR DESCRIPTION
### What Is This Change?
In the Jira aiUnifiedEvent analytics we need to send an initiate event every time a prompt is sent. By sending the events to Jira through the vscode bridge we will be able to track the entire journey for the analytics team.
<!--
Passing the analytic events through to vscode so that we can pass them through the bridge to be read as part of the ai-analytics

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change