### PR TITLE
[SNWC-950] removing sentry logs for client-side errors

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -412,6 +412,55 @@ describe('Logger', () => {
             // Should still log to output channel
             expect(mockOutputChannel.appendLine).toHaveBeenCalled();
         });
+
+        describe('isExpectedHttpError filtering', () => {
+            it.each([401, 403, 404, 429])(
+                'should NOT send to Sentry when error has HTTP status %i via response.status',
+                (status) => {
+                    const err = Object.assign(new Error(`Request failed with status code ${status}`), {
+                        response: { status },
+                    });
+                    Logger.error(err, 'HTTP error');
+                    expect(mockSentryService.captureException).not.toHaveBeenCalled();
+                },
+            );
+
+            it.each([401, 403, 404, 429])(
+                'should NOT send to Sentry when error has HTTP status %i via top-level status',
+                (status) => {
+                    const err = Object.assign(new Error(`Request failed with status code ${status}`), { status });
+                    Logger.error(err, 'HTTP error');
+                    expect(mockSentryService.captureException).not.toHaveBeenCalled();
+                },
+            );
+
+            it.each([
+                "'Unauthorized' captured",
+                "'Forbidden' captured",
+                "'Not Found' captured",
+                "'Too Many Requests' captured",
+                'Request failed with status code 401',
+                'Request failed with status code 403',
+                'Request failed with status code 404',
+                'Request failed with status code 429',
+            ])('should NOT send to Sentry when error message contains "%s"', (message) => {
+                const err = new Error(message);
+                Logger.error(err, 'HTTP error');
+                expect(mockSentryService.captureException).not.toHaveBeenCalled();
+            });
+
+            it('should send to Sentry for non-HTTP errors', () => {
+                const err = new Error('Something unexpected happened');
+                Logger.error(err, 'Unexpected error');
+                expect(mockSentryService.captureException).toHaveBeenCalledWith(err, expect.anything());
+            });
+
+            it('should send to Sentry for HTTP 500 errors (server errors are actionable)', () => {
+                const err = Object.assign(new Error('Internal Server Error'), { response: { status: 500 } });
+                Logger.error(err, 'Server error');
+                expect(mockSentryService.captureException).toHaveBeenCalledWith(err, expect.anything());
+            });
+        });
     });
 
     describe('rovoDevErrorInternal', () => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -221,6 +221,32 @@ export class Logger {
         }
     }
 
+    /**
+     * Returns true if the error is a known, expected HTTP error that should not be sent to Sentry.
+     * These are client-side HTTP errors (401, 403, 404, 429) that are expected to occur during
+     * normal operation (e.g. expired credentials, rate limiting, missing resources) and generate
+     * high event volume with no actionable signal.
+     */
+    private isExpectedHttpError(ex: Error): boolean {
+        const status = (ex as any)?.response?.status ?? (ex as any)?.status;
+        const FILTERED_HTTP_STATUS_CODES = [401, 403, 404, 429];
+        if (status && FILTERED_HTTP_STATUS_CODES.includes(status)) {
+            return true;
+        }
+        // Also catch errors where the status is embedded in the message (e.g. GraphQL errors)
+        const message = ex?.message?.toLowerCase() ?? '';
+        return (
+            message.includes("'unauthorized'") ||
+            message.includes("'forbidden'") ||
+            message.includes("'not found'") ||
+            message.includes("'too many requests'") ||
+            message.includes('status code 401') ||
+            message.includes('status code 403') ||
+            message.includes('status code 404') ||
+            message.includes('status code 429')
+        );
+    }
+
     private logSentry(
         productArea: ErrorProductArea,
         ex: Error,
@@ -229,6 +255,11 @@ export class Logger {
         extraTags: Record<string, string> = {},
         extraExtra: Record<string, any> = {},
     ) {
+        if (this.isExpectedHttpError(ex)) {
+            Logger.debug('Skipping Sentry capture for expected HTTP error', ex?.message);
+            return;
+        }
+
         if (SentryService.getInstance().isInitialized()) {
             try {
                 SentryService.getInstance().captureException(ex, {


### PR DESCRIPTION
### What Is This Change?

No need to log to Sentry 401, 403, 404, and 429 errors as they are client side errors and cannot be fixed by server side change.

### How Has This Been Tested?

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ]  `new tests`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change