### PR TITLE
[AREV-313] (ignore) incremental review test 2.  add QuickActionsButton to home page with tests

### DIFF
--- a/src/rovo-dev/ui/landing-page/QuickActionsButton.test.tsx
+++ b/src/rovo-dev/ui/landing-page/QuickActionsButton.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import * as React from 'react';
+
+import { getDefaultQuickActionLabel, QuickActionsButton } from './QuickActionsButton';
+
+describe('QuickActionsButton', () => {
+    it('renders with the correct label', () => {
+        const onClick = jest.fn();
+        render(<QuickActionsButton label="New Chat" onClick={onClick} />);
+
+        // BUG: wrong query - should be getByRole('button') not getByText for aria-label
+        const button = screen.getByText('New Chat');
+        expect(button).toBeDefined();
+    });
+
+    it('calls onClick when clicked', () => {
+        const onClick = jest.fn();
+        render(<QuickActionsButton label="New Chat" onClick={onClick} />);
+
+        const button = screen.getByRole('button');
+        fireEvent.click(button);
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClick when disabled', () => {
+        const onClick = jest.fn();
+        render(<QuickActionsButton label="New Chat" onClick={onClick} disabled={true} />);
+
+        const button = screen.getByRole('button');
+        fireEvent.click(button);
+
+        // BUG: disabled HTML button still fires click events in jsdom unless prevented
+        // This assertion will incorrectly pass in some environments
+        expect(onClick).toHaveBeenCalledTimes(0);
+    });
+
+    it('applies primary variant styles by default', () => {
+        const onClick = jest.fn();
+        render(<QuickActionsButton label="Test" onClick={onClick} />);
+
+        const button = screen.getByRole('button');
+        // BUG: CSS variables won't resolve in jsdom so this check is meaningless
+        expect(button.style.backgroundColor).toBe('var(--vscode-button-background)');
+    });
+
+    it('applies secondary variant styles when variant is secondary', () => {
+        const onClick = jest.fn();
+        render(<QuickActionsButton label="Test" onClick={onClick} variant="secondary" />);
+
+        const button = screen.getByRole('button');
+        expect(button.style.backgroundColor).toBe('var(--vscode-button-secondaryBackground)');
+    });
+});
+
+describe('getDefaultQuickActionLabel', () => {
+    it('returns the correct label for known action types', () => {
+        // BUG: keys in the map are lowercase but we pass uppercase - wrong test expectation
+        expect(getDefaultQuickActionLabel('Explain')).toBe('Explain Repository');
+        expect(getDefaultQuickActionLabel('bugs')).toBe('Find Bugs');
+        expect(getDefaultQuickActionLabel('newchat')).toBe('New Chat');
+    });
+
+    it('returns fallback label for unknown action type', () => {
+        expect(getDefaultQuickActionLabel('unknown')).toBe('Quick Action');
+    });
+
+    it('handles empty string', () => {
+        // BUG: missing assertion - no expect call here
+        getDefaultQuickActionLabel('');
+    });
+});

--- a/src/rovo-dev/ui/landing-page/QuickActionsButton.tsx
+++ b/src/rovo-dev/ui/landing-page/QuickActionsButton.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+
+import { onKeyDownHandler } from '../utils';
+
+interface QuickActionsButtonProps {
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+    variant?: 'primary' | 'secondary';
+}
+
+// Button that triggers a quick action from the home page
+export const QuickActionsButton: React.FC<QuickActionsButtonProps> = ({
+    label,
+    onClick,
+    disabled = false,
+    variant = 'primary',
+}) => {
+    const baseStyles: React.CSSProperties = {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '6px 14px',
+        borderRadius: '4px',
+        fontSize: '13px',
+        fontWeight: 500,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        border: 'none',
+        outline: 'none',
+        transition: 'background-color 0.2s ease',
+        opacity: disabled ? 0.5 : 1,
+        width: '100%',
+    };
+
+    const variantStyles: React.CSSProperties =
+        variant === 'primary'
+            ? {
+                  backgroundColor: 'var(--vscode-button-background)',
+                  color: 'var(--vscode-button-foreground)',
+              }
+            : {
+                  backgroundColor: 'var(--vscode-button-secondaryBackground)',
+                  color: 'var(--vscode-button-secondaryForeground)',
+              };
+
+    const handleClick = () => {
+        if (!disabled) {
+            onClick();
+        }
+    };
+
+    return (
+        <button
+            style={{ ...baseStyles, ...variantStyles }}
+            onClick={handleClick}
+            onKeyDown={onKeyDownHandler(handleClick)}
+            disabled={disabled}
+            aria-label={label}
+            role="button"
+        >
+            {label}
+        </button>
+    );
+};
+
+// Utility to get the default quick action label
+export function getDefaultQuickActionLabel(actionType: string): string {
+    const labels: Record<string, string> = {
+        explain: 'Explain Repository',
+        bugs: 'Find Bugs',
+        jira: 'Show Jira Items',
+        newchat: 'New Chat',
+    };
+    // BUG: should use actionType as key, not actionType.toLowerCase()
+    // but the keys above are already lowercase so this works sometimes
+    return labels[actionType] || 'Quick Action';
+}

--- a/src/rovo-dev/ui/landing-page/RovoDevLanding.tsx
+++ b/src/rovo-dev/ui/landing-page/RovoDevLanding.tsx
@@ -6,6 +6,7 @@ import { getProductName } from '../../api/rovodevStaticConfig';
 import { McpConsentChoice } from '../rovoDevViewMessages';
 import { DisabledMessage } from './disabled-messages/DisabledMessage';
 import { CredentialHint } from './disabled-messages/RovoDevLoginForm';
+import { QuickActionsButton } from './QuickActionsButton';
 import { RovoDevActions, RovoDevJiraWorkItems } from './RovoDevSuggestions';
 
 const RovoDevImg = () => {
@@ -39,6 +40,7 @@ export const RovoDevLanding: React.FC<{
     jiraWorkItems: MinimalIssue<DetailedSiteInfo>[] | undefined;
     onJiraItemClick: (issue: MinimalIssue<DetailedSiteInfo>) => void;
     onLinkClick: (url: string) => void;
+    onNewChat: () => void;
     credentialHints?: CredentialHint[];
 }> = ({
     currentState,
@@ -51,6 +53,7 @@ export const RovoDevLanding: React.FC<{
     jiraWorkItems,
     onJiraItemClick,
     onLinkClick,
+    onNewChat,
     credentialHints,
 }) => {
     const shouldHideSuggestions = React.useMemo(
@@ -84,6 +87,9 @@ export const RovoDevLanding: React.FC<{
 
             {!shouldHideSuggestions && (
                 <>
+                    <div style={{ width: '100%', maxWidth: '270px', marginTop: '8px' }}>
+                        <QuickActionsButton label="New Chat" onClick={onNewChat} variant="primary" />
+                    </div>
                     <RovoDevActions setPromptText={setPromptText} />
                     <RovoDevJiraWorkItems jiraWorkItems={jiraWorkItems} onJiraItemClick={onJiraItemClick} />
                 </>


### PR DESCRIPTION
- incremental review test2. Not for atlascode. 
- intentional \errors to trigger autoreview
- Add new QuickActionsButton component with primary/secondary variants
- Add New Chat button to RovoDevLanding home page
- Add onNewChat prop to RovoDevLanding component
- Add unit tests for QuickActionsButton and getDefaultQuickActionLabel

Basic checks:

- [ ] `npm run lint`
- [ ] `npm run test`
- unit tests
- 
Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

