### PR TITLE
fix(rovodev): hide diagnostics from external users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,8 @@
 
 ### Bug Fixes
 
-<<<<<<< HEAD
 - **RovoDev**: Hid stack traces, stderr, and log details from external users while preserving them for Atlassian users.
-- **RovoDev (BBY)**: Fixed the `ROVODEV_REBRAND_JCA` environment variable so that the "Jira Coding Agent" feature gate from devai-sandbox is correctly applied at runtime.
-=======
 - **RovoDev (BBY)**: Fixed `ROVODEV_REBRAND_JCA` env var handling so the "Jira Coding Agent" rebrand works correctly in webviews.
->>>>>>> main
 - **Notifications**: Fixed `atlassianNotificationNotifier` to correctly flush all promise levels, resolving a test reliability issue.
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- **RovoDev**: Hid stack traces, stderr, and log details from external users while preserving them for Atlassian users.
 - **RovoDev (BBY)**: Fixed the `ROVODEV_REBRAND_JCA` environment variable so that the "Jira Coding Agent" feature gate from devai-sandbox is correctly applied at runtime.
 - **Notifications**: Fixed `atlassianNotificationNotifier` to correctly flush all promise levels, resolving a test reliability issue.
 

--- a/src/rovo-dev/ui/RovoDevErrorBoundary.tsx
+++ b/src/rovo-dev/ui/RovoDevErrorBoundary.tsx
@@ -12,6 +12,7 @@ interface Props {
     children: ReactNode;
     postMessage: PostMessageFunc<RovoDevViewResponse>;
     onStartNewSession?: () => void;
+    isAtlassianUser?: boolean;
 }
 
 interface State {
@@ -101,6 +102,7 @@ export class RovoDevErrorBoundary extends Component<Props, State> {
                         onClick: this.handleStartNewSession,
                     }}
                     onLinkClick={() => {}} // Required prop, but not used for error boundary
+                    isAtlassianUser={this.props.isAtlassianUser}
                 />
             );
         }

--- a/src/rovo-dev/ui/common/DialogMessage.test.tsx
+++ b/src/rovo-dev/ui/common/DialogMessage.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { ErrorDialogMessage } from '../utils';
+import { DialogMessageItem } from './DialogMessage';
+
+const errorMessage: ErrorDialogMessage = {
+    event_kind: '_RovoDevDialog',
+    type: 'error',
+    uid: 'test-error',
+    title: 'Something went wrong',
+    text: 'A friendly error message',
+    statusCode: '500',
+    stackTrace: 'Error: boom\n    at stack frame',
+    stderr: 'component stack details',
+    rovoDevLogs: ['log line 1', 'log line 2'],
+};
+
+describe('DialogMessageItem', () => {
+    const onLinkClick = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: {
+                writeText: jest.fn(),
+            },
+        });
+    });
+
+    it('hides diagnostic details from external users', () => {
+        render(<DialogMessageItem msg={errorMessage} onLinkClick={onLinkClick} isAtlassianUser={false} />);
+
+        expect(screen.getByText('Something went wrong')).toBeTruthy();
+        expect(screen.getByText('A friendly error message')).toBeTruthy();
+        expect(screen.queryByText(/Extension Stack Trace/)).toBeNull();
+        expect(screen.queryByText(/Error: boom/)).toBeNull();
+        expect(screen.queryByText(/Rovo Dev Logs/)).toBeNull();
+        expect(screen.queryByText(/log line 1/)).toBeNull();
+        expect(screen.queryByText(/Rovo Dev Stderr/)).toBeNull();
+        expect(screen.queryByText(/component stack details/)).toBeNull();
+        expect(screen.queryByLabelText('copy-details-button')).toBeNull();
+    });
+
+    it('shows diagnostic details to Atlassian users and includes them in copied text', () => {
+        render(<DialogMessageItem msg={errorMessage} onLinkClick={onLinkClick} isAtlassianUser />);
+
+        expect(screen.getByText(/Extension Stack Trace/)).toBeTruthy();
+        expect(screen.getByText(/Error: boom/)).toBeTruthy();
+        expect(screen.getByText(/Rovo Dev Logs/)).toBeTruthy();
+        expect(screen.getByText(/log line 1/)).toBeTruthy();
+        expect(screen.getByText(/Rovo Dev Stderr/)).toBeTruthy();
+        expect(screen.getByText(/component stack details/)).toBeTruthy();
+
+        fireEvent.click(screen.getByLabelText('copy-details-button'));
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+            expect.stringContaining('Extension Stack Trace:\nError: boom'),
+        );
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+            expect.stringContaining('Rovo Dev Logs:\nlog line 1'),
+        );
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+            expect.stringContaining('Rovo Dev Stderr:\ncomponent stack details'),
+        );
+    });
+});

--- a/src/rovo-dev/ui/common/DialogMessage.tsx
+++ b/src/rovo-dev/ui/common/DialogMessage.tsx
@@ -49,6 +49,7 @@ export const DialogMessageItem: React.FC<{
     customButton?: { text: string; onClick?: () => void };
     onLinkClick: (href: string) => void;
     onRestartProcess?: () => void;
+    isAtlassianUser?: boolean;
 }> = ({
     msg,
     isRetryAfterErrorButtonEnabled,
@@ -57,8 +58,10 @@ export const DialogMessageItem: React.FC<{
     customButton,
     onLinkClick,
     onRestartProcess,
+    isAtlassianUser = false,
 }) => {
     const [isCopied, setIsCopied] = React.useState(false);
+    const shouldShowErrorDetails = isAtlassianUser;
 
     const errorDetailsText = React.useMemo(() => {
         const parts = [];
@@ -69,17 +72,19 @@ export const DialogMessageItem: React.FC<{
         if (msg.statusCode) {
             parts.push(`\n${msg.statusCode}`);
         }
-        if (msg.stackTrace) {
-            parts.push(`\n\nExtension Stack Trace:\n${msg.stackTrace}`);
-        }
-        if (msg.rovoDevLogs && msg.rovoDevLogs.length > 0) {
-            parts.push(`\n\n${getProductName()} Logs:\n${msg.rovoDevLogs.join('\n')}`);
-        }
-        if (msg.stderr) {
-            parts.push(`\n\n${getProductName()} Stderr:\n${msg.stderr}`);
+        if (shouldShowErrorDetails) {
+            if (msg.stackTrace) {
+                parts.push(`\n\nExtension Stack Trace:\n${msg.stackTrace}`);
+            }
+            if (msg.rovoDevLogs && msg.rovoDevLogs.length > 0) {
+                parts.push(`\n\n${getProductName()} Logs:\n${msg.rovoDevLogs.join('\n')}`);
+            }
+            if (msg.stderr) {
+                parts.push(`\n\n${getProductName()} Stderr:\n${msg.stderr}`);
+            }
         }
         return parts.join('');
-    }, [msg.title, msg.text, msg.statusCode, msg.stackTrace, msg.stderr, msg.rovoDevLogs]);
+    }, [msg.title, msg.text, msg.statusCode, msg.stackTrace, msg.stderr, msg.rovoDevLogs, shouldShowErrorDetails]);
 
     const copyToClipboard = () => {
         navigator.clipboard.writeText(errorDetailsText);
@@ -209,62 +214,63 @@ export const DialogMessageItem: React.FC<{
                         </div>
                     )}
 
-                    {(msg.stackTrace || msg.stderr || (msg.rovoDevLogs && msg.rovoDevLogs.length > 0)) && (
-                        <div style={{ marginTop: '12px' }}>
-                            <div
-                                style={{
-                                    position: 'relative',
-                                    height: '300px',
-                                    overflow: 'auto',
-                                    backgroundColor: 'var(--vscode-editor-background)',
-                                    color: 'var(--vscode-editor-foreground)',
-                                    padding: '8px',
-                                    fontFamily: 'monospace',
-                                    fontSize: '12px',
-                                    whiteSpace: 'pre-wrap',
-                                    wordWrap: 'break-word',
-                                    borderRadius: '4px',
-                                    border: '1px solid var(--vscode-editorGroup-border)',
-                                }}
-                            >
+                    {shouldShowErrorDetails &&
+                        (msg.stackTrace || msg.stderr || (msg.rovoDevLogs && msg.rovoDevLogs.length > 0)) && (
+                            <div style={{ marginTop: '12px' }}>
                                 <div
                                     style={{
-                                        position: 'sticky',
-                                        top: '8px',
-                                        right: '8px',
-                                        zIndex: 10,
-                                        display: 'flex',
-                                        justifyContent: 'flex-end',
-                                        paddingRight: '8px',
-                                        paddingTop: '8px',
+                                        position: 'relative',
+                                        height: '300px',
+                                        overflow: 'auto',
                                         backgroundColor: 'var(--vscode-editor-background)',
-                                        marginLeft: 'auto',
-                                        width: 'fit-content',
-                                        marginRight: '0',
+                                        color: 'var(--vscode-editor-foreground)',
+                                        padding: '8px',
+                                        fontFamily: 'monospace',
+                                        fontSize: '12px',
+                                        whiteSpace: 'pre-wrap',
+                                        wordWrap: 'break-word',
+                                        borderRadius: '4px',
+                                        border: '1px solid var(--vscode-editorGroup-border)',
                                     }}
                                 >
-                                    <Tooltip
-                                        key={isCopied ? 'copied' : 'copy'}
-                                        content={isCopied ? 'Copied!' : 'Copy to clipboard'}
+                                    <div
+                                        style={{
+                                            position: 'sticky',
+                                            top: '8px',
+                                            right: '8px',
+                                            zIndex: 10,
+                                            display: 'flex',
+                                            justifyContent: 'flex-end',
+                                            paddingRight: '8px',
+                                            paddingTop: '8px',
+                                            backgroundColor: 'var(--vscode-editor-background)',
+                                            marginLeft: 'auto',
+                                            width: 'fit-content',
+                                            marginRight: '0',
+                                        }}
                                     >
-                                        <button
-                                            aria-label="copy-details-button"
-                                            className={`chat-message-action copy-button ${isCopied ? 'copied' : ''}`}
-                                            onClick={copyToClipboard}
+                                        <Tooltip
+                                            key={isCopied ? 'copied' : 'copy'}
+                                            content={isCopied ? 'Copied!' : 'Copy to clipboard'}
                                         >
-                                            {isCopied ? (
-                                                <CheckCircleIcon label="Copied!" spacing="none" />
-                                            ) : (
-                                                <CopyIcon label="Copy to clipboard" spacing="none" />
-                                            )}
-                                        </button>
-                                    </Tooltip>
-                                </div>
+                                            <button
+                                                aria-label="copy-details-button"
+                                                className={`chat-message-action copy-button ${isCopied ? 'copied' : ''}`}
+                                                onClick={copyToClipboard}
+                                            >
+                                                {isCopied ? (
+                                                    <CheckCircleIcon label="Copied!" spacing="none" />
+                                                ) : (
+                                                    <CopyIcon label="Copy to clipboard" spacing="none" />
+                                                )}
+                                            </button>
+                                        </Tooltip>
+                                    </div>
 
-                                {errorDetailsText}
+                                    {errorDetailsText}
+                                </div>
                             </div>
-                        </div>
-                    )}
+                        )}
                 </div>
             </div>
         </div>

--- a/src/rovo-dev/ui/common/common.tsx
+++ b/src/rovo-dev/ui/common/common.tsx
@@ -211,6 +211,7 @@ export const renderChatHistory = (
     isRetryAfterErrorButtonEnabled: (uid: string) => boolean,
     retryAfterError: () => void,
     onError: (error: Error, errorMessage: string) => void,
+    isAtlassianUser?: boolean,
 ) => {
     switch (msg.event_kind) {
         case 'tool-return':
@@ -241,6 +242,7 @@ export const renderChatHistory = (
                     }
                     customButton={customButton}
                     onLinkClick={onLinkClick}
+                    isAtlassianUser={isAtlassianUser}
                 />
             );
         case 'text':

--- a/src/rovo-dev/ui/messaging/ChatItem.tsx
+++ b/src/rovo-dev/ui/messaging/ChatItem.tsx
@@ -28,6 +28,7 @@ interface ChatItemProps {
     onLinkClick: (href: string) => void;
     deepPlanCreated?: string | null;
     onGeneratePlanClick?: (planId: string, proceed: boolean) => void;
+    isAtlassianUser?: boolean;
 }
 
 export const ChatItem = React.memo<ChatItemProps>(
@@ -42,6 +43,7 @@ export const ChatItem = React.memo<ChatItemProps>(
         onLinkClick,
         deepPlanCreated,
         onGeneratePlanClick,
+        isAtlassianUser,
     }) => {
         if (!block) {
             return null;
@@ -55,6 +57,7 @@ export const ChatItem = React.memo<ChatItemProps>(
                     renderProps={renderProps}
                     onCollapsiblePanelExpanded={onCollapsiblePanelExpanded}
                     onLinkClick={onLinkClick}
+                    isAtlassianUser={isAtlassianUser}
                 />
             );
         } else if (
@@ -103,6 +106,7 @@ export const ChatItem = React.memo<ChatItemProps>(
                     onToolPermissionChoice={onToolPermissionChoice}
                     customButton={customButton}
                     onLinkClick={onLinkClick}
+                    isAtlassianUser={isAtlassianUser}
                 />
             );
         } else if (block.event_kind === 'retry-prompt') {

--- a/src/rovo-dev/ui/messaging/ChatStream.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStream.tsx
@@ -49,6 +49,7 @@ interface ChatStreamProps {
     credentialHints?: CredentialHint[];
     onGeneratePlanClick?: (planId: string, proceed: boolean) => void;
     showLivePreviewButton?: boolean;
+    isAtlassianUser?: boolean;
 }
 
 export const ChatStream: React.FC<ChatStreamProps> = ({
@@ -74,6 +75,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
     credentialHints,
     onGeneratePlanClick,
     showLivePreviewButton,
+    isAtlassianUser,
 }) => {
     const chatEndRef = React.useRef<HTMLDivElement>(null);
     const sentinelRef = React.useRef<HTMLDivElement>(null);
@@ -231,6 +233,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                     onLinkClick={onLinkClick}
                     deepPlanCreated={deepPlanCreated}
                     onGeneratePlanClick={onGeneratePlanClick}
+                    isAtlassianUser={isAtlassianUser}
                 />
             )}
 
@@ -254,6 +257,7 @@ export const ChatStream: React.FC<ChatStreamProps> = ({
                             onRestartProcess={renderProps.onRestartProcess}
                             onToolPermissionChoice={onToolPermissionChoice}
                             onLinkClick={onLinkClick}
+                            isAtlassianUser={isAtlassianUser}
                         />
                     ))}
                     {modalDialogs.length > 1 && modalDialogs.every((d) => d.type === 'toolPermissionRequest') && (

--- a/src/rovo-dev/ui/messaging/ChatStreamMessageRenderer.tsx
+++ b/src/rovo-dev/ui/messaging/ChatStreamMessageRenderer.tsx
@@ -25,6 +25,7 @@ interface ChatStreamMessageRendererProps {
     onLinkClick: (href: string) => void;
     deepPlanCreated?: string | null;
     onGeneratePlanClick?: (planId: string, proceed: boolean) => void;
+    isAtlassianUser?: boolean;
 }
 
 export const ChatStreamMessageRenderer = React.memo<ChatStreamMessageRendererProps>(
@@ -39,6 +40,7 @@ export const ChatStreamMessageRenderer = React.memo<ChatStreamMessageRendererPro
         onLinkClick,
         deepPlanCreated,
         onGeneratePlanClick,
+        isAtlassianUser,
     }) => {
         if (!chatHistory) {
             return null;
@@ -80,6 +82,7 @@ export const ChatStreamMessageRenderer = React.memo<ChatStreamMessageRendererPro
                     onLinkClick={onLinkClick}
                     deepPlanCreated={deepPlanCreated}
                     onGeneratePlanClick={onGeneratePlanClick}
+                    isAtlassianUser={isAtlassianUser}
                 />
             );
         });

--- a/src/rovo-dev/ui/messaging/MessageDrawer.tsx
+++ b/src/rovo-dev/ui/messaging/MessageDrawer.tsx
@@ -18,6 +18,7 @@ interface MessageDrawerProps {
     opened: boolean;
     onCollapsiblePanelExpanded: () => void;
     onLinkClick: (link: string) => void;
+    isAtlassianUser?: boolean;
 }
 
 export const MessageDrawer: React.FC<MessageDrawerProps> = ({
@@ -33,6 +34,7 @@ export const MessageDrawer: React.FC<MessageDrawerProps> = ({
     onCollapsiblePanelExpanded,
     opened,
     onLinkClick,
+    isAtlassianUser,
 }) => {
     const [isOpen, setIsOpen] = React.useState(opened);
 
@@ -77,6 +79,7 @@ export const MessageDrawer: React.FC<MessageDrawerProps> = ({
                         isRetryAfterErrorButtonEnabled,
                         retryPromptAfterError,
                         onError,
+                        isAtlassianUser,
                     ),
                 )}
             </div>

--- a/src/rovo-dev/ui/rovoDevView.tsx
+++ b/src/rovo-dev/ui/rovoDevView.tsx
@@ -1031,7 +1031,7 @@ const RovoDevView: React.FC = () => {
 
     return (
         <RovoDevErrorContext.Provider value={{ reportError }}>
-            <RovoDevErrorBoundary postMessage={postMessage}>
+            <RovoDevErrorBoundary postMessage={postMessage} isAtlassianUser={isAtlassianUser}>
                 <div
                     id="rovoDevDragDropOverlay"
                     onDragLeave={(event) => {
@@ -1103,6 +1103,7 @@ const RovoDevView: React.FC = () => {
                         onJiraItemClick={onJiraItemClick}
                         onToolPermissionChoice={onToolPermissionChoice}
                         onLinkClick={onLinkClick}
+                        isAtlassianUser={isAtlassianUser}
                         credentialHints={credentialHints}
                         onGeneratePlanClick={(e: string, proceed: boolean) => handleExitPlanMode(proceed, e)}
                         showLivePreviewButton={showLivePreviewButton}


### PR DESCRIPTION
Hide stack trace etc from the error message UI. We shouldn't show this to external users.
For now, only hide for externals. I'd like more time testing with internal dogfooders to ensure we can easily debug without this information.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

