### PR TITLE
FLOW-2419: created new events and sent them to the vscode bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **RovoDev**: Updated Rovo Dev version to 202606.10.1b3
 - **Notifications**: Added `siteId` to the `notificationFeedVSCode` GraphQL query so notification feeds are correctly scoped per Atlassian site.
 - **Logger**: Removed a spurious client-side error from Sentry to reduce noise in error reporting.
+- **RovoDev (BBY)**: Added a new `rovoDevPromptCompleted` telemetry event that fires exactly once per user-submitted prompt with a closed-enum `result` (`success`, `error`, `cancelled`, `timeout`, `parse_error`) and optional `errorReason` / `httpStatus` / `messagePartsCount`. The event is only emitted in Boysenberry mode (no consumer in the standard IDE) and is forwarded through the Boysenberry → Jira analytics bridge so a chat-response SLO can be computed as a simple counter ratio without joining on `promptId`. Never emitted for the replay streaming path.
 
 ### Cleanup
 

--- a/src/rovo-dev/analytics/events.ts
+++ b/src/rovo-dev/analytics/events.ts
@@ -203,6 +203,59 @@ export namespace Track {
         };
     };
 
+    /**
+     * Closed enum for `PromptCompleted.attributes.result`.
+     *
+     * Values outside this set will be dropped by the Boysenberry → Jira analytics
+     * bridge, so this MUST be kept aligned with the bridge spec. Add new values
+     * via a coordinated change on both sides.
+     */
+    export type PromptCompletedResult = 'success' | 'error' | 'cancelled' | 'timeout' | 'parse_error';
+
+    /**
+     * Closed enum for `PromptCompleted.attributes.errorReason`.
+     *
+     * Only present when `result !== 'success'`. Values outside this set will be
+     * dropped by the bridge. Add new values via a coordinated change.
+     */
+    export type PromptCompletedErrorReason =
+        | 'stream_exception' // event_kind: 'exception' arrived in the response stream
+        | 'parsing_error' // event_kind: '_parsing_error'
+        | 'network_error' // fetch / reader threw
+        | 'http_4xx' // local-server returned 4xx (excluding 401/403 which short-circuit to login)
+        | 'http_5xx' // local-server returned 5xx
+        | 'aborted' // user pressed stop, OR new prompt aborted in-flight
+        | 'no_response' // stream ended without any user-visible message parts
+        | 'unknown'; // catch-all when the cause cannot be classified
+
+    /**
+     * Emitted exactly once per user-submitted prompt as the terminal outcome of
+     * the chat-streaming flow. Used to drive the chat-response SLO downstream
+     * (success rate = count(result='success') / count(all results)).
+     *
+     * Invariants:
+     *   - Exactly-once per `promptId`.
+     *   - `result: 'success'` implies at least one user-visible message part was rendered.
+     *   - Never emitted for the `replay` streaming path.
+     */
+    export type PromptCompleted = {
+        action: 'rovoDevPromptCompleted';
+        subject: 'atlascode';
+        attributes: {
+            rovoDevEnv: RovoDevEnv;
+            appInstanceId: string;
+            sessionId: string;
+            promptId: string;
+            result: PromptCompletedResult;
+            /** Only present when `result !== 'success'`. */
+            errorReason?: PromptCompletedErrorReason;
+            /** Optional: HTTP status when the error was an HTTP-layer failure. */
+            httpStatus?: number;
+            /** Optional: number of user-visible message parts processed in the stream. */
+            messagePartsCount?: number;
+        };
+    };
+
     // TODO: rovodev metadata fields here are different from other events, reconcile later?
     export type PerformanceEvent = {
         action: 'performanceEvent';
@@ -231,4 +284,5 @@ export type TrackEvent =
     | Track.RestartProcessAction
     | Track.ReplayCompleted
     | Track.PerformanceEvent
-    | Track.LocalServerPromptReceived;
+    | Track.LocalServerPromptReceived
+    | Track.PromptCompleted;

--- a/src/rovo-dev/rovoDevChatProvider.test.ts
+++ b/src/rovo-dev/rovoDevChatProvider.test.ts
@@ -1106,4 +1106,158 @@ describe('RovoDevChatProvider', () => {
             );
         });
     });
+
+    // The rovoDevPromptCompleted event is the terminal SLO signal forwarded
+    // through the Boysenberry → Jira analytics bridge. The bridge relies on
+    // three strict invariants that these tests pin down:
+    //   1) Only emitted in Boysenberry mode (no consumer in the standard IDE).
+    //   2) Exactly-once per promptId — the first terminal classification wins.
+    //   3) Never emitted for the replay streaming path.
+    // We exercise the helper directly here (via bracket access) so the tests
+    // focus on those invariants without the heavy executeChat scaffolding.
+    describe('rovoDevPromptCompleted (SLO)', () => {
+        beforeEach(() => {
+            // Re-create the provider with isBoysenberry=true so the helper
+            // does not early-return. The "non-boysenberry suppression" test
+            // below covers the false case explicitly.
+            chatProvider = new RovoDevChatProvider(true, mockTelemetryProvider);
+            chatProvider.setWebview(mockWebview);
+            // Place the provider in a state equivalent to "an in-flight prompt
+            // is being processed" so firePromptCompleted has a promptId to use.
+            chatProvider['_currentPromptId'] = 'prompt-A';
+            mockTelemetryProvider.fireTelemetryEvent.mockClear();
+        });
+
+        it('does not emit when not running in Boysenberry mode (standard IDE)', () => {
+            const ideProvider = new RovoDevChatProvider(false, mockTelemetryProvider);
+            ideProvider.setWebview(mockWebview);
+            ideProvider['_currentPromptId'] = 'prompt-ide';
+
+            ideProvider['firePromptCompleted']('success', { messagePartsCount: 1 });
+            ideProvider['firePromptCompleted']('error', { errorReason: 'stream_exception' });
+
+            expect(mockTelemetryProvider.fireTelemetryEvent).not.toHaveBeenCalled();
+        });
+
+        it('emits rovoDevPromptCompleted with result=success and messagePartsCount', () => {
+            chatProvider['firePromptCompleted']('success', { messagePartsCount: 3 });
+
+            expect(mockTelemetryProvider.fireTelemetryEvent).toHaveBeenCalledTimes(1);
+            expect(mockTelemetryProvider.fireTelemetryEvent).toHaveBeenCalledWith({
+                action: 'rovoDevPromptCompleted',
+                subject: 'atlascode',
+                attributes: {
+                    promptId: 'prompt-A',
+                    result: 'success',
+                    messagePartsCount: 3,
+                },
+            });
+        });
+
+        it('emits rovoDevPromptCompleted with errorReason and httpStatus when provided', () => {
+            chatProvider['firePromptCompleted']('error', {
+                errorReason: 'http_5xx',
+                httpStatus: 503,
+            });
+
+            expect(mockTelemetryProvider.fireTelemetryEvent).toHaveBeenCalledTimes(1);
+            expect(mockTelemetryProvider.fireTelemetryEvent).toHaveBeenCalledWith({
+                action: 'rovoDevPromptCompleted',
+                subject: 'atlascode',
+                attributes: {
+                    promptId: 'prompt-A',
+                    result: 'error',
+                    errorReason: 'http_5xx',
+                    httpStatus: 503,
+                },
+            });
+        });
+
+        it('omits optional attributes when not provided (bridge expects closed shape)', () => {
+            chatProvider['firePromptCompleted']('cancelled', { errorReason: 'aborted' });
+
+            const call = mockTelemetryProvider.fireTelemetryEvent.mock.calls[0][0];
+            expect(call.attributes).not.toHaveProperty('httpStatus');
+            expect(call.attributes).not.toHaveProperty('messagePartsCount');
+            expect(call.attributes).toEqual({
+                promptId: 'prompt-A',
+                result: 'cancelled',
+                errorReason: 'aborted',
+            });
+        });
+
+        it('is exactly-once per promptId — subsequent calls for the same prompt are dropped', () => {
+            chatProvider['firePromptCompleted']('error', { errorReason: 'stream_exception' });
+            chatProvider['firePromptCompleted']('success', { messagePartsCount: 2 });
+            chatProvider['firePromptCompleted']('cancelled', { errorReason: 'aborted' });
+
+            expect(mockTelemetryProvider.fireTelemetryEvent).toHaveBeenCalledTimes(1);
+            // Cast to any: the TelemetryEvent union narrows `attributes` per-event,
+            // and the test only cares about the dedupe behaviour for the call we made.
+            const firstCallAttributes = (mockTelemetryProvider.fireTelemetryEvent.mock.calls[0][0] as any).attributes;
+            expect(firstCallAttributes.result).toBe('error');
+        });
+
+        it('emits independently for distinct promptIds', () => {
+            chatProvider['firePromptCompleted']('success', { messagePartsCount: 1 });
+
+            chatProvider['_currentPromptId'] = 'prompt-B';
+            chatProvider['firePromptCompleted']('error', { errorReason: 'no_response' });
+
+            expect(mockTelemetryProvider.fireTelemetryEvent).toHaveBeenCalledTimes(2);
+            const promptIds = mockTelemetryProvider.fireTelemetryEvent.mock.calls.map(
+                (c: any[]) => (c[0] as any).attributes.promptId,
+            );
+            expect(promptIds).toEqual(['prompt-A', 'prompt-B']);
+        });
+
+        it('does nothing when there is no current promptId', () => {
+            chatProvider['_currentPromptId'] = '';
+
+            chatProvider['firePromptCompleted']('success', { messagePartsCount: 1 });
+
+            expect(mockTelemetryProvider.fireTelemetryEvent).not.toHaveBeenCalled();
+        });
+
+        it('bounds the dedupe Set to avoid unbounded memory growth', () => {
+            // Fill the set just past the cap to confirm eviction kicks in.
+            const cap = (RovoDevChatProvider as any)._completedPromptIdsCap as number;
+            for (let i = 0; i < cap + 5; i++) {
+                chatProvider['_currentPromptId'] = `prompt-${i}`;
+                chatProvider['firePromptCompleted']('success', { messagePartsCount: 1 });
+            }
+
+            const dedupe: Set<string> = chatProvider['_completedPromptIds'];
+            expect(dedupe.size).toBeLessThanOrEqual(cap);
+            // The oldest entries must have been evicted.
+            expect(dedupe.has('prompt-0')).toBe(false);
+            // The most recent entry must still be present.
+            expect(dedupe.has(`prompt-${cap + 4}`)).toBe(true);
+        });
+
+        describe('classifyStreamingError', () => {
+            // The classifier produces the errorReason + httpStatus attributes
+            // attached to rovoDevPromptCompleted for fetch/HTTP failures. The
+            // SLO downstream slices on these closed-enum values, so the
+            // boundaries here are part of the bridge contract.
+            it('classifies RovoDevApiError 5xx as http_5xx with the status code', async () => {
+                const { RovoDevApiError } = await import('./client/rovoDevApiClient');
+                const err = new RovoDevApiError('boom', 502, undefined);
+                const result = chatProvider['classifyStreamingError'](err);
+                expect(result).toEqual({ errorReason: 'http_5xx', httpStatus: 502 });
+            });
+
+            it('classifies RovoDevApiError 4xx as http_4xx with the status code', async () => {
+                const { RovoDevApiError } = await import('./client/rovoDevApiClient');
+                const err = new RovoDevApiError('bad request', 422, undefined);
+                const result = chatProvider['classifyStreamingError'](err);
+                expect(result).toEqual({ errorReason: 'http_4xx', httpStatus: 422 });
+            });
+
+            it('falls back to network_error for non-API errors', () => {
+                const result = chatProvider['classifyStreamingError'](new Error('socket hang up'));
+                expect(result).toEqual({ errorReason: 'network_error' });
+            });
+        });
+    });
 });

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -5,6 +5,7 @@ import { v4 } from 'uuid';
 import { commands, Event, EventEmitter } from 'vscode';
 
 import { Container } from '../container';
+import { Track } from './analytics/events';
 import { ExtensionApi } from './api/extensionApi';
 import {
     AgentMode,
@@ -77,6 +78,20 @@ export class RovoDevChatProvider {
     private _rovoDevApiClient: RovoDevApiClient | undefined;
     private _webView: TypedWebview<RovoDevProviderMessage, RovoDevViewResponse> | undefined;
     private _onUnauthorizedCallback: (() => Promise<void>) | undefined;
+
+    /**
+     * Bounded LRU of `promptId`s for which `rovoDevPromptCompleted` has already
+     * been fired. Used to enforce the exactly-once-per-prompt invariant on the
+     * `rovoDevPromptCompleted` telemetry event without unbounded memory growth.
+     *
+     * Insertion-ordered (a `Set` preserves insertion order); when the cap is
+     * exceeded the oldest entry is evicted. The cap is set well above the
+     * realistic number of concurrent in-flight + recently-finished prompts.
+     */
+    private _completedPromptIds: Set<string> = new Set<string>();
+    private static readonly _completedPromptIdsCap = 64;
+    /** Counts user-visible message parts seen during the current prompt's stream. */
+    private _currentPromptUserVisiblePartsCount = 0;
 
     private _replayInProgress = false;
     private _lastMessageSentTime: number | undefined;
@@ -383,6 +398,15 @@ export class RovoDevChatProvider {
                     failed: success ? undefined : true,
                 },
             });
+
+            // Fire the terminal `rovoDevPromptCompleted` for this prompt so the
+            // chat-response SLO sees a cancelled outcome. We only emit when the
+            // cancel actually succeeded; a failed cancel leaves the stream
+            // running, in which case the eventual stream-end path will classify
+            // the prompt instead.
+            if (success) {
+                this.firePromptCompleted('cancelled', { errorReason: 'aborted' });
+            }
         }
 
         return success;
@@ -390,6 +414,10 @@ export class RovoDevChatProvider {
 
     private beginNewPrompt(overrideId?: string): void {
         this._currentPromptId = overrideId || v4();
+        // Reset the per-prompt user-visible message-part counter so that the
+        // `no_response` vs `success` classification at the end of the stream
+        // reflects only this prompt.
+        this._currentPromptUserVisiblePartsCount = 0;
         this._telemetryProvider.startNewPrompt(this._currentPromptId);
     }
 
@@ -467,6 +495,14 @@ export class RovoDevChatProvider {
                     isFirstMessage = false;
                 }
 
+                // Count user-visible parts so the terminal classification can
+                // distinguish a successful response from a stream that ended
+                // without delivering anything (`no_response`). Only the chat
+                // path participates in the SLO.
+                if (sourceApi === 'chat' && this.isUserVisiblePart(msg)) {
+                    this._currentPromptUserVisiblePartsCount++;
+                }
+
                 await this.processRovoDevResponse(sourceApi, msg);
             }
         }
@@ -478,6 +514,9 @@ export class RovoDevChatProvider {
         this._lastMessageSentTime = performance.now();
 
         for (const msg of parser.flush()) {
+            if (sourceApi === 'chat' && this.isUserVisiblePart(msg)) {
+                this._currentPromptUserVisiblePartsCount++;
+            }
             await this.processRovoDevResponse(sourceApi, msg);
         }
 
@@ -485,6 +524,41 @@ export class RovoDevChatProvider {
         // While we should handle such events in real time, this is meant to capture anything that we
         // may have missed, and make sure the agent selector is always in sync with Rovo Dev
         this._onAgentModelChanged.fire();
+
+        // Terminal classification for the SLO:
+        //   - `success` ⇒ at least one user-visible part was rendered.
+        //   - `no_response` ⇒ stream ended cleanly but no part was rendered
+        //     (e.g. backend returned an empty stream).
+        // The dedupe Set ensures this is a no-op if a mid-stream error already
+        // classified the prompt (e.g. `_parsing_error`, `exception`).
+        if (sourceApi === 'chat') {
+            const partsCount = this._currentPromptUserVisiblePartsCount;
+            if (partsCount > 0) {
+                this.firePromptCompleted('success', { messagePartsCount: partsCount });
+            } else {
+                this.firePromptCompleted('error', {
+                    errorReason: 'no_response',
+                    messagePartsCount: 0,
+                });
+            }
+        }
+    }
+
+    /**
+     * Whether a streamed `RovoDevResponse` represents a "user-visible" message
+     * part for the purposes of the chat-response SLO. Text and tool activity
+     * count as user-visible output; control / lifecycle events (warnings,
+     * prune notices, replay markers, dialog signals, …) do not.
+     */
+    private isUserVisiblePart(response: RovoDevResponse): boolean {
+        switch (response.event_kind) {
+            case 'text':
+            case 'tool-call':
+            case 'tool-return':
+                return true;
+            default:
+                return false;
+        }
     }
 
     private async processRovoDevReplayResponse(responses: RovoDevResponse[]): Promise<void> {
@@ -634,6 +708,12 @@ export class RovoDevChatProvider {
                 break;
 
             case '_parsing_error':
+                // Terminal classification for this prompt. The dedupe Set in
+                // firePromptCompleted ensures the later `success` emit from
+                // processResponse's normal exit path becomes a no-op.
+                if (sourceApi !== 'replay') {
+                    this.firePromptCompleted('parse_error', { errorReason: 'parsing_error' });
+                }
                 await this.processError(response.error, { showOnlyInDebug: true });
                 break;
 
@@ -664,6 +744,13 @@ export class RovoDevChatProvider {
                     response.title || undefined,
                     ...(response.params || []),
                 );
+
+                // Terminal classification: an `exception` event_kind from the
+                // stream means the agent surfaced a hard error mid-response.
+                // Replay path never fires PromptCompleted.
+                if (sourceApi !== 'replay') {
+                    this.firePromptCompleted('error', { errorReason: 'stream_exception' });
+                }
 
                 const { text, link } = this.parseExceptionMessage(response.message);
                 await webview.postMessage({
@@ -974,6 +1061,13 @@ export class RovoDevChatProvider {
                 await func(this._rovoDevApiClient);
             } catch (error) {
                 if (error.name === 'AbortError' || (error instanceof TypeError && error.message === 'terminated')) {
+                    // Unexpected mid-stream abort that did not go through
+                    // executeCancel (which would have already emitted
+                    // 'cancelled'). The dedupe Set keeps this a no-op when the
+                    // user-initiated cancel already classified the prompt.
+                    if (sourceApi === 'chat') {
+                        this.firePromptCompleted('cancelled', { errorReason: 'aborted' });
+                    }
                     await webview.postMessage({
                         type: RovoDevProviderMessageType.CompleteMessage,
                         promptId: this._currentPromptId,
@@ -989,14 +1083,32 @@ export class RovoDevChatProvider {
                 if (isUnauthorizedError) {
                     Logger.info('Detected unauthorized error - triggering login UI');
                     if (this._onUnauthorizedCallback) {
+                        // Intentionally do NOT emit rovoDevPromptCompleted here:
+                        // the user will re-authenticate and the next prompt
+                        // (or retry) provides a clean SLO sample.
                         await this._onUnauthorizedCallback();
                         return;
                     }
+                }
+                // Terminal classification for fetch / HTTP / reader errors.
+                // Replay path is excluded — the SLO only covers user-submitted
+                // prompts. The dedupe Set ensures that if an in-stream event
+                // (e.g. `_parsing_error` or `exception`) already classified
+                // this prompt, this call becomes a no-op.
+                if (sourceApi === 'chat') {
+                    const { errorReason, httpStatus } = this.classifyStreamingError(error);
+                    this.firePromptCompleted('error', {
+                        errorReason,
+                        ...(httpStatus !== undefined ? { httpStatus } : {}),
+                    });
                 }
                 // the error is retriable only when it happens during the streaming of a 'chat' response
                 await this.processError(error, { isRetriable: sourceApi === 'chat' });
             }
         } else {
+            if (sourceApi === 'chat') {
+                this.firePromptCompleted('error', { errorReason: 'unknown' });
+            }
             await this.processError(new Error('RovoDev client not initialized'));
         }
 
@@ -1009,6 +1121,84 @@ export class RovoDevChatProvider {
 
         // Signal that the prompt is complete so listeners can refresh data
         this._onPromptComplete.fire();
+    }
+
+    /**
+     * Classify a thrown error from the streaming-API catch block into a
+     * `PromptCompletedErrorReason` and (when applicable) an HTTP status code.
+     * Kept in one place so the chat-response SLO classification stays in sync
+     * with the user-facing error dialog logic in `processError`.
+     */
+    private classifyStreamingError(error: unknown): {
+        errorReason: Track.PromptCompletedErrorReason;
+        httpStatus?: number;
+    } {
+        if (error instanceof RovoDevApiError && typeof error.httpStatus === 'number') {
+            const status = error.httpStatus;
+            if (status >= 500 && status < 600) {
+                return { errorReason: 'http_5xx', httpStatus: status };
+            }
+            if (status >= 400 && status < 500) {
+                return { errorReason: 'http_4xx', httpStatus: status };
+            }
+        }
+        return { errorReason: 'network_error' };
+    }
+
+    /**
+     * Emit the terminal `rovoDevPromptCompleted` event for the current prompt.
+     *
+     * Enforces the exactly-once-per-prompt invariant via `_completedPromptIds`,
+     * so it is safe to call from multiple terminal paths (in-stream exception,
+     * parse error, fetch error catch block, normal stream end, user cancel) for
+     * the same prompt — the first call wins.
+     *
+     * Only emits when running in Boysenberry mode — this event exists solely to
+     * drive the chat-response SLO computed on the host Jira page via the
+     * VSCode → Jira analytics bridge. In the standard IDE there is no consumer
+     * for the event and emitting it would just add noise to the analytics
+     * pipeline.
+     *
+     * Never emits for the replay streaming path (the caller should not invoke
+     * this with `sourceApi === 'replay'`).
+     */
+    private firePromptCompleted(
+        result: Track.PromptCompletedResult,
+        extras: {
+            errorReason?: Track.PromptCompletedErrorReason;
+            httpStatus?: number;
+            messagePartsCount?: number;
+        } = {},
+    ): void {
+        if (!this._isBoysenberry) {
+            return;
+        }
+
+        const promptId = this._currentPromptId;
+        if (!promptId || this._completedPromptIds.has(promptId)) {
+            return; // exactly-once dedupe
+        }
+
+        // Bounded LRU: evict oldest entry when at cap. `Set` preserves insertion order.
+        if (this._completedPromptIds.size >= RovoDevChatProvider._completedPromptIdsCap) {
+            const oldest = this._completedPromptIds.values().next().value;
+            if (oldest !== undefined) {
+                this._completedPromptIds.delete(oldest);
+            }
+        }
+        this._completedPromptIds.add(promptId);
+
+        this._telemetryProvider.fireTelemetryEvent({
+            action: 'rovoDevPromptCompleted',
+            subject: 'atlascode',
+            attributes: {
+                promptId,
+                result,
+                ...(extras.errorReason !== undefined ? { errorReason: extras.errorReason } : {}),
+                ...(extras.httpStatus !== undefined ? { httpStatus: extras.httpStatus } : {}),
+                ...(extras.messagePartsCount !== undefined ? { messagePartsCount: extras.messagePartsCount } : {}),
+            },
+        });
     }
 
     private async processError(

--- a/src/rovo-dev/rovoDevTelemetryProvider.ts
+++ b/src/rovo-dev/rovoDevTelemetryProvider.ts
@@ -35,7 +35,8 @@ export type TelemetryEvent =
     | PartialEvent<Track.ForkSessionClicked>
     | PartialEvent<Track.DeleteSessionClicked>
     | PartialEvent<Track.ReplayCompleted>
-    | PartialEvent<Track.LocalServerPromptReceived>;
+    | PartialEvent<Track.LocalServerPromptReceived>
+    | PartialEvent<Track.PromptCompleted>;
 
 export type TelemetryScreenEvent = 'rovoDevSessionHistoryPicker';
 


### PR DESCRIPTION
### What Is This Change?

Added a new `rovoDevPromptCompleted` telemetry event that fires exactly once per user-submitted prompt with a closed-enum `result` (`success`, `error`, `cancelled`, `timeout`, `parse_error`) and optional `errorReason` / `httpStatus` / `messagePartsCount`. The event is only emitted in Boysenberry mode (no consumer in the standard IDE) and is forwarded through the Boysenberry → Jira analytics bridge so a chat-response SLO can be computed as a simple counter ratio without joining on `promptId`. Never emitted for the replay streaming path.

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

