### PR TITLE
bump version to 202606.12.1b1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     ],
     "main": "./build/extension/extension",
     "rovoDev": {
-        "version": "202606.10.1b3"
+        "version": "202606.12.1b1"
     },
     "scripts": {
         "vscode:uninstall": "node ./build/extension/uninstall.js",


### PR DESCRIPTION
Bump RovoDev version to 202606.12.1b1 to fix live preview for JCA



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

