### PR TITLE
Security: Content Security Policy Allows Unsafe Inline Styles

### DIFF
--- a/resources/html/reactView.html
+++ b/resources/html/reactView.html
@@ -11,7 +11,7 @@
 
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src https://api.atlassian.com ; img-src data: {{cspSource}} http: https: blob:; object-src data:; script-src {{cspSource}};style-src {{cspSource}} 'unsafe-inline' blob: http: https: data:;"
+            content="default-src https://api.atlassian.com ; img-src data: {{cspSource}} http: https: blob:; object-src data:; script-src {{cspSource}} 'nonce-{{nonce}}'; style-src {{cspSource}} 'nonce-{{nonce}}';"
         />
     </head>
 


### PR DESCRIPTION
## Summary

Security: Content Security Policy Allows Unsafe Inline Styles

## Problem

**Severity**: `Medium` | **File**: `resources/html/reactView.html:L12`

The CSP in `resources/html/reactView.html` allows `'unsafe-inline'` in `style-src` and also allows `blob:`, `http:`, `https:`, and `data:` for styles. This weakens the CSP protection and could allow injection of malicious styles or other content. Additionally, `script-src` only uses `{{cspSource}}` without a nonce, which may be insufficient depending on how `cspSource` is constructed.

## Solution

Remove `'unsafe-inline'` from style-src if possible, or use a nonce-based approach for styles. Restrict the `style-src` directive to only necessary sources. Consider adding a nonce to script-src as done in reactWebview.html.

## Changes

- `resources/html/reactView.html` (modified)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

