### PR TITLE
Differentiate RovoDev version for BBY and standard IDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### [Report an Issue](https://github.com/atlassian/atlascode/issues)
 
+## What's new in 4.0.32
+
+### Improvements
+
+- **RovoDev**: Differentiated RovoDev binary version into separate `version` (standard IDE) and `version_bby` (Boysenberry) settings in `package.json`, so each environment can track its own binary version independently.
+
 ## What's new in 4.0.31
 
 ### Bug Fixes

--- a/__mocks__/packagejson.ts
+++ b/__mocks__/packagejson.ts
@@ -3,7 +3,8 @@ module.exports = {
         name: 'atlascode',
         publisher: 'atlassian',
         rovoDev: {
-            version: '1.0.0'
+            version: '1.0.0',
+            version_bby: '1.0.0-bby'
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     ],
     "main": "./build/extension/extension",
     "rovoDev": {
-        "version": "202606.17.1"
+        "version": "202606.5.1",
+        "version_bby": "202606.18.1"
     },
     "scripts": {
         "vscode:uninstall": "node ./build/extension/uninstall.js",

--- a/src/rovo-dev/rovoDevFeedbackManager.ts
+++ b/src/rovo-dev/rovoDevFeedbackManager.ts
@@ -3,7 +3,7 @@ import { UserInfo } from 'src/rovo-dev/api/extensionApiTypes';
 import * as vscode from 'vscode';
 
 import { ExtensionApi, getAxiosInstance } from './api/extensionApi';
-import { MIN_SUPPORTED_ROVODEV_VERSION } from './rovoDevProcessManager';
+import { ROVODEV_VERSION, ROVODEV_VERSION_BBY } from './rovoDevProcessManager';
 import { RovoDevTelemetryProvider } from './rovoDevTelemetryProvider';
 
 interface FeedbackObject {
@@ -103,7 +103,7 @@ export class RovoDevFeedbackManager {
             component: isBBY ? 'Boysenberry - vscode' : 'IDE - vscode',
             extensionVersion: extensionApi.metadata.version(),
             vscodeVersion: vscode.version,
-            rovoDevVersion: MIN_SUPPORTED_ROVODEV_VERSION,
+            rovoDevVersion: isBBY ? ROVODEV_VERSION_BBY : ROVODEV_VERSION,
             ...(rovoDevSessionId && { rovoDevSessionId }),
         };
     }

--- a/src/rovo-dev/rovoDevLanguageServerProvider.test.ts
+++ b/src/rovo-dev/rovoDevLanguageServerProvider.test.ts
@@ -53,6 +53,7 @@ jest.mock('./api/extensionApi', () => {
             },
             metadata: {
                 appInstanceId: jest.fn().mockReturnValue('test-sandbox-id'),
+                isBoysenberry: jest.fn().mockReturnValue(false),
             },
         })),
     };

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -13,13 +13,15 @@ import { waitFor } from 'src/rovo-dev/util/waitFor';
 import { v4 } from 'uuid';
 import { Disposable, Event, EventEmitter, ExtensionContext, Uri, workspace } from 'vscode';
 
+import { Container } from '../container';
 import { FeatureFlagClient } from '../util/featureFlags/featureFlagClient';
 import { Features } from '../util/features';
 import { ExtensionApi, ValidBasicAuthSiteData } from './api/extensionApi';
 import { RovoDevTelemetryProvider } from './rovoDevTelemetryProvider';
 import { RovoDevDisabledReason, RovoDevEntitlementCheckFailedDetail } from './rovoDevWebviewProviderMessages';
 
-export const MIN_SUPPORTED_ROVODEV_VERSION = packageJson.rovoDev.version;
+export const ROVODEV_VERSION = packageJson.rovoDev.version;
+export const ROVODEV_VERSION_BBY = packageJson.rovoDev.version_bby;
 
 // Rovodev port mapping settings
 const RovoDevInfo = {
@@ -34,11 +36,13 @@ const RovoDevInfo = {
 };
 
 export function GetRovoDevURIs(context: ExtensionContext) {
+    const isBoysenberry = Container.isBoysenberryMode;
     const platform = process.platform;
     const arch = process.arch;
     const extensionPath = context.storageUri!.fsPath;
     const rovoDevBaseDir = path.join(extensionPath, 'atlascode-rovodev-bin');
-    const rovoDevVersionDir = path.join(rovoDevBaseDir, MIN_SUPPORTED_ROVODEV_VERSION);
+    const version = isBoysenberry ? ROVODEV_VERSION_BBY : ROVODEV_VERSION;
+    const rovoDevVersionDir = path.join(rovoDevBaseDir, version);
     const rovoDevBinPath = path.join(rovoDevVersionDir, 'atlassian_cli_rovodev') + (platform === 'win32' ? '.exe' : '');
 
     let rovoDevZipUrl = undefined;
@@ -46,7 +50,6 @@ export function GetRovoDevURIs(context: ExtensionContext) {
         const platformDir = platform === 'win32' ? 'windows' : platform;
         if (arch === 'x64' || arch === 'arm64') {
             const archDir = arch === 'x64' ? 'amd64' : arch;
-            const version = MIN_SUPPORTED_ROVODEV_VERSION;
             rovoDevZipUrl = Uri.parse(
                 `https://acli.atlassian.com/plugins/rovodev/${platformDir}/${archDir}/${version}/rovodev.zip`,
             );
@@ -220,7 +223,7 @@ export abstract class RovoDevProcessManager {
     }
 
     public static get state(): RovoDevProcessState {
-        if (RovoDevProcessManager.extensionApi.metadata.isBoysenberry()) {
+        if (Container.isBoysenberryMode) {
             const httpPort = parseInt(process.env[RovoDevInfo.envVars.port] || '0');
             const sessionToken = process.env.ROVODEV_SERVE_SESSION_TOKEN || '';
             return { state: 'Boysenberry', hostname: RovoDevInfo.hostname, httpPort, sessionToken };


### PR DESCRIPTION
## Fork RovoDev version for Boysenberry (BBY)

### Reason

Currently, Rovo Dev new binaries for Windows are not releasing due to issues with the release pipeline.
While for BBY this is not an issue, since it runs on linux, for general VS Code usage this is a problem as the "latest" Rovo Dev doesn't exist on windows.

This change allows specifying two versions, one for regular VS Code, and one for BBY.

### Summary

The RovoDev binary version was previously a single constant shared between the standard IDE extension and the Boysenberry (BBY) variant. This change splits it into two independent version fields so each environment can track and update its own binary version separately.

### Changes

package.json: Added version_bby alongside version in the rovoDev section
Renamed MIN_SUPPORTED_ROVODEV_VERSION → ROVODEV_VERSION and added ROVODEV_VERSION_BBY (the old name implied a minimum, but it’s the only supported version)
GetRovoDevURIs now reads Container.isBoysenberryMode internally to select the correct version for binary directory paths and download URLs
RovoDevProcessManager.state getter and rovoDevFeedbackManager similarly use Container.isBoysenberryMode to report the correct version per environment



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

