### PR TITLE
fix: support arbitrary-depth issue hierarchy in fetchMissingAncestorIssues

### DIFF
--- a/src/views/jira/treeViews/customJqlViewProvider.ts
+++ b/src/views/jira/treeViews/customJqlViewProvider.ts
@@ -178,22 +178,30 @@ class JiraIssueQueryNode extends TreeItem {
         return [...rootIssues];
     }
 
-    // Fetch any parents and grandparents that might be missing from the set to ensure that the a path can be drawn all
-    // the way from a subtask to an epic.
+    // Fetch any ancestors that might be missing from the set to ensure that a path can be drawn all
+    // the way from a subtask up to the root issue, regardless of hierarchy depth.
     private async fetchMissingAncestorIssues(newIssues: TreeViewIssue[]): Promise<TreeViewIssue[]> {
         if (!newIssues.length) {
             return [];
         }
         const site = newIssues[0].siteDetails;
 
-        const missingParentKeys = this.calculateMissingParentKeys(newIssues);
-        const parentIssues = await this.fetchIssuesForKeys(site, missingParentKeys);
+        // Iteratively fetch missing ancestors until the full hierarchy is resolved or the depth
+        // cap is reached. A fixed 2-round approach fails for projects with hierarchies deeper than
+        // subtask -> task -> epic (e.g. Sub-Initiative -> Epic -> Task -> Root).
+        const fetched: TreeViewIssue[] = [];
+        let allIssues = [...newIssues];
+        for (let depth = 0; depth < 10; depth++) {
+            const missingKeys = this.calculateMissingParentKeys(allIssues);
+            if (!missingKeys.length) {
+                break;
+            }
+            const batch = await this.fetchIssuesForKeys(site, missingKeys);
+            fetched.push(...batch);
+            allIssues = [...allIssues, ...batch];
+        }
 
-        // If a jqlIssue is a sub-task we make a second call to make sure we get its parent's epic.
-        const missingGrandparentKeys = this.calculateMissingParentKeys([...newIssues, ...parentIssues]);
-        const grandparentIssues = await this.fetchIssuesForKeys(site, missingGrandparentKeys);
-
-        return [...parentIssues, ...grandparentIssues];
+        return fetched;
     }
 
     private calculateMissingParentKeys(issues: TreeViewIssue[]): string[] {


### PR DESCRIPTION
## Summary

`fetchMissingAncestorIssues` made exactly **two rounds** of ancestor fetching — parents, then grandparents — designed for the standard subtask → task → epic chain. Projects using deeper Jira hierarchy levels (e.g. Sub-Initiative → Epic → Task → Root) exceed this limit.

When `constructIssueTree` then tries to attach the unresolved top-level ancestor to its parent, the parent isn't in the combined list, so the issue is **silently dropped along with its entire subtree**. This means issues that match the JQL filter never appear in the tree view when "Group issues by epic" is enabled.

## Change

Replace the two-round approach with an iterative loop that keeps fetching missing ancestor keys until none remain, with a depth cap of 10 to prevent runaway requests.

**Before:**
```typescript
const missingParentKeys = this.calculateMissingParentKeys(newIssues);
const parentIssues = await this.fetchIssuesForKeys(site, missingParentKeys);

// If a jqlIssue is a sub-task we make a second call to make sure we get its parent's epic.
const missingGrandparentKeys = this.calculateMissingParentKeys([...newIssues, ...parentIssues]);
const grandparentIssues = await this.fetchIssuesForKeys(site, missingGrandparentKeys);

return [...parentIssues, ...grandparentIssues];
```

**After:**
```typescript
const fetched: TreeViewIssue[] = [];
let allIssues = [...newIssues];
for (let depth = 0; depth < 10; depth++) {
    const missingKeys = this.calculateMissingParentKeys(allIssues);
    if (!missingKeys.length) {
        break;
    }
    const batch = await this.fetchIssuesForKeys(site, missingKeys);
    fetched.push(...batch);
    allIssues = [...allIssues, ...batch];
}
return fetched;
```

## Behaviour

- For standard 2-level hierarchies (subtask → epic) behaviour is identical — the loop exits after 2 iterations as before.
- For deeper hierarchies the loop continues until the root is found.
- The depth cap of 10 prevents runaway API calls in pathological cases.




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

