### PR TITLE
Fix Jira create issue handling for empty create screens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,18 @@ AtlasCode VSCode extension - Atlassian integration (Jira, Bitbucket, RovoDev)
 - Unit: `*.test.ts` alongside source (`npm test`)
 - React: `jest.react.config.ts` (`npm run test:react`) 
 - E2E: `e2e/` directory (`npm run test:e2e`)
+- Create issue React coverage lives under `src/webviews/components/issue/create-issue-screen/`; compact Create Work Item reducer/UI coverage lives under `src/react/atlascode/create-work-item/`
 
 ### Architecture
 - All Atlassian API calls → `src/atlclients/`
 - Webview communication → `src/ipc/`
 - Authentication → `authStore.ts`
+- Jira create flows have two surfaces: full editor (`src/webviews/createIssueWebview.ts` + `CreateIssuePage.tsx`) and compact work item view (`src/work-items/create-work-item/` + `src/react/atlascode/create-work-item/`)
+- Jira API error payloads often include actionable field errors in `errors`; preserve and render those instead of replacing them with generic Axios status messages
+
+### Common Gotchas
+- `npm ci` may fail if `package-lock.json` is out of sync with `package.json`; avoid committing lockfile churn unless dependency updates are the task
+- Public npm installs may fail on private Atlassian packages such as `@atlassian/assets-workspace-host`; note this explicitly when tests or lint cannot run locally
 
 ## Environment Context
 - `atlascode:bbyEnvironmentActive` = Boysenberry (internal Atlassian environment)
@@ -51,4 +58,4 @@ AtlasCode VSCode extension - Atlassian integration (Jira, Bitbucket, RovoDev)
 3. Keep concise and actionable - focus on helping future agents avoid problems
 
 **Include:** File patterns, integration points, auth requirements, testing strategies, error patterns
-**Exclude:** Implementation details, temporary workarounds, user preferences 
+**Exclude:** Implementation details, temporary workarounds, user preferences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- **Jira**: Show a clear create issue warning when Jira returns an empty create screen, and surface field-level Jira API errors instead of a generic 400 message.
 - **RovoDev**: Hid stack traces, stderr, and log details from external users while preserving them for Atlassian users.
 - **RovoDev (BBY)**: Fixed `ROVODEV_REBRAND_JCA` env var handling so the "Jira Coding Agent" rebrand works correctly in webviews.
 - **Notifications**: Fixed `atlassianNotificationNotifier` to correctly flush all promise levels, resolving a test reliability issue.

--- a/src/react/atlascode/create-work-item/createWorkItemWebview.tsx
+++ b/src/react/atlascode/create-work-item/createWorkItemWebview.tsx
@@ -2,6 +2,7 @@ import './CreateWorkItem.css';
 
 import Form, { Field } from '@atlaskit/form';
 import ChevronDownIcon from '@atlaskit/icon/core/chevron-down';
+import SectionMessage from '@atlaskit/section-message';
 import Select from '@atlaskit/select';
 import React from 'react';
 import { ConnectionTimeout } from 'src/util/time';
@@ -25,6 +26,7 @@ const emptyState: CreateFormState = {
     selectedProjectId: undefined,
     selectedIssueTypeId: undefined,
     requiredFieldsForIssueType: [],
+    createScreenHasFields: true,
 };
 
 const CreateWorkItemWebview: React.FC = () => {
@@ -69,6 +71,9 @@ const CreateWorkItemWebview: React.FC = () => {
             if (!state.summary || state.summary.trim().length === 0) {
                 errors['summary'] = 'EMPTY';
             }
+            if (!state.createScreenHasFields) {
+                errors['_form'] = 'No create fields are configured for the selected work type.';
+            }
             if (Object.keys(errors).length > 0) {
                 return errors;
             }
@@ -83,7 +88,13 @@ const CreateWorkItemWebview: React.FC = () => {
 
             return undefined;
         },
-        [state.selectedIssueTypeId, state.selectedProjectId, state.selectedSiteId, state.summary],
+        [
+            state.createScreenHasFields,
+            state.selectedIssueTypeId,
+            state.selectedProjectId,
+            state.selectedSiteId,
+            state.summary,
+        ],
     );
 
     const onMessageHandler = React.useCallback(
@@ -272,10 +283,20 @@ const CreateWorkItemWebview: React.FC = () => {
                                     className="form-input"
                                     placeholder="What needs to be done?"
                                     type="text"
+                                    disabled={!state.createScreenHasFields}
                                     onChange={handleUpdateSummary}
                                 />
                             )}
                         </Field>
+                        {!state.createScreenHasFields && (
+                            <SectionMessage appearance="warning" title="No create fields are configured">
+                                <p>
+                                    This project&apos;s create screen has no fields configured for the selected work
+                                    type. Contact your Jira administrator to add the required fields to the create
+                                    screen.
+                                </p>
+                            </SectionMessage>
+                        )}
                         <div className="form-actions-row">
                             <button type="button" className="more-options-link" onClick={handleOpenFullEditor}>
                                 More options
@@ -286,11 +307,16 @@ const CreateWorkItemWebview: React.FC = () => {
                                 Cancel
                             </button>
                             <div>
-                                <button className="form-button button-primary" type="submit">
+                                <button
+                                    className="form-button button-primary"
+                                    disabled={!state.createScreenHasFields}
+                                    type="submit"
+                                >
                                     Create
                                 </button>
                                 <button
                                     className="form-button button-primary"
+                                    disabled={!state.createScreenHasFields}
                                     style={{
                                         borderLeft: '1px solid var(--vscode-button-foreground)',
                                         padding: '6px',

--- a/src/react/atlascode/create-work-item/utils.test.tsx
+++ b/src/react/atlascode/create-work-item/utils.test.tsx
@@ -1,0 +1,54 @@
+import { CreateWorkItemWebviewProviderMessageType } from 'src/work-items/create-work-item/messages/createWorkItemWebviewProviderMessages';
+import { expansionCastTo } from 'testsutil';
+
+import { CreateFormState, createReducer } from './utils';
+
+describe('createReducer', () => {
+    const emptyState: CreateFormState = {
+        summary: '',
+        availableSites: [],
+        availableProjects: [],
+        availableIssueTypes: [],
+        selectedSiteId: undefined,
+        selectedProjectId: undefined,
+        selectedIssueTypeId: undefined,
+        requiredFieldsForIssueType: [],
+        createScreenHasFields: true,
+    };
+
+    it('stores whether the selected issue type has create screen fields on init', () => {
+        const result = createReducer(emptyState, {
+            type: CreateWorkItemWebviewProviderMessageType.InitFields,
+            payload: {
+                availableSites: [expansionCastTo({ id: 'site-1', name: 'Site 1', avatarUrl: '' })],
+                availableProjects: [
+                    expansionCastTo({ id: 'project-1', key: 'TEST', name: 'Test Project', avatarUrls: {} }),
+                ],
+                hasMoreProjects: false,
+                availableIssueTypes: [expansionCastTo({ id: 'issue-type-1', name: 'Task', iconUrl: '' })],
+                selectedSiteId: 'site-1',
+                selectedProjectId: 'project-1',
+                selectedIssueTypeId: 'issue-type-1',
+                requiredFields: [],
+                createScreenHasFields: false,
+            },
+        });
+
+        expect(result.createScreenHasFields).toBe(false);
+    });
+
+    it('updates whether the selected issue type has create screen fields', () => {
+        const result = createReducer(
+            { ...emptyState, createScreenHasFields: false },
+            {
+                type: CreateWorkItemWebviewProviderMessageType.UpdatedSelectedIssueType,
+                payload: {
+                    requiredFields: [],
+                    createScreenHasFields: true,
+                },
+            },
+        );
+
+        expect(result.createScreenHasFields).toBe(true);
+    });
+});

--- a/src/react/atlascode/create-work-item/utils.tsx
+++ b/src/react/atlascode/create-work-item/utils.tsx
@@ -21,6 +21,7 @@ export interface CreateFormState {
     selectedIssueTypeId?: string;
     hasMoreProjects?: boolean;
     requiredFieldsForIssueType: CreateWorkItemViewRequiredField[];
+    createScreenHasFields: boolean;
 }
 
 export enum CreateFormActionType {
@@ -78,6 +79,7 @@ export function createReducer(state: CreateFormState, action: CreateFormAction):
                 selectedProjectId: action.payload.selectedProjectId || action.payload.availableProjects[0]?.id,
                 selectedIssueTypeId: action.payload.selectedIssueTypeId || action.payload.availableIssueTypes[0]?.id,
                 requiredFieldsForIssueType: action.payload.requiredFields,
+                createScreenHasFields: action.payload.createScreenHasFields,
             };
         }
         case CreateFormActionType.SetSummary: {
@@ -103,6 +105,7 @@ export function createReducer(state: CreateFormState, action: CreateFormAction):
                 selectedProjectId: action.payload.selectedProjectId || action.payload.availableProjects[0]?.id,
                 selectedIssueTypeId: action.payload.selectedIssueTypeId || action.payload.availableIssueTypes[0]?.id,
                 requiredFieldsForIssueType: action.payload.requiredFields,
+                createScreenHasFields: action.payload.createScreenHasFields,
             };
         }
         case CreateWorkItemWebviewProviderMessageType.UpdatedSelectedProject: {
@@ -115,12 +118,14 @@ export function createReducer(state: CreateFormState, action: CreateFormAction):
                 })),
                 selectedIssueTypeId: action.payload.selectedIssueTypeId || action.payload.availableIssueTypes[0]?.id,
                 requiredFieldsForIssueType: action.payload.requiredFields,
+                createScreenHasFields: action.payload.createScreenHasFields,
             };
         }
         case CreateWorkItemWebviewProviderMessageType.UpdatedSelectedIssueType: {
             return {
                 ...state,
                 requiredFieldsForIssueType: action.payload.requiredFields,
+                createScreenHasFields: action.payload.createScreenHasFields,
             };
         }
         case CreateFormActionType.SetSelectedField: {

--- a/src/webviews/components/ErrorBanner.test.tsx
+++ b/src/webviews/components/ErrorBanner.test.tsx
@@ -215,6 +215,28 @@ describe('ErrorBanner', () => {
             expect(container.textContent).toContain('Custom Error Title');
         });
 
+        it('displays Jira field errors when errorMessages is omitted', () => {
+            const { container } = render(
+                <ErrorBanner
+                    errorDetails={{
+                        title: 'Error creating issue',
+                        errors: {
+                            summary: "Field 'summary' cannot be set. It is not on the appropriate screen, or unknown.",
+                        },
+                    }}
+                    onDismissError={mockOnDismissError}
+                    onRetry={mockOnRetry}
+                />,
+            );
+
+            expect(container.textContent).toContain('Error creating issue');
+            expect(container.textContent).toContain('summary:');
+            expect(container.textContent).toContain(
+                "Field 'summary' cannot be set. It is not on the appropriate screen, or unknown.",
+            );
+            expect(container.textContent).not.toContain('{"summary"');
+        });
+
         it('displays default title when not provided', () => {
             const { container } = render(
                 <ErrorBanner errorDetails="Some error" onDismissError={mockOnDismissError} onRetry={mockOnRetry} />,

--- a/src/webviews/components/ErrorBanner.tsx
+++ b/src/webviews/components/ErrorBanner.tsx
@@ -12,6 +12,7 @@ export type ErrorDetails =
     | ErrorCollection
     | ErrorWithMessages
     | { message: string }
+    | { title?: string; errors: Record<string, string>; errorMessages?: string[] }
     | { title?: string }
     | undefined;
 
@@ -71,6 +72,33 @@ export default class ErrorBanner extends React.Component<ErrorBannerProps, { err
         return '';
     }
 
+    private getErrorCollectionMarkup(errorDetails: ErrorCollection) {
+        const errorMarkup: React.ReactNode[] = [];
+
+        Object.keys(errorDetails.errors).forEach((key) => {
+            errorMarkup.push(
+                <p className="force-wrap" key={`field-${key}`}>
+                    <b>{key}:</b>
+                    <span className="force-wrap" style={{ marginLeft: '5px' }}>
+                        {errorDetails.errors[key]}
+                    </span>
+                </p>,
+            );
+        });
+
+        errorDetails.errorMessages.forEach((msg, index) => {
+            errorMarkup.push(
+                <p className="force-wrap" key={`message-${index}`}>
+                    <span className="force-wrap" style={{ marginLeft: '5px' }}>
+                        {msg}
+                    </span>
+                </p>,
+            );
+        });
+
+        return errorMarkup;
+    }
+
     /**
      * Determines if an error is retryable based on its content
      * Auth/permission errors cannot be retried - user must re-authenticate
@@ -107,26 +135,7 @@ export default class ErrorBanner extends React.Component<ErrorBannerProps, { err
         const errorDetails = this.state.errorDetails;
 
         if (isErrorCollection(errorDetails)) {
-            Object.keys(errorDetails.errors).forEach((key) => {
-                errorMarkup.push(
-                    <p className="force-wrap">
-                        <b>{key}:</b>
-                        <span className="force-wrap" style={{ marginLeft: '5px' }}>
-                            {errorDetails.errors[key]}
-                        </span>
-                    </p>,
-                );
-            });
-
-            errorDetails.errorMessages.forEach((msg) => {
-                errorMarkup.push(
-                    <p className="force-wrap">
-                        <span className="force-wrap" style={{ marginLeft: '5px' }}>
-                            {msg}
-                        </span>
-                    </p>,
-                );
-            });
+            errorMarkup.push(...this.getErrorCollectionMarkup(errorDetails));
         } else if (isErrorWithMessages(errorDetails)) {
             errorDetails.errorMessages.forEach((msg) => {
                 errorMarkup.push(
@@ -138,17 +147,26 @@ export default class ErrorBanner extends React.Component<ErrorBannerProps, { err
                 );
             });
         } else if (typeof errorDetails === 'object') {
-            Object.keys(errorDetails).forEach((key) => {
-                const value = errorDetails[key as keyof typeof errorDetails];
-                errorMarkup.push(
-                    <p className="force-wrap">
-                        <b>{key}:</b>
-                        <span className="force-wrap" style={{ marginLeft: '5px' }}>
-                            {JSON.stringify(value)}
-                        </span>
-                    </p>,
-                );
-            });
+            const maybeErrorCollection = {
+                errorMessages: [],
+                ...errorDetails,
+            };
+
+            if (isErrorCollection(maybeErrorCollection)) {
+                errorMarkup.push(...this.getErrorCollectionMarkup(maybeErrorCollection));
+            } else {
+                Object.keys(errorDetails).forEach((key) => {
+                    const value = errorDetails[key as keyof typeof errorDetails];
+                    errorMarkup.push(
+                        <p className="force-wrap">
+                            <b>{key}:</b>
+                            <span className="force-wrap" style={{ marginLeft: '5px' }}>
+                                {JSON.stringify(value)}
+                            </span>
+                        </p>,
+                    );
+                });
+            }
         } else {
             errorMarkup.push(<p className="force-wrap">{errorDetails}</p>);
         }

--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.test.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.test.tsx
@@ -45,6 +45,16 @@ jest.mock('@atlaskit/page', () => ({
     default: ({ children }: any) => <div data-testid="page">{children}</div>,
 }));
 
+jest.mock('@atlaskit/section-message', () => ({
+    __esModule: true,
+    default: ({ children, title }: any) => (
+        <div data-testid="section-message">
+            {title}
+            {children}
+        </div>
+    ),
+}));
+
 jest.mock('@atlaskit/select', () => ({
     __esModule: true,
     default: (props: any) => <div data-testid="select">{props.value?.name || 'Select'}</div>,
@@ -138,6 +148,30 @@ describe('CreateIssuePage', () => {
         jest.clearAllMocks();
     });
 
+    const projectField = {
+        key: 'project',
+        name: 'Project',
+        required: true,
+        uiType: UIType.Select,
+        displayOrder: 1,
+        valueType: ValueType.Project,
+        advanced: false,
+        isArray: false,
+        schema: 'project',
+    };
+
+    const issueTypeField = {
+        key: 'issuetype',
+        name: 'Work type',
+        required: true,
+        uiType: UIType.Select,
+        displayOrder: 2,
+        valueType: ValueType.IssueType,
+        advanced: false,
+        isArray: false,
+        schema: 'issuetype',
+    };
+
     describe('Error state rendering', () => {
         it('should show ErrorBanner and form content when isErrorBannerOpen is true', () => {
             const component = new CreateIssuePage({});
@@ -218,6 +252,63 @@ describe('CreateIssuePage', () => {
             // Error banner should NOT be visible
             expect(queryByTestId('error-banner')).toBeNull();
             expect(container.textContent).not.toContain('Error:');
+        });
+    });
+
+    describe('Empty create screen rendering', () => {
+        it('shows an explanation and disables create when no fields are configured beyond project and issue type', () => {
+            const component = new CreateIssuePage({});
+            component.state = {
+                ...component.state,
+                isErrorBannerOpen: false,
+                siteDetails: mockSiteDetails,
+                fieldValues: {
+                    issuetype: { id: '1', name: 'Task' },
+                    project: { key: 'TEST', name: 'Test Project' },
+                },
+                fields: {
+                    project: projectField,
+                    issuetype: issueTypeField,
+                },
+                selectFieldOptions: {
+                    site: [mockSiteDetails],
+                },
+            };
+            component.updateInternals(component.state);
+
+            const { container, queryByTestId } = render(component.render());
+
+            expect(queryByTestId('section-message')).not.toBeNull();
+            expect(container.textContent).toContain('No create fields are configured');
+            expect(container.textContent).toContain(
+                "This project's create screen has no fields configured for the selected work type.",
+            );
+            expect((container.querySelector('button[name="Create"]') as HTMLButtonElement).disabled).toBe(true);
+        });
+
+        it('does not post createIssue when no create fields are configured', async () => {
+            const component = new CreateIssuePage({});
+            const postMessageSpy = jest.spyOn(component, 'postMessage');
+            component.state = {
+                ...component.state,
+                siteDetails: mockSiteDetails,
+                fieldValues: {
+                    issuetype: { id: '1', name: 'Task' },
+                    project: { key: 'TEST', name: 'Test Project' },
+                },
+                fields: {
+                    project: projectField,
+                    issuetype: issueTypeField,
+                },
+                selectFieldOptions: {
+                    site: [mockSiteDetails],
+                },
+            };
+
+            await expect(component.handleSubmit({} as any)).resolves.toEqual({
+                _form: 'No create fields are configured for the selected work type.',
+            });
+            expect(postMessageSpy).not.toHaveBeenCalledWith(expect.objectContaining({ action: 'createIssue' }));
         });
     });
 

--- a/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
+++ b/src/webviews/components/issue/create-issue-screen/CreateIssuePage.tsx
@@ -1,6 +1,7 @@
 import Button from '@atlaskit/button';
 import Form, { ErrorMessage, Field, FormFooter, FormHeader, RequiredAsterisk } from '@atlaskit/form';
 import Page from '@atlaskit/page';
+import SectionMessage from '@atlaskit/section-message';
 import Select, { components } from '@atlaskit/select';
 import Spinner from '@atlaskit/spinner';
 import { IssueKeyAndSite } from '@atlassian-pi/jira-pi-common-models';
@@ -49,6 +50,7 @@ const emptyState: ViewState = {
 };
 
 const fallbackTimerDuration = 5000; // 5 seconds
+const universalCreateFieldKeys = new Set(['project', 'issuetype']);
 
 const getFaviconUrl = (siteData: any): string | null => {
     if (siteData?.baseLinkUrl) {
@@ -272,6 +274,25 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
         });
     }
 
+    private hasCreateScreenFields(): boolean {
+        return Object.values(this.state.fields).some((field) => !universalCreateFieldKeys.has(field.key));
+    }
+
+    private getEmptyCreateScreenMessage(): React.ReactElement | undefined {
+        if (this.hasCreateScreenFields()) {
+            return undefined;
+        }
+
+        return (
+            <SectionMessage appearance="warning" title="No create fields are configured">
+                <p>
+                    This project&apos;s create screen has no fields configured for the selected work type. Contact your
+                    Jira administrator to add the required fields to the create screen.
+                </p>
+            </SectionMessage>
+        );
+    }
+
     checkRequiredFields(): Record<string, string> {
         const requiredFields = Object.values(this.state.fields).filter((field) => field.required);
 
@@ -321,6 +342,10 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
     handleSubmit = async (e: any) => {
         if (this.state.isLoggedOut) {
             return { _form: 'You have been logged out. Please close this tab and log in again.' };
+        }
+
+        if (!this.hasCreateScreenFields()) {
+            return { _form: 'No create fields are configured for the selected work type.' };
         }
 
         const errs = this.checkRequiredFields();
@@ -552,6 +577,8 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
             return <AtlLoader />;
         }
 
+        const emptyCreateScreenMessage = this.getEmptyCreateScreenMessage();
+
         return (
             <Page>
                 <AtlascodeErrorBoundary
@@ -637,13 +664,16 @@ export default class CreateIssuePage extends AbstractIssueEditorPage<Emit, Accep
                                                         <div>{this.getAdvancedFieldMarkup()}</div>
                                                     </Panel>
                                                 )}
+                                                {emptyCreateScreenMessage}
                                                 <FormFooter actions={{}}>
                                                     <CreateIssueButton
                                                         type="submit"
                                                         name="Create"
                                                         className="ac-button"
                                                         disabled={
-                                                            this.state.isSomethingLoading || this.state.isLoggedOut
+                                                            this.state.isSomethingLoading ||
+                                                            this.state.isLoggedOut ||
+                                                            !!emptyCreateScreenMessage
                                                         }
                                                         isLoading={
                                                             this.state.isSomethingLoading &&

--- a/src/webviews/components/issue/create-issue-screen/actions/CreateIssueButton.tsx
+++ b/src/webviews/components/issue/create-issue-screen/actions/CreateIssueButton.tsx
@@ -32,6 +32,7 @@ export const CreateIssueButton: React.FC<CreateIssueButtonProps> = (props) => {
                     color: 'var(--vscode-button-foreground)',
                     cursor: 'pointer',
                 }}
+                disabled={props.disabled}
                 className="ac-button ac-button-spinner"
                 data-vscode-context='{"webviewSection": "createButton", "preventDefaultContextMenuItems": true}'
                 onClick={(e) => {

--- a/src/work-items/create-work-item/createWorkItemWebviewProvider.ts
+++ b/src/work-items/create-work-item/createWorkItemWebviewProvider.ts
@@ -48,7 +48,9 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
     private _selectedProject?: Project;
     private _hasMoreProjects: boolean = false;
     private _selectedIssueType?: IssueType;
+    private _issueTypeUIs: IssueTypeUIs<DetailedSiteInfo> = {};
     private _requiredFieldsForIssueType: CreateWorkItemRequiredField[] = [];
+    private _createScreenHasFields: boolean = false;
     private _id: string = 'createWorkItemWebview';
     private _disposables: Disposable[] = [];
 
@@ -204,6 +206,7 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
                 selectedProjectId: this._selectedProject?.id,
                 selectedIssueTypeId: this._selectedIssueType?.id,
                 requiredFields: this._requiredFieldsForIssueType,
+                createScreenHasFields: this._createScreenHasFields,
             },
         });
     }
@@ -248,10 +251,12 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
 
             this._availableIssueTypes = this.toFieldMap(issueTypes);
             this._selectedIssueType = selectedIssueType;
+            this._issueTypeUIs = issueTypeUIs;
 
             const requiredFields = this.getRequiredFieldsForIssueType(issueTypeUIs[this._selectedIssueType.id]);
 
             this._requiredFieldsForIssueType = requiredFields;
+            this._createScreenHasFields = this.hasCreateScreenFields(issueTypeUIs[this._selectedIssueType.id]);
             this._pendingState = false;
             if (this._isWebviewReady) {
                 await this.initFields();
@@ -346,10 +351,12 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
 
             this._selectedIssueType = selectedIssueType;
             this._availableIssueTypes = this.toFieldMap(issueTypes);
+            this._issueTypeUIs = issueTypeUIs;
 
             const requiredFields = this.getRequiredFieldsForIssueType(issueTypeUIs[this._selectedIssueType.id]);
 
             this._requiredFieldsForIssueType = requiredFields;
+            this._createScreenHasFields = this.hasCreateScreenFields(issueTypeUIs[this._selectedIssueType.id]);
             this._pendingState = false;
 
             this.webview.postMessage({
@@ -361,6 +368,7 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
                     selectedProjectId: this._selectedProject.id,
                     selectedIssueTypeId: this._selectedIssueType.id,
                     requiredFields: this._requiredFieldsForIssueType,
+                    createScreenHasFields: this._createScreenHasFields,
                 },
             });
         } catch (err) {
@@ -410,10 +418,12 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
 
             this._availableIssueTypes = this.toFieldMap(issueTypes);
             this._selectedIssueType = selectedIssueType;
+            this._issueTypeUIs = issueTypeUIs;
 
             const requiredFields = this.getRequiredFieldsForIssueType(issueTypeUIs[this._selectedIssueType.id]);
 
             this._requiredFieldsForIssueType = requiredFields;
+            this._createScreenHasFields = this.hasCreateScreenFields(issueTypeUIs[this._selectedIssueType.id]);
 
             await this.webview.postMessage({
                 type: CreateWorkItemWebviewProviderMessageType.UpdatedSelectedProject,
@@ -421,6 +431,7 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
                     availableIssueTypes: Object.values(this._availableIssueTypes),
                     selectedIssueTypeId: this._selectedIssueType.id,
                     requiredFields: this._requiredFieldsForIssueType,
+                    createScreenHasFields: this._createScreenHasFields,
                 },
             });
             this._pendingState = false;
@@ -447,6 +458,17 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
             }
 
             this._selectedIssueType = selectedIssueType;
+            const issueTypeUI = this._issueTypeUIs[this._selectedIssueType.id];
+            this._requiredFieldsForIssueType = this.getRequiredFieldsForIssueType(issueTypeUI);
+            this._createScreenHasFields = this.hasCreateScreenFields(issueTypeUI);
+
+            await this.webview?.postMessage({
+                type: CreateWorkItemWebviewProviderMessageType.UpdatedSelectedIssueType,
+                payload: {
+                    requiredFields: this._requiredFieldsForIssueType,
+                    createScreenHasFields: this._createScreenHasFields,
+                },
+            });
         } catch (err) {
             console.error('Error updating selected issue type in Create Work Item webview:', err);
         } finally {
@@ -463,6 +485,13 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
         }
         if (!this._selectedSite || !this._selectedProject || !this._selectedIssueType || !message.payload.summary) {
             window.showErrorMessage('Cannot create work item. Missing required information.');
+            return;
+        }
+
+        if (!this._createScreenHasFields) {
+            window.showErrorMessage(
+                'Cannot create work item. This project has no create fields configured for the selected work type.',
+            );
             return;
         }
 
@@ -608,6 +637,10 @@ export class CreateWorkItemWebviewProvider extends Disposable implements Webview
         }
 
         return requiredFields;
+    }
+
+    private hasCreateScreenFields<S extends JiraSiteInfo>(issueTypeUI: IssueTypeUI<S>): boolean {
+        return Object.keys(issueTypeUI.fields).some((key) => key !== 'project' && key !== 'issuetype');
     }
 
     private toFieldMap<T extends { id: string }>(arr: T[]): Record<string, T> {

--- a/src/work-items/create-work-item/messages/createWorkItemWebviewProviderMessages.ts
+++ b/src/work-items/create-work-item/messages/createWorkItemWebviewProviderMessages.ts
@@ -28,6 +28,7 @@ export type CreateWorkItemWebviewProviderMessage =
               selectedProjectId?: string;
               selectedIssueTypeId?: string;
               requiredFields: CreateWorkItemRequiredField[];
+              createScreenHasFields: boolean;
           };
       }
     | {
@@ -39,6 +40,7 @@ export type CreateWorkItemWebviewProviderMessage =
               selectedProjectId?: string;
               selectedIssueTypeId?: string;
               requiredFields: CreateWorkItemRequiredField[];
+              createScreenHasFields: boolean;
           };
       }
     | {
@@ -47,12 +49,14 @@ export type CreateWorkItemWebviewProviderMessage =
               availableIssueTypes: IssueType[];
               selectedIssueTypeId?: string;
               requiredFields: CreateWorkItemRequiredField[];
+              createScreenHasFields: boolean;
           };
       }
     | {
           type: CreateWorkItemWebviewProviderMessageType.UpdatedSelectedIssueType;
           payload: {
               requiredFields: CreateWorkItemRequiredField[];
+              createScreenHasFields: boolean;
           };
       }
     | {


### PR DESCRIPTION
Fixes #1852

## Summary
- Detect Jira create metadata with no fields beyond project/issue type.
- Show an explanatory warning instead of an empty form in both create issue surfaces.
- Prevent create submission when the selected work type has no configured create fields.
- Surface Jira field-level API errors in the error banner instead of an opaque 400 response.
- Add agent notes for the create issue surfaces and local dependency install gotchas.

## Testing
- Added React/reducer coverage for empty create screens and Jira field errors.
- Ran `git diff --check`.
- Could not run Jest/lint locally because dependency install requires private Atlassian packages: `npm ci` reports lockfile drift, and `npm install --package-lock=false` fails on `@atlassian/assets-workspace-host`.


