### PR TITLE
Fix project selection after changing Jira sites

### DIFF
--- a/src/react/atlascode/create-work-item/utils.test.tsx
+++ b/src/react/atlascode/create-work-item/utils.test.tsx
@@ -1,0 +1,51 @@
+import { Project } from '@atlassian-pi/jira-pi-common-models';
+import {
+    CreateWorkItemWebviewProviderMessage,
+    CreateWorkItemWebviewProviderMessageType,
+} from 'src/work-items/create-work-item/messages/createWorkItemWebviewProviderMessages';
+
+import { CreateFormState, createReducer } from './utils';
+
+describe('createReducer', () => {
+    it('uses the project ID as the option value after changing Jira sites', () => {
+        const project = {
+            id: '10001',
+            key: 'TEST',
+            name: 'Test Project',
+            avatarUrls: {
+                '48x48': 'https://example.com/project-avatar.png',
+            },
+        } as Project;
+
+        const initialState: CreateFormState = {
+            summary: '',
+            availableSites: [],
+            availableProjects: [],
+            availableIssueTypes: [],
+            requiredFieldsForIssueType: [],
+        };
+
+        const action: CreateWorkItemWebviewProviderMessage = {
+            type: CreateWorkItemWebviewProviderMessageType.UpdatedSelectedSite,
+            payload: {
+                availableProjects: [project],
+                hasMoreProjects: false,
+                availableIssueTypes: [],
+                selectedProjectId: project.id,
+                requiredFields: [],
+            },
+        };
+
+        const result = createReducer(initialState, action);
+
+        expect(result.availableProjects).toEqual([
+            {
+                name: project.name,
+                value: project.id,
+                iconPath: project.avatarUrls['48x48'],
+            },
+        ]);
+
+        expect(result.selectedProjectId).toBe(result.availableProjects[0].value);
+    });
+});

--- a/src/react/atlascode/create-work-item/utils.tsx
+++ b/src/react/atlascode/create-work-item/utils.tsx
@@ -91,7 +91,7 @@ export function createReducer(state: CreateFormState, action: CreateFormAction):
                 ...state,
                 availableProjects: action.payload.availableProjects.map((project) => ({
                     name: project.name,
-                    value: project.key,
+                    value: project.id,
                     iconPath: project.avatarUrls['48x48'],
                 })),
                 hasMoreProjects: action.payload.hasMoreProjects,


### PR DESCRIPTION
### What Is This Change?

Fixes #1896.

This change fixes the selected Jira project disappearing from the project dropdown after switching Jira sites.

The issue was caused by inconsistent project identifiers:

- Initial project options used `project.id`.
- Project options loaded after changing sites used `project.key`.
- The selected project value was still represented by `project.id`.

Because the dropdown option value and selected project value did not match, the selected project could not be displayed.

This change standardizes the project option value on `project.id` in the `UpdatedSelectedSite` reducer path.

A regression test has also been added to verify that, after changing Jira sites, the selected project ID matches the corresponding project option value.

### How Has This Been Tested?

Added a focused React unit test covering the `UpdatedSelectedSite` reducer flow.

The test verifies that:

- Project options use `project.id` as their value.
- The selected project ID matches the corresponding dropdown option value after changing Jira sites.

Command used:

```bash
npm run test:react -- --runTestsByPath \
  src/react/atlascode/create-work-item/utils.test.tsx \
  --runInBand
````

Result:

```text
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
```

Basic checks:

* [x] `npm run lint`
* [ ] `npm run test`

Advanced checks:

* [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [[See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:

* [ ] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

