### PR TITLE
Recover OAuth credentials marked invalid instead of requiring a manual re-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- **Authentication**: OAuth credentials that were previously marked invalid are now re-validated by attempting a token refresh instead of being skipped forever. A credential invalidated by a transient token-endpoint error now self-heals on the next refresh, so users no longer see a persistent "There was an error connecting to ... Please log in again." message in every new window despite still being signed in.
 - **RovoDev**: Hid stack traces, stderr, and log details from external users while preserving them for Atlassian users.
 - **RovoDev (BBY)**: Fixed `ROVODEV_REBRAND_JCA` env var handling so the "Jira Coding Agent" rebrand works correctly in webviews.
 - **Notifications**: Fixed `atlassianNotificationNotifier` to correctly flush all promise levels, resolving a test reliability issue.

--- a/src/atlclients/authStore.test.ts
+++ b/src/atlclients/authStore.test.ts
@@ -1169,8 +1169,7 @@ describe('CredentialManager', () => {
             expect(Logger.debug).toHaveBeenCalledWith(expect.stringContaining('permanent previous failure'));
         });
 
-        it('should skip refreshAccessToken when OAuth credentials are already invalid', async () => {
-            const Logger = require('../logger').Logger;
+        it('should attempt a recovery refresh when OAuth credentials are marked invalid', async () => {
             const site = { ...mockJiraSite, isCloud: true };
             const invalidOAuthInfo: OAuthInfo = {
                 ...mockOAuthInfo,
@@ -1182,46 +1181,82 @@ describe('CredentialManager', () => {
             const saveAuthInfoSpy = jest.spyOn(credentialManager as any, 'saveAuthInfo');
             saveAuthInfoSpy.mockResolvedValue(true);
 
-            Logger.debug.mockClear();
-            mockRefresher.getNewTokens.mockClear();
+            mockRefresher.getNewTokens.mockResolvedValue({
+                tokens: {
+                    accessToken: 'new-access-token',
+                    refreshToken: 'new-refresh-token',
+                    expiration: Date.now() + 3600000,
+                    receivedAt: Date.now(),
+                },
+                shouldSlowDown: false,
+                shouldInvalidate: false,
+            });
 
-            const result = await (credentialManager as any).refreshAccessToken(site);
+            await (credentialManager as any).refreshAccessToken(site);
 
-            expect(result).toBeUndefined();
-            expect(mockRefresher.getNewTokens).not.toHaveBeenCalled();
-            expect(saveAuthInfoSpy).not.toHaveBeenCalled();
-            expect(Logger.debug).toHaveBeenCalledWith(expect.stringContaining('credentials are invalid'));
-
-            const failedRefresh = (credentialManager as any)._failedRefreshCache.get(site.credentialId);
-            expect(failedRefresh?.permanentFailure).toBe(true);
+            expect(mockRefresher.getNewTokens).toHaveBeenCalled();
+            expect(saveAuthInfoSpy).toHaveBeenCalledWith(
+                site,
+                expect.objectContaining({
+                    state: AuthInfoState.Valid,
+                    access: 'new-access-token',
+                }),
+            );
         });
 
-        it('should skip token refresh when credentials state is Invalid', async () => {
-            const Logger = require('../logger').Logger;
+        it('should keep credentials invalid when the recovery refresh fails permanently', async () => {
             const site = { ...mockJiraSite, isCloud: true };
-            const invalidOAuthInfo = {
+            const invalidOAuthInfo: OAuthInfo = {
                 ...mockOAuthInfo,
                 state: AuthInfoState.Invalid,
             };
 
-            const getAuthInfoForProductSpy = jest.spyOn(
-                credentialManager as any,
-                'getAuthInfoForProductAndCredentialId',
-            );
-            getAuthInfoForProductSpy.mockResolvedValue(invalidOAuthInfo);
-            const softRefreshSpy = jest.spyOn(credentialManager as any, 'softRefreshOAuth');
-            softRefreshSpy.mockImplementation(async (site: DetailedSiteInfo, authInfo: AuthInfo) => {
-                if (!authInfo || authInfo.state === AuthInfoState.Invalid) {
-                    Logger.debug(`Skipping token refresh for ${site.baseApiUrl}; credentials are invalid.`);
-                    return authInfo;
-                }
-                return authInfo;
+            const getAuthInfoSpy = jest.spyOn(credentialManager as any, 'getAuthInfoForProductAndCredentialId');
+            getAuthInfoSpy.mockResolvedValue(invalidOAuthInfo);
+            const saveAuthInfoSpy = jest.spyOn(credentialManager as any, 'saveAuthInfo');
+            saveAuthInfoSpy.mockResolvedValue(true);
+
+            mockRefresher.getNewTokens.mockResolvedValue({
+                tokens: undefined,
+                shouldInvalidate: true,
+                shouldSlowDown: false,
             });
 
-            const result = await credentialManager.getAuthInfo(site);
+            await (credentialManager as any).refreshAccessToken(site);
 
-            expect(Logger.debug).toHaveBeenCalledWith(expect.stringContaining('credentials are invalid'));
-            expect(result?.state).toBe(AuthInfoState.Invalid);
+            expect(saveAuthInfoSpy).toHaveBeenCalledWith(
+                site,
+                expect.objectContaining({ state: AuthInfoState.Invalid }),
+            );
+            const failedRefresh = (credentialManager as any)._failedRefreshCache.get(site.credentialId);
+            expect(failedRefresh?.permanentFailure).toBe(true);
+        });
+
+        it('should not retry a recovery refresh after a permanent failure in the same session', async () => {
+            const site = { ...mockJiraSite, isCloud: true };
+            const invalidOAuthInfo: OAuthInfo = {
+                ...mockOAuthInfo,
+                state: AuthInfoState.Invalid,
+            };
+
+            const getAuthInfoSpy = jest.spyOn(credentialManager as any, 'getAuthInfoForProductAndCredentialId');
+            getAuthInfoSpy.mockResolvedValue(invalidOAuthInfo);
+            const saveAuthInfoSpy = jest.spyOn(credentialManager as any, 'saveAuthInfo');
+            saveAuthInfoSpy.mockResolvedValue(true);
+
+            mockRefresher.getNewTokens.mockResolvedValue({
+                tokens: undefined,
+                shouldInvalidate: true,
+                shouldSlowDown: false,
+            });
+
+            await (credentialManager as any).refreshAccessToken(site);
+
+            mockRefresher.getNewTokens.mockClear();
+            const result = await (credentialManager as any).refreshAccessToken(site);
+
+            expect(result).toBeUndefined();
+            expect(mockRefresher.getNewTokens).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/atlclients/authStore.ts
+++ b/src/atlclients/authStore.ts
@@ -394,14 +394,13 @@ export class CredentialManager implements Disposable {
             return authInfo; // not an OAuth info, no need to refresh
         }
 
-        if (credentials.state === AuthInfoState.Invalid) {
-            Logger.debug(`Skipping token refresh for ${site.baseApiUrl}; credentials are invalid.`);
-            return credentials;
-        }
-
         const GRACE_PERIOD = 30 * Time.MINUTES;
 
-        if (credentials.expirationDate) {
+        if (credentials.state === AuthInfoState.Invalid) {
+            // Credentials may have been invalidated spuriously (e.g. a transient 401 from the token
+            // endpoint), so attempt a refresh anyway; a successful one marks them Valid again.
+            Logger.debug(`Credentials for ${site.baseApiUrl} are marked invalid; attempting to recover.`);
+        } else if (credentials.expirationDate) {
             const diff = credentials.expirationDate - Date.now();
             Logger.debug(
                 `${Math.floor(diff / 1000)} seconds remaining for ${site.name} refresh token. ${diff > GRACE_PERIOD ? 'No refresh needed yet.' : 'refreshing...'}`,
@@ -567,13 +566,9 @@ export class CredentialManager implements Disposable {
         }
 
         if (credentials.state === AuthInfoState.Invalid) {
-            Logger.debug(`Skipping token refresh for credentialID: ${site.credentialId}; credentials are invalid.`);
-            this._failedRefreshCache.set(site.credentialId, {
-                attemptsCount: this._failedRefreshCache.get(site.credentialId)?.attemptsCount ?? 0,
-                lastAttemptAt: new Date(),
-                permanentFailure: true,
-            });
-            return undefined;
+            Logger.debug(
+                `Credentials for credentialID: ${site.credentialId} are marked invalid; attempting to recover.`,
+            );
         }
 
         const failedRefresh = this._failedRefreshCache.get(site.credentialId);
@@ -618,6 +613,8 @@ export class CredentialManager implements Disposable {
                     credentials.refresh = newTokens.refreshToken;
                     credentials.iat = newTokens.iat ?? 0;
                 }
+                // A successful refresh proves the credentials work, even if they were marked invalid before
+                credentials.state = AuthInfoState.Valid;
 
                 await this.saveAuthInfo(site, credentials);
                 if (this._failedRefreshCache.has(site.credentialId)) {


### PR DESCRIPTION
### What Is This Change?

Fixes #1827 (likely also #1818, and part of #1635).

**Symptom:** "There was an error connecting to Bitbucket Cloud. Please log in again." appears in *every* new VS Code window, even though the user is signed in and their stored refresh token is still valid. Bitbucket features silently stop working while the auth UI continues to show the user as logged in.

**Root cause:** once `refreshAccessToken` persists `AuthInfoState.Invalid` to secret storage, the credential can never recover:

- `softRefreshOAuth` returns early for `Invalid` credentials, so a refresh is never attempted again (#1719).
- `refreshAccessToken` also skips `Invalid` credentials and re-seeds the in-session `permanentFailure` cache, so restarting VS Code doesn't help either (#1740).
- The only code path that sets a credential back to `Valid` is a fresh login (`loginManager.saveDetails`).

Meanwhile `ClientManager.createClient` shows the modal once per `ClientManager` instance (`hasWarnedOfFailure`), and a new instance is created per window — hence "every new window", indefinitely.

The `Invalid` flag is easy to acquire spuriously: `OAuthRefesher.getNewTokens` classifies **any** 401 from the token endpoint as permanent (`shouldInvalidate`), including transient gateway/proxy 401s and RFC 6749 `invalid_client` responses that say nothing about the user's refresh token. (Until #1747 any 403 did too.) On an affected install the credential had been stuck `Invalid` since March; replaying the stored refresh token against `https://bitbucket.org/site/oauth2/access_token` returned **HTTP 200 with fresh tokens** — the invalidation was bogus, but the extension refused to retry for months.

**The change:** treat persisted `Invalid` as "needs re-validation" rather than "dead forever":

- `softRefreshOAuth` no longer skips `Invalid` OAuth credentials; it proceeds to attempt a refresh.
- `refreshAccessToken` no longer short-circuits on `Invalid`; the existing `_failedRefreshCache` backoff still bounds retries (a refresh that comes back `shouldInvalidate` marks `permanentFailure`, so a genuinely dead token is attempted only once per session).
- A successful refresh now explicitly sets `state = AuthInfoState.Valid` before saving, so a spuriously-invalidated credential self-heals on the next `getAuthInfo` call — typically at window startup, before the modal would have been shown.

Behavior for genuinely dead refresh tokens is unchanged: the recovery attempt fails, the credential stays `Invalid`, and the existing modal still appears.

### How Has This Been Tested?

- Updated the two unit tests that asserted the old skip-on-`Invalid` behavior, and added coverage for: recovery success (state persisted back to `Valid`), permanent failure (stays `Invalid` + `permanentFailure` cached), and no same-session retry after a permanent failure. `authStore.test.ts` passes (53/53); the rest of the unit suite is unaffected.
- Confirmed the bug empirically on an affected Cloud install: decrypted the stored credential (`state: 1`) and replayed its refresh token against the Bitbucket token endpoint — HTTP 200, still valid — establishing that the persisted `Invalid` was spurious.
- Built the patched extension and installed it locally against that same install for manual verification that the credential re-validates on startup and the modal no longer appears.

Basic checks:

- [x] `npm run lint`
- [x] `npm run test` (unit)

Advanced checks:
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? — n/a (external contributor; change is OAuth-cloud-path only, DC/basic/PAT auth is untouched)

Recommendations:
- [x] Update the CHANGELOG if making a user facing change
