### PR TITLE
FLOW-2585: Fix markdown formatting in RovoDev chat view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- **RovoDev**: Fixed markdown formatting in the chat view - headers now render at a consistent 16px, and tables are responsive so they no longer overflow the narrow sidebar.
 - **RovoDev**: Hid stack traces, stderr, and log details from external users while preserving them for Atlassian users.
 - **RovoDev (BBY)**: Fixed `ROVODEV_REBRAND_JCA` env var handling so the "Jira Coding Agent" rebrand works correctly in webviews.
 - **Notifications**: Fixed `atlassianNotificationNotifier` to correctly flush all promise levels, resolving a test reliability issue.

--- a/src/rovo-dev/ui/RovoDev.css
+++ b/src/rovo-dev/ui/RovoDev.css
@@ -468,6 +468,66 @@ body {
     color: var(--ds-text-inverse) !important;
 }
 
+/* Markdown headers: keep them a consistent, readable size in the narrow sidebar */
+.message-content h1,
+.message-content h2,
+.message-content h3,
+.message-content h4,
+.message-content h5,
+.message-content h6,
+.tool-return-content h1,
+.tool-return-content h2,
+.tool-return-content h3,
+.tool-return-content h4,
+.tool-return-content h5,
+.tool-return-content h6 {
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.4;
+    margin: 12px 0 6px;
+}
+
+.message-content h1:first-child,
+.message-content h2:first-child,
+.message-content h3:first-child,
+.message-content h4:first-child,
+.message-content h5:first-child,
+.message-content h6:first-child,
+.tool-return-content h1:first-child,
+.tool-return-content h2:first-child,
+.tool-return-content h3:first-child,
+.tool-return-content h4:first-child,
+.tool-return-content h5:first-child,
+.tool-return-content h6:first-child {
+    margin-top: 0;
+}
+
+/* Markdown tables: make them responsive so they don't overflow the sidebar */
+.message-content table,
+.tool-return-content table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    border-collapse: collapse;
+    margin: 8px 0;
+}
+
+.message-content th,
+.message-content td,
+.tool-return-content th,
+.tool-return-content td {
+    padding: 4px 8px;
+    border: 1px solid var(--vscode-editorWidget-border);
+    text-align: left;
+    word-break: break-word;
+}
+
+.message-content th,
+.tool-return-content th {
+    background-color: var(--vscode-editorWidget-background);
+    font-weight: 600;
+}
+
 .rovodev-markdown-link {
     cursor: pointer;
     color: var(--vscode-textLink-foreground);


### PR DESCRIPTION
Problem: 
- Headers in the RovoDev chat and tool-return content rendered at inconsistent, oversized sizes in the narrow sidebar.
- Markdown tables could also overflow horizontally and break the layout.

Solution: 
- Normalize h1-h6 to a consistent 16px/600 with sensible margins (and no top margin on the first heading)
- Make tables responsive: scrollable overflow, full-width cap, bordered cells that wrap long content

Applies to both .message-content and .tool-return-content.


| Before | After |
|--------|-------|
| <img width="380" src="https://github.com/user-attachments/assets/a59dc537-a7c6-46ed-854f-333a4fab4f53" /> | <img width="380" src="https://github.com/user-attachments/assets/c66fd99a-e0b2-4774-b19c-cc4eaa3f2dfd" /> |
| <img width="380" src="https://github.com/user-attachments/assets/f0e6202c-23fa-4248-8802-d8fec96a8400" /> | <img width="380" src="https://github.com/user-attachments/assets/25e8d012-4691-4d90-ac7f-5b2e1aff56e3" /> |

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Recommendations:
- [x] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

