### PR TITLE
FLOW-2615: Ensure only one prompt toolbar popup is open at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **RovoDev**: Hid stack traces, stderr, and log details from external users while preserving them for Atlassian users.
 - **RovoDev (BBY)**: Fixed `ROVODEV_REBRAND_JCA` env var handling so the "Jira Coding Agent" rebrand works correctly in webviews.
 - **Notifications**: Fixed `atlassianNotificationNotifier` to correctly flush all promise levels, resolving a test reliability issue.
+- **RovoDev**: Fixed the prompt toolbar so only one dropdown (Add, Preferences, or model selector) can be open at a time - opening one now closes any other that was open, instead of stacking a dropdown over a dropdown.
 
 ### Improvements
 

--- a/src/rovo-dev/ui/prompt-box/agent-model-selection/AgentModelSelector.tsx
+++ b/src/rovo-dev/ui/prompt-box/agent-model-selection/AgentModelSelector.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { RovodevStaticConfig } from 'src/rovo-dev/api/rovodevStaticConfig';
 import { RovoDevAgentModel } from 'src/rovo-dev/rovoDevWebviewProviderMessages';
 
+import { useControllableOpen } from '../useControllableOpen';
 import { PromptAgentModel } from './AgentModelItem';
 
 interface AgentModelSelectorProps {
@@ -12,6 +13,8 @@ interface AgentModelSelectorProps {
     availableModels: RovoDevAgentModel[];
     onModelChange: (model: RovoDevAgentModel) => void;
     isDisabled?: boolean;
+    isOpen?: boolean;
+    onOpenChange?: (isOpen: boolean) => void;
 }
 
 // TODO - this is a patch, the id format needs to be returned consistently by Rovo Dev
@@ -54,8 +57,10 @@ export const AgentModelSelector: React.FC<AgentModelSelectorProps> = ({
     availableModels,
     onModelChange,
     isDisabled,
+    isOpen: controlledIsOpen,
+    onOpenChange,
 }) => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useControllableOpen(controlledIsOpen, onOpenChange);
 
     // try to match the current model against the available models
     const currentModelFromAvailable = React.useMemo(
@@ -87,7 +92,7 @@ export const AgentModelSelector: React.FC<AgentModelSelectorProps> = ({
                     appearance="subtle"
                     isSelected={isOpen}
                     iconAfter={<ChevronDownIcon label="Open" />}
-                    onClick={() => setIsOpen((prev) => !prev)}
+                    onClick={() => setIsOpen(!isOpen)}
                     aria-label="Agent model selection"
                     isDisabled={isDisabled}
                 >

--- a/src/rovo-dev/ui/prompt-box/prompt-context-popup/PromptContextPopup.tsx
+++ b/src/rovo-dev/ui/prompt-box/prompt-context-popup/PromptContextPopup.tsx
@@ -9,6 +9,7 @@ import Tooltip from '@atlaskit/tooltip';
 import React from 'react';
 
 import { SavedPrompt } from '../../utils';
+import { useControllableOpen } from '../useControllableOpen';
 import { SavedPromptMenu } from './saved-prompt-menu/SavedPromptMenu';
 
 interface PromptContextPopupProps {
@@ -17,6 +18,8 @@ interface PromptContextPopupProps {
     canFetchSavedPrompts?: boolean;
     onSelectedSavedPrompt?: (prompt: SavedPrompt) => void;
     onClose?: () => void;
+    isOpen?: boolean;
+    onOpenChange?: (isOpen: boolean) => void;
 }
 
 const PopupContainer = React.forwardRef<HTMLDivElement, PopupComponentProps>(
@@ -33,8 +36,10 @@ const PromptContextPopup: React.FC<PromptContextPopupProps> = ({
     canFetchSavedPrompts,
     onSelectedSavedPrompt,
     onClose,
+    isOpen: controlledIsOpen,
+    onOpenChange,
 }) => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useControllableOpen(controlledIsOpen, onOpenChange);
     const [isSavedPromptsMenuOpen, setIsSavedPromptsMenuOpen] = React.useState(false);
 
     const handlePromptSelected = React.useCallback(
@@ -43,7 +48,7 @@ const PromptContextPopup: React.FC<PromptContextPopupProps> = ({
             setIsSavedPromptsMenuOpen(false);
             setIsOpen(false);
         },
-        [onSelectedSavedPrompt],
+        [onSelectedSavedPrompt, setIsOpen],
     );
 
     return (

--- a/src/rovo-dev/ui/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/rovo-dev/ui/prompt-box/prompt-input/PromptInput.tsx
@@ -139,6 +139,14 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
 }) => {
     const [editor, setEditor] = React.useState<ReturnType<typeof createEditor>>(undefined);
     const [isEmpty, setIsEmpty] = React.useState(true);
+    // Tracks which prompt toolbar popup is currently open so that only one can be open at a time.
+    const [openPopup, setOpenPopup] = React.useState<'context' | 'settings' | 'model' | null>(null);
+
+    const makePopupOpenChangeHandler = React.useCallback(
+        (popup: 'context' | 'settings' | 'model') => (isOpen: boolean) =>
+            setOpenPopup((prev) => (isOpen ? popup : prev === popup ? null : prev)),
+        [],
+    );
     const promptCompletionProviderRef = React.useRef<monaco.IDisposable | null>(null);
     const contentChangeListenerRef = React.useRef<monaco.IDisposable | null>(null);
     const autoResizeRef = React.useRef<monaco.IDisposable | null>(null);
@@ -374,6 +382,8 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                         canFetchSavedPrompts={canFetchSavedPrompts}
                         onSelectedSavedPrompt={handleSelectSavedPrompt}
                         onAddRepositoryFile={onAddContext}
+                        isOpen={openPopup === 'context'}
+                        onOpenChange={makePopupOpenChangeHandler('context')}
                     />
                     <PromptSettingsPopup
                         onDeepPlanToggled={onDeepPlanToggled}
@@ -385,6 +395,8 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                         currentAgentMode={currentAgentMode}
                         onAgentModeChange={onAgentModeChange}
                         onClose={() => {}}
+                        isOpen={openPopup === 'settings'}
+                        onOpenChange={makePopupOpenChangeHandler('settings')}
                     />
                     {isDeepPlanEnabled && onDeepPlanToggled && (
                         <Tooltip content="Disable deep plan">
@@ -453,6 +465,8 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                         currentModel={currentAgentModel}
                         onModelChange={onAgentModelChange}
                         isDisabled={disableAgentModelSelector}
+                        isOpen={openPopup === 'model'}
+                        onOpenChange={makePopupOpenChangeHandler('model')}
                     />
                 </div>
                 <div style={{ display: 'flex', gap: 8, marginLeft: 'auto' }}>

--- a/src/rovo-dev/ui/prompt-box/prompt-input/PromptInput.tsx
+++ b/src/rovo-dev/ui/prompt-box/prompt-input/PromptInput.tsx
@@ -142,9 +142,18 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
     // Tracks which prompt toolbar popup is currently open so that only one can be open at a time.
     const [openPopup, setOpenPopup] = React.useState<'context' | 'settings' | 'model' | null>(null);
 
-    const makePopupOpenChangeHandler = React.useCallback(
-        (popup: 'context' | 'settings' | 'model') => (isOpen: boolean) =>
-            setOpenPopup((prev) => (isOpen ? popup : prev === popup ? null : prev)),
+    // Pre-memoize one stable handler per popup so `onOpenChange` keeps a stable reference across
+    // renders (a fresh reference would defeat memoization in useControllableOpen).
+    const handleContextOpenChange = React.useCallback(
+        (isOpen: boolean) => setOpenPopup((prev) => (isOpen ? 'context' : prev === 'context' ? null : prev)),
+        [],
+    );
+    const handleSettingsOpenChange = React.useCallback(
+        (isOpen: boolean) => setOpenPopup((prev) => (isOpen ? 'settings' : prev === 'settings' ? null : prev)),
+        [],
+    );
+    const handleModelOpenChange = React.useCallback(
+        (isOpen: boolean) => setOpenPopup((prev) => (isOpen ? 'model' : prev === 'model' ? null : prev)),
         [],
     );
     const promptCompletionProviderRef = React.useRef<monaco.IDisposable | null>(null);
@@ -383,7 +392,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                         onSelectedSavedPrompt={handleSelectSavedPrompt}
                         onAddRepositoryFile={onAddContext}
                         isOpen={openPopup === 'context'}
-                        onOpenChange={makePopupOpenChangeHandler('context')}
+                        onOpenChange={handleContextOpenChange}
                     />
                     <PromptSettingsPopup
                         onDeepPlanToggled={onDeepPlanToggled}
@@ -396,7 +405,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                         onAgentModeChange={onAgentModeChange}
                         onClose={() => {}}
                         isOpen={openPopup === 'settings'}
-                        onOpenChange={makePopupOpenChangeHandler('settings')}
+                        onOpenChange={handleSettingsOpenChange}
                     />
                     {isDeepPlanEnabled && onDeepPlanToggled && (
                         <Tooltip content="Disable deep plan">
@@ -466,7 +475,7 @@ export const PromptInputBox: React.FC<PromptInputBoxProps> = ({
                         onModelChange={onAgentModelChange}
                         isDisabled={disableAgentModelSelector}
                         isOpen={openPopup === 'model'}
-                        onOpenChange={makePopupOpenChangeHandler('model')}
+                        onOpenChange={handleModelOpenChange}
                     />
                 </div>
                 <div style={{ display: 'flex', gap: 8, marginLeft: 'auto' }}>

--- a/src/rovo-dev/ui/prompt-box/prompt-settings-popup/PromptSettingsPopup.tsx
+++ b/src/rovo-dev/ui/prompt-box/prompt-settings-popup/PromptSettingsPopup.tsx
@@ -10,6 +10,7 @@ import Tooltip from '@atlaskit/tooltip';
 import React, { useCallback, useMemo } from 'react';
 import { AgentMode, RovoDevModeInfo } from 'src/rovo-dev/client';
 
+import { useControllableOpen } from '../useControllableOpen';
 import AgentModeSection from './AgentModeSection';
 import PromptSettingsItem from './PromptSettingsItem';
 
@@ -41,6 +42,8 @@ interface PromptSettingsPopupProps {
     currentAgentMode: AgentMode | null;
     onAgentModeChange: (mode: AgentMode) => void;
     onClose: () => void;
+    isOpen?: boolean;
+    onOpenChange?: (isOpen: boolean) => void;
 }
 
 const PopupContainer = React.forwardRef<HTMLDivElement, PopupComponentProps>(
@@ -74,8 +77,10 @@ const PromptSettingsPopup: React.FC<PromptSettingsPopupProps> = ({
     currentAgentMode,
     onAgentModeChange,
     onClose,
+    isOpen: controlledIsOpen,
+    onOpenChange,
 }) => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useControllableOpen(controlledIsOpen, onOpenChange);
 
     const handleAgentModeChange = useCallback(
         (mode: AgentMode) => {
@@ -83,7 +88,7 @@ const PromptSettingsPopup: React.FC<PromptSettingsPopupProps> = ({
             setIsOpen(false);
             onClose();
         },
-        [onAgentModeChange, onClose],
+        [onAgentModeChange, onClose, setIsOpen],
     );
 
     const otherSectionItems = useMemo((): OtherSectionItem[] => {
@@ -127,7 +132,7 @@ const PromptSettingsPopup: React.FC<PromptSettingsPopupProps> = ({
                     {isOpen ? (
                         <button
                             {...props}
-                            onClick={() => setIsOpen((prev) => !prev)}
+                            onClick={() => setIsOpen(false)}
                             className="prompt-button-secondary-open"
                             aria-label="Prompt settings (open)"
                         >
@@ -136,7 +141,7 @@ const PromptSettingsPopup: React.FC<PromptSettingsPopupProps> = ({
                     ) : (
                         <button
                             {...props}
-                            onClick={() => setIsOpen((prev) => !prev)}
+                            onClick={() => setIsOpen(true)}
                             className="prompt-button-secondary"
                             aria-label="Prompt settings"
                         >

--- a/src/rovo-dev/ui/prompt-box/useControllableOpen.test.tsx
+++ b/src/rovo-dev/ui/prompt-box/useControllableOpen.test.tsx
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useControllableOpen } from './useControllableOpen';
+
+describe('useControllableOpen', () => {
+    it('manages its own state when uncontrolled', () => {
+        const { result } = renderHook(() => useControllableOpen());
+
+        expect(result.current[0]).toBe(false);
+
+        act(() => result.current[1](true));
+        expect(result.current[0]).toBe(true);
+
+        act(() => result.current[1](false));
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('reflects the controlled value and does not manage internal state', () => {
+        const onOpenChange = jest.fn();
+        const { result, rerender } = renderHook(
+            ({ isOpen }: { isOpen: boolean }) => useControllableOpen(isOpen, onOpenChange),
+            { initialProps: { isOpen: false } },
+        );
+
+        expect(result.current[0]).toBe(false);
+
+        // Requesting open should not change the displayed value on its own (parent owns state)...
+        act(() => result.current[1](true));
+        expect(onOpenChange).toHaveBeenCalledWith(true);
+        expect(result.current[0]).toBe(false);
+
+        // ...only when the parent updates the prop does the value change.
+        rerender({ isOpen: true });
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('still notifies onOpenChange when uncontrolled', () => {
+        const onOpenChange = jest.fn();
+        const { result } = renderHook(() => useControllableOpen(undefined, onOpenChange));
+
+        act(() => result.current[1](true));
+        expect(onOpenChange).toHaveBeenCalledWith(true);
+        expect(result.current[0]).toBe(true);
+    });
+});

--- a/src/rovo-dev/ui/prompt-box/useControllableOpen.ts
+++ b/src/rovo-dev/ui/prompt-box/useControllableOpen.ts
@@ -1,0 +1,33 @@
+import React from 'react';
+
+/**
+ * A hook that supports both controlled and uncontrolled "open" state for popups.
+ *
+ * When `controlledIsOpen` / `onOpenChange` are provided, the hook operates in controlled
+ * mode and defers state ownership to the parent. This allows a parent to coordinate multiple
+ * popups so that only one can be open at a time.
+ *
+ * When they are omitted, the hook falls back to managing its own internal state, so components
+ * can still be used standalone (e.g. in tests).
+ */
+export function useControllableOpen(
+    controlledIsOpen?: boolean,
+    onOpenChange?: (isOpen: boolean) => void,
+): [boolean, (next: boolean) => void] {
+    const isControlled = controlledIsOpen !== undefined;
+    const [internalIsOpen, setInternalIsOpen] = React.useState(false);
+
+    const isOpen = isControlled ? controlledIsOpen : internalIsOpen;
+
+    const setIsOpen = React.useCallback(
+        (next: boolean) => {
+            if (!isControlled) {
+                setInternalIsOpen(next);
+            }
+            onOpenChange?.(next);
+        },
+        [isControlled, onOpenChange],
+    );
+
+    return [isOpen, setIsOpen];
+}


### PR DESCRIPTION
The RovoDev prompt toolbar has three independent dropdowns (Add, Preferences, and the model selector), each managing its own open state. Because they render to the parent via atlaskit's shouldRenderToParent, opening one did not close the others, producing a dropdown-over-dropdown.

Lift the open/closed decision to PromptInputBox via a single openPopup state, and make each popup support controlled open state through a new useControllableOpen hook (with an uncontrolled fallback so the components still work standalone). Opening any popup now closes the others.

| Before | After |
| --- | --- |
| <img width="790" alt="Before" src="https://github.com/user-attachments/assets/f2154d3c-435c-4df4-96a1-65aef852dc02" /> | <img width="812" alt="After" src="https://github.com/user-attachments/assets/d4162277-8458-4e64-a78d-edfdea0fb0f8" /> |


🔧 Did you make sure the proposed change works, before submitting the PR?
Manual test - see screenshots

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Recommendations:
- [x] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

