### PR TITLE
JOLT-3435 Update message to remove credit total and remaining for Rovo Credits

### DIFF
--- a/src/rovo-dev/rovoDevUtils.test.ts
+++ b/src/rovo-dev/rovoDevUtils.test.ts
@@ -1,5 +1,10 @@
-import { RovoDevModelsResponse } from './client/responseParserInterfaces';
-import { modelsJsonResponseToMarkdown, parseCustomCliTagsForMarkdown, removeCustomCliTags } from './rovoDevUtils';
+import { RovoDevModelsResponse, RovoDevUsageResponse } from './client/responseParserInterfaces';
+import {
+    modelsJsonResponseToMarkdown,
+    parseCustomCliTagsForMarkdown,
+    removeCustomCliTags,
+    usageJsonResponseToMarkdown,
+} from './rovoDevUtils';
 
 describe('rovoDevUtils', () => {
     describe('modelsJsonResponseToMarkdown', () => {
@@ -111,6 +116,53 @@ describe('rovoDevUtils', () => {
                 text: 'Model changed',
                 agentModelChanged: true,
             });
+        });
+    });
+
+    describe('usageJsonResponseToMarkdown', () => {
+        const baseContent = {
+            isBetaSite: false,
+            title: 'Credits',
+            status: 'ok',
+            credit_type: 'standard',
+            credit_used: 500,
+            credit_remaining: 1500,
+            credit_total: 2000,
+            retry_after_seconds: 3600,
+        };
+
+        const makeResponse = (overrides: Partial<typeof baseContent>): RovoDevUsageResponse => ({
+            event_kind: 'usage',
+            data: { content: { ...baseContent, ...overrides } },
+        });
+
+        it('should include Remaining and Total when credit_total is a positive number', () => {
+            const result = usageJsonResponseToMarkdown(makeResponse({}));
+            expect(result.usage_response).toContain('- Remaining:');
+            expect(result.usage_response).toContain('- Total:');
+        });
+
+        it('should omit Remaining and Total when credit_total is 0', () => {
+            const result = usageJsonResponseToMarkdown(makeResponse({ credit_total: 0 }));
+            expect(result.usage_response).not.toContain('- Remaining:');
+            expect(result.usage_response).not.toContain('- Total:');
+        });
+
+        it('should show Unlimited for Remaining and Total when credit_total is -1', () => {
+            const result = usageJsonResponseToMarkdown(makeResponse({ credit_total: -1 }));
+            expect(result.usage_response).toContain('- Remaining: Unlimited');
+            expect(result.usage_response).toContain('- Total: Unlimited');
+        });
+
+        it('should omit Remaining and Total when credit_total is NaN', () => {
+            const result = usageJsonResponseToMarkdown(makeResponse({ credit_total: NaN }));
+            expect(result.usage_response).not.toContain('- Remaining:');
+            expect(result.usage_response).not.toContain('- Total:');
+        });
+
+        it('should always include Used line', () => {
+            const result = usageJsonResponseToMarkdown(makeResponse({ credit_total: 0 }));
+            expect(result.usage_response).toContain('- Used:');
         });
     });
 

--- a/src/rovo-dev/rovoDevUtils.ts
+++ b/src/rovo-dev/rovoDevUtils.ts
@@ -163,13 +163,22 @@ export function usageJsonResponseToMarkdown(response: RovoDevUsageResponse): {
         }
     } else {
         // If credit_total returns -1, it means unlimited credits
+        // If credit_total is 0 or missing, omit Remaining and Total lines
+        const hasValidTotal =
+            data.credit_total !== undefined &&
+            data.credit_total !== null &&
+            data.credit_total !== 0 &&
+            !Number.isNaN(data.credit_total);
+
         const remaining = data.credit_total === -1 ? 'Unlimited' : numberFormatter.format(data.credit_remaining);
         const total = data.credit_total === -1 ? 'Unlimited' : numberFormatter.format(data.credit_total);
 
         buffer += `**${data.title}**\n`;
         buffer += `- Used: ${numberFormatter.format(data.credit_used)}\n`;
-        buffer += `- Remaining: ${remaining}\n`;
-        buffer += `- Total: ${total}\n`;
+        if (hasValidTotal) {
+            buffer += `- Remaining: ${remaining}\n`;
+            buffer += `- Total: ${total}\n`;
+        }
         buffer += '\n';
     }
 


### PR DESCRIPTION
### What Is This Change?

Updating messaging for the Rovo Dev /usage command

### How Has This Been Tested?

Tested locally and increased unit test coverage.

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`