### PR TITLE
fix(RovoDev): store binary bundle in global storage instead of per-workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed arbitrary code execution via `core.fsmonitor` in repository `.git/config`
 
+### Bug Fixes
+
+- **RovoDev**: Store the downloaded Rovo Dev binary bundle in global storage instead of per-workspace storage. The bundle is version-pinned and identical across workspaces, so it was previously duplicated (~400MB each) into every workspace's storage folder. Leftover per-workspace copies are now removed automatically when a workspace is opened.
+
 ## What's new in 4.0.31
 
 ### Bug Fixes

--- a/src/rovo-dev/rovoDevProcessManager.ts
+++ b/src/rovo-dev/rovoDevProcessManager.ts
@@ -36,8 +36,11 @@ const RovoDevInfo = {
 export function GetRovoDevURIs(context: ExtensionContext) {
     const platform = process.platform;
     const arch = process.arch;
-    const extensionPath = context.storageUri!.fsPath;
-    const rovoDevBaseDir = path.join(extensionPath, 'atlascode-rovodev-bin');
+    // The binary bundle is version-pinned and identical across workspaces, so store it in
+    // global storage (shared, keyed by version) rather than per-workspace storage. Using
+    // storageUri duplicated the ~400MB bundle into every workspace's storage folder.
+    const globalStoragePath = context.globalStorageUri.fsPath;
+    const rovoDevBaseDir = path.join(globalStoragePath, 'atlascode-rovodev-bin');
     const rovoDevVersionDir = path.join(rovoDevBaseDir, MIN_SUPPORTED_ROVODEV_VERSION);
     const rovoDevBinPath = path.join(rovoDevVersionDir, 'atlassian_cli_rovodev') + (platform === 'win32' ? '.exe' : '');
 
@@ -219,6 +222,39 @@ export abstract class RovoDevProcessManager {
         this.rovoDevInstance = undefined;
     }
 
+    /** Ensures the legacy per-workspace binary cleanup only runs once per session. */
+    private static legacyBinaryCleanupDone = false;
+
+    /**
+     * Prior versions stored the Rovo Dev binary bundle under per-workspace storage
+     * (`context.storageUri`), which duplicated the ~400MB bundle into every workspace's
+     * storage folder. The bundle now lives in global storage, so remove any leftover
+     * per-workspace copy for the current workspace to reclaim the space automatically.
+     */
+    private static async cleanupLegacyWorkspaceBinary(context: ExtensionContext) {
+        if (this.legacyBinaryCleanupDone) {
+            return;
+        }
+        this.legacyBinaryCleanupDone = true;
+
+        // storageUri is undefined when no workspace/folder is open; in that case there is
+        // no legacy per-workspace bundle to clean up.
+        const workspaceStoragePath = context.storageUri?.fsPath;
+        if (!workspaceStoragePath) {
+            return;
+        }
+
+        const legacyBinDir = path.join(workspaceStoragePath, 'atlascode-rovodev-bin');
+        try {
+            if (fs.existsSync(legacyBinDir)) {
+                await getFsPromise((callback) => fs.rm(legacyBinDir, { recursive: true, force: true }, callback));
+                Logger.info(`Removed legacy per-workspace Rovo Dev binary bundle at ${legacyBinDir}`);
+            }
+        } catch (error) {
+            Logger.warn(`Failed to remove legacy per-workspace Rovo Dev binary bundle: ${error}`);
+        }
+    }
+
     public static get state(): RovoDevProcessState {
         if (RovoDevProcessManager.extensionApi.metadata.isBoysenberry()) {
             const httpPort = parseInt(process.env[RovoDevInfo.envVars.port] || '0');
@@ -364,6 +400,8 @@ export abstract class RovoDevProcessManager {
     }
 
     public static async initializeRovoDev(context: ExtensionContext, forceNewInstance?: boolean) {
+        await this.cleanupLegacyWorkspaceBinary(context);
+
         if (this.asyncLocked) {
             throw new Error('Multiple initialization of Rovo Dev attempted');
         }


### PR DESCRIPTION
### What Is This Change?

The Rovo Dev CLI binary bundle is downloaded into **per-workspace** storage (`context.storageUri`) instead of shared **global** storage. The bundle is version-pinned and byte-for-byte identical across workspaces — it contains a bundled Python 3.13 runtime, the full `tree_sitter_language_pack`, ripgrep, `git-ai`, native crypto/grpc libraries, and the `atlassian_cli_rovodev` binary (~366–435 MB per version).

Because it's keyed to each workspace, every workspace you open downloads and stores its own full copy. On my machine with 34 workspaces this added up to **~14 GB** of duplicated binaries:

```
14.2 GB total across 34 workspaces
  22 × 202606.17.1  (435 MB each)  =  9.6 GB
   8 × 202604.30.2  (366 MB each)  =  2.9 GB
   4 × 202604.11.1  (366 MB each)  =  1.5 GB
```

I verified the copies are identical (same SHA-256 for `atlassian_cli_rovodev` across workspaces on the same version), so all but one copy per version is pure waste.

**The fix:**

1. Root the bundle at `context.globalStorageUri` instead of `context.storageUri` in `GetRovoDevURIs`. The code already nests the bundle under a per-version subdirectory (`MIN_SUPPORTED_ROVODEV_VERSION`), which is a safe global cache key, so the download now happens **once per version** and is shared across all workspaces. Nothing about the bundle is workspace-specific — the process is already launched with the workspace folder as `cwd`, which is unaffected. As a bonus this removes the `context.storageUri!` non-null assertion; `storageUri` is `undefined` when no workspace/folder is open, whereas `globalStorageUri` is always defined.

2. **Automatically reclaim existing duplication.** When Rovo Dev initializes in a workspace, any leftover bundle at the old per-workspace location (`context.storageUri/atlascode-rovodev-bin`) is removed. This is self-healing — each workspace cleans itself on next open — and uses only documented API, without reaching into other workspaces' storage folders (which VS Code provides no supported way to enumerate). Combined with VS Code's own garbage collection of storage for folders that no longer exist, no manual cleanup is required.

Storage footprint after this change: **~435 MB** (one shared copy of the current version) instead of scaling linearly with the number of workspaces.

### How Has This Been Tested?

- `npm run lint` — passes (also enforced by the pre-commit hook).
- `npm run test:unit` for `src/rovo-dev/` — passes (9/9 in `rovoDevLanguageServerProvider.test.ts`; `GetRovoDevURIs` is mocked in the suite, so behavior is unchanged).
- TypeScript `--noEmit` typecheck — clean.
- Manual: confirmed existing per-workspace copies are byte-identical across workspaces, confirming the duplication and that a single shared copy is sufficient.

Note: the legacy cleanup is deliberately scoped to the current workspace on activation rather than walking the entire `workspaceStorage` tree, to avoid depending on undocumented on-disk layout. If maintainers would prefer a one-shot sweep of all workspaces, I'm happy to adjust.
