### PR TITLE
feat(rovodev): add errorName to rovoDevPromptCompleted for SLO diagnosis

### DIFF
--- a/src/rovo-dev/analytics/events.ts
+++ b/src/rovo-dev/analytics/events.ts
@@ -249,6 +249,16 @@ export namespace Track {
             result: PromptCompletedResult;
             /** Only present when `result !== 'success'`. */
             errorReason?: PromptCompletedErrorReason;
+            /**
+             * Optional free-form name of the specific underlying error, present
+             * only when `result !== 'success'`. Unlike the closed `errorReason`
+             * bucket, this carries the concrete cause so backend failures can be
+             * diagnosed from the SLO without cross-referencing Sentry — e.g. the
+             * agent exception class (`response.type`) for `stream_exception`, or
+             * `error.name` for fetch/HTTP failures. High-cardinality: intended for
+             * grouping/inspection, not as a primary SLO dimension.
+             */
+            errorName?: string;
             /** Optional: HTTP status when the error was an HTTP-layer failure. */
             httpStatus?: number;
             /** Optional: number of user-visible message parts processed in the stream. */

--- a/src/rovo-dev/rovoDevChatProvider.test.ts
+++ b/src/rovo-dev/rovoDevChatProvider.test.ts
@@ -1277,6 +1277,25 @@ describe('RovoDevChatProvider', () => {
             });
         });
 
+        it('emits rovoDevPromptCompleted with errorName when provided (diagnostic breakdown)', () => {
+            chatProvider['firePromptCompleted']('error', {
+                errorReason: 'stream_exception',
+                errorName: 'UserError',
+            });
+
+            expect(mockTelemetryProvider.fireTelemetryEvent).toHaveBeenCalledTimes(1);
+            expect(mockTelemetryProvider.fireTelemetryEvent).toHaveBeenCalledWith({
+                action: 'rovoDevPromptCompleted',
+                subject: 'atlascode',
+                attributes: {
+                    promptId: 'prompt-A',
+                    result: 'error',
+                    errorReason: 'stream_exception',
+                    errorName: 'UserError',
+                },
+            });
+        });
+
         it('omits optional attributes when not provided (bridge expects closed shape)', () => {
             chatProvider['firePromptCompleted']('cancelled', { errorReason: 'aborted' });
 
@@ -1344,22 +1363,27 @@ describe('RovoDevChatProvider', () => {
             // attached to rovoDevPromptCompleted for fetch/HTTP failures. The
             // SLO downstream slices on these closed-enum values, so the
             // boundaries here are part of the bridge contract.
-            it('classifies RovoDevApiError 5xx as http_5xx with the status code', async () => {
+            it('classifies RovoDevApiError 5xx as http_5xx with the status code and error name', async () => {
                 const { RovoDevApiError } = await import('./client/rovoDevApiClient');
                 const err = new RovoDevApiError('boom', 502, undefined);
                 const result = chatProvider['classifyStreamingError'](err);
-                expect(result).toEqual({ errorReason: 'http_5xx', httpStatus: 502 });
+                expect(result).toEqual({ errorReason: 'http_5xx', errorName: err.name, httpStatus: 502 });
             });
 
-            it('classifies RovoDevApiError 4xx as http_4xx with the status code', async () => {
+            it('classifies RovoDevApiError 4xx as http_4xx with the status code and error name', async () => {
                 const { RovoDevApiError } = await import('./client/rovoDevApiClient');
                 const err = new RovoDevApiError('bad request', 422, undefined);
                 const result = chatProvider['classifyStreamingError'](err);
-                expect(result).toEqual({ errorReason: 'http_4xx', httpStatus: 422 });
+                expect(result).toEqual({ errorReason: 'http_4xx', errorName: err.name, httpStatus: 422 });
             });
 
-            it('falls back to network_error for non-API errors', () => {
-                const result = chatProvider['classifyStreamingError'](new Error('socket hang up'));
+            it('falls back to network_error for non-API errors and captures the error name', () => {
+                const result = chatProvider['classifyStreamingError'](new TypeError('socket hang up'));
+                expect(result).toEqual({ errorReason: 'network_error', errorName: 'TypeError' });
+            });
+
+            it('omits errorName for non-Error thrown values', () => {
+                const result = chatProvider['classifyStreamingError']('a string error');
                 expect(result).toEqual({ errorReason: 'network_error' });
             });
         });

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -719,7 +719,10 @@ export class RovoDevChatProvider {
                 // firePromptCompleted ensures the later `success` emit from
                 // processResponse's normal exit path becomes a no-op.
                 if (sourceApi !== 'replay') {
-                    this.firePromptCompleted('parse_error', { errorReason: 'parsing_error' });
+                    this.firePromptCompleted('parse_error', {
+                        errorReason: 'parsing_error',
+                        errorName: response.error?.name || undefined,
+                    });
                 }
                 await this.processError(response.error, { showOnlyInDebug: true });
                 break;
@@ -756,7 +759,13 @@ export class RovoDevChatProvider {
                 // stream means the agent surfaced a hard error mid-response.
                 // Replay path never fires PromptCompleted.
                 if (sourceApi !== 'replay') {
-                    this.firePromptCompleted('error', { errorReason: 'stream_exception' });
+                    this.firePromptCompleted('error', {
+                        errorReason: 'stream_exception',
+                        // `response.type` is the concrete agent error class (e.g.
+                        // `UserError`, `RuntimeError`), letting the SLO break down
+                        // stream_exception by real cause.
+                        errorName: response.type || undefined,
+                    });
                 }
 
                 const { text, link } = this.parseExceptionMessage(response.message);
@@ -1103,9 +1112,10 @@ export class RovoDevChatProvider {
                 // (e.g. `_parsing_error` or `exception`) already classified
                 // this prompt, this call becomes a no-op.
                 if (sourceApi === 'chat') {
-                    const { errorReason, httpStatus } = this.classifyStreamingError(error);
+                    const { errorReason, errorName, httpStatus } = this.classifyStreamingError(error);
                     this.firePromptCompleted('error', {
                         errorReason,
+                        ...(errorName !== undefined ? { errorName } : {}),
                         ...(httpStatus !== undefined ? { httpStatus } : {}),
                     });
                 }
@@ -1140,18 +1150,22 @@ export class RovoDevChatProvider {
      */
     private classifyStreamingError(error: unknown): {
         errorReason: Track.PromptCompletedErrorReason;
+        errorName?: string;
         httpStatus?: number;
     } {
+        // Concrete error name for diagnosis (e.g. `TypeError`, `RovoDevApiError`,
+        // `FetchError`). High-cardinality companion to the closed `errorReason`.
+        const errorName = error instanceof Error ? error.name : undefined;
         if (error instanceof RovoDevApiError && typeof error.httpStatus === 'number') {
             const status = error.httpStatus;
             if (status >= 500 && status < 600) {
-                return { errorReason: 'http_5xx', httpStatus: status };
+                return { errorReason: 'http_5xx', errorName, httpStatus: status };
             }
             if (status >= 400 && status < 500) {
-                return { errorReason: 'http_4xx', httpStatus: status };
+                return { errorReason: 'http_4xx', errorName, httpStatus: status };
             }
         }
-        return { errorReason: 'network_error' };
+        return { errorReason: 'network_error', errorName };
     }
 
     /**
@@ -1175,6 +1189,7 @@ export class RovoDevChatProvider {
         result: Track.PromptCompletedResult,
         extras: {
             errorReason?: Track.PromptCompletedErrorReason;
+            errorName?: string;
             httpStatus?: number;
             messagePartsCount?: number;
         } = {},
@@ -1204,6 +1219,7 @@ export class RovoDevChatProvider {
                 promptId,
                 result,
                 ...(extras.errorReason !== undefined ? { errorReason: extras.errorReason } : {}),
+                ...(extras.errorName !== undefined ? { errorName: extras.errorName } : {}),
                 ...(extras.httpStatus !== undefined ? { httpStatus: extras.httpStatus } : {}),
                 ...(extras.messagePartsCount !== undefined ? { messagePartsCount: extras.messagePartsCount } : {}),
             },


### PR DESCRIPTION
The chat-response SLO's failed metric only carried the closed `errorReason` bucket, so backend failures (stream_exception, http_5xx, ...) were indistinguishable in aggregate - the concrete cause only went to Sentry via a separate sink. This adds an optional, free-form `errorName` capturing the specific cause so failures can be broken down directly from the SLO:

- exception (stream_exception): errorName = response.type (agent error class, e.g. UserError / RuntimeError)
- _parsing_error: errorName = response.error?.name
- fetch/HTTP catch: classifyStreamingError now also returns error.name (TypeError, RovoDevApiError, ...) alongside errorReason/httpStatus

errorName is only emitted for non-success results and is high-cardinality (intended for grouping/inspection, not as a primary SLO dimension).

NOTE: requires the paired analytics-bridge change in atlassian-frontend-monorepo (use-rovodev-analytics-bridge.ts) to forward the attribute; without it the field is dropped before reaching the Jira operational event.

Tests: firePromptCompleted forwards errorName; classifyStreamingError returns error.name for HTTP/network errors and omits it for non-Error throws.

### What Is This Change?

<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

