### PR TITLE
FRIEND-224: improve SLO errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Fixed arbitrary code execution via `core.fsmonitor` in repository `.git/config`
 
+### Bug Fixes
+
+- **RovoDev (BBY)**: Fixed the response-stream parser so well-formed responses whose `data:` payload contains newlines (e.g. multi-line tool output, code blocks, stack traces) are no longer misclassified as parse errors. The parser now follows the SSE line grammar (multi-line `data:` fields are concatenated) and ignores all comment/keep-alive lines, which removes a large source of false `parse_error` outcomes in the `rovoDevPromptCompleted` telemetry / chat-response SLO. Parser failures are now tagged with distinct error names (`RovoDevChunkShapeError`, `RovoDevJsonParseError`, `RovoDevIncompleteStreamError`) so the remaining genuine cases surface via the event's `errorName` attribute.
+- **RovoDev (BBY)**: The `no_response` outcome of the `rovoDevPromptCompleted` telemetry event is now sub-classified via `errorName` (`no_response_empty_stream` when the stream carried no messages at all, vs `no_response_control_only` when only control/lifecycle events were received and no user-visible part was rendered), so the chat-response SLO can distinguish genuinely-empty backend streams from benign control-only turns.
+
 ## What's new in 4.0.31
 
 ### Bug Fixes

--- a/src/rovo-dev/client/responseParser.test.ts
+++ b/src/rovo-dev/client/responseParser.test.ts
@@ -417,6 +417,16 @@ describe('RovoDevResponseParser', () => {
                     timestamp: '2025-07-02T12:00:00Z',
                 });
             });
+
+            it('ignores generic SSE comment lines (not just ": ping - ")', () => {
+                const input =
+                    ': keep-alive\n\nevent: user-prompt\ndata: {"content": "Hi", "timestamp": "2025-07-02T12:00:00Z"}\n\n';
+
+                const results = Array.from(parser.parse(input));
+
+                expect(results).toHaveLength(1);
+                expect(results[0].event_kind).toBe('user-prompt');
+            });
         });
 
         describe('error handling', () => {
@@ -469,6 +479,52 @@ describe('RovoDevResponseParser', () => {
                 // In practice, this shouldn't happen according to the parser logic, but we test the defensive code
                 // The important thing is that tool-return responses work correctly in normal scenarios
                 expect(true).toBe(true); // Placeholder - this error condition is defensive code
+            });
+
+            it('does NOT misclassify a well-formed chunk whose JSON data spans multiple lines', () => {
+                // A single `data:` payload that legitimately contains newlines
+                // (e.g. multi-line tool output). Previously the single-line
+                // regex would fail to match this and emit a `_parsing_error`,
+                // inflating the parse_error SLO bucket.
+                const input = 'event: text\ndata: {"index": 0, "content": "line one\\nline two\\nline three"}\n\n';
+
+                const results = Array.from(parser.parse(input));
+
+                expect(results).toHaveLength(1);
+                expect(results[0].event_kind).toBe('text');
+                expect((results[0] as any).content).toBe('line one\nline two\nline three');
+            });
+
+            it('parses a payload split across multiple data: lines (SSE multi-line data)', () => {
+                // Per the SSE spec, successive `data:` lines are concatenated
+                // with `\n`. The JSON below is valid once the lines are joined.
+                const input = 'event: text\ndata: {"index": 0,\ndata: "content": "hello"}\n\n';
+
+                const results = Array.from(parser.parse(input));
+
+                expect(results).toHaveLength(1);
+                expect(results[0].event_kind).toBe('text');
+                expect((results[0] as any).content).toBe('hello');
+            });
+
+            it('tags a malformed (missing event:) chunk with RovoDevChunkShapeError', () => {
+                const input = 'data: {"index": 0, "content": "no event line"}\n\n';
+
+                const results = Array.from(parser.parse(input));
+
+                expect(results).toHaveLength(1);
+                expect(results[0].event_kind).toBe('_parsing_error');
+                expect((results[0] as any).error.name).toBe('RovoDevChunkShapeError');
+            });
+
+            it('tags an invalid-JSON payload with RovoDevJsonParseError', () => {
+                const input = 'event: text\ndata: {not valid json}\n\n';
+
+                const results = Array.from(parser.parse(input));
+
+                expect(results).toHaveLength(1);
+                expect(results[0].event_kind).toBe('_parsing_error');
+                expect((results[0] as any).error.name).toBe('RovoDevJsonParseError');
             });
         });
     });

--- a/src/rovo-dev/client/responseParser.ts
+++ b/src/rovo-dev/client/responseParser.ts
@@ -385,10 +385,96 @@ function parseDeferredRequest(data: RovoDevDeferredRequestResponseRaw): RovoDevD
 }
 // the parser
 
+/**
+ * The SSE chunk did not match the expected `event: <kind>\ndata: <payload>`
+ * shape. Named distinctly so the `rovoDevPromptCompleted` SLO can break
+ * `parsing_error` down by concrete cause via the `errorName` attribute.
+ */
+export class RovoDevChunkShapeError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'RovoDevChunkShapeError';
+    }
+}
+
+/**
+ * The `data:` payload of an SSE chunk was not valid JSON.
+ */
+export class RovoDevJsonParseError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'RovoDevJsonParseError';
+    }
+}
+
+/**
+ * The stream ended while a partial chunk was still buffered (truncated stream).
+ */
+export class RovoDevIncompleteStreamError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'RovoDevIncompleteStreamError';
+    }
+}
+
 function generateError(error: Error): RovoDevParsingError {
     return {
         event_kind: '_parsing_error',
         error,
+    };
+}
+
+interface ParsedSseChunk {
+    /** The `event:` field value, or `undefined` when the chunk is malformed. */
+    eventKind?: string;
+    /** The concatenated `data:` field payload. */
+    data: string;
+    /** Whether the entire chunk is an SSE comment (keep-alive / ping). */
+    isComment: boolean;
+}
+
+/**
+ * Parse a single SSE chunk (already split on the blank-line boundary) following
+ * the SSE line grammar. Supports multi-line `data:` payloads by concatenating
+ * successive `data:` lines with `\n`, so JSON payloads that legitimately contain
+ * newlines are preserved rather than misparsed.
+ *
+ * Returns `isComment: true` for chunks whose lines are all comments (lines
+ * starting with `:`), which covers keep-alive pings. Returns
+ * `eventKind: undefined` when no `event:` field is present (malformed chunk).
+ */
+function parseSseChunk(chunkRaw: string): ParsedSseChunk {
+    const lines = chunkRaw.split(/\r?\n/);
+
+    let eventKind: string | undefined;
+    const dataLines: string[] = [];
+    let sawNonComment = false;
+
+    for (const line of lines) {
+        if (line === '') {
+            continue;
+        }
+        // Comment line per the SSE spec (e.g. ": ping - 1641024000").
+        if (line.startsWith(':')) {
+            continue;
+        }
+        sawNonComment = true;
+
+        if (line.startsWith('event:')) {
+            eventKind = line.slice('event:'.length).trim();
+        } else if (line.startsWith('data:')) {
+            // Preserve the payload verbatim, only trimming a single optional
+            // leading space after the colon (per the SSE spec).
+            const value = line.slice('data:'.length);
+            dataLines.push(value.startsWith(' ') ? value.slice(1) : value);
+        }
+        // Unknown fields (e.g. `id:`, `retry:`) are ignored, matching SSE.
+    }
+
+    return {
+        eventKind,
+        data: dataLines.join('\n'),
+        isComment: !sawNonComment,
     };
 }
 
@@ -420,31 +506,44 @@ export class RovoDevResponseParser {
         this.buffer = responseChunks.pop() || '';
 
         for (const chunkRaw of responseChunks) {
-            // it seems sometimes RovoDev sends a ping back - we just ignore it
-            if (chunkRaw.startsWith(': ping - ')) {
+            // Parse the chunk following the SSE line grammar. A chunk is a set
+            // of lines; `event:` names the type and `data:` carries the payload.
+            // Per the SSE spec a `data:` payload can span multiple lines (each
+            // prefixed with `data:`), which are re-joined with `\n`. Handling
+            // this explicitly — instead of a single-line regex — prevents
+            // well-formed responses whose JSON payload contains newlines (e.g.
+            // multi-line tool output, code blocks, stack traces) from being
+            // misclassified as `_parsing_error` and inflating the SLO.
+            const { eventKind, data, isComment } = parseSseChunk(chunkRaw);
+
+            // Comment lines (starting with `:`) are keep-alives / pings — ignore.
+            if (isComment) {
                 continue;
             }
 
-            const match = chunkRaw.match(/^event: ([^\r\n]+)\r?\ndata: (.*)$/);
-            if (!match) {
-                yield generateError(new Error(`Rovo Dev parser error: unable to parse chunk: "${chunkRaw}"`));
+            if (eventKind === undefined) {
+                yield generateError(
+                    new RovoDevChunkShapeError(`Rovo Dev parser error: unable to parse chunk: "${chunkRaw}"`),
+                );
                 continue;
             }
 
             let parsedData: any = '';
-            if (match[2]) {
+            if (data) {
                 try {
-                    parsedData = typeof match[2] === 'string' ? JSON.parse(match[2]) : match[2];
+                    parsedData = JSON.parse(data);
                 } catch (e) {
                     yield generateError(
-                        new Error(`Rovo Dev parser error: unable to parse JSON data: "${match[2]}", error: ${e}`),
+                        new RovoDevJsonParseError(
+                            `Rovo Dev parser error: unable to parse JSON data: "${data}", error: ${e}`,
+                        ),
                     );
                     continue;
                 }
             }
 
             const chunk: RovoDevSingleChunk | RovoDevPartStartChunk | RovoDevPartDeltaChunk = {
-                event_kind: match[1].trim() as any,
+                event_kind: eventKind as any,
                 data: parsedData,
             };
 
@@ -520,7 +619,9 @@ export class RovoDevResponseParser {
     *flush() {
         // if there is still data in the buffer, something went wrong.
         if (this.buffer) {
-            yield generateError(new Error('Rovo Dev parser error: flushed with non-empty buffer'));
+            yield generateError(
+                new RovoDevIncompleteStreamError('Rovo Dev parser error: flushed with non-empty buffer'),
+            );
         }
 
         const chunk = this.flushPreviousChunk();

--- a/src/rovo-dev/rovoDevChatProvider.test.ts
+++ b/src/rovo-dev/rovoDevChatProvider.test.ts
@@ -1296,6 +1296,67 @@ describe('RovoDevChatProvider', () => {
             });
         });
 
+        // The terminal `no_response` classification is sub-typed via `errorName`
+        // so the SLO can separate genuinely-empty backend streams from turns
+        // that only emitted control/lifecycle events (and thus legitimately
+        // rendered nothing user-visible). We drive processResponse end-to-end
+        // because the discriminator (isFirstMessage) lives inside that loop.
+        describe('no_response sub-classification', () => {
+            const findPromptCompletedCall = () =>
+                mockTelemetryProvider.fireTelemetryEvent.mock.calls
+                    .map((c: any[]) => c[0])
+                    .find((e: any) => e.action === 'rovoDevPromptCompleted');
+
+            it('classifies a completely empty stream as no_response_empty_stream', async () => {
+                await chatProvider.setReady(mockApiClient);
+                chatProvider['_currentPromptId'] = 'prompt-empty';
+                mockTelemetryProvider.fireTelemetryEvent.mockClear();
+
+                const emptyStream = new ReadableStream({
+                    start(controller) {
+                        controller.close();
+                    },
+                });
+                const response = { body: emptyStream } as Response;
+
+                await chatProvider['processResponse']('chat', response);
+
+                const event = findPromptCompletedCall();
+                expect(event).toBeDefined();
+                expect(event.attributes.result).toBe('error');
+                expect(event.attributes.errorReason).toBe('no_response');
+                expect(event.attributes.errorName).toBe('no_response_empty_stream');
+                expect(event.attributes.messagePartsCount).toBe(0);
+            });
+
+            it('classifies a control-only stream (no user-visible parts) as no_response_control_only', async () => {
+                await chatProvider.setReady(mockApiClient);
+                chatProvider['_currentPromptId'] = 'prompt-control';
+                mockTelemetryProvider.fireTelemetryEvent.mockClear();
+
+                // A `thinking` event is a control/lifecycle message: it is parsed
+                // (so isFirstMessage flips) but is not a user-visible part.
+                const controlOnlyStream = new ReadableStream({
+                    start(controller) {
+                        controller.enqueue(
+                            new TextEncoder().encode('event: thinking\ndata: {"content": "pondering"}\n\n'),
+                        );
+                        controller.close();
+                    },
+                });
+                const response = { body: controlOnlyStream } as Response;
+
+                await chatProvider['processResponse']('chat', response);
+
+                const event = findPromptCompletedCall();
+                expect(event).toBeDefined();
+                expect(event.attributes.result).toBe('error');
+                expect(event.attributes.errorReason).toBe('no_response');
+                expect(event.attributes.errorName).toBe('no_response_control_only');
+                expect(event.attributes.messagePartsCount).toBe(0);
+            });
+        });
+
         it('omits optional attributes when not provided (bridge expects closed shape)', () => {
             chatProvider['firePromptCompleted']('cancelled', { errorReason: 'aborted' });
 

--- a/src/rovo-dev/rovoDevChatProvider.ts
+++ b/src/rovo-dev/rovoDevChatProvider.ts
@@ -542,8 +542,19 @@ export class RovoDevChatProvider {
             if (partsCount > 0) {
                 this.firePromptCompleted('success', { messagePartsCount: partsCount });
             } else {
+                // Sub-classify `no_response` via `errorName` so the SLO can tell
+                // genuinely-empty backend streams apart from turns that only
+                // produced control/lifecycle events (thinking, warning,
+                // deferred permission request, …) and therefore legitimately
+                // rendered no user-visible part:
+                //   - `no_response_empty_stream`  ⇒ not a single message was
+                //     parsed from the stream (isFirstMessage never flipped).
+                //   - `no_response_control_only`  ⇒ messages arrived but none
+                //     were user-visible (often a benign, expected outcome).
+                const errorName = isFirstMessage ? 'no_response_empty_stream' : 'no_response_control_only';
                 this.firePromptCompleted('error', {
                     errorReason: 'no_response',
+                    errorName,
                     messagePartsCount: 0,
                 });
             }


### PR DESCRIPTION
### What Is This Change?

Why
The rovoDevPromptCompleted event feeds the chat-response SLO. Investigation (FRIEND-224) found most “failures” are false positives: parsing_error (~35%) and no_response (~33%) dominate, ahead of genuine stream_exception (~24%) and client-side network_error (~10%).

What
SSE parser hardening (responseParser.ts): the single-line regex misclassified any data: payload containing a newline (multi-line tool output, code blocks, stack traces) as parse_error. Replaced with an SSE-line-grammar parser that concatenates multi-line data: fields and ignores all comment/keep-alive lines. Parser failures now carry distinct names (RovoDevChunkShapeError, RovoDevJsonParseError, RovoDevIncompleteStreamError) exposed via errorName.
no_response sub-classification (rovoDevChatProvider.ts): sets errorName to no_response_empty_stream (nothing parsed) vs no_response_control_only (control/lifecycle events only), so the SLO can separate genuine empty streams from benign turns.
<!--

Main branch should always be clean and ready for release. If you need make a large feature, use a dev branch to do so. 

Thanks for considering making a PR to this repository!👋

Please give us a brief description of what the proposed change is.

As reviewers, we'd really appreciate if you could elaborate on the context of the change.
* If there is an issue related to the change, please make sure to link it!
* If not - please describe the change from a user perspective.
* Is there a user concern the change is addressing that we might not be aware of?

If you're making changes to UI components, or affects UX in other ways - please include before-and-after screenshots 🖼️ or videos (e.g. loom) 🎥
-->

### How Has This Been Tested?

<!--
🔧 Did you make sure the proposed change works, before submitting the PR?
If yes, please tell us how!

If you can, and if this is applicable to your change - please don't forget to test your changes with both Cloud and Data Center versions Jira/BB.

In particular, if you're making changes not covered by tests - please describe the manual testing you've done - this would be very helpful!
-->

Basic checks:

- [x] `npm run lint`
- [x] `npm run test`

Advanced checks: 
- [ ] If Atlassian employee & Bitbucket changes: did you test with DC in mind? [See Instructions](https://www.loom.com/share/71e5d17734a547f68fd6128be6cd760e?sid=835e58a7-1240-498d-b2d7-fa7fdf8ffa36)

Recommendations:
- [ ] Update the CHANGELOG if making a user facing change



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

