### PR TITLE
Fix: support Bitbucket Server URL redirects (alias hostnames)

### DIFF
--- a/src/bitbucket/bbContext.test.ts
+++ b/src/bitbucket/bbContext.test.ts
@@ -22,8 +22,16 @@ import { Time } from '../util/time';
 import { PullRequestCommentController } from '../views/pullrequest/prCommentController';
 import { PullRequestsExplorer } from '../views/pullrequest/pullRequestsExplorer';
 import { BitbucketContext } from './bbContext';
-import { clientForSite, getBitbucketCloudRemotes, getBitbucketRemotes, workspaceRepoFor } from './bbUtils';
+import {
+    clientForSite,
+    getBitbucketCloudRemotes,
+    getBitbucketRemotes,
+    parseGitUrl,
+    urlForRemote,
+    workspaceRepoFor,
+} from './bbUtils';
 import { BitbucketSite, PullRequest, User, WorkspaceRepo } from './model';
+import { resolveRedirectHostname } from './redirectResolver';
 
 // Mock all other dependencies
 jest.mock('../container');
@@ -31,6 +39,7 @@ jest.mock('../logger');
 jest.mock('../views/pullrequest/prCommentController');
 jest.mock('../views/pullrequest/pullRequestsExplorer');
 jest.mock('./bbUtils');
+jest.mock('./redirectResolver');
 jest.mock('../util/cachemap');
 
 describe('BitbucketContext', () => {
@@ -59,6 +68,7 @@ describe('BitbucketContext', () => {
             onDidSitesAvailableChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
             getSitesAvailable: jest.fn().mockReturnValue([]),
             getFirstAAID: jest.fn(),
+            getSiteForHostname: jest.fn().mockReturnValue(undefined),
         };
 
         mockClientManager = {
@@ -441,6 +451,80 @@ describe('BitbucketContext', () => {
 
             const result = bitbucketContext.getMirrors('bitbucket.org');
             expect(result).toEqual([]);
+        });
+    });
+
+    describe('getRedirectHost', () => {
+        beforeEach(() => {
+            bitbucketContext = new BitbucketContext(mockGitApi);
+        });
+
+        it('should return resolved redirect host for hostname', () => {
+            const mockRedirectsCache = bitbucketContext['_redirectsCache'];
+            mockRedirectsCache.getItem = jest.fn().mockReturnValue('real-host.example.com');
+
+            const result = bitbucketContext.getRedirectHost('alias-host.example.com');
+            expect(result).toEqual('real-host.example.com');
+            expect(mockRedirectsCache.getItem).toHaveBeenCalledWith('alias-host.example.com');
+        });
+
+        it('should return undefined if no redirect resolved', () => {
+            const mockRedirectsCache = bitbucketContext['_redirectsCache'];
+            mockRedirectsCache.getItem = jest.fn().mockReturnValue(undefined);
+
+            const result = bitbucketContext.getRedirectHost('unknown-host.example.com');
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('resolveUnmatchedRemoteHosts', () => {
+        beforeEach(() => {
+            Object.defineProperty(mockGitApi, 'repositories', { value: [mockRepository], writable: true });
+        });
+
+        it('should skip probing when no Bitbucket Server sites are configured', async () => {
+            mockSiteManager.getSitesAvailable.mockReturnValue([{ ...mockBitbucketSite.details, isCloud: true }]);
+
+            bitbucketContext = new BitbucketContext(mockGitApi);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(resolveRedirectHostname).not.toHaveBeenCalled();
+        });
+
+        it('should probe unmatched remote hostnames and cache resolved redirects', async () => {
+            const serverSite = { ...mockBitbucketSite.details, host: 'bitbucket.example.com', isCloud: false };
+            mockSiteManager.getSitesAvailable.mockReturnValue([serverSite]);
+            mockSiteManager.getSiteForHostname.mockReturnValue(undefined);
+
+            (urlForRemote as jest.Mock).mockReturnValue('https://old-alias.example.com/scm/proj/repo.git');
+            (parseGitUrl as jest.Mock).mockReturnValue({ resource: 'old-alias.example.com' });
+            (resolveRedirectHostname as jest.Mock).mockResolvedValue('bitbucket.example.com');
+
+            bitbucketContext = new BitbucketContext(mockGitApi);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(resolveRedirectHostname).toHaveBeenCalledWith('old-alias.example.com');
+
+            const mockRedirectsCache = bitbucketContext['_redirectsCache'];
+            expect(mockRedirectsCache.setItem).toHaveBeenCalledWith(
+                'old-alias.example.com',
+                'bitbucket.example.com',
+                60 * Time.MINUTES,
+            );
+        });
+
+        it('should not probe hostnames that already resolve to a configured site', async () => {
+            const serverSite = { ...mockBitbucketSite.details, host: 'bitbucket.example.com', isCloud: false };
+            mockSiteManager.getSitesAvailable.mockReturnValue([serverSite]);
+            mockSiteManager.getSiteForHostname.mockReturnValue(serverSite);
+
+            (urlForRemote as jest.Mock).mockReturnValue('https://bitbucket.example.com/scm/proj/repo.git');
+            (parseGitUrl as jest.Mock).mockReturnValue({ resource: 'bitbucket.example.com' });
+
+            bitbucketContext = new BitbucketContext(mockGitApi);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(resolveRedirectHostname).not.toHaveBeenCalled();
         });
     });
 

--- a/src/bitbucket/bbContext.ts
+++ b/src/bitbucket/bbContext.ts
@@ -10,8 +10,16 @@ import { CacheMap } from '../util/cachemap';
 import { Time } from '../util/time';
 import { PullRequestCommentController } from '../views/pullrequest/prCommentController';
 import { PullRequestsExplorer } from '../views/pullrequest/pullRequestsExplorer';
-import { clientForSite, getBitbucketCloudRemotes, getBitbucketRemotes, workspaceRepoFor } from './bbUtils';
+import {
+    clientForSite,
+    getBitbucketCloudRemotes,
+    getBitbucketRemotes,
+    parseGitUrl,
+    urlForRemote,
+    workspaceRepoFor,
+} from './bbUtils';
 import { BitbucketSite, PullRequest, User, WorkspaceRepo } from './model';
+import { resolveRedirectHostname } from './redirectResolver';
 
 // BitbucketContext stores the context (hosts, auth, current repo etc.)
 // for all Bitbucket related actions.
@@ -26,6 +34,7 @@ export class BitbucketContext extends Disposable {
     private _currentUsers: CacheMap;
     private _pullRequestCache = new CacheMap();
     private _mirrorsCache = new CacheMap();
+    private _redirectsCache = new CacheMap();
     public readonly prCommentController: PullRequestCommentController;
 
     constructor(gitApi: GitApi) {
@@ -108,6 +117,8 @@ export class BitbucketContext extends Disposable {
             );
 
             const repos = this.getAllRepositoriesRaw();
+            await this.resolveUnmatchedRemoteHosts(repos);
+
             for (let i = 0; i < repos.length; i++) {
                 const repo: Repository = repos[i];
 
@@ -143,6 +154,52 @@ export class BitbucketContext extends Disposable {
             }
             Logger.error(err, 'Error refreshing Bitbucket repositories');
         }
+    }
+
+    /**
+     * Some Bitbucket Server instances are reachable under an old/alias hostname that the
+     * webserver 301/302-redirects to the real host (e.g. after a server migration). Since
+     * that alias won't match any configured site by hostname/domain/mirror, probe it directly
+     * for a redirect and cache the resolved hostname so `siteManager.getSiteForHostname` can
+     * match remotes using the alias. See GH issue about "no redirection when remote is an
+     * alias of true URL".
+     */
+    private async resolveUnmatchedRemoteHosts(repos: Repository[]) {
+        const serverSites = Container.siteManager.getSitesAvailable(ProductBitbucket).filter((s) => !s.isCloud);
+        if (serverSites.length === 0) {
+            return;
+        }
+
+        const hostnames = new Set<string>();
+        repos.forEach((repo) => {
+            (repo.state?.remotes || []).forEach((remote) => {
+                const url = urlForRemote(remote);
+                if (!url) {
+                    return;
+                }
+                try {
+                    hostnames.add(parseGitUrl(url).resource);
+                } catch {
+                    // ignore unparsable remote urls
+                }
+            });
+        });
+
+        await Promise.all(
+            Array.from(hostnames).map(async (hostname) => {
+                if (
+                    Container.siteManager.getSiteForHostname(ProductBitbucket, hostname) ||
+                    this._redirectsCache.getItem(hostname) !== undefined
+                ) {
+                    return;
+                }
+
+                const resolvedHostname = await resolveRedirectHostname(hostname);
+                if (resolvedHostname) {
+                    this._redirectsCache.setItem(hostname, resolvedHostname, 60 * Time.MINUTES);
+                }
+            }),
+        );
     }
 
     private updateUsers(sites: DetailedSiteInfo[]) {
@@ -194,6 +251,10 @@ export class BitbucketContext extends Disposable {
 
     public getMirrors(hostname: string): string[] {
         return this._mirrorsCache.getItem<string[]>(hostname) || [];
+    }
+
+    public getRedirectHost(hostname: string): string | undefined {
+        return this._redirectsCache.getItem<string>(hostname);
     }
 
     override dispose() {

--- a/src/bitbucket/redirectResolver.test.ts
+++ b/src/bitbucket/redirectResolver.test.ts
@@ -1,0 +1,63 @@
+import axios from 'axios';
+
+import { resolveRedirectHostname } from './redirectResolver';
+
+jest.mock('axios');
+jest.mock('../logger');
+
+describe('resolveRedirectHostname', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return the resolved hostname when the server responds with a redirect', async () => {
+        (axios.get as jest.Mock).mockResolvedValueOnce({
+            headers: { location: 'https://real-host.example.com/' },
+        });
+
+        const result = await resolveRedirectHostname('old-alias.example.com');
+
+        expect(result).toEqual('real-host.example.com');
+        expect(axios.get).toHaveBeenCalledWith(
+            'https://old-alias.example.com/',
+            expect.objectContaining({ maxRedirects: 0 }),
+        );
+    });
+
+    it('should return undefined when there is no location header', async () => {
+        (axios.get as jest.Mock).mockResolvedValue({ headers: {} });
+
+        const result = await resolveRedirectHostname('no-redirect.example.com');
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when the redirect points to the same hostname', async () => {
+        (axios.get as jest.Mock).mockResolvedValue({
+            headers: { location: 'https://same-host.example.com/other-path' },
+        });
+
+        const result = await resolveRedirectHostname('same-host.example.com');
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should try http after https fails and still resolve a redirect', async () => {
+        (axios.get as jest.Mock)
+            .mockRejectedValueOnce(new Error('TLS error'))
+            .mockResolvedValueOnce({ headers: { location: 'http://real-host.example.com/' } });
+
+        const result = await resolveRedirectHostname('old-alias.example.com');
+
+        expect(result).toEqual('real-host.example.com');
+        expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return undefined when both protocols fail', async () => {
+        (axios.get as jest.Mock).mockRejectedValue(new Error('connection refused'));
+
+        const result = await resolveRedirectHostname('unreachable.example.com');
+
+        expect(result).toBeUndefined();
+    });
+});

--- a/src/bitbucket/redirectResolver.ts
+++ b/src/bitbucket/redirectResolver.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+import { Logger } from '../logger';
+import { ConnectionTimeout } from '../util/time';
+
+/**
+ * Probes a hostname for an HTTP redirect (e.g. a DNS alias that a webserver
+ * 301/302-redirects to the real Bitbucket Server host) and returns the
+ * hostname it redirects to, if any.
+ *
+ * This does not follow the redirect (no auth headers, no request body) - it
+ * only inspects the `Location` header of a 3xx response to discover the
+ * real host so that it can be matched against configured sites.
+ */
+export async function resolveRedirectHostname(hostname: string): Promise<string | undefined> {
+    for (const protocol of ['https', 'http']) {
+        try {
+            const response = await axios.get(`${protocol}://${hostname}/`, {
+                timeout: ConnectionTimeout,
+                maxRedirects: 0,
+                validateStatus: (status) => status >= 200 && status < 400,
+            });
+
+            const location = response.headers?.location;
+            if (!location) {
+                continue;
+            }
+
+            const resolvedHostname = new URL(location, `${protocol}://${hostname}/`).hostname;
+            if (resolvedHostname && resolvedHostname !== hostname) {
+                return resolvedHostname;
+            }
+        } catch (e) {
+            Logger.debug(`Failed to probe ${hostname} for redirects over ${protocol}: ${e}`);
+        }
+    }
+
+    return undefined;
+}

--- a/src/siteManager.test.ts
+++ b/src/siteManager.test.ts
@@ -74,6 +74,7 @@ describe('SiteManager', () => {
             credentialManager: mockCredentialManager,
             bitbucketContext: {
                 getMirrors: jest.fn((host) => []),
+                getRedirectHost: jest.fn((host) => undefined),
             },
             config: {
                 jira: {
@@ -309,6 +310,32 @@ describe('SiteManager', () => {
             const result = siteManager.getSiteForHostname(ProductBitbucket, 'mirror.example.com');
 
             expect(result).toBe(site);
+        });
+
+        it('should find a site via a resolved HTTP redirect hostname (alias URL)', () => {
+            const site = createDetailedSiteInfo(ProductBitbucket);
+            site.host = 'https://bitbucket.example.com';
+
+            storedSites.set(`${ProductBitbucket.key}Sites`, [site]);
+
+            (Container.bitbucketContext!.getRedirectHost as jest.Mock).mockImplementation((host: string) =>
+                host === 'old-alias.example.com' ? 'bitbucket.example.com' : undefined,
+            );
+
+            const result = siteManager.getSiteForHostname(ProductBitbucket, 'old-alias.example.com');
+
+            expect(result).toBe(site);
+        });
+
+        it('should return undefined if no match is found via hostname, mirrors, or redirects', () => {
+            const site = createDetailedSiteInfo(ProductBitbucket);
+            site.host = 'https://bitbucket.example.com';
+
+            storedSites.set(`${ProductBitbucket.key}Sites`, [site]);
+
+            const result = siteManager.getSiteForHostname(ProductBitbucket, 'unrelated.other.com');
+
+            expect(result).toBeUndefined();
         });
     });
 

--- a/src/siteManager.ts
+++ b/src/siteManager.ts
@@ -310,20 +310,19 @@ export class SiteManager extends Disposable {
         // look for match in mirror hosts (for Bitbucket Server)
         site = this.getSitesAvailable(product).find((site) =>
             Container.bitbucketContext
-                ? Container.bitbucketContext.getMirrors(site.host).find((mirror) => mirror.includes(hostname)) !==
-                  undefined
+                ? Container.bitbucketContext
+                      .getMirrors(site.host)
+                      .some((mirror) => mirror.includes(hostname) || mirror.includes(domain))
                 : false,
         );
         if (site) {
             return site;
         }
 
-        return this.getSitesAvailable(product).find((site) =>
-            Container.bitbucketContext
-                ? Container.bitbucketContext.getMirrors(site.host).find((mirror) => mirror.includes(domain)) !==
-                  undefined
-                : false,
-        );
+        // look for match via a resolved HTTP redirect (e.g. an old/alias hostname that the
+        // webserver redirects to the real Bitbucket Server host)
+        const redirectedHostname = Container.bitbucketContext?.getRedirectHost(hostname);
+        return redirectedHostname ? this.getSiteForHostname(product, redirectedHostname) : undefined;
     }
 
     public getSiteForId(product: Product, id: string): DetailedSiteInfo | undefined {


### PR DESCRIPTION
**Summary**
Fixes an issue (closes [#56](https://github.com/atlassian/atlascode/issues/56) - [#802](https://bitbucket.org/atlassianlabs/atlascode/issues/802/jira-and-bitbucket-extension-for-vs-code) where git remotes using aliased hostnames that return 301/302 HTTP redirects fail to match configured Bitbucket Server sites, preventing features like the PR panel from loading.

**Changes**

* **`redirectResolver.ts`**: Added utility to probe unmapped hostnames (HTTPS/HTTP without following redirects) and read the `Location` header from 3xx responses.
* **`BitbucketContext`**: Integrated the probe during repository refresh for unknown hostnames and added a 1-hour cache for `alias → resolved host`.
* **`siteManager`**: Updated `getSiteForHostname` to check the resolved redirect cache as a final fallback.

**Testing**

* Unit tests added for `redirectResolver`, `BitbucketContext`, and `siteManager` caching/fallback logic.
* Verified `tsc --noEmit` and `eslint` pass cleanly.
* Requesting maintainer smoke-testing against an active aliased Bitbucket Server setup.

---

**Key Cuts & Improvements**

* **Removed informal filler:** Cut conversational idioms ("trippin'", "clutch 🙏", "shoutout") to keep the git log clean and professional.
* **Streamlined context:** Removed baseline explanations of why webservers use 301 redirects and internal `axios` behavior.
* **Standardized layout:** Formatted into concise PR sections (Summary, Changes, Testing) for faster maintainer scannability.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

